### PR TITLE
chore: add calculator to sitemap for SEO

### DIFF
--- a/src/app/sitemap.xml
+++ b/src/app/sitemap.xml
@@ -83,4 +83,15 @@
     <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/movie-database" />
     <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/movie-database" />
   </url>
+
+  <url>
+    <loc>https://qingqi.dev/calculator</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/calculator" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/calculator" />
+  </url>
+  <url>
+    <loc>https://qingqi.dev/zh/calculator</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/calculator" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/calculator" />
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary

Register the calculator page with search engines for improved discoverability. Adds both English and Chinese URLs with bidirectional hreflang links for proper multilingual indexing.

## Changes

- Added `/calculator` URL entry with alternate language links
- Added `/zh/calculator` URL entry with alternate language links

## Key Details

- Follows the established multilingual sitemap pattern used for all other pages
- Each language version includes bidirectional links to both English and Chinese variants