### PR TITLE
build: upgrade pnpm to 10.28.1

### DIFF
--- a/.claude/skills/package-management/SKILL.md
+++ b/.claude/skills/package-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Managing Packages
-description: Package management using pnpm and corepack with packageManager field in package.json. Use when installing dependencies, upgrading packages, troubleshooting package manager issues, working with pnpm commands, npm install, or when the user mentions pnpm, corepack, package installation, dependency updates, or packageManager field.
+description: Package management using pnpm and corepack with packageManager field in package.json. This skill should be used when installing dependencies, upgrading packages, troubleshooting package manager issues, or working with pnpm commands. Explicit triggers include "upgrade pnpm", "update pnpm", "pnpm version", "pnpm install", "pnpm add", "corepack", "package installation", "dependency updates", or "packageManager field".
 ---
 
 # Package Management

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "24.x",
     "pnpm": ">=9"
   },
-  "packageManager": "pnpm@10.20.0+sha512.cf9998222162dd85864d0a8102e7892e7ba4ceadebbf5a31f9c2fce48dfce317a9c53b9f6464d1ef9042cba2e02ae02a9f7c143a2b438cd93c91840f0192b9dd",
+  "packageManager": "pnpm@10.28.1+sha512.7d7dbbca9e99447b7c3bf7a73286afaaf6be99251eb9498baefa7d406892f67b879adb3a1d7e687fc4ccc1a388c7175fbaae567a26ab44d1067b54fcb0d6a316",
   "imports": {
     "#src/*": "./src/*"
   },


### PR DESCRIPTION
## Summary

Maintenance update to keep the package manager current with the latest stable release.

## Changes

- Update `packageManager` field from pnpm 10.20.0 to 10.28.1
- Refine package-management skill description for better trigger clarity

## Key Details

- Uses Corepack's `packageManager` field with SHA512 hash for integrity verification
- Ensures all contributors use the exact same pnpm version