### PR TITLE
refactor(tmdb): extract types from tmdb-api.ts into separate types.ts

### DIFF
--- a/src/components/movie-database/media-card.tsx
+++ b/src/components/movie-database/media-card.tsx
@@ -3,8 +3,8 @@ import { Card } from "@/components/shared/card";
 import { useTranslations } from "@/hooks/use-translations";
 import { border, color, font, layer, ratio, space } from "@/tokens.stylex";
 import { getLocalePath } from "@/utils/pathname";
-import type { MediaListItem } from "@/utils/tmdb-api";
 import { useTranslationContext } from "@/utils/translation-context";
+import type { MediaListItem } from "@/utils/types";
 import { PosterImage } from "./poster-image";
 import type translations from "./poster-image.translations.json";
 

--- a/src/components/movie-database/media-list.tsx
+++ b/src/components/movie-database/media-list.tsx
@@ -8,9 +8,9 @@ import { breakpoints } from "@/breakpoints";
 import { Grid } from "@/components/movie-database/grid";
 import { useMediaFilters } from "@/hooks/use-media-filters";
 import { color, ratio, space } from "@/tokens.stylex";
-import type { MediaListItem } from "@/utils/tmdb-api";
 import * as tmdbQueries from "@/utils/tmdb-queries";
 import { useTranslationContext } from "@/utils/translation-context";
+import type { MediaListItem } from "@/utils/types";
 import { Skeleton } from "../shared/skeleton";
 import { MediaCard } from "./media-card";
 

--- a/src/utils/tmdb-api.ts
+++ b/src/utils/tmdb-api.ts
@@ -5,10 +5,9 @@ import { cache } from "react";
 import type { paths } from "@/_generated/tmdbV3";
 import type {
   Configuration,
-  MovieListItem,
+  MediaListItem,
   MovieDetails,
   MovieVideos,
-  TvShowListItem,
   TvShowDetails,
   TvShowVideos,
 } from "./types";
@@ -83,7 +82,7 @@ export const fetchMovieList = cache(async function fetchMovieList({
           title: movie.title,
           posterPath: movie.poster_path,
           rating: movie.vote_average,
-        }) satisfies MovieListItem,
+        }) satisfies MediaListItem,
     ),
   };
 });
@@ -207,7 +206,7 @@ export const fetchSimilarMovies = cache(async function fetchSimilarMovies({
           title: movie.title,
           posterPath: movie.poster_path,
           rating: movie.vote_average,
-        }) satisfies MovieListItem,
+        }) satisfies MediaListItem,
     ),
   };
 });
@@ -259,7 +258,7 @@ export const fetchTvShowList = cache(async function fetchTvShowList({
           title: tvShow.name,
           posterPath: tvShow.poster_path,
           rating: tvShow.vote_average,
-        }) satisfies TvShowListItem,
+        }) satisfies MediaListItem,
     ),
   };
 });
@@ -383,7 +382,7 @@ export const fetchSimilarTvShows = cache(async function fetchSimilarTvShows({
           title: tvShow.name,
           posterPath: tvShow.poster_path,
           rating: tvShow.vote_average,
-        }) satisfies TvShowListItem,
+        }) satisfies MediaListItem,
     ),
   };
 });

--- a/src/utils/tmdb-api.ts
+++ b/src/utils/tmdb-api.ts
@@ -3,12 +3,18 @@
 import "server-only";
 import { cache } from "react";
 import type { paths } from "@/_generated/tmdbV3";
+import type {
+  Configuration,
+  MovieListItem,
+  MovieDetails,
+  MovieVideos,
+  TvShowListItem,
+  TvShowDetails,
+  TvShowVideos,
+} from "./types";
 
 const BASE_URL = "https://api.themoviedb.org";
 const API = process.env.TMDB_API_TOKEN;
