### PR TITLE
refactor(tmdb): consolidate genre queries and standardize queryKeys

### DIFF
--- a/src/components/movie-database/genre-filter.tsx
+++ b/src/components/movie-database/genre-filter.tsx
@@ -32,10 +32,7 @@ export function GenreFilter({ hideTitle }: GenreFilterProps) {
   const { locale } = useTranslationContext();
 
   // Fetch genres based on current media type
-  const genreQuery =
-    mediaType === "tv"
-      ? tmdbQueries.tvGenres({ language: locale })
-      : tmdbQueries.movieGenres({ language: locale });
+  const genreQuery = tmdbQueries.genres({ type: mediaType, language: locale });
 
   const { data: genreData } = useSuspenseQuery(genreQuery);
   const allGenres = genreData.genres;

--- a/src/utils/tmdb-queries.ts
+++ b/src/utils/tmdb-queries.ts
@@ -17,7 +17,7 @@ type TvShowListParams = Parameters<typeof fetchTvShowList>[0] & { type: "tv" };
 
 export const mediaList = (params: MovieListParams | TvShowListParams) => {
   return infiniteQueryOptions({
-    queryKey: [{ ...tmdbScope, ...params, query: "discover/tv" }],
+    queryKey: [{ query: "mediaList", ...tmdbScope, ...params }],
     initialPageParam: params.page,
     queryFn: async ({ pageParam }) => {
       if (params.type === "tv") {
@@ -59,7 +59,7 @@ type SimilarMediaParams = {
 
 export const similarMedia = (params: SimilarMediaParams) => {
   return infiniteQueryOptions({
-    queryKey: [{ ...tmdbScope, ...params }],
+    queryKey: [{ query: "similarMedia", ...tmdbScope, ...params }],
     initialPageParam: params.page,
     queryFn: async ({ pageParam }) => {
       if (params.type === "tv") {
@@ -103,26 +103,29 @@ export const configuration = queryOptions({
   gcTime: 24 * 60 * 60 * 1000,
 });
 
-export const movieGenres = (params: Parameters<typeof fetchMovieGenres>[0]) =>
-  queryOptions({
-    queryKey: [{ query: "movie/genres", ...tmdbScope, ...params }],
-    queryFn: async () =>
-      apiRequestWrapper<typeof fetchMovieGenres>(
-        "/api/tmdb/movie-genres",
-        params,
-      ),
-    staleTime: 24 * 60 * 60 * 1000,
-    gcTime: 24 * 60 * 60 * 1000,
-  });
+type GenresParams = {
+  type: "movie" | "tv";
+  language?: string;
+};
 
-export const tvGenres = (params: Parameters<typeof fetchTvShowGenres>[0]) =>
+export const genres = (params: GenresParams) =>
   queryOptions({
-    queryKey: [{ query: "tv/genres", ...tmdbScope, ...params }],
-    queryFn: async () =>
-      apiRequestWrapper<typeof fetchTvShowGenres>(
-        "/api/tmdb/tv-genres",
-        params,
-      ),
+    queryKey: [{ query: "genres", ...tmdbScope, ...params }],
+    queryFn: async () => {
+      if (params.type === "tv") {
+        const { type, ...queryParams } = params;
+        return apiRequestWrapper<typeof fetchTvShowGenres>(
+          "/api/tmdb/tv-genres",
+          queryParams,
+        );
+      } else {
+        const { type, ...queryParams } = params;
+        return apiRequestWrapper<typeof fetchMovieGenres>(
+          "/api/tmdb/movie-genres",
+          queryParams,
+        );
+      }
+    },
     staleTime: 24 * 60 * 60 * 1000,
     gcTime: 24 * 60 * 60 * 1000,
   });


### PR DESCRIPTION
## Summary
- Merged `movieGenres` and `tvGenres` into a single `genres` query with type parameter
- Updated `mediaList` and `similarMedia` queryKeys to use consistent naming patterns
- Simplified genre-filter.tsx to use the unified genres query

## Test plan
- [ ] Verify genre filtering still works for movies
- [ ] Verify genre filtering still works for TV shows  
- [ ] Run TypeScript checks to ensure no type errors
- [ ] Test that query caching behavior remains consistent

🤖 Generated with [Claude Code](https://claude.ai/code)