### PR TITLE
fix: return 404 instead of 500 for invalid locale paths

### DIFF
--- a/.claude/skills/playwright-e2e/SKILL.md
+++ b/.claude/skills/playwright-e2e/SKILL.md
@@ -187,9 +187,21 @@ if (await page.getByRole("button", { name: "Accept" }).isVisible()) {
 ## Running Tests
 
 ```bash
-pnpm test:e2e    # Run all E2E tests (auto-starts dev server)
-pnpm test        # Run unit tests (Vitest)
+pnpm test:e2e                              # Run all E2E tests (auto-starts dev server)
+pnpm test:e2e e2e/some-file.spec.ts        # Run specific test file
+pnpm test:e2e --grep "test name"           # Run tests matching pattern
+pnpm test                                  # Run unit tests (Vitest)
 ```
+
+## Verification Workflow
+
+**IMPORTANT: After writing or modifying E2E tests, YOU must run them to verify they pass.**
+
+1. Run the specific test file or use `--grep` to run just the new test
+2. If the test fails, fix the issue and re-run
+3. Only report completion after the test passes
+
+Do NOT tell the user to run the tests themselves - run them and report the results.
 
 ## Key Reminders
 

--- a/e2e/language-toggle.spec.ts
+++ b/e2e/language-toggle.spec.ts
@@ -200,4 +200,18 @@ test.describe("Language Toggle", () => {
     // Should return 404 for invalid locale
     expect(response?.status()).toBe(404);
   });
+
+  test("should return 404 for file-like paths misinterpreted as locales", async ({
+    page,
+  }) => {
+    // This path was previously causing a 500 error because "icon.c148568d.png"
+    // was being interpreted as a locale
+    const response = await page.goto("/icon.c148568d.png");
+
+    // Verify 404 status (not 500 server error)
+    expect(response?.status()).toBe(404);
+
+    // Verify user sees the 404 page
+    await expect(page.getByRole("heading", { name: "404" })).toBeVisible();
+  });
 });

--- a/src/app/[locale]/(home)/(details)/education/altrincham-grammar-school-for-boys/layout.tsx
+++ b/src/app/[locale]/(home)/(details)/education/altrincham-grammar-school-for-boys/layout.tsx
@@ -31,10 +31,6 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   } satisfies Metadata;
 }
 
-export function generateStaticParams() {
-  return [{ locale: "en" }, { locale: "zh" }];
-}
-
 export default function Layout({
   children,
 }: {

--- a/src/app/[locale]/(home)/(details)/education/university-of-bristol/layout.tsx
+++ b/src/app/[locale]/(home)/(details)/education/university-of-bristol/layout.tsx
@@ -25,10 +25,6 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   } satisfies Metadata;
 }
 
-export function generateStaticParams() {
-  return [{ locale: "en" }, { locale: "zh" }];
-}
-
 export default function Layout({
   children,
 }: {

--- a/src/app/[locale]/(home)/(details)/education/university-of-nottingham/layout.tsx
+++ b/src/app/[locale]/(home)/(details)/education/university-of-nottingham/layout.tsx
@@ -28,10 +28,6 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   } satisfies Metadata;
 }
 
-export function generateStaticParams() {
-  return [{ locale: "en" }, { locale: "zh" }];
-}
-
 export default function Layout({
   children,
 }: {

--- a/src/app/[locale]/(home)/(details)/experiences/citadel/layout.tsx
+++ b/src/app/[locale]/(home)/(details)/experiences/citadel/layout.tsx
@@ -22,10 +22,6 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   } satisfies Metadata;
 }
 
-export function generateStaticParams() {
-  return [{ locale: "en" }, { locale: "zh" }];
-}
-
 export default function Layout({
   children,
 }: {

--- a/src/app/[locale]/(home)/(details)/experiences/spotify/layout.tsx
+++ b/src/app/[locale]/(home)/(details)/experiences/spotify/layout.tsx
@@ -22,10 +22,6 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   } satisfies Metadata;
 }
 
-export function generateStaticParams() {
-  return [{ locale: "en" }, { locale: "zh" }];
-}
-
 export default function Layout({
   children,
 }: {

--- a/src/app/[locale]/(home)/(details)/experiences/wunderman-thompson-commerce/layout.tsx
+++ b/src/app/[locale]/(home)/(details)/experiences/wunderman-thompson-commerce/layout.tsx
@@ -31,10 +31,6 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   } satisfies Metadata;
 }
 
-export function generateStaticParams() {
-  return [{ locale: "en" }, { locale: "zh" }];
-}
-
 export default function Layout({
   children,
 }: {

--- a/src/app/[locale]/(home)/layout.tsx
+++ b/src/app/[locale]/(home)/layout.tsx
@@ -38,10 +38,6 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   } satisfies Metadata;
 }
 
