### PR TITLE
upgrade: update pnpm from 10.6.2 to 10.15.1 via corepack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,15 @@ pnpm codegen            # Generate TMDB API types and server functions
 pnpm codegen:tmdb       # Generate only TMDB server functions
 ```
 
+# Package Management
+
+This project uses corepack to manage pnpm versions:
+
+- pnpm version is specified in package.json's `packageManager` field
+- corepack automatically uses the exact version specified
+- To upgrade pnpm: run `corepack use pnpm@latest` (automatically updates package.json)
+- If getting signature verification errors, update corepack first: `npm install -g corepack@latest`
+
 # Key Architecture Patterns
 
 <pattern>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "22.x",
     "pnpm": ">=9"
   },
-  "packageManager": "pnpm@10.6.2+sha512.47870716bea1572b53df34ad8647b42962bc790ce2bf4562ba0f643237d7302a3d6a8ecef9e4bdfc01d23af1969aa90485d4cebb0b9638fa5ef1daef656f6c1b",
+  "packageManager": "pnpm@10.15.1+sha512.34e538c329b5553014ca8e8f4535997f96180a1d0f614339357449935350d924e22f8614682191264ec33d1462ac21561aff97f6bb18065351c162c7e8f6de67",
   "scripts": {
     "predev": "rimraf .next && rimraf public/sw.js",
     "prebuild": "rimraf .next && rimraf public/sw.js && pnpm codegen",


### PR DESCRIPTION
## Summary
- Upgraded pnpm from 10.6.2 to 10.15.1 using corepack
- Added comprehensive Package Management documentation to CLAUDE.md
- Fixed corepack signature verification issues by updating to latest version

## Changes Made
- Updated packageManager field in package.json to pnpm@10.15.1 with new SHA hash
- Added Package Management section to CLAUDE.md with corepack usage instructions
- Resolved "Cannot find matching keyid" error by updating corepack from 0.29.4 to 0.34.0

## Test Plan
- [x] All tests pass (`pnpm test`)
- [x] TypeScript compilation successful (`pnpm build:tsc`)
- [x] Linting passes (`pnpm lint:changed`)
- [x] Project commands work with new pnpm version

🤖 Generated with [Claude Code](https://claude.ai/code)