### PR TITLE
fix: extend lint:changed and format:changed to include .js and .mjs files

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "build:tsc": "tsc --noEmit",
     "start": "next start",
     "lint": "next lint",
-    "lint:changed": "git diff --name-only --diff-filter=d HEAD | grep -E '\\.(jsx|ts|tsx)$' | xargs -r next lint --fix --file",
+    "lint:changed": "git diff --name-only --diff-filter=d HEAD | grep -E '\\.(js|jsx|ts|tsx)$' | xargs -r next lint --fix --file",
     "format:write": "prettier --write '**/*.{js,jsx,ts,tsx,json,css,md,mjs}' --ignore-path .gitignore",
     "format:check": "prettier --check '**/*.{js,jsx,ts,tsx,json,css,md,mjs}' --ignore-path .gitignore",
-    "format:changed": "git diff --name-only --diff-filter=d HEAD | grep -E '\\.(ts|tsx|json|css|md)$' | xargs -r prettier --write",
+    "format:changed": "git diff --name-only --diff-filter=d HEAD | grep -E '\\.(js|jsx|ts|tsx|json|css|md|mjs)$' | xargs -r prettier --write",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage"


### PR DESCRIPTION
## Summary
- Add `.js` extension to `lint:changed` script to catch JavaScript files during linting
- Add `.js` and `.mjs` extensions to `format:changed` script to match `format:write`/`format:check`
- Ensures consistent file type coverage across all formatting and linting commands

## Test plan
- [ ] Verify `lint:changed` now processes `.js` files
- [ ] Verify `format:changed` now processes `.js` and `.mjs` files  
- [ ] Confirm all format scripts cover the same file extensions

🤖 Generated with [Claude Code](https://claude.ai/code)