### PR TITLE
perf: reduce list request payload size

### DIFF
--- a/src/components/movie-database/movie-card.tsx
+++ b/src/components/movie-database/movie-card.tsx
@@ -1,13 +1,11 @@
 import * as stylex from "@stylexjs/stylex";
-import type { paths } from "@/_generated/tmdbV3";
 import { Card } from "@/components/shared/card";
 import { layer, ratio } from "@/tokens.stylex";
+import type { MovieListItem } from "@/utils/tmdb-api";
 import { PosterImage } from "./poster-image";
 
 interface MovieCardProps {
-  movie: NonNullable<
-    paths["/3/discover/movie"]["get"]["responses"]["200"]["content"]["application/json"]["results"]
-  >[number];
+  movie: MovieListItem;
 }
 
 export function MovieCard({ movie }: MovieCardProps) {
@@ -18,9 +16,9 @@ export function MovieCard({ movie }: MovieCardProps) {
       aria-label={movie.title}
       onClick={(e) => e.preventDefault()}
     >
-      {movie.poster_path && movie.title && (
+      {movie.posterPath && movie.title && (
         <div css={styles.posterContainer}>
-          <PosterImage posterPath={movie.poster_path} alt={movie.title} />
+          <PosterImage posterPath={movie.posterPath} alt={movie.title} />
         </div>
       )}
       {/* TODO: Render ratings */}

--- a/src/utils/tmdb-api.ts
+++ b/src/utils/tmdb-api.ts
@@ -29,9 +29,11 @@ export async function fetchConfiguration() {
   return (await response.json()) as Configuration;
 }
 
-export type Movie = NonNullable<
-  paths["/3/discover/movie"]["get"]["responses"]["200"]["content"]["application/json"]["results"]
->[number];
+export type MovieListItem = {
+  id: number;
+  title?: string;
+  posterPath?: string;
+};
 
 /** Fetch list of movies */
 export async function fetchMovieList({
@@ -57,5 +59,17 @@ export async function fetchMovieList({
     );
   }
 
-  return (await response.json()) as paths["/3/discover/movie"]["get"]["responses"]["200"]["content"]["application/json"];
+  const result =
+    (await response.json()) as paths["/3/discover/movie"]["get"]["responses"]["200"]["content"]["application/json"];
+  return {
+    ...result,
+    results: result.results?.map(
+      (movie) =>
+        ({
+          id: movie.id,
+          title: movie.title,
+          posterPath: movie.poster_path,
+        }) satisfies MovieListItem
+    ),
+  };
 }


### PR DESCRIPTION
Not rendering descriptions etc when rendering the list, by sending only the required data back, the payload size for each page reduces from 5kb to 1kb.