### PR TITLE
design: tweak light mode flow gradient

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -64,7 +64,6 @@ export default async function RootLayout({ params, children }: LayoutProps) {
             <FlowGradient />
           </Suspense>
         </div>
-        <div {...stylex.props(styles.contentMask)} role="presentation" />
         <div {...stylex.props(styles.glow)} role="presentation" />
         <div {...stylex.props(styles.container)}>
           <div {...stylex.props(styles.wrapperInner)}>
@@ -182,21 +181,6 @@ const styles = stylex.create({
       [lg]: "30rem",
       [minXl]: "max(35rem, 80dvh)",
     },
-  },
-  contentMask: {
-    position: "absolute",
-    top: 0,
-    left: 0,
-    right: 0,
-    zIndex: 0,
-    overflow: "hidden",
-    pointerEvents: "none",
-    height: {
-      default: "calc(540px + 10rem)",
-      [minXl]: "calc(1000px + 10rem)",
-    },
-    mixBlendMode: tokens.maskBlendMode,
-    background: `radial-gradient(circle ${tokens.layoutMaskRadius} at center calc(${tokens.layoutMaskRadius}), ${tokens.backgroundMain} 50%, transparent)`,
   },
   glow: {
     position: "absolute",

--- a/src/server-components/flow-gradient/flow-gradient-client.tsx
+++ b/src/server-components/flow-gradient/flow-gradient-client.tsx
@@ -32,7 +32,15 @@ function Internal({ vs, fs }: FlowGradientClientProps) {
     if (context) {
       return start(
         context,
-        isDark ? { colorBackground: [0, 0, 0] } : { colorBackground: [1, 1, 1] }
+        isDark
+          ? { colorBackground: [0, 0, 0] }
+          : {
+              colorBackground: [1, 1, 1],
+              colorTop: [0.3, 0.3, 0.5],
+              colorBottom: [0.3, 0.3, 1],
+              colorAltTop: [1, 0.3, 0.3],
+              colorAltBottom: [1, 0.3, 0.3],
+            }
       );
     }
   }, [vs, fs, isDark, context]);


### PR DESCRIPTION
The mix-blend-mode was required because in light mode the flowing gradient was too dark and would make the heading illegible, however this property is very slow for devices that are not hardware accelerated. Therefore in the PR I've removed the content mask that's using the mix-blend-mode property, and tweaked the light mode colors to be more legible.