### PR TITLE
fix: eliminate double fetching with genre prefetching and client-side assertions

### DIFF
--- a/src/app/[locale]/movie-database/(list)/page.tsx
+++ b/src/app/[locale]/movie-database/(list)/page.tsx
@@ -5,6 +5,8 @@ import {
   discoverMovies,
   discoverTvShows,
   getConfiguration,
+  getMovieGenres,
+  getTvShowGenres,
 } from "@/_generated/tmdb-server-functions";
 import { Filters } from "@/components/movie-database/filters";
 import { FiltersSkeleton } from "@/components/movie-database/filters-skeleton";
@@ -46,11 +48,18 @@ export default async function Page(
     Array.isArray(searchParams.sort) ? searchParams.sort[0] : searchParams.sort
   ) as Sort | undefined;
 
-  // Fetch config and initial page
+  // Fetch config, genres, and initial page
   const queryClient = getQueryClient();
   void queryClient.prefetchQuery({
     ...tmdbQueries.configuration,
     queryFn: () => getConfiguration(),
+  });
+  void queryClient.prefetchQuery({
+    ...tmdbQueries.genres({ type: mediaType, language: params.locale }),
+    queryFn: () =>
+      mediaType === "tv"
+        ? getTvShowGenres({ language: params.locale })
+        : getMovieGenres({ language: params.locale }),
   });
   const queryParams = {
     language: params.locale,

--- a/src/utils/api-request-wrapper.ts
+++ b/src/utils/api-request-wrapper.ts
@@ -6,12 +6,10 @@ export async function apiRequestWrapper<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   T extends (params: any) => Promise<unknown>,
 >(apiRoute: `/api/${string}`, params: Parameters<T>[0] = {}) {
-  const baseUrl =
-    typeof window !== "undefined"
-      ? window.location.origin
-      : process.env.VERCEL_URL
-        ? `https://${process.env.VERCEL_URL}`
-        : "http://localhost:3000";
+  if (typeof window === "undefined") {
+    throw new Error("apiRequestWrapper called during SSR - missing prefetch");
+  }
+  const baseUrl = window.location.origin;
   const url = new URL(`${baseUrl}${apiRoute}`);
   for (const entry of Object.entries(params)) {
     if (entry[1]) {
@@ -27,7 +25,6 @@ export async function apiRequestWrapper<
   const response = await fetch(url.toString(), {
     // 24 Hours
     cache: "force-cache",
-    next: { revalidate: 86400 },
   });
   if (!response.ok) {
     let errorMessage = response.statusText;


### PR DESCRIPTION
## Summary
Eliminates double fetching issue where genre data was being fetched both during SSR and client hydration, improving performance and fixing 500 errors.

## Changes
- **Add genre prefetching** to movie-database page server component using direct TMDB server functions
- **Remove SSR fallback** in `apiRequestWrapper` and replace with client-side assertion  
- **Remove problematic `next.revalidate` option** that was causing 500 errors in browser
- **Ensure all data is prefetched** during SSR for optimal performance

## Technical Details
- Genres are now prefetched server-side using `getMovieGenres`/`getTvShowGenres` and dehydrated to client
- `apiRequestWrapper` now throws descriptive error if called during SSR (catches missing prefetches)
- Consistent with existing prefetch patterns for media lists and configuration
- No more conditional `typeof window` checks needed since data is properly prefetched

## Test plan
- [x] Navigate to `/en/movie-database` - page loads without errors
- [x] Check Network tab - no calls to `/api/tmdb/get-movie-genres` on initial load
- [x] Verify genre dropdown populates immediately with all genres
- [x] Test assertion catches missing prefetches (temporarily disabled prefetch)
- [x] Switch between Movies/TV Shows - client-side navigation works correctly
- [x] All linting and type checking passes

🤖 Generated with [Claude Code](https://claude.ai/code)