### PR TITLE
fix: migrate ESLint config to proper flat config format

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,20 +1,14 @@
-import { FlatCompat } from "@eslint/eslintrc";
 import js from "@eslint/js";
+import nextPlugin from "@next/eslint-plugin-next";
+import importPlugin from "eslint-plugin-import";
+import reactPlugin from "eslint-plugin-react";
+import reactHooksPlugin from "eslint-plugin-react-hooks";
 import stylexjs from "@stylexjs/eslint-plugin";
 import reactCompiler from "eslint-plugin-react-compiler";
 import eslintPluginUnicorn from "eslint-plugin-unicorn";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import tsEslint from "typescript-eslint";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-});
-
-const eslintConfig = tsEslint.config([
+export default tsEslint.config([
   {
     ignores: [
       ".babelrc.js",
@@ -25,25 +19,29 @@ const eslintConfig = tsEslint.config([
       "src/_generated/**/*",
     ],
   },
-  ...compat.extends("next/core-web-vitals"),
   js.configs.recommended,
-  tsEslint.configs.recommendedTypeChecked,
+  ...tsEslint.configs.recommendedTypeChecked,
   {
-    name: "custom",
     plugins: {
+      "@next/next": nextPlugin,
+      import: importPlugin,
+      react: reactPlugin,
+      "react-hooks": reactHooksPlugin,
       "@stylexjs": stylexjs,
       "react-compiler": reactCompiler,
       unicorn: eslintPluginUnicorn,
     },
     languageOptions: {
       ecmaVersion: "latest",
-      sourceType: "script",
+      sourceType: "module",
       parserOptions: {
         projectService: true,
         tsconfigRootDir: import.meta.dirname,
       },
     },
     rules: {
+      ...nextPlugin.configs.recommended.rules,
+      ...nextPlugin.configs["core-web-vitals"].rules,
       "@stylexjs/valid-styles": "error",
       "@typescript-eslint/consistent-type-imports": "error",
       "@typescript-eslint/consistent-type-exports": "error",
@@ -91,5 +89,3 @@ const eslintConfig = tsEslint.config([
     },
   },
 ]);
-
-export default eslintConfig;


### PR DESCRIPTION
## Summary

Migrates the ESLint configuration from a compatibility-layer approach to a proper flat config format, resolving several configuration issues.

## Changes

- **Removed FlatCompat layer**: Eliminated compatibility issues with newer ESLint versions that were causing runtime errors
- **Added direct plugin imports**: Imported all required plugins directly (Next.js, import, react, react-hooks, StyleX, react-compiler, unicorn)
- **Consolidated plugin configuration**: Combined all plugins in a single config block with proper Next.js rules applied
- **Simplified config structure**: Used direct export with `tsEslint.config()` wrapper for cleaner flat config format
- **Fixed sourceType**: Changed from 'script' to 'module' for proper ES module handling

## Test Plan

- [x] ESLint runs without import plugin errors
- [x] All existing rules remain active
- [x] Next.js-specific rules are properly applied
- [x] TypeScript project service integration works

## Impact

- Resolves "Could not find plugin 'import'" errors
- Ensures all Next.js ESLint rules are active and working correctly
- Modernizes configuration to follow current ESLint flat config best practices

Note: The Next.js plugin detection warning may persist due to a known issue with Next.js 15's detection logic for flat configs, but functionality is fully working.

🤖 Generated with [Claude Code](https://claude.ai/code)