### PR TITLE
build: add scripts for linting and formatting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm prettier:change && pnpm lint:changed"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,37 @@
+# Dependencies
+node_modules/
+
+# Build outputs
+.next/
+out/
+build/
+dist/
+
+# Generated files
+src/_generated/
+public/sw.js
+public/sw.js.map
+
+# Lock files
+pnpm-lock.yaml
+
+# TypeScript build info
+tsconfig.tsbuildinfo
+
+# Cache directories
+.cache/
+.turbo/
+
+# Environment files
+.env*
+
+# IDE
+.vscode/
+.idea/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Zone identifier files
+*.Zone.Identifier

--- a/package.json
+++ b/package.json
@@ -13,8 +13,12 @@
     "codegen": "openapi-typescript https://developer.themoviedb.org/openapi/64542913e1f86100738e227f -o src/_generated/tmdbV3.d.ts && prettier src/_generated/tmdbV3.d.ts -w",
     "dev": "pnpm codegen && next dev",
     "build": "next build",
+    "build:tsc": "tsc --noEmit",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "lint:changed": "git diff --name-only --diff-filter=d HEAD | grep -E '\\.(js|jsx|ts|tsx)$' | xargs -r next lint --fix --file",
+    "prettier": "prettier --write '**/*.{js,jsx,ts,tsx,json,css,md,mjs}' --ignore-path .gitignore",
+    "prettier:changed": "git diff --name-only --diff-filter=d HEAD | grep -E '\\.(js|jsx|ts|tsx|json|css|md)$' | xargs -r prettier --write"
   },
   "dependencies": {
     "@mui/utils": "^6.4.8",

--- a/src/app/[locale]/(home)/(details)/education/altrincham-grammar-school-for-boys/layout.tsx
+++ b/src/app/[locale]/(home)/(details)/education/altrincham-grammar-school-for-boys/layout.tsx
@@ -13,16 +13,16 @@ export async function generateMetadata(props: PageProps) {
     alternates: {
       canonical: new URL(
         "/education/altrincham-grammar-school-for-boys",
-        BASE_URL
+        BASE_URL,
       ).toString(),
       languages: {
         en: new URL(
           "/education/altrincham-grammar-school-for-boys",
-          BASE_URL
+          BASE_URL,
         ).toString(),
         zh: new URL(
           "/zh/education/altrincham-grammar-school-for-boys",
-          BASE_URL
+          BASE_URL,
         ).toString(),
       },
     },

--- a/src/app/[locale]/(home)/(details)/education/university-of-bristol/layout.tsx
+++ b/src/app/[locale]/(home)/(details)/education/university-of-bristol/layout.tsx
@@ -13,7 +13,7 @@ export async function generateMetadata(props: PageProps) {
     alternates: {
       canonical: new URL(
         "/education/university-of-bristol",
-        BASE_URL
+        BASE_URL,
       ).toString(),
       languages: {
         en: new URL("/education/university-of-bristol", BASE_URL).toString(),

--- a/src/app/[locale]/(home)/(details)/education/university-of-nottingham/layout.tsx
+++ b/src/app/[locale]/(home)/(details)/education/university-of-nottingham/layout.tsx
@@ -13,13 +13,13 @@ export async function generateMetadata(props: PageProps) {
     alternates: {
       canonical: new URL(
         "/education/university-of-nottingham",
-        BASE_URL
+        BASE_URL,
       ).toString(),
       languages: {
         en: new URL("/education/university-of-nottingham", BASE_URL).toString(),
         zh: new URL(
           "/zh/education/university-of-nottingham",
-          BASE_URL
+          BASE_URL,
         ).toString(),
       },
     },

--- a/src/app/[locale]/(home)/(details)/experiences/wunderman-thompson-commerce/layout.tsx
+++ b/src/app/[locale]/(home)/(details)/experiences/wunderman-thompson-commerce/layout.tsx
@@ -13,16 +13,16 @@ export async function generateMetadata(props: PageProps) {
     alternates: {
       canonical: new URL(
         "/experiences/wunderman-thompson-commerce",
-        BASE_URL
+        BASE_URL,
       ).toString(),
       languages: {
         en: new URL(
           "/experiences/wunderman-thompson-commerce",
-          BASE_URL
+          BASE_URL,
         ).toString(),
         zh: new URL(
           "/zh/experiences/wunderman-thompson-commerce",
-          BASE_URL
+          BASE_URL,
         ).toString(),
       },
     },

--- a/src/app/[locale]/(home)/page.tsx
+++ b/src/app/[locale]/(home)/page.tsx
@@ -79,7 +79,7 @@ export default async function Home(props: PageProps) {
             dates={t("wtcDate")}
             href={getLocalePath(
               "/experiences/wunderman-thompson-commerce",
-              locale
+              locale,
             )}
             css={styles.card}
             aria-label={t("wtcLabel")}
@@ -109,7 +109,7 @@ export default async function Home(props: PageProps) {
             dates={t("agsbDate")}
             href={getLocalePath(
               "/education/altrincham-grammar-school-for-boys",
-              locale
+              locale,
             )}
             css={styles.card}
           />

--- a/src/app/[locale]/movie-database/(list)/page.tsx
+++ b/src/app/[locale]/movie-database/(list)/page.tsx
@@ -16,7 +16,7 @@ import translations from "../translations.json";
 export default async function Page(
   props: PageProps & {
     searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
-  }
+  },
 ) {
   await connection();
   const params = await props.params;

--- a/src/app/[locale]/movie-database/tv/page.tsx
+++ b/src/app/[locale]/movie-database/tv/page.tsx
@@ -16,7 +16,7 @@ import translations from "../translations.json";
 export default async function Page(
   props: PageProps & {
     searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
-  }
+  },
 ) {
   await connection();
   const params = await props.params;

--- a/src/components/movie-database/backdrop-image.tsx
+++ b/src/components/movie-database/backdrop-image.tsx
@@ -30,7 +30,7 @@ export async function BackdropImage({ backdropPath, alt }: BackdropImageProps) {
   const srcSet = sizes
     .map(
       (size) =>
-        `${config.images?.secure_base_url}w${size}${backdropPath} ${size}w`
+        `${config.images?.secure_base_url}w${size}${backdropPath} ${size}w`,
     )
     .join(", ");
 

--- a/src/components/movie-database/media-list.tsx
+++ b/src/components/movie-database/media-list.tsx
@@ -43,14 +43,14 @@ export function MediaList<T extends { id: number }>({
 
   const { data, fetchNextPage, hasNextPage, isFetching } =
     useSuspenseInfiniteQuery(
-      tmdbQueryOptions as Parameters<typeof useSuspenseInfiniteQuery>[0]
+      tmdbQueryOptions as Parameters<typeof useSuspenseInfiniteQuery>[0],
     );
 
   const items = data as T[];
 
   // Get viewport height, used for infinite scroll padding
   const [height, setHeight] = useState(() =>
-    typeof window !== "undefined" ? window.innerHeight : 0
+    typeof window !== "undefined" ? window.innerHeight : 0,
   );
   useLayoutEffect(() => {
     const onResize = () => setHeight(window.innerHeight);
@@ -76,7 +76,7 @@ export function MediaList<T extends { id: number }>({
           renderItem={
             renderItem as (
               item: unknown,
-              allowFollow: boolean
+              allowFollow: boolean,
             ) => React.ReactNode
           }
         />

--- a/src/components/movie-database/poster-image.tsx
+++ b/src/components/movie-database/poster-image.tsx
@@ -42,7 +42,7 @@ export function PosterImage({ posterPath, alt }: PosterImageProps) {
   const srcSet = sizes
     .map(
       (size) =>
-        `${config.images?.secure_base_url}w${size}${posterPath} ${size}w`
+        `${config.images?.secure_base_url}w${size}${posterPath} ${size}w`,
     )
     .join(", ");
 

--- a/src/components/movie-database/similar-movie-list.tsx
+++ b/src/components/movie-database/similar-movie-list.tsx
@@ -39,7 +39,7 @@ export function SimilarMovieList({
 
   // Get viewport height, used for infinite scroll padding
   const [height, setHeight] = useState(() =>
-    typeof window !== "undefined" ? window.innerHeight : 0
+    typeof window !== "undefined" ? window.innerHeight : 0,
   );
   useLayoutEffect(() => {
     const onResize = () => setHeight(window.innerHeight);

--- a/src/components/movie-database/similar-tv-show-list.tsx
+++ b/src/components/movie-database/similar-tv-show-list.tsx
@@ -39,7 +39,7 @@ export function SimilarTvShowList({
 
   // Get viewport height, used for infinite scroll padding
   const [height, setHeight] = useState(() =>
-    typeof window !== "undefined" ? window.innerHeight : 0
+    typeof window !== "undefined" ? window.innerHeight : 0,
   );
   useLayoutEffect(() => {
     const onResize = () => setHeight(window.innerHeight);

--- a/src/components/movie-database/sort-filter.tsx
+++ b/src/components/movie-database/sort-filter.tsx
@@ -30,7 +30,7 @@ export function SortFilter({ bright, hideLabel }: SortFilterProps) {
           onClick={(e) => {
             e.preventDefault();
             setSort(
-              sort === "popularity.desc" ? "popularity.asc" : "popularity.desc"
+              sort === "popularity.desc" ? "popularity.asc" : "popularity.desc",
             );
           }}
           bright={bright}
@@ -52,7 +52,7 @@ export function SortFilter({ bright, hideLabel }: SortFilterProps) {
             setSort(
               sort === "vote_average.desc"
                 ? "vote_average.asc"
-                : "vote_average.desc"
+                : "vote_average.desc",
             );
           }}
           bright={bright}

--- a/src/components/movie-database/trailer.tsx
+++ b/src/components/movie-database/trailer.tsx
@@ -17,7 +17,7 @@ export async function Trailer({ movieId, locale }: TrailerProps) {
   const { t } = getTranslations(translations, locale);
 
   const trailer = trailers.results?.find(
-    (video) => video.type === "Trailer" && video.official
+    (video) => video.type === "Trailer" && video.official,
   );
   if (!trailer || !trailer.key) return null;
 

--- a/src/components/movie-database/tv-show-trailer.tsx
+++ b/src/components/movie-database/tv-show-trailer.tsx
@@ -17,7 +17,7 @@ export async function TvShowTrailer({ tvShowId, locale }: TvShowTrailerProps) {
   const { t } = getTranslations(translations, locale);
 
   const trailer = trailers.results?.find(
-    (video) => video.type === "Trailer" && video.official
+    (video) => video.type === "Trailer" && video.official,
   );
   if (!trailer || !trailer.key) return null;
 

--- a/src/components/shared/animate-to-target.tsx
+++ b/src/components/shared/animate-to-target.tsx
@@ -103,7 +103,7 @@ export function AnimateToTarget({
               : progress / 0.3,
         };
       }),
-      animationOptions
+      animationOptions,
     );
     const innerAnimation = innerEl.animate(
       Array.from({ length: keyFramesCount }, (_, i) => {
@@ -116,7 +116,7 @@ export function AnimateToTarget({
           transform: `scale(${1 / currentScaleX}, ${1 / currentScaleY})`,
         };
       }),
-      animationOptions
+      animationOptions,
     );
     return () => {
       containerAnimation.cancel();

--- a/src/components/shared/back-button.tsx
+++ b/src/components/shared/back-button.tsx
@@ -31,7 +31,7 @@ export function BackButton({ locale, label }: BackButtonProps) {
     urlParts.length === 1
       ? "/"
       : `/${urlParts.slice(0, urlParts.length - 1).join("/")}`,
-    locale
+    locale,
   );
 
   return (

--- a/src/components/shared/flow-gradient/flow-gradient-client.tsx
+++ b/src/components/shared/flow-gradient/flow-gradient-client.tsx
@@ -32,7 +32,7 @@ export function FlowGradientClient({ vs, fs }: FlowGradientClientProps) {
                     colorBottom: [0.3, 0.3, 1],
                     colorAltTop: [1, 0.3, 0.3],
                     colorAltBottom: [1, 0.3, 0.3],
-                  }
+                  },
             );
           }
         }

--- a/src/components/shared/flow-gradient/flow-gradient.tsx
+++ b/src/components/shared/flow-gradient/flow-gradient.tsx
@@ -12,7 +12,7 @@ export async function FlowGradient() {
               // 24 Hours
               cache: "force-cache",
               next: { revalidate: 86400 },
-            }
+            },
           ).then((result) => result.text()),
           fetch(
             "https://0tius9gdxi32io0t.public.blob.vercel-storage.com/shaders/vs.glsl",
@@ -20,25 +20,25 @@ export async function FlowGradient() {
               // 24 Hours
               cache: "force-cache",
               next: { revalidate: 86400 },
-            }
+            },
           ).then((result) => result.text()),
         ]
       : [
           fs.readFile(
             path.resolve(
               process.cwd(),
-              "./src/components/shared/flow-gradient/shaders/fs.glsl"
+              "./src/components/shared/flow-gradient/shaders/fs.glsl",
             ),
-            "utf-8"
+            "utf-8",
           ),
           fs.readFile(
             path.resolve(
               process.cwd(),
-              "./src/components/shared/flow-gradient/shaders/vs.glsl"
+              "./src/components/shared/flow-gradient/shaders/vs.glsl",
             ),
-            "utf-8"
+            "utf-8",
           ),
-        ]
+        ],
   );
   return <FlowGradientClient fs={fragShader} vs={vertShader} />;
 }

--- a/src/components/shared/flow-gradient/loop.ts
+++ b/src/components/shared/flow-gradient/loop.ts
@@ -16,7 +16,7 @@ interface Context {
 }
 
 function getWebGLContext(
-  canvas: HTMLCanvasElement
+  canvas: HTMLCanvasElement,
 ): WebGLRenderingContext | undefined {
   const context = canvas.getContext("webgl2", {
     premultipliedAlpha: false,
@@ -27,7 +27,7 @@ function getWebGLContext(
 export function init(
   canvas: HTMLCanvasElement,
   vertexShaderSrc: string,
-  fragmentShaderSrc: string
+  fragmentShaderSrc: string,
 ): Context | undefined {
   const gl = getWebGLContext(canvas);
   if (!gl) {
@@ -47,7 +47,7 @@ export function init(
 function getBufferInfo(
   { gl, programInfo }: Context,
   width: number,
-  height: number
+  height: number,
 ) {
   const mesh = createMesh(width, height, 10);
   const arrays: Arrays = {
@@ -95,7 +95,7 @@ interface PointerState {
 
 function setupPointerEvents(
   canvas: HTMLCanvasElement,
-  signal: AbortSignal
+  signal: AbortSignal,
 ): PointerState {
   const pointerState: PointerState = {
     mousePosition: [0, 0],
@@ -114,7 +114,7 @@ function setupPointerEvents(
           document.documentElement.scrollTop * window.devicePixelRatio,
       ];
     },
-    { signal, passive: true }
+    { signal, passive: true },
   );
 
   document.addEventListener(
@@ -128,7 +128,7 @@ function setupPointerEvents(
       }
       pointerState.rippleStrengthTarget = 1.5;
     },
-    { signal }
+    { signal },
   );
 
   document.addEventListener(
@@ -142,7 +142,7 @@ function setupPointerEvents(
       }
       pointerState.rippleStrengthTarget = 1;
     },
-    { signal }
+    { signal },
   );
 
   return pointerState;
@@ -203,7 +203,7 @@ export function start(
     colorAltTop = [1, 0, 0],
     colorAltBottom = [1, 0, 0],
     colorBackground = [0.953, 0.929, 0.929],
-  }: Options
+  }: Options,
 ) {
   const abortController = new AbortController();
 
@@ -232,7 +232,7 @@ export function start(
       bufferInfo = getBufferInfo(
         { gl, programInfo, canvas },
         gl.canvas.width,
-        gl.canvas.height
+        gl.canvas.height,
       );
       resized = false;
     }

--- a/src/components/shared/switch.tsx
+++ b/src/components/shared/switch.tsx
@@ -49,7 +49,7 @@ export function Switch({
       setValue(newValue);
       onChange?.(newValue);
     },
-    [onChange, setValue]
+    [onChange, setValue],
   );
 
   // Sync value with input due to check box having two different value states (specifically `indeterminate`)

--- a/src/components/shared/theme-switch.tsx
+++ b/src/components/shared/theme-switch.tsx
@@ -47,7 +47,7 @@ export function ThemeSwitch({ labels }: ThemeSwitchProps) {
           : "#ffffff"
         : theme === "dark"
           ? "#000000"
-          : "#ffffff"
+          : "#ffffff",
     );
   }, [preferDark, theme]);
 

--- a/src/components/shared/translation-provider.tsx
+++ b/src/components/shared/translation-provider.tsx
@@ -22,9 +22,9 @@ export function TranslationProvider({
         Object.entries(componentTranslations).map(([key, value]) => [
           key,
           value[locale],
-        ])
+        ]),
       ),
-    ])
+    ]),
   );
   return (
     <TranslationContextProvider

--- a/src/hooks/use-click-away.ts
+++ b/src/hooks/use-click-away.ts
@@ -2,7 +2,7 @@
 import { useEffect, useRef } from "react";
 
 export function useClickAway<T extends HTMLElement = HTMLElement>(
-  callback: (event: MouseEvent | TouchEvent) => void
+  callback: (event: MouseEvent | TouchEvent) => void,
 ) {
   const ref = useRef<T>(null);
 

--- a/src/hooks/use-media-filters.ts
+++ b/src/hooks/use-media-filters.ts
@@ -5,7 +5,7 @@ export function useMediaFilters() {
   const value = use(MediaFiltersContext);
   if (!value) {
     throw new Error(
-      "`useMediaFilters` must be used within a `MediaFiltersProvider`"
+      "`useMediaFilters` must be used within a `MediaFiltersProvider`",
     );
   }
   return value;

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -26,7 +26,7 @@ export function useTheme() {
   const theme = useSyncExternalStore(
     subscribe,
     () => themeSingleton ?? localStorage.getItem(STORAGE_KEY),
-    () => "system"
+    () => "system",
   );
   return [getSupportedTheme(theme), setIsMenuShown] as const;
 }

--- a/src/hooks/use-translations.ts
+++ b/src/hooks/use-translations.ts
@@ -8,7 +8,7 @@ import { useTranslationContext } from "@/utils/translation-context";
  * Instead of passing translations to the hook directly, translations must be pass to the `TranslationProvider`.
  */
 export function useTranslations<T extends TranslationConfig>(
-  namespace: string
+  namespace: string,
 ) {
   const { translations } = useTranslationContext();
   if (!translations[namespace]) {
@@ -19,7 +19,7 @@ export function useTranslations<T extends TranslationConfig>(
   function t(key: keyof T, opts: { parse?: boolean }): ReactNode;
   function t(
     key: keyof T,
-    { parse }: { parse?: boolean } = {}
+    { parse }: { parse?: boolean } = {},
   ): ReactNode | string {
     const message =
       translations[namespace][key as keyof (typeof translations)[string]];

--- a/src/utils/api-route-wrapper.ts
+++ b/src/utils/api-route-wrapper.ts
@@ -12,8 +12,8 @@ export function apiRouteWrapper(
   serverFunction: (
     // `any` type required here to handle required fields
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    params: any
-  ) => Promise<unknown>
+    params: any,
+  ) => Promise<unknown>,
 ) {
   return async function routeHandler(request: NextRequest) {
     const referer = request.headers.get("Referer") ?? "";
@@ -21,13 +21,13 @@ export function apiRouteWrapper(
     if (
       referer &&
       !ALLOWED_REFERER.some((allowedReferer) =>
-        refererUrl.origin.endsWith(allowedReferer)
+        refererUrl.origin.endsWith(allowedReferer),
       )
     ) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
     }
     const result = await serverFunction(
-      Object.fromEntries(request.nextUrl.searchParams.entries())
+      Object.fromEntries(request.nextUrl.searchParams.entries()),
     );
 
     return NextResponse.json(result);

--- a/src/utils/get-translations.ts
+++ b/src/utils/get-translations.ts
@@ -5,21 +5,21 @@ import { parseMessage } from "./parse-message";
 
 export function getTranslations<T extends TranslationConfig>(
   translationConfig: T,
-  locale: SupportedLocale
+  locale: SupportedLocale,
 ) {
   function t(key: keyof typeof translationConfig): string;
   function t(
     key: keyof typeof translationConfig,
-    opts: { parse?: boolean }
+    opts: { parse?: boolean },
   ): ReactNode;
   function t(
     key: keyof typeof translationConfig,
-    { parse }: { parse?: boolean } = {}
+    { parse }: { parse?: boolean } = {},
   ): ReactNode | string {
     const message = translationConfig[key][locale];
     if (!message) {
       throw new Error(
-        `Translation for key "${key as string}" in locale "${locale}" not found`
+        `Translation for key "${key as string}" in locale "${locale}" not found`,
       );
     }
     if (parse) {

--- a/src/utils/parse-message.tsx
+++ b/src/utils/parse-message.tsx
@@ -59,7 +59,7 @@ function parseTokens(tokens: string[], componentMap: typeof defaultComponents) {
 
       const children = tokens.slice(i + 1, endIndex);
       parsed.push(
-        <Component key={i}>{parseTokens(children, componentMap)}</Component>
+        <Component key={i}>{parseTokens(children, componentMap)}</Component>,
       );
 
       i += endIndex - i;

--- a/src/utils/pathname.ts
+++ b/src/utils/pathname.ts
@@ -12,7 +12,7 @@ export function normalizePath(pathname: string | null): string {
 export function getLocalePath(
   pathname: string | null,
   locale: SupportedLocale,
-  defaultLocale = "en"
+  defaultLocale = "en",
 ): string {
   const normalizedPathname = normalizePath(pathname);
   if (locale === defaultLocale) return normalizedPathname;

--- a/src/utils/start-view-transition.ts
+++ b/src/utils/start-view-transition.ts
@@ -2,7 +2,7 @@ import { flushSync } from "react-dom";
 
 /** Wrapper around document.startViewTransition to fallback gracefully */
 export async function startViewTransition(
-  callback: () => void | Promise<void>
+  callback: () => void | Promise<void>,
 ) {
   if (!("startViewTransition" in document)) {
     await callback();

--- a/src/utils/tmdb-api.ts
+++ b/src/utils/tmdb-api.ts
@@ -24,7 +24,7 @@ export const fetchConfiguration = cache(async function fetchConfiguration() {
   });
   if (!response.ok) {
     throw new Error(
-      `Failed to fetch TMDB configurations. (${response.status}:${response.statusText})`
+      `Failed to fetch TMDB configurations. (${response.status}:${response.statusText})`,
     );
   }
   return (await response.json()) as Configuration;
@@ -69,7 +69,7 @@ export const fetchMovieList = cache(async function fetchMovieList({
 
   if (!response.ok) {
     throw new Error(
-      `Failed to fetch movies. (${response.status}:${response.statusText})`
+      `Failed to fetch movies. (${response.status}:${response.statusText})`,
     );
   }
 
@@ -84,7 +84,7 @@ export const fetchMovieList = cache(async function fetchMovieList({
           title: movie.title,
           posterPath: movie.poster_path,
           rating: movie.vote_average,
-        }) satisfies MovieListItem
+        }) satisfies MovieListItem,
     ),
   };
 });
@@ -112,7 +112,7 @@ export const fetchMovieGenres = cache(async function fetchMovieGenres({
 
   if (!response.ok) {
     throw new Error(
-      `Failed to fetch movie genres. (${response.status}:${response.statusText})`
+      `Failed to fetch movie genres. (${response.status}:${response.statusText})`,
     );
   }
 
@@ -127,7 +127,7 @@ export const fetchMovieDetails = cache(async function fetchMovieDetails(
   movieId: string,
   {
     language,
-  }: NonNullable<paths["/3/movie/{movie_id}"]["get"]["parameters"]["query"]>
+  }: NonNullable<paths["/3/movie/{movie_id}"]["get"]["parameters"]["query"]>,
 ) {
   const url = new URL(`${BASE_URL}/3/movie/${movieId}`);
   if (language && language !== "en") url.searchParams.set("language", language);
@@ -145,7 +145,7 @@ export const fetchMovieDetails = cache(async function fetchMovieDetails(
 
   if (!response.ok) {
     throw new Error(
-      `Failed to fetch movie genres. (${response.status}:${response.statusText})`
+      `Failed to fetch movie genres. (${response.status}:${response.statusText})`,
     );
   }
 
@@ -157,7 +157,7 @@ export type MovieVideos = NonNullable<
 >;
 
 export const fetchMovieVideos = cache(async function fetchMovieVideos(
-  movieId: string
+  movieId: string,
 ) {
   const url = new URL(`${BASE_URL}/3/movie/${movieId}/videos`);
 
@@ -174,7 +174,7 @@ export const fetchMovieVideos = cache(async function fetchMovieVideos(
 
   if (!response.ok) {
     throw new Error(
-      `Failed to fetch movie genres. (${response.status}:${response.statusText})`
+      `Failed to fetch movie genres. (${response.status}:${response.statusText})`,
     );
   }
 
@@ -205,7 +205,7 @@ export const fetchSimilarMovies = cache(async function fetchSimilarMovies({
 
   if (!response.ok) {
     throw new Error(
-      `Failed to fetch movie genres. (${response.status}:${response.statusText})`
+      `Failed to fetch movie genres. (${response.status}:${response.statusText})`,
     );
   }
 
@@ -220,7 +220,7 @@ export const fetchSimilarMovies = cache(async function fetchSimilarMovies({
           title: movie.title,
           posterPath: movie.poster_path,
           rating: movie.vote_average,
-        }) satisfies MovieListItem
+        }) satisfies MovieListItem,
     ),
   };
 });
@@ -279,7 +279,7 @@ export const fetchTvShowList = cache(async function fetchTvShowList({
 
   if (!response.ok) {
     throw new Error(
-      `Failed to fetch TV shows. (${response.status}:${response.statusText})`
+      `Failed to fetch TV shows. (${response.status}:${response.statusText})`,
     );
   }
 
@@ -294,7 +294,7 @@ export const fetchTvShowList = cache(async function fetchTvShowList({
           name: tvShow.name,
           posterPath: tvShow.poster_path,
           rating: tvShow.vote_average,
-        }) satisfies TvShowListItem
+        }) satisfies TvShowListItem,
     ),
   };
 });
@@ -318,7 +318,7 @@ export const fetchTvShowGenres = cache(async function fetchTvShowGenres({
 
   if (!response.ok) {
     throw new Error(
-      `Failed to fetch TV show genres. (${response.status}:${response.statusText})`
+      `Failed to fetch TV show genres. (${response.status}:${response.statusText})`,
     );
   }
 
@@ -333,7 +333,7 @@ export const fetchTvShowDetails = cache(async function fetchTvShowDetails(
   seriesId: string,
   {
     language,
-  }: NonNullable<paths["/3/tv/{series_id}"]["get"]["parameters"]["query"]>
+  }: NonNullable<paths["/3/tv/{series_id}"]["get"]["parameters"]["query"]>,
 ) {
   const url = new URL(`${BASE_URL}/3/tv/${seriesId}`);
   if (language && language !== "en") url.searchParams.set("language", language);
@@ -351,7 +351,7 @@ export const fetchTvShowDetails = cache(async function fetchTvShowDetails(
 
   if (!response.ok) {
     throw new Error(
-      `Failed to fetch TV show details. (${response.status}:${response.statusText})`
+      `Failed to fetch TV show details. (${response.status}:${response.statusText})`,
     );
   }
 
@@ -363,7 +363,7 @@ export type TvShowVideos = NonNullable<
 >;
 
 export const fetchTvShowVideos = cache(async function fetchTvShowVideos(
-  seriesId: string
+  seriesId: string,
 ) {
   const url = new URL(`${BASE_URL}/3/tv/${seriesId}/videos`);
 
@@ -380,7 +380,7 @@ export const fetchTvShowVideos = cache(async function fetchTvShowVideos(
 
   if (!response.ok) {
     throw new Error(
-      `Failed to fetch TV show videos. (${response.status}:${response.statusText})`
+      `Failed to fetch TV show videos. (${response.status}:${response.statusText})`,
     );
   }
 
@@ -411,7 +411,7 @@ export const fetchSimilarTvShows = cache(async function fetchSimilarTvShows({
 
   if (!response.ok) {
     throw new Error(
-      `Failed to fetch similar TV shows. (${response.status}:${response.statusText})`
+      `Failed to fetch similar TV shows. (${response.status}:${response.statusText})`,
     );
   }
 
@@ -426,7 +426,7 @@ export const fetchSimilarTvShows = cache(async function fetchSimilarTvShows({
           name: tvShow.name,
           posterPath: tvShow.poster_path,
           rating: tvShow.vote_average,
-        }) satisfies TvShowListItem
+        }) satisfies TvShowListItem,
     ),
   };
 });

--- a/src/utils/tmdb-queries.ts
+++ b/src/utils/tmdb-queries.ts
@@ -31,7 +31,7 @@ export const movieList = ({
         .flatMap((page) => page.results)
         .filter((x) => !!x);
       return Array.from(
-        new Map(movies.map((movie) => [movie.id, movie])).values()
+        new Map(movies.map((movie) => [movie.id, movie])).values(),
       );
     },
   });
@@ -41,7 +41,7 @@ export const configuration = queryOptions({
   queryFn: async () =>
     apiRequestWrapper<typeof fetchConfiguration>(
       "/api/tmdb/get-configuration",
-      undefined
+      undefined,
     ),
   staleTime: 24 * 60 * 60 * 1000,
   gcTime: 24 * 60 * 60 * 1000,
@@ -68,7 +68,7 @@ export const similarMovies = ({
         .flatMap((page) => page.results)
         .filter((x) => !!x);
       return Array.from(
-        new Map(movies.map((movie) => [movie.id, movie])).values()
+        new Map(movies.map((movie) => [movie.id, movie])).values(),
       );
     },
   });
@@ -94,7 +94,7 @@ export const tvShowList = ({
         .flatMap((page) => page.results)
         .filter((x) => !!x);
       return Array.from(
-        new Map(tvShows.map((tvShow) => [tvShow.id, tvShow])).values()
+        new Map(tvShows.map((tvShow) => [tvShow.id, tvShow])).values(),
       );
     },
   });
@@ -112,7 +112,7 @@ export const similarTvShows = ({
         {
           ...params,
           page: pageParam,
-        }
+        },
       ),
     getPreviousPageParam: (firstPage) =>
       firstPage.page > 1 ? firstPage.page - 1 : undefined,
@@ -123,7 +123,7 @@ export const similarTvShows = ({
         .flatMap((page) => page.results)
         .filter((x) => !!x);
       return Array.from(
-        new Map(tvShows.map((tvShow) => [tvShow.id, tvShow])).values()
+        new Map(tvShows.map((tvShow) => [tvShow.id, tvShow])).values(),
       );
     },
   });

--- a/src/utils/translation-context.ts
+++ b/src/utils/translation-context.ts
@@ -10,7 +10,7 @@ export function useTranslationContext() {
   const value = use(TranslationContext);
   if (!value) {
     throw new Error(
-      "`useTranslationContext` must be used within a `TranslationProvider`"
+      "`useTranslationContext` must be used within a `TranslationProvider`",
     );
   }
   return value;

--- a/tooling/stylex-breakpoints/index.js
+++ b/tooling/stylex-breakpoints/index.js
@@ -83,7 +83,7 @@ module.exports = function ({ types: t }) {
       CallExpression(innerPath) {
         if (!breakpoints || typeof breakpoints !== "object") {
           throw new Error(
-            "Invalid or missing `breakpoints` option. Expected an object."
+            "Invalid or missing `breakpoints` option. Expected an object.",
           );
         }
 
@@ -105,12 +105,12 @@ module.exports = function ({ types: t }) {
               const breakpointKey = prop.key.property.name;
               if (!(breakpointKey in breakpointsConfig)) {
                 throw new Error(
-                  `Specified breakpoint ${breakpointKey} doesn't have a matching config`
+                  `Specified breakpoint ${breakpointKey} doesn't have a matching config`,
                 );
               }
               if (typeof breakpointsConfig[breakpointKey] !== "number") {
                 throw new Error(
-                  `Breakpoint config for ${breakpointKey} is not a number`
+                  `Breakpoint config for ${breakpointKey} is not a number`,
                 );
               }
               definedBreakpointKeys.push(breakpointKey);
@@ -119,7 +119,7 @@ module.exports = function ({ types: t }) {
 
           // Sort the defined keys based on their breakpoint value
           definedBreakpointKeys.sort(
-            (a, b) => breakpointsConfig[a] - breakpointsConfig[b]
+            (a, b) => breakpointsConfig[a] - breakpointsConfig[b],
           );
 
           // Go through again to replace the media query

--- a/tooling/stylex-css-prop/index.js
+++ b/tooling/stylex-css-prop/index.js
@@ -24,7 +24,7 @@ module.exports = function stylexBabelPlugin({ types: t }) {
           /** @type {import('@babel/core').NodePath<JSXOpeningElement> | null} Get the parent JSXOpeningElement */
           // @ts-expect-error
           const jsxElement = path.findParent((p) =>
-            t.isJSXOpeningElement(p.node)
+            t.isJSXOpeningElement(p.node),
           );
           if (!jsxElement) return;
 
@@ -33,12 +33,12 @@ module.exports = function stylexBabelPlugin({ types: t }) {
           /** @type {JSXAttribute | undefined} */
           // @ts-expect-error
           const classNameAttr = openingElement.attributes.find(
-            (attr) => t.isJSXAttribute(attr) && attr.name.name === "className"
+            (attr) => t.isJSXAttribute(attr) && attr.name.name === "className",
           );
           /** @type {JSXAttribute | undefined} */
           // @ts-expect-error
           const styleAttr = openingElement.attributes.find(
-            (attr) => t.isJSXAttribute(attr) && attr.name.name === "style"
+            (attr) => t.isJSXAttribute(attr) && attr.name.name === "style",
           );
 
           // Get the value of the `css` prop
@@ -63,22 +63,22 @@ module.exports = function stylexBabelPlugin({ types: t }) {
                 t.callExpression(
                   t.memberExpression(
                     t.identifier("stylex"),
-                    t.identifier("props")
+                    t.identifier("props"),
                   ),
-                  attributesToMerge
-                )
-              )
+                  attributesToMerge,
+                ),
+              ),
             );
             return;
           }
 
           const classNameAttrValue = t.isJSXExpressionContainer(
-            classNameAttr?.value
+            classNameAttr?.value,
           )
             ? t.isJSXEmptyExpression(classNameAttr.value.expression)
               ? (() => {
                   throw path.buildCodeFrameError(
-                    "Empty expressions are not allowed."
+                    "Empty expressions are not allowed.",
                   );
                 })()
               : classNameAttr.value.expression
@@ -88,7 +88,7 @@ module.exports = function stylexBabelPlugin({ types: t }) {
             ? t.isJSXEmptyExpression(styleAttr.value.expression)
               ? (() => {
                   throw path.buildCodeFrameError(
-                    "Empty expressions are not allowed."
+                    "Empty expressions are not allowed.",
                   );
                 })()
               : styleAttr.value.expression
@@ -104,10 +104,10 @@ module.exports = function stylexBabelPlugin({ types: t }) {
                   t.callExpression(
                     t.memberExpression(
                       t.identifier("stylex"),
-                      t.identifier("props")
+                      t.identifier("props"),
                     ),
-                    attributesToMerge
-                  )
+                    attributesToMerge,
+                  ),
                 ),
               ]),
               t.returnStatement(
@@ -130,9 +130,9 @@ module.exports = function stylexBabelPlugin({ types: t }) {
                                 "??",
                                 t.memberExpression(
                                   t.identifier("$_props"),
-                                  t.identifier("className")
+                                  t.identifier("className"),
                                 ),
-                                t.stringLiteral("")
+                                t.stringLiteral(""),
                               ),
                               t.conditionalExpression(
                                 classNameAttrValue,
@@ -147,12 +147,12 @@ module.exports = function stylexBabelPlugin({ types: t }) {
                                       cooked: "",
                                     }),
                                   ],
-                                  [classNameAttrValue]
+                                  [classNameAttrValue],
                                 ),
-                                t.stringLiteral("")
+                                t.stringLiteral(""),
                               ),
-                            ]
-                          )
+                            ],
+                          ),
                         ),
                       ]
                     : []),
@@ -167,36 +167,36 @@ module.exports = function stylexBabelPlugin({ types: t }) {
                               styleAttrValue,
                               t.memberExpression(
                                 t.identifier("$_props"),
-                                t.identifier("style")
-                              )
+                                t.identifier("style"),
+                              ),
                             ),
                             t.objectExpression([
                               t.spreadElement(
                                 t.memberExpression(
                                   t.identifier("$_props"),
-                                  t.identifier("style")
-                                )
+                                  t.identifier("style"),
+                                ),
                               ),
                               t.spreadElement(styleAttrValue),
                             ]),
-                            t.identifier("undefined")
-                          )
+                            t.identifier("undefined"),
+                          ),
                         ),
                       ]
                     : []),
-                ])
+                ]),
               ),
-            ])
+            ]),
           );
 
           // Replace the JSX attributes with the merged props
           path.replaceWith(
-            t.jsxSpreadAttribute(t.callExpression(mergedPropsFunction, []))
+            t.jsxSpreadAttribute(t.callExpression(mergedPropsFunction, [])),
           );
 
           // Remove original `className` and `style` attributes
           openingElement.attributes = openingElement.attributes.filter(
-            (attr) => attr !== classNameAttr && attr !== styleAttr
+            (attr) => attr !== classNameAttr && attr !== styleAttr,
           );
         }
       },
@@ -208,7 +208,7 @@ module.exports = function stylexBabelPlugin({ types: t }) {
           importPath.node.specifiers.some(
             (specifier) =>
               t.isImportNamespaceSpecifier(specifier) &&
-              specifier.local.name === "stylex"
+              specifier.local.name === "stylex",
           )
         ) {
           state.stylexImportExists = true;
@@ -221,8 +221,8 @@ module.exports = function stylexBabelPlugin({ types: t }) {
             path.node.body.unshift(
               t.importDeclaration(
                 [t.importNamespaceSpecifier(t.identifier("stylex"))],
-                t.stringLiteral("@stylexjs/stylex")
-              )
+                t.stringLiteral("@stylexjs/stylex"),
+              ),
             );
           }
         },


### PR DESCRIPTION
## Summary
- Added TypeScript-only build script and scripts for linting/formatting changed files
- Created .prettierignore file with appropriate exclusions
- Configured post-tool-use hooks for auto-formatting in Claude Code

## Changes
- `build:tsc`: TypeScript compilation without emitting files
- `lint:changed`: Lint only changed files using next lint
- `prettier:changed`: Format only changed files 
- `prettier`: Format entire codebase
- Added .prettierignore file
- Added .claude/settings.json with formatting hooks

## Test plan
- [x] Run `pnpm build:tsc` to verify TypeScript compilation
- [x] Run `pnpm lint:changed` to verify changed file linting
- [x] Run `pnpm prettier:changed` to verify changed file formatting
- [x] Run `pnpm prettier` to verify full codebase formatting

🤖 Generated with [Claude Code](https://claude.ai/code)