### PR TITLE
chore: remove outdated onlyBuiltDependencies configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,13 +100,5 @@
     "typescript-eslint": "^8.46.3",
     "vite-plugin-babel": "^1.3.2",
     "vitest": "^4.0.7"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@vercel/speed-insights@1.2.0",
-      "esbuild@0.25.11",
-      "sharp@0.34.4",
-      "unrs-resolver@1.11.1"
-    ]
   }
 }


### PR DESCRIPTION
## Summary

Removes pnpm's dependency rebuild constraints that were forcing specific versions of native/binary dependencies. The pinned versions in `onlyBuiltDependencies` were becoming outdated and no longer matching actual dependency versions, creating maintenance friction during routine dependency updates.

## Changes

- Removed `pnpm.onlyBuiltDependencies` configuration block from package.json
- Previously pinned versions: @vercel/speed-insights@1.2.0, esbuild@0.25.11, sharp@0.34.4, unrs-resolver@1.11.1

## Key Details

- Hardcoded versions were stale (e.g., esbuild@0.25.11 vs current 0.25.12, sharp@0.34.4 vs current 0.34.5)
- Modern versions of these native dependencies include proper prebuilt binaries for common platforms
- No functional changes to the application - only affects how pnpm handles package installation
- Reduces maintenance burden during dependency updates