### PR TITLE
perf: implement cacheSignal for automatic request cancellation

### DIFF
--- a/src/ai/agent.ts
+++ b/src/ai/agent.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { zodTextFormat } from "openai/helpers/zod";
 import type { ResponseInput } from "openai/resources/responses/responses.mjs";
+import { cacheSignal } from "react";
 import "server-only";
 import { z } from "zod";
 import {
@@ -105,7 +106,10 @@ async function getSystemInstructions(locale: SupportedLocale): Promise<string> {
         .join(", ");
     }
   } catch (error) {
-    console.error("Failed to fetch reference data:", error);
+    // Only log real errors, not cancellation errors
+    if (!cacheSignal()?.aborted) {
+      console.error("Failed to fetch reference data:", error);
+    }
     throw error;
   }
 
@@ -206,7 +210,10 @@ export async function agent(
               result: result.result,
             };
           } catch (error) {
-            console.error("Tool execution error:", error);
+            // Only log real errors, not cancellation errors
+            if (!cacheSignal()?.aborted) {
+              console.error("Tool execution error:", error);
+            }
             return {
               success: false,
               call_id: toolCall.call_id,

--- a/src/components/shared/flow-gradient/flow-gradient.tsx
+++ b/src/components/shared/flow-gradient/flow-gradient.tsx
@@ -1,5 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { cacheSignal } from "react";
 import { FlowGradientClient } from "./flow-gradient-client";
 
 export async function FlowGradient() {
@@ -12,6 +13,7 @@ export async function FlowGradient() {
               // 24 Hours
               cache: "force-cache",
               next: { revalidate: 86400 },
+              signal: cacheSignal(),
             },
           ).then((result) => result.text()),
           fetch(
@@ -20,6 +22,7 @@ export async function FlowGradient() {
               // 24 Hours
               cache: "force-cache",
               next: { revalidate: 86400 },
+              signal: cacheSignal(),
             },
           ).then((result) => result.text()),
         ]

--- a/src/utils/tmdb-client.ts
+++ b/src/utils/tmdb-client.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import "server-only";
-import { cache } from "react";
+import { cache, cacheSignal } from "react";
 import type { paths } from "@/_generated/tmdbV3";
 import { buildTmdbUrl } from "./build-tmdb-url";
 
@@ -44,6 +44,7 @@ async function tmdbFetch<T>(url: string, errorMessage: string): Promise<T> {
     },
     cache: "force-cache",
     next: { revalidate: 86400 },
+    signal: cacheSignal(),
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary

Implements React 19's `cacheSignal` API for server-side fetch operations to enable automatic request cancellation when rendering completes.

## Changes

- **TMDB Client** (`src/utils/tmdb-client.ts`): Add `cacheSignal()` to all TMDB API requests
- **Flow Gradient** (`src/components/shared/flow-gradient/flow-gradient.tsx`): Add `cacheSignal()` to shader file fetches in production
- **AI Agent** (`src/ai/agent.ts`): Add abort checks before logging errors to prevent false error logs from cancelled requests

## Benefits

- ✅ Automatic request cancellation for unused server-side fetches
- ✅ Cleaner error logs (no false errors from aborted requests)
- ✅ Better performance by stopping unnecessary network requests
- ✅ Follows React 19 best practices

## Testing

- ✅ All unit tests passed (102 tests)
- ✅ All E2E tests passed (40 tests)
- ✅ Type checking passed
- ✅ Linting passed