### PR TITLE
perf: implement hover-based link prefetching

### DIFF
--- a/src/components/shared/anchor.tsx
+++ b/src/components/shared/anchor.tsx
@@ -1,14 +1,32 @@
+"use client";
+
 import * as stylex from "@stylexjs/stylex";
 import Link from "next/link";
+import { useState } from "react";
 import { border } from "#src/tokens.stylex.ts";
 import { anchorTokens } from "./anchor.stylex";
 
 export function Anchor({
   className,
   style,
+  onMouseEnter,
   ...props
 }: React.ComponentProps<typeof Link>) {
-  return <Link {...props} className={className} style={style} css={styles.a} />;
+  const [prefetch, setPrefetch] = useState(false);
+
+  return (
+    <Link
+      {...props}
+      prefetch={prefetch ? null : false}
+      onMouseEnter={(e) => {
+        setPrefetch(true);
+        onMouseEnter?.(e);
+      }}
+      className={className}
+      style={style}
+      css={styles.a}
+    />
+  );
 }
 
 const styles = stylex.create({


### PR DESCRIPTION
## Summary

Implements performance optimization by deferring link prefetching until user hover. This reduces initial page load overhead by preventing Next.js from automatically prefetching all visible links on mount, instead only prefetching when users show navigation intent.

## Changes

- Added `"use client"` directive to Anchor component
- Added `useState` to track prefetch activation state
- Implemented conditional prefetch: `false` initially, `null` (Next.js default) on hover
- Preserved existing `onMouseEnter` handlers via optional chaining

## Key Details

- Uses [official Next.js hover-prefetch pattern](https://nextjs.org/docs/app/guides/prefetching)
- One-way state transition: once activated on hover, remains enabled for that link instance
- Reduces unnecessary RSC requests while maintaining fast navigation on user intent
- Applies to all links using the shared Anchor component

## Test Plan

1. Open the site and check Network tab
2. Verify no RSC prefetch requests on page load for visible links
3. Hover over a link and verify RSC request fires
4. Click link and verify navigation uses prefetched data