### PR TITLE
chore: remove unused breakpoints mock file

### DIFF
--- a/src/test/mocks/breakpoints.ts
+++ b/src/test/mocks/breakpoints.ts
@@ -1,6 +1,0 @@
-export const breakpoints = {
-  sm: "@media (min-width: 320px)",
-  md: "@media (min-width: 768px)",
-  lg: "@media (min-width: 1080px)",
-  xl: "@media (min-width: 2000px)",
-};


### PR DESCRIPTION
## Summary
- Removed `src/test/mocks/breakpoints.ts` as it's no longer being used in the test suite

## Test plan
- [x] All existing tests pass
- [x] No references to the removed mock file in the codebase

🤖 Generated with [Claude Code](https://claude.ai/code)