### PR TITLE
refactor: migrate to eslint-plugin-react-hooks recommended-latest preset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,8 +204,6 @@ const styles = stylex.create({
 - Use `use()` hook instead of `useContext()` for consuming context
 - React Compiler enabled, so
   - No need for `useMemo`, `useCallback`, or `memo()` - React Compiler handles optimization automatically
-  - Use `@inferEffectDependencies` comment at top of client component files to enable automatic useEffect dependency inference
-  - Can omit useEffect dependency arrays when using `@inferEffectDependencies` - React Compiler infers them
   - Avoid manual memoization patterns
 </notes>
 </pattern>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,6 @@ import nextPlugin from "@next/eslint-plugin-next";
 import stylexjs from "@stylexjs/eslint-plugin";
 import importPlugin from "eslint-plugin-import";
 import reactPlugin from "eslint-plugin-react";
-import reactCompiler from "eslint-plugin-react-compiler";
 import reactHooksPlugin from "eslint-plugin-react-hooks";
 import eslintPluginUnicorn from "eslint-plugin-unicorn";
 import { defineConfig } from "eslint/config";
@@ -32,7 +31,6 @@ export default defineConfig([
       react: reactPlugin,
       "react-hooks": reactHooksPlugin,
       "@stylexjs": stylexjs,
-      "react-compiler": reactCompiler,
       unicorn: eslintPluginUnicorn,
     },
     languageOptions: {
@@ -46,6 +44,7 @@ export default defineConfig([
     rules: {
       ...nextPlugin.configs.recommended.rules,
       ...nextPlugin.configs["core-web-vitals"].rules,
+      ...reactHooksPlugin.configs["recommended-latest"].rules,
       "@stylexjs/valid-styles": "error",
       "@typescript-eslint/consistent-type-imports": "error",
       "@typescript-eslint/consistent-type-exports": "error",
@@ -76,7 +75,6 @@ export default defineConfig([
         },
       ],
       "one-var": ["error", "never"],
-      "react-compiler/react-compiler": "error",
       "unicorn/no-unused-properties": "error",
       "@typescript-eslint/no-unused-vars": [
         "error",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "eslint": "^9.37.0",
     "eslint-config-next": "16.0.0-beta.0",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-react-compiler": "19.0.0-beta-714736e-20250131",
     "eslint-plugin-unicorn": "^61.0.2",
     "jsdom": "^27.0.0",
     "modern-normalize": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,9 +149,6 @@ importers:
       eslint-plugin-import:
         specifier: ^2.32.0
         version: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0)
-      eslint-plugin-react-compiler:
-        specifier: 19.0.0-beta-714736e-20250131
-        version: 19.0.0-beta-714736e-20250131(eslint@9.37.0)
       eslint-plugin-unicorn:
         specifier: ^61.0.2
         version: 61.0.2(eslint@9.37.0)
@@ -235,26 +232,12 @@ packages:
     resolution: {integrity: sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-annotate-as-pure@7.25.9':
-    resolution: {integrity: sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-compilation-targets@7.27.2':
     resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-create-class-features-plugin@7.26.9':
-    resolution: {integrity: sha512-ubbUqCofvxPRurw5L8WTsCLSkQiVpov4Qx0WMA+jUN+nXBK8ADPlJO1grkFw5CWKC5+sZSOfuGMdX1aI1iT9Sg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
   '@babel/helper-globals@7.28.0':
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-member-expression-to-functions@7.25.9':
-    resolution: {integrity: sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.27.1':
@@ -267,26 +250,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-optimise-call-expression@7.25.9':
-    resolution: {integrity: sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-plugin-utils@7.26.5':
-    resolution: {integrity: sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-plugin-utils@7.27.1':
     resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-replace-supers@7.26.5':
-    resolution: {integrity: sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
-    resolution: {integrity: sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.25.9':
@@ -313,13 +278,6 @@ packages:
     resolution: {integrity: sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  '@babel/plugin-proposal-private-methods@7.18.6':
-    resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
-    engines: {node: '>=6.9.0'}
-    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
 
   '@babel/plugin-transform-react-jsx-self@7.27.1':
     resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
@@ -2304,12 +2262,6 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
 
-  eslint-plugin-react-compiler@19.0.0-beta-714736e-20250131:
-    resolution: {integrity: sha512-iTPUaHzvBejGqicSwZLCDBgWBxLzU1Dvqjs31loNoOPRnsey5dcOupaZajECKVvXmB1wcbIWNp6/VR5+dM9d6w==}
-    engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
-    peerDependencies:
-      eslint: '>=7'
-
   eslint-plugin-react-hooks@7.0.0:
     resolution: {integrity: sha512-fNXaOwvKwq2+pXiRpXc825Vd63+KM4DLL40Rtlycb8m7fYpp6efrTp1sa6ZbP/Ap58K2bEKFXRmhURE+CJAQWw==}
     engines: {node: '>=18'}
@@ -4244,10 +4196,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
-  '@babel/helper-annotate-as-pure@7.25.9':
-    dependencies:
-      '@babel/types': 7.28.4
-
   '@babel/helper-compilation-targets@7.27.2':
     dependencies:
       '@babel/compat-data': 7.28.4
@@ -4256,27 +4204,7 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.26.9(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-member-expression-to-functions': 7.25.9
-      '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/helper-replace-supers': 7.26.5(@babel/core@7.28.4)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/traverse': 7.28.4
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-globals@7.28.0': {}
-
-  '@babel/helper-member-expression-to-functions@7.25.9':
-    dependencies:
-      '@babel/traverse': 7.28.4
-      '@babel/types': 7.28.4
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-module-imports@7.27.1':
     dependencies:
@@ -4294,29 +4222,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-optimise-call-expression@7.25.9':
-    dependencies:
-      '@babel/types': 7.28.4
-
-  '@babel/helper-plugin-utils@7.26.5': {}
-
   '@babel/helper-plugin-utils@7.27.1': {}
-
-  '@babel/helper-replace-supers@7.26.5(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-member-expression-to-functions': 7.25.9
-      '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/traverse': 7.28.4
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
-    dependencies:
-      '@babel/traverse': 7.28.4
-      '@babel/types': 7.28.4
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-string-parser@7.25.9': {}
 
@@ -4334,14 +4240,6 @@ snapshots:
   '@babel/parser@7.28.4':
     dependencies:
       '@babel/types': 7.28.4
-
-  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-create-class-features-plugin': 7.26.9(@babel/core@7.28.4)
-      '@babel/helper-plugin-utils': 7.26.5
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.4)':
     dependencies:
@@ -6402,18 +6300,6 @@ snapshots:
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
-
-  eslint-plugin-react-compiler@19.0.0-beta-714736e-20250131(eslint@9.37.0):
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/parser': 7.28.4
-      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.28.4)
-      eslint: 9.37.0
-      hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 3.4.0(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
 
   eslint-plugin-react-hooks@7.0.0(eslint@9.37.0):
     dependencies:

--- a/src/components/movie-database/media-filters-provider.tsx
+++ b/src/components/movie-database/media-filters-provider.tsx
@@ -1,4 +1,3 @@
-// @inferEffectDependencies
 "use client";
 
 import { usePathname, useSearchParams } from "next/navigation";

--- a/src/components/movie-database/media-list.tsx
+++ b/src/components/movie-database/media-list.tsx
@@ -1,4 +1,3 @@
-// @inferEffectDependencies
 "use client";
 
 import * as stylex from "@stylexjs/stylex";

--- a/src/components/movie-database/search-button.tsx
+++ b/src/components/movie-database/search-button.tsx
@@ -1,4 +1,3 @@
-// @inferEffectDependencies
 "use client";
 
 import { SparkleIcon } from "@phosphor-icons/react/dist/ssr/Sparkle";

--- a/src/components/movie-database/similar-media-list.tsx
+++ b/src/components/movie-database/similar-media-list.tsx
@@ -1,4 +1,3 @@
-// @inferEffectDependencies
 "use client";
 
 import * as stylex from "@stylexjs/stylex";

--- a/src/components/shared/animate-to-target.tsx
+++ b/src/components/shared/animate-to-target.tsx
@@ -1,4 +1,3 @@
-// @inferEffectDependencies
 "use client";
 
 import * as stylex from "@stylexjs/stylex";

--- a/src/components/shared/menu-button.tsx
+++ b/src/components/shared/menu-button.tsx
@@ -1,4 +1,3 @@
-// @inferEffectDependencies
 "use client";
 
 import * as stylex from "@stylexjs/stylex";

--- a/src/components/shared/overlay.tsx
+++ b/src/components/shared/overlay.tsx
@@ -1,4 +1,3 @@
-// @inferEffectDependencies
 "use client";
 
 import { XIcon } from "@phosphor-icons/react/X";

--- a/src/components/shared/switch.tsx
+++ b/src/components/shared/switch.tsx
@@ -1,9 +1,8 @@
-// @inferEffectDependencies
 "use client";
 
 import useControlled from "@mui/utils/useControlled";
 import * as stylex from "@stylexjs/stylex";
-import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
+import React, { useLayoutEffect, useRef, useState } from "react";
 import {
   border,
   color,
@@ -30,6 +29,7 @@ export function Switch({
   ...rest
 }: SwitchProps) {
   const elRef = useRef<HTMLInputElement>(null);
+  const hasSetInitialRendered = useRef(false);
 
   // Optionally controlled state
   const [value, setValue] = useControlled({
@@ -129,13 +129,18 @@ export function Switch({
   // Enable animation styles only after the component has fully mounted
   // This prevents switches from animating when switching routes or changing locales
   const [initialRendered, setInitialRendered] = useState(false);
-  useEffect(() => {
-    setInitialRendered(true);
-  });
+
+  const refCallback = (node: HTMLInputElement | null) => {
+    elRef.current = node;
+    if (node && !hasSetInitialRendered.current) {
+      hasSetInitialRendered.current = true;
+      setInitialRendered(true);
+    }
+  };
 
   return (
     <input
-      ref={elRef}
+      ref={refCallback}
       {...rest}
       className={className}
       style={style}

--- a/src/components/shared/theme-switch.tsx
+++ b/src/components/shared/theme-switch.tsx
@@ -1,4 +1,3 @@
-// @inferEffectDependencies
 "use client";
 
 import { MoonIcon } from "@phosphor-icons/react/Moon";

--- a/src/hooks/use-click-away.ts
+++ b/src/hooks/use-click-away.ts
@@ -1,4 +1,3 @@
-// @inferEffectDependencies
 import { useEffect, useRef } from "react";
 
 export function useClickAway<T extends HTMLElement = HTMLElement>(


### PR DESCRIPTION
## Summary

Consolidates React Compiler linting by migrating from the standalone `eslint-plugin-react-compiler` to the integrated React Compiler rules in `eslint-plugin-react-hooks@7.0.0`.

## Changes

- **Removed** `eslint-plugin-react-compiler` package (now consolidated into `eslint-plugin-react-hooks`)
- **Enabled** `recommended-latest` preset for bleeding-edge experimental React Compiler rules
- **Removed** `@inferEffectDependencies` directive from 10 files (it was an internal prototype, not a public API)
- **Refactored** `switch.tsx` to use ref callback instead of `useEffect` for cleaner pattern that passes strict linting
- **Updated** `CLAUDE.md` to remove references to unofficial directives

## Motivation

Following the [official React team guidance](https://react.dev/blog/2025/04/21/react-compiler-rc#migrating-from-eslint-plugin-react-compiler-to-eslint-plugin-react-hooks) for consolidating linting tools. This ensures we're using only documented, public APIs with the latest stable version.

## Test Plan

- [x] Linting passes with new `recommended-latest` preset
- [x] All unit tests pass (102 tests)
- [x] TypeScript compilation succeeds