### PR TITLE
refactor: standardize prettier commands to format:* naming

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pnpm prettier:changed"
+            "command": "pnpm format:changed"
           }
         ]
       }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        task: [test, prettier]
+        task: [test, format]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -25,5 +25,5 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
         if: matrix.task == 'test'
-      - run: pnpm prettier --check .
-        if: matrix.task == 'prettier'
+      - run: pnpm format:check
+        if: matrix.task == 'format'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Personal portfolio website built with Next.js 15, featuring a movie database pow
 pnpm dev                 # Start dev server
 pnpm build:tsc          # TypeScript type checking
 pnpm lint:changed       # Lint changed files
-pnpm prettier:changed   # Format changed files
+pnpm format:changed     # Format changed files
 pnpm codegen            # Generate TMDB API types
 ```
 
@@ -17,7 +17,7 @@ pnpm codegen            # Generate TMDB API types
 **CRITICAL: Before considering ANY task complete, ALWAYS run:**
 
 ```bash
-pnpm prettier:changed
+pnpm format:changed
 pnpm lint:changed
 pnpm build:tsc
 pnpm test

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "start": "next start",
     "lint": "next lint",
     "lint:changed": "git diff --name-only --diff-filter=d HEAD | grep -E '\\.(jsx|ts|tsx)$' | xargs -r next lint --fix --file",
-    "prettier": "prettier --write '**/*.{js,jsx,ts,tsx,json,css,md,mjs}' --ignore-path .gitignore",
-    "prettier:changed": "git diff --name-only --diff-filter=d HEAD | grep -E '\\.(ts|tsx|json|css|md)$' | xargs -r prettier --write",
+    "format:write": "prettier --write '**/*.{js,jsx,ts,tsx,json,css,md,mjs}' --ignore-path .gitignore",
+    "format:check": "prettier --check '**/*.{js,jsx,ts,tsx,json,css,md,mjs}' --ignore-path .gitignore",
+    "format:changed": "git diff --name-only --diff-filter=d HEAD | grep -E '\\.(ts|tsx|json|css|md)$' | xargs -r prettier --write",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage"


### PR DESCRIPTION
## Summary
- Rename `prettier` → `format:write` (clear it modifies files)
- Rename `prettier:changed` → `format:changed` (consistency) 
- Add `format:check` for CI (check-only, no file modifications)
- Update CI workflow to use proper `format:check` command
- Update all references in CLAUDE.md and .claude/settings.json

## Problem Solved
The previous CI implementation had a critical flaw: it used `pnpm prettier --check .` which actually ran the `prettier` script from package.json (with `--write`) AND appended `--check .`. This caused CI to:
- Silently fix formatting issues instead of failing
- Always pass even when formatting was wrong

## Test plan
- [ ] CI workflow runs `pnpm format:check` correctly
- [ ] CI fails if formatting is wrong (doesn't silently fix)
- [ ] Local development uses `pnpm format:changed` 
- [ ] PostToolUse hook uses new command name

🤖 Generated with [Claude Code](https://claude.ai/code)