### PR TITLE
feat: add CI workflow for tests and prettier checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main, master]
+  push:
+    branches: [main, master]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        task: [test, prettier]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
+        if: matrix.task == 'test'
+      - run: pnpm prettier --check .
+        if: matrix.task == 'prettier'


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow that runs tests and prettier checks in parallel
- Uses matrix strategy to avoid duplication while maintaining parallel execution
- Only runs tests and prettier (Vercel already handles build/TypeScript/lint)

## Test plan
- [ ] CI workflow triggers on this PR
- [ ] Both test and prettier jobs run successfully
- [ ] Jobs run in parallel (check timing in Actions tab)

🤖 Generated with [Claude Code](https://claude.ai/code)