### PR TITLE
fix: approve build scripts for required dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,12 @@
   "pnpm": {
     "patchedDependencies": {
       "@stylexjs/eslint-plugin": "patches/@stylexjs__eslint-plugin.patch"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "@vercel/speed-insights",
+      "esbuild",
+      "sharp",
+      "unrs-resolver"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Approved build scripts for required dependencies that were being blocked by pnpm security settings
- Resolved "Ignored build scripts" warnings during installation

## Changes
- Added `onlyBuiltDependencies` configuration to approve build scripts for:
  - `@vercel/speed-insights`: Provides migration warnings and config checks
  - `esbuild`: Native binary setup for JavaScript bundling
  - `sharp`: Native binary setup for image processing
  - `unrs-resolver`: URL resolution utilities

## Test plan
- [x] Build scripts warning no longer appears during `pnpm install`
- [x] All approved packages are legitimate and commonly used in Next.js projects
- [x] Package functionality remains intact with approved scripts

🤖 Generated with [Claude Code](https://claude.ai/code)