### PR TITLE
chore: add cleanup service worker for migration from old path

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,7 @@ export default defineConfig([
       ".next/**/*",
       "next-env.d.ts",
       "public/sw.js",
+      "public/serwist/**/*",
       "playwright-report/**/*",
     ],
   },

--- a/public/serwist/sw.js
+++ b/public/serwist/sw.js
@@ -1,0 +1,26 @@
+// Cleanup service worker - unregisters the old SW at /serwist/sw.js
+// This allows the new SW at /sw.js to take over
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", async (event) => {
+  event.waitUntil(
+    (async () => {
+      // Clear all caches
+      const cacheNames = await caches.keys();
+      await Promise.all(cacheNames.map((name) => caches.delete(name)));
+
+      // Unregister this service worker
+      const registration = await self.registration;
+      await registration.unregister();
+
+      // Claim clients so they get the message
+      await self.clients.claim();
+
+      // Notify all clients to reload
+      const clients = await self.clients.matchAll({ type: "window" });
+      clients.forEach((client) => client.navigate(client.url));
+    })(),
+  );
+});


### PR DESCRIPTION
## Summary

After migrating the service worker from `/serwist/sw.js` to `/sw.js` in #1559, existing users still have the old SW registered. This adds a cleanup service worker at the old path that will unregister itself, clear caches, and reload the page so the new SW can be discovered and activated.

## Changes

- Added `public/serwist/sw.js` - cleanup service worker that self-destructs
- Added `public/serwist/**/*` to ESLint ignores (consistent with existing `public/sw.js` ignore)

## Key Details

- Service worker migration pattern - transitional cleanup code
- Prevents stale cache issues during the service worker location change
- Users will experience one automatic reload to pick up the new SW
- This cleanup SW can be removed after sufficient time has passed for all users to migrate