### PR TITLE
fix: resolve ViewTransition hydration error with Suspense

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,9 +4,6 @@ module.exports = async () => {
     reactStrictMode: true,
     reactCompiler: true,
     serverExternalPackages: ["esbuild-wasm"],
-    experimental: {
-      viewTransition: true,
-    },
   };
 
   return nextConfig;

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -61,7 +61,7 @@ export default async function RootLayout({
               <Suspense fallback={<HeaderSkeleton />}>
                 <Header locale={validatedLocale} />
               </Suspense>
-              {children}
+              <Suspense fallback={null}>{children}</Suspense>
             </PortalTargetProvider>
           </ViewTransition>
           <Analytics />


### PR DESCRIPTION
## Summary

Fixes hydration mismatch error that occurs when ViewTransition wraps mixed Suspense/non-Suspense children. The issue manifested as React detecting style attribute differences for `view-transition-name` between server and client rendering.

## Changes

- Wrapped `{children}` in `<Suspense fallback={null}>` in root layout
- Removed `experimental.viewTransition: true` configuration flag (feature is now stable)
- Added comprehensive documentation section to react19-patterns skill

## Key Details

- **Pattern discovered**: ViewTransition + Suspense requires consistency - all children must be in Suspense boundaries
- **Root cause**: ViewTransition's just-in-time style application triggers during hydration when content reveals are inconsistent
- **Minimal code change**: Only one line changed in production code
- **Documentation-first**: Added detailed explanation with examples to prevent future occurrences

## Test Plan

- Verify no hydration errors appear in browser console on page load
- Confirm ViewTransition animations still work correctly
- Test on both initial load and navigation