### PR TITLE
fix: exclude _global-error from service worker precache

### DIFF
--- a/serwist.config.mjs
+++ b/serwist.config.mjs
@@ -3,4 +3,5 @@ import { serwist } from "@serwist/next/config";
 export default await serwist({
   swSrc: "src/sw.ts",
   swDest: "public/sw.js",
+  globIgnores: ["**/_global-error*"],
 });


### PR DESCRIPTION
## Summary

The `_global-error` route returns 404 because no `global-error.tsx` exists in the app. This was blocking the new service worker from installing since precaching fails on 404 responses.

## Changes

- Added `globIgnores: ["**/_global-error*"]` to serwist.config.mjs

## Key Details

- This was the root cause of the SW installation being stuck in "installing" state
- The new SW now precaches 43 URLs instead of 44