### PR TITLE
feat: add component library project to portfolio

### DIFF
--- a/src/app/[locale]/(home)/page.tsx
+++ b/src/app/[locale]/(home)/page.tsx
@@ -1,4 +1,5 @@
 import { FilmSlateIcon } from "@phosphor-icons/react/dist/ssr/FilmSlate";
+import { PackageIcon } from "@phosphor-icons/react/dist/ssr/Package";
 import * as stylex from "@stylexjs/stylex";
 import { breakpoints } from "#src/breakpoints.stylex.ts";
 import { BackgroundLines } from "#src/components/home/background-lines.tsx";
@@ -51,6 +52,14 @@ export default async function Home(props: PageProps) {
             css={[styles.card, styles.movieDatabase]}
             name={t("movieDatabase")}
             description={t("movieDatabaseDescription")}
+            scroll
+          />
+          <ProjectCard
+            icon={<PackageIcon size={64} weight="fill" />}
+            href={getLocalePath("/component-library", locale)}
+            css={[styles.card, styles.componentLibrary]}
+            name={t("componentLibrary")}
+            description={t("componentLibraryDescription")}
             scroll
           />
         </div>
@@ -159,5 +168,8 @@ const styles = stylex.create({
   },
   movieDatabase: {
     [svgTokens.fill]: color.brandTmdb,
+  },
+  componentLibrary: {
+    [svgTokens.fill]: color.controlActive,
   },
 });

--- a/src/app/[locale]/(home)/translations.json
+++ b/src/app/[locale]/(home)/translations.json
@@ -90,5 +90,13 @@
   "movieDatabaseDescription": {
     "en": "Find your next blockbuster, one filter at a time.",
     "zh": "你的下一个大片，只差一次筛选!"
+  },
+  "componentLibrary": {
+    "en": "Component Library",
+    "zh": "组件库"
+  },
+  "componentLibraryDescription": {
+    "en": "Beautiful components, crafted with care.",
+    "zh": "精心打造的精美组件。"
   }
 }

--- a/src/app/[locale]/component-library/layout.tsx
+++ b/src/app/[locale]/component-library/layout.tsx
@@ -1,0 +1,75 @@
+import * as stylex from "@stylexjs/stylex";
+import type { Metadata } from "next";
+import { breakpoints } from "#src/breakpoints.stylex.ts";
+import { TranslationProvider } from "#src/components/shared/translation-provider.tsx";
+import { BASE_URL } from "#src/constants.ts";
+import { controlSize, space } from "#src/tokens.stylex.ts";
+import type { PageProps, SupportedLocale } from "#src/types.ts";
+import { getTranslations } from "#src/utils/get-translations.ts";
+import { validateLocale } from "#src/utils/validate-locale.ts";
+import translations from "./translations.json";
+
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const params = await props.params;
+  const validatedLocale: SupportedLocale = validateLocale(params.locale);
+  const { t } = getTranslations(translations, validatedLocale);
+  return {
+    title: {
+      default: t("title"),
+      template: t("titleTemplate"),
+    },
+    description: t("description"),
+    alternates: {
+      canonical: new URL("/component-library", BASE_URL).toString(),
+      languages: {
+        en: new URL("/component-library", BASE_URL).toString(),
+        zh: new URL("/zh/component-library", BASE_URL).toString(),
+      },
+    },
+  } satisfies Metadata;
+}
+
+export function generateStaticParams() {
+  return [{ locale: "en" }, { locale: "zh" }];
+}
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const validatedLocale: SupportedLocale = validateLocale(locale);
+
+  return (
+    <TranslationProvider
+      locale={validatedLocale}
+      translations={{ componentLibrary: translations }}
+    >
+      <div css={styles.container}>
+        <main css={styles.main}>{children}</main>
+      </div>
+    </TranslationProvider>
+  );
+}
+
+const styles = stylex.create({
+  container: {
+    maxWidth: {
+      default: "1080px",
+      [breakpoints.xl]: "calc((1080 / 24) * 1rem)",
+    },
+    marginBlock: 0,
+    marginInline: "auto",
+    paddingBlock: 0,
+    paddingLeft: `calc(${space._3} + env(safe-area-inset-left))`,
+    paddingRight: `calc(${space._3} + env(safe-area-inset-right))`,
+  },
+  main: {
+    paddingTop: {
+      default: `calc(${space._10} + env(safe-area-inset-top) + ${controlSize._9} + ${space._3})`,
+    },
+  },
+});

