### PR TITLE
chore: include @next/eslint-plugin-next in dependabot next group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,7 @@ updates:
         patterns:
           - "next"
           - "eslint-config-next"
+          - "@next/eslint-plugin-next"
       eslint:
         patterns:
           - eslint


### PR DESCRIPTION
This PR updates the dependabot configuration to include `@next/eslint-plugin-next` in the next group.

This ensures that updates to the Next.js ESLint plugin are grouped together with other Next.js dependencies (next and eslint-config-next), making dependency management more organized and reducing the number of separate PRs for related packages.