-
-export type Configuration =
-  paths["/3/configuration"]["get"]["responses"]["200"]["content"]["application/json"];
 
 /** Fetch TMDB configurations containing available image sizes */
 export const fetchConfiguration = cache(async function fetchConfiguration() {
@@ -29,15 +35,6 @@ export const fetchConfiguration = cache(async function fetchConfiguration() {
   }
   return (await response.json()) as Configuration;
 });
-
-export type MediaListItem = {
-  id: number;
-  title?: string;
-  posterPath?: string;
-  rating?: number;
-};
-
-export type MovieListItem = MediaListItem;
 
 /** Fetch list of movies */
 export const fetchMovieList = cache(async function fetchMovieList({
@@ -91,10 +88,6 @@ export const fetchMovieList = cache(async function fetchMovieList({
   };
 });
 
-export type Genre = NonNullable<
-  paths["/3/genre/movie/list"]["get"]["responses"]["200"]["content"]["application/json"]["genres"]
->[number];
-
 export const fetchMovieGenres = cache(async function fetchMovieGenres({
   language,
 }: NonNullable<paths["/3/genre/movie/list"]["get"]["parameters"]["query"]>) {
@@ -120,10 +113,6 @@ export const fetchMovieGenres = cache(async function fetchMovieGenres({
 
   return (await response.json()) as paths["/3/genre/movie/list"]["get"]["responses"]["200"]["content"]["application/json"];
 });
-
-export type MovieDetails = NonNullable<
-  paths["/3/movie/{movie_id}"]["get"]["responses"]["200"]["content"]["application/json"]
->;
 
 export const fetchMovieDetails = cache(async function fetchMovieDetails(
   movieId: string,
@@ -153,10 +142,6 @@ export const fetchMovieDetails = cache(async function fetchMovieDetails(
 
   return (await response.json()) as MovieDetails;
 });
-
-type MovieVideos = NonNullable<
-  paths["/3/movie/{movie_id}/videos"]["get"]["responses"]["200"]["content"]["application/json"]
->;
 
 export const fetchMovieVideos = cache(async function fetchMovieVideos(
   movieId: string,
@@ -226,23 +211,6 @@ export const fetchSimilarMovies = cache(async function fetchSimilarMovies({
     ),
   };
 });
-
-// TV Show types and functions
-export type TvShowListItem = MediaListItem;
-
-export type TvShowSort =
-  | "first_air_date.asc"
-  | "first_air_date.desc"
-  | "name.asc"
-  | "name.desc"
-  | "original_name.asc"
-  | "original_name.desc"
-  | "popularity.asc"
-  | "popularity.desc"
-  | "vote_average.asc"
-  | "vote_average.desc"
-  | "vote_count.asc"
-  | "vote_count.desc";
 
 /** Fetch list of TV shows */
 export const fetchTvShowList = cache(async function fetchTvShowList({
@@ -322,10 +290,6 @@ export const fetchTvShowGenres = cache(async function fetchTvShowGenres({
   return (await response.json()) as paths["/3/genre/tv/list"]["get"]["responses"]["200"]["content"]["application/json"];
 });
 
-export type TvShowDetails = NonNullable<
-  paths["/3/tv/{series_id}"]["get"]["responses"]["200"]["content"]["application/json"]
->;
-
 export const fetchTvShowDetails = cache(async function fetchTvShowDetails(
   seriesId: string,
   {
@@ -354,10 +318,6 @@ export const fetchTvShowDetails = cache(async function fetchTvShowDetails(
 
   return (await response.json()) as TvShowDetails;
 });
-
-export type TvShowVideos = NonNullable<
-  paths["/3/tv/{series_id}/videos"]["get"]["responses"]["200"]["content"]["application/json"]
->;
 
 export const fetchTvShowVideos = cache(async function fetchTvShowVideos(
   seriesId: string,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -10,8 +10,6 @@ export type MediaListItem = {
   rating?: number;
 };
 
-export type MovieListItem = MediaListItem;
-
 export type Genre = NonNullable<
   paths["/3/genre/movie/list"]["get"]["responses"]["200"]["content"]["application/json"]["genres"]
 >[number];
@@ -23,8 +21,6 @@ export type MovieDetails = NonNullable<
 export type MovieVideos = NonNullable<
   paths["/3/movie/{movie_id}/videos"]["get"]["responses"]["200"]["content"]["application/json"]
 >;
-
-export type TvShowListItem = MediaListItem;
 
 export type TvShowSort =
   | "first_air_date.asc"

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,49 @@
+import type { paths } from "@/_generated/tmdbV3";
+
+export type Configuration =
+  paths["/3/configuration"]["get"]["responses"]["200"]["content"]["application/json"];
+
+export type MediaListItem = {
+  id: number;
+  title?: string;
+  posterPath?: string;
+  rating?: number;
+};
+
+export type MovieListItem = MediaListItem;
+
+export type Genre = NonNullable<
+  paths["/3/genre/movie/list"]["get"]["responses"]["200"]["content"]["application/json"]["genres"]
+>[number];
+
+export type MovieDetails = NonNullable<
+  paths["/3/movie/{movie_id}"]["get"]["responses"]["200"]["content"]["application/json"]
+>;
+
+export type MovieVideos = NonNullable<
+  paths["/3/movie/{movie_id}/videos"]["get"]["responses"]["200"]["content"]["application/json"]
+>;
+
+export type TvShowListItem = MediaListItem;
+
+export type TvShowSort =
+  | "first_air_date.asc"
+  | "first_air_date.desc"
+  | "name.asc"
+  | "name.desc"
+  | "original_name.asc"
+  | "original_name.desc"
+  | "popularity.asc"
+  | "popularity.desc"
+  | "vote_average.asc"
+  | "vote_average.desc"
+  | "vote_count.asc"
+  | "vote_count.desc";
+
+export type TvShowDetails = NonNullable<
+  paths["/3/tv/{series_id}"]["get"]["responses"]["200"]["content"]["application/json"]
+>;
+
+export type TvShowVideos = NonNullable<
+  paths["/3/tv/{series_id}/videos"]["get"]["responses"]["200"]["content"]["application/json"]
+>;


### PR DESCRIPTION
## Summary
- Create new `src/utils/types.ts` with all TMDB type definitions
- Update `tmdb-api.ts` to import types from `types.ts` instead of defining inline  
- Update component imports to use `types.ts` for `MediaListItem` type
- Improve code organization by separating type definitions from implementation

## Test plan
- [x] All existing functionality preserved
- [x] TypeScript compilation passes (`pnpm build:tsc`)
- [x] ESLint passes (`pnpm lint:changed`)  
- [x] Prettier formatting applied (`pnpm prettier:changed`)

🤖 Generated with [Claude Code](https://claude.ai/code)