### PR TITLE
chore: upgrade pnpm to 10.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "22.x",
     "pnpm": ">=9"
   },
-  "packageManager": "pnpm@10.19.0+sha512.c9fc7236e92adf5c8af42fd5bf1612df99c2ceb62f27047032f4720b33f8eacdde311865e91c411f2774f618d82f320808ecb51718bfa82c060c4ba7c76a32b8",
+  "packageManager": "pnpm@10.20.0+sha512.cf9998222162dd85864d0a8102e7892e7ba4ceadebbf5a31f9c2fce48dfce317a9c53b9f6464d1ef9042cba2e02ae02a9f7c143a2b438cd93c91840f0192b9dd",
   "imports": {
     "#src/*": "./src/*"
   },


### PR DESCRIPTION
## Summary

Updates pnpm package manager to version 10.20.0 to include latest bug fixes, performance improvements, and features. This is part of ongoing dependency maintenance to keep the toolchain current.

## Changes

- Updated `packageManager` field in package.json from pnpm@10.19.0 to pnpm@10.20.0
- Updated SHA512 hash for integrity verification (automatically updated by corepack)

## Key Details

- Uses corepack to enforce the specific pnpm version across the team
- Minor version bump suggests non-breaking changes
- Consistent with recent dependency maintenance pattern