--- a/src/app/[locale]/component-library/page.tsx
+++ b/src/app/[locale]/component-library/page.tsx
@@ -1,0 +1,35 @@
+import * as stylex from "@stylexjs/stylex";
+import { ViewTransition } from "react";
+import { font, space } from "#src/tokens.stylex.ts";
+import type { PageProps } from "#src/types.ts";
+import { getTranslations } from "#src/utils/get-translations.ts";
+import translations from "./translations.json";
+
+export default async function ComponentLibrary(props: PageProps) {
+  const { locale } = await props.params;
+  const { t } = getTranslations(translations, locale);
+
+  return (
+    <div css={styles.container}>
+      <ViewTransition name={`project-card-name-${t("heading")}`}>
+        <h1 css={styles.heading}>{t("heading")}</h1>
+      </ViewTransition>
+      <p css={styles.message}>{t("comingSoon")}</p>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  container: {
+    padding: `${space._6} 0`,
+  },
+  heading: {
+    margin: `0 0 ${space._4} 0`,
+    fontSize: font.size_6,
+    fontWeight: font.weight_8,
+  },
+  message: {
+    margin: 0,
+    fontSize: font.size_3,
+  },
+});

--- a/src/app/[locale]/component-library/translations.json
+++ b/src/app/[locale]/component-library/translations.json
@@ -1,0 +1,22 @@
+{
+  "title": {
+    "en": "Component Library | Qingqi Shi",
+    "zh": "组件库 | 石清琪"
+  },
+  "description": {
+    "en": "Explore Qingqi Shi's component library - a collection of beautiful, reusable components crafted with care for modern web applications.",
+    "zh": "探索石清琪的组件库 - 为现代网页应用精心打造的精美、可重用组件集合。"
+  },
+  "titleTemplate": {
+    "en": "%s | Component Library | Qingqi Shi",
+    "zh": "%s | 组件库 | 石清琪"
+  },
+  "heading": {
+    "en": "Component Library",
+    "zh": "组件库"
+  },
+  "comingSoon": {
+    "en": "Coming soon. Stay tuned for beautiful, reusable components crafted with care.",
+    "zh": "即将推出。敬请期待精心打造的精美、可重用组件。"
+  }
+}

--- a/src/components/home/project-card.tsx
+++ b/src/components/home/project-card.tsx
@@ -1,5 +1,5 @@
 import * as stylex from "@stylexjs/stylex";
-import type { ReactNode } from "react";
+import { ViewTransition, type ReactNode } from "react";
 import { Card } from "#src/components/shared/card.tsx";
 import { svgTokens } from "#src/logos/svg.stylex.ts";
 import { color, font, space } from "#src/tokens.stylex.ts";
@@ -22,7 +22,9 @@ export function ProjectCard({
     <Card {...rest} className={className} style={style} css={styles.card}>
       <div css={styles.row}>
         <div css={styles.logo}>{icon}</div>
-        <div css={styles.name}>{name}</div>
+        <ViewTransition name={`project-card-name-${name}`}>
+          <div css={styles.name}>{name}</div>
+        </ViewTransition>
       </div>
       <div css={styles.description}>{description}</div>
     </Card>


### PR DESCRIPTION
## Summary

Adds a new Component Library project section to showcase a future component library. This establishes the route structure, SEO metadata, and internationalization infrastructure before populating with actual components.

## Changes

- Created `/component-library` route with layout, page, and translations
- Added Component Library ProjectCard to homepage with PackageIcon
- Implemented bilingual support (English/Chinese) for all new content
- Added ViewTransition animation for smooth navigation from homepage card
- Set up proper SEO with canonical URLs and language alternates

## Key Details

- Full i18n implementation with locale-specific translations
- Follows existing Next.js App Router patterns with static params generation
- Uses StyleX design tokens and responsive breakpoints for consistency
- Custom purple accent color (controlActive) distinguishes from other projects
- "Coming soon" placeholder indicates work in progress

## Test Plan

- Navigate to `/component-library` and `/zh/component-library` to verify routes work
- Verify homepage displays new Component Library card alongside Movie Database
- Check SEO metadata in page source
- Test view transitions when clicking project card