### PR TITLE
feat: add dynamic genre lists to AI agent system prompt

### DIFF
--- a/src/ai/system-instructions.md
+++ b/src/ai/system-instructions.md
@@ -29,12 +29,18 @@ Identify the primary request type:
 
 Extract these entities from user queries:
 
-**Genres & Categories:**
+**Movie Genres:**
 
-- Action (28), Adventure (12), Animation (16), Comedy (35), Crime (80), Documentary (99)
-- Drama (18), Family (10751), Fantasy (14), History (36), Horror (27), Music (10402)
-- Mystery (9648), Romance (10749), Science Fiction (878), TV Movie (10770), Thriller (53), War (10752), Western (37)
-- **Synonyms**: "Superhero" → Action/Adventure, "RomCom" → Romance+Comedy, "Scary" → Horror
+{movieGenres}
+
+**TV Show Genres:**
+
+{tvGenres}
+
+**Genre Synonyms:**
+
+- "Superhero" → Action/Adventure, "RomCom" → Romance+Comedy, "Scary" → Horror
+- "Reality TV" → Reality, "Sitcom" → Comedy, "Drama Series" → Drama
 
 **Time Periods:**
 


### PR DESCRIPTION
## Summary

Enhanced the AI agent to use live genre data from TMDB API instead of hardcoded values, ensuring accuracy and localization support.

## Key Changes

### Dynamic Genre Fetching (`src/ai/agent.ts`)
- **Made `getSystemInstructions` async** to fetch live genre data
- **Parallel API calls** to fetch both movie and TV genres using existing `fetchMovieGenres` and `fetchTvShowGenres` functions
- **Proper locale handling** - passes locale directly to TMDB API (no conversion needed)
- **Error resilience** - falls back to hardcoded genres if API fails
- **Formatted output** - genres displayed as "Genre Name (ID)" for clear AI parsing

### Updated System Instructions (`src/ai/system-instructions.md`)
- **Replaced hardcoded genre list** with dynamic placeholders `{movieGenres}` and `{tvGenres}`
- **Separated movie and TV genres** to handle their differences:
  - **Movie genres**: 19 types (Action, Adventure separate)
  - **TV genres**: 16 types (Action & Adventure combined, plus TV-specific like Reality, Talk)
- **Enhanced synonyms** for better genre mapping

## Technical Benefits

- ✅ **Always up-to-date** genre information
- ✅ **Localized genres** based on user locale (en/zh)
- ✅ **Handles differences** between movie and TV genre systems  
- ✅ **Robust error handling** with fallback support
- ✅ **Performance optimized** with parallel API calls

## Testing

✅ All tests pass  
✅ TypeScript compilation successful  
✅ ESLint validation passed  
✅ Error handling verified

The AI agent now provides more accurate genre-based recommendations with current TMDB data rather than static, potentially outdated information.

🤖 Generated with [Claude Code](https://claude.ai/code)