-export function generateStaticParams() {
-  return [{ lang: "en" }, { lang: "zh" }];
-}
-
 export default async function Layout({
   children,
   params,

--- a/src/app/[locale]/(home)/page.tsx
+++ b/src/app/[locale]/(home)/page.tsx
@@ -21,10 +21,6 @@ import { getTranslations } from "#src/utils/get-translations.ts";
 import { getLocalePath } from "#src/utils/pathname.ts";
 import translations from "./translations.json";
 
-export function generateStaticParams() {
-  return [{ locale: "en" }, { locale: "zh" }];
-}
-
 export default async function Home(props: PageProps) {
   const { locale } = await props.params;
   const { t } = getTranslations(translations, locale);

--- a/src/app/[locale]/component-library/layout.tsx
+++ b/src/app/[locale]/component-library/layout.tsx
@@ -28,10 +28,6 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   } satisfies Metadata;
 }
 
-export function generateStaticParams() {
-  return [{ locale: "en" }, { locale: "zh" }];
-}
-
 export default async function Layout({
   children,
   params,

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -8,16 +8,21 @@ import { SerwistProvider } from "#src/components/serwist-provider.tsx";
 import { PortalTargetProvider } from "#src/components/shared/fixed-element-portal-target.tsx";
 import { HeaderSkeleton } from "#src/components/shared/header-skeleton.tsx";
 import { Header } from "#src/components/shared/header.tsx";
-import { i18nConfig } from "#src/i18n-config.ts";
-import type { SupportedLocale } from "#src/types.ts";
 import { themeHack } from "#src/utils/theme-hack.ts";
-import { validateLocale } from "#src/utils/validate-locale.ts";
+import { isValidLocale } from "#src/utils/validate-locale.ts";
 
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1.0,
   viewportFit: "cover",
 };
+
+// Only allow locales defined in generateStaticParams, return 404 for others
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return [{ locale: "en" }, { locale: "zh" }];
+}
 
 export default async function RootLayout({
   params,
@@ -27,14 +32,13 @@ export default async function RootLayout({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
-  const validatedLocale: SupportedLocale = validateLocale(locale);
 
-  if (!i18nConfig.locales.includes(validatedLocale)) {
+  if (!isValidLocale(locale)) {
     notFound();
   }
 
   return (
-    <html lang={validatedLocale} suppressHydrationWarning>
+    <html lang={locale} suppressHydrationWarning>
       <head>
         {/* Cleanup old service worker at /serwist/sw.js - can be removed after migration */}
         <script
@@ -57,7 +61,7 @@ export default async function RootLayout({
           // eslint-disable-next-line @next/next/no-sync-scripts
           <script src="https://unpkg.com/react-scan/dist/auto.global.js" />
         )}
-        {validatedLocale === "en" && (
+        {locale === "en" && (
           <link
             rel="preload"
             href="/InterVariableOptimized.woff2"
@@ -76,7 +80,7 @@ export default async function RootLayout({
           <ViewTransition>
             <PortalTargetProvider>
               <Suspense fallback={<HeaderSkeleton />}>
-                <Header locale={validatedLocale} />
+                <Header locale={locale} />
               </Suspense>
               <Suspense fallback={null}>{children}</Suspense>
             </PortalTargetProvider>

--- a/src/utils/validate-locale.ts
+++ b/src/utils/validate-locale.ts
@@ -1,9 +1,12 @@
 import type { SupportedLocale } from "#src/types.ts";
 
+export function isValidLocale(locale: string): locale is SupportedLocale {
+  return locale === "en" || locale === "zh";
+}
+
 export function validateLocale(locale: string): SupportedLocale {
-  if (locale === "en" || locale === "zh") {
+  if (isValidLocale(locale)) {
     return locale;
   }
-  // Fallback to English for invalid locales (should never happen with Next.js routing)
   return "en";
 }


### PR DESCRIPTION
## Summary

Fixes a routing bug where file-like paths (e.g., `/icon.c148568d.png`) were being incorrectly interpreted as locale routes, causing 500 server errors instead of proper 404 responses.

## Changes

- Add `dynamicParams = false` to root layout to strictly enforce valid locales ("en", "zh")
- Centralize `generateStaticParams()` at the root layout level
- Remove redundant `generateStaticParams()` from 9 child layouts
- Add `isValidLocale()` type guard for proper TypeScript type narrowing
- Add E2E test to prevent regression

## Key Details

- **Next.js routing strategy**: `dynamicParams = false` blocks any `[locale]` value not in `generateStaticParams()`, converting runtime errors into proper 404s
- **DRY principle**: Centralized static params definition prevents drift across route files
- **Type safety**: `isValidLocale()` provides proper TypeScript narrowing (`locale is SupportedLocale`)

## Test Plan

- Run `pnpm test:e2e --grep "file-like paths"` to verify the fix
- Visit `/icon.c148568d.png` and confirm 404 response instead of 500