### PR TITLE
feat: add press animation feedback to buttons

### DIFF
--- a/src/components/calculator/calculator-button.tsx
+++ b/src/components/calculator/calculator-button.tsx
@@ -60,7 +60,6 @@ const styles = stylex.create({
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
-    transition: "background-color 0.2s ease",
     [buttonTokens.backgroundColor]: color.backgroundCalculatorButton,
     [buttonTokens.backgroundColorHover]: color.backgroundCalculatorButton,
     filter: { ":hover": "brightness(1.1)" },

--- a/src/components/shared/anchor-button.tsx
+++ b/src/components/shared/anchor-button.tsx
@@ -1,8 +1,12 @@
+"use client";
+
 import * as stylex from "@stylexjs/stylex";
-import { breakpoints } from "#src/breakpoints.stylex.ts";
-import { color, controlSize } from "#src/tokens.stylex.ts";
+import { useRef } from "react";
+import { usePressHandlers } from "#src/hooks/use-press-handlers.ts";
+import { controlSize } from "#src/tokens.stylex.ts";
 import { Anchor } from "./anchor";
 import { anchorTokens } from "./anchor.stylex";
+import { sharedStyles } from "./button-shared.stylex";
 import { buttonTokens } from "./button.stylex";
 
 interface AnchorButtonProps extends React.ComponentProps<typeof Anchor> {
@@ -20,28 +24,44 @@ export function AnchorButton({
   icon,
   isActive,
   style,
-  ...props
+  ...restProps
 }: AnchorButtonProps) {
+  const anchorRef = useRef<HTMLAnchorElement>(null);
+
+  const { isPressed, releasedOutside, pressedStyle, handlers } =
+    usePressHandlers({
+      targetRef: anchorRef,
+      ...restProps,
+    });
+
   return (
     <Anchor
-      {...props}
+      {...restProps}
+      ref={anchorRef}
       className={className}
-      style={style}
+      style={{ ...style, ...pressedStyle }}
       css={[
-        styles.button,
+        sharedStyles.base,
+        styles.anchorButton,
         !!icon &&
           !!children &&
-          (hideLabelOnMobile ? styles.hasIconHideLabel : styles.hasIcon),
-        bright && styles.bright,
-        isActive && styles.active,
+          (hideLabelOnMobile
+            ? sharedStyles.hasIconHideLabel
+            : sharedStyles.hasIcon),
+        bright && sharedStyles.bright,
+        isActive && sharedStyles.active,
+        isPressed && sharedStyles.pressed,
+        isPressed && bright && sharedStyles.pressedBright,
+        releasedOutside && sharedStyles.releasedOutside,
       ]}
+      {...handlers}
     >
-      {icon && <span css={styles.icon}>{icon}</span>}
+      {icon && <span css={sharedStyles.icon}>{icon}</span>}
       {children && (
         <span
           css={[
-            styles.childrenContainer,
-            hideLabelOnMobile && styles.hideLabelOnMobile,
+            sharedStyles.childrenContainer,
+            hideLabelOnMobile && sharedStyles.hideLabelOnMobile,
           ]}
         >
           {children}
@@ -52,66 +72,14 @@ export function AnchorButton({
 }
 
 const styles = stylex.create({
-  button: {
-    // Reset
+  anchorButton: {
+    // Anchor-specific resets
     fontSize: controlSize._4,
     textDecoration: "none",
     cursor: "pointer",
 
-    // Custom styles
-    display: "inline-flex",
-    alignItems: "center",
-    gap: controlSize._2,
+    // Anchor-specific styles
     height: buttonTokens.height,
-    paddingBlock: controlSize._1,
-    paddingInline: controlSize._3,
-    borderRadius: buttonTokens.borderRadius,
-    boxShadow: buttonTokens.boxShadow,
-    transition: "background 0.2s ease",
-    backgroundColor: {
-      default: buttonTokens.backgroundColor,
-      ":hover": buttonTokens.backgroundColorHover,
-      ":disabled:hover": buttonTokens.backgroundColorDisabledHover,
-    },
-    opacity: {
-      default: null,
-      ":disabled": 0.7,
-    },
     [anchorTokens.color]: buttonTokens.color,
-  },
-  hasIcon: {
-    paddingLeft: controlSize._2,
-  },
-  hasIconHideLabel: {
-    paddingLeft: { default: controlSize._3, [breakpoints.md]: controlSize._2 },
-  },
-  icon: {
-    display: "inline-flex",
-  },
-  childrenContainer: {
-    display: "inline-flex",
-    alignItems: "center",
-    gap: controlSize._2,
-  },
-  hideLabelOnMobile: {
-    display: { default: "none", [breakpoints.md]: "inline-flex" },
-  },
-  active: {
-    [anchorTokens.color]: {
-      default: color.textOnActive,
-      ":hover": color.textOnActive,
-    },
-    backgroundColor: {
-      default: color.controlActive,
-      ":hover": color.controlActiveHover,
-      ":disabled:hover": color.controlActive,
-    },
-  },
-  bright: {
-    backgroundColor: color.controlThumb,
-    [buttonTokens.color]: color.textOnControlThumb,
-    filter: {
-      ":hover": "brightness(1.2)",
-    },
   },
 });

--- a/src/components/shared/anchor.tsx
+++ b/src/components/shared/anchor.tsx
@@ -2,21 +2,20 @@
 
 import * as stylex from "@stylexjs/stylex";
 import Link from "next/link";
-import { useState } from "react";
+import { forwardRef, useState } from "react";
 import { border } from "#src/tokens.stylex.ts";
 import { anchorTokens } from "./anchor.stylex";
 
-export function Anchor({
-  className,
-  style,
-  onMouseEnter,
-  ...props
-}: React.ComponentProps<typeof Link>) {
+export const Anchor = forwardRef<
+  HTMLAnchorElement,
+  React.ComponentProps<typeof Link>
+>(function Anchor({ className, style, onMouseEnter, ...props }, ref) {
   const [prefetch, setPrefetch] = useState(false);
 
   return (
     <Link
       {...props}
+      ref={ref}
       prefetch={prefetch ? null : false}
       onMouseEnter={(e) => {
         setPrefetch(true);
@@ -27,7 +26,7 @@ export function Anchor({
       css={styles.a}
     />
   );
-}
+});
 
 const styles = stylex.create({
   a: {

--- a/src/components/shared/button-shared.stylex.ts
+++ b/src/components/shared/button-shared.stylex.ts
@@ -1,0 +1,99 @@
+import * as stylex from "@stylexjs/stylex";
+import { breakpoints } from "#src/breakpoints.stylex.ts";
+import { color, controlSize } from "#src/tokens.stylex.ts";
+import { anchorTokens } from "./anchor.stylex";
+import { buttonTokens } from "./button.stylex";
+
+export const PRESS_ANIMATION_DURATION = 150;
+const RELEASE_OUTSIDE_ANIMATION_DURATION = 300;
+
+const REDUCED_MOTION = "@media (prefers-reduced-motion: reduce)";
+
+export const sharedStyles = stylex.create({
+  base: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: controlSize._2,
+    paddingBlock: controlSize._1,
+    paddingInline: controlSize._3,
+    borderRadius: buttonTokens.borderRadius,
+    boxShadow: buttonTokens.boxShadow,
+    transition: {
+      default: `background 0.2s ease, transform ${PRESS_ANIMATION_DURATION}ms ease-out, filter ${PRESS_ANIMATION_DURATION}ms ease-out`,
+      [REDUCED_MOTION]: "background 0.2s ease",
+    },
+    backgroundColor: {
+      default: buttonTokens.backgroundColor,
+      ":hover": buttonTokens.backgroundColorHover,
+    },
+    // Base transform for pressed state
+    transform: "scale(1) translate(0, 0)",
+    filter: "brightness(1)",
+    // Touch action to prevent browser gestures from interfering
+    touchAction: "manipulation",
+  },
+  hasIcon: {
+    paddingLeft: controlSize._2,
+  },
+  hasIconHideLabel: {
+    paddingLeft: { default: controlSize._3, [breakpoints.md]: controlSize._2 },
+  },
+  icon: {
+    display: "inline-flex",
+  },
+  childrenContainer: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: controlSize._2,
+  },
+  hideLabelOnMobile: {
+    display: { default: "none", [breakpoints.md]: "inline-flex" },
+  },
+  active: {
+    [buttonTokens.color]: {
+      default: color.textOnActive,
+      ":hover": color.textOnActive,
+    },
+    [anchorTokens.color]: {
+      default: color.textOnActive,
+      ":hover": color.textOnActive,
+    },
+    backgroundColor: {
+      default: color.controlActive,
+      ":hover": color.controlActiveHover,
+      ":disabled:hover": color.controlActive,
+    },
+  },
+  bright: {
+    backgroundColor: color.controlThumb,
+    [buttonTokens.color]: color.textOnControlThumb,
+    [anchorTokens.color]: color.textOnControlThumb,
+    filter: {
+      default: "brightness(1)",
+      ":hover": "brightness(1.1)",
+    },
+  },
+  pressed: {
+    transform: {
+      default:
+        "scale(1.05) translate(var(--button-nudge-x, 0), var(--button-nudge-y, 0))",
+      [REDUCED_MOTION]: "scale(1) translate(0, 0)",
+    },
+    filter: {
+      default: "brightness(1.15)",
+      [REDUCED_MOTION]: "brightness(1)",
+    },
+  },
+  pressedBright: {
+    filter: {
+      default: "brightness(1.25)",
+      [REDUCED_MOTION]: "brightness(1)",
+    },
+  },
+  releasedOutside: {
+    transition: {
+      default: `background 0.2s ease, transform ${RELEASE_OUTSIDE_ANIMATION_DURATION}ms ease-out, filter ${RELEASE_OUTSIDE_ANIMATION_DURATION}ms ease-out`,
+      [REDUCED_MOTION]: "background 0.2s ease",
+    },
+  },
+});

--- a/src/hooks/use-press-animation.ts
+++ b/src/hooks/use-press-animation.ts
@@ -1,0 +1,258 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type RefObject,
+  type PointerEvent as ReactPointerEvent,
+  type KeyboardEvent,
+  type MouseEvent,
+} from "react";
+
+const PRESS_ANIMATION_DURATION = 150;
+const MAX_NUDGE_OFFSET = 4;
+
+function isPointerOutside(
+  rect: DOMRect | undefined,
+  clientX: number,
+  clientY: number,
+): boolean {
+  return (
+    !rect ||
+    clientX < rect.left ||
+    clientX > rect.right ||
+    clientY < rect.top ||
+    clientY > rect.bottom
+  );
+}
+
+interface UsePressAnimationOptions<T extends HTMLElement> {
+  disabled?: boolean;
+  targetRef: RefObject<T | null>;
+}
+
+interface UsePressAnimationReturn<T extends HTMLElement> {
+  isPressed: boolean;
+  releasedOutside: boolean;
+  nudgeOffset: { x: number; y: number };
+  handlers: {
+    onPointerDown: (event: ReactPointerEvent<T>) => void;
+    onPointerUp: (event: ReactPointerEvent<T>) => void;
+    onPointerMove: (event: ReactPointerEvent<T>) => void;
+    onKeyDown: (event: KeyboardEvent<T>) => void;
+    onKeyUp: (event: KeyboardEvent<T>) => void;
+    onContextMenu: (event: MouseEvent<T>) => void;
+  };
+  /** Returns true if click should be allowed, false if it was released outside */
+  shouldAllowClick: () => boolean;
+}
+
+export function usePressAnimation<T extends HTMLElement>({
+  disabled,
+  targetRef,
+}: UsePressAnimationOptions<T>): UsePressAnimationReturn<T> {
+  const pressStartTimeRef = useRef<number>(0);
+  const releaseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pointerIdRef = useRef<number | null>(null);
+  const isPressedRef = useRef(false);
+  const releasedOutsideRef = useRef(false);
+
+  const [isPressed, setIsPressed] = useState(false);
+  const [releasedOutside, setReleasedOutside] = useState(false);
+  const [nudgeOffset, setNudgeOffset] = useState({ x: 0, y: 0 });
+
+  const clearReleaseTimeout = useCallback(() => {
+    if (releaseTimeoutRef.current !== null) {
+      clearTimeout(releaseTimeoutRef.current);
+      releaseTimeoutRef.current = null;
+    }
+  }, []);
+
+  const handlePress = useCallback(() => {
+    if (disabled) return;
+    clearReleaseTimeout();
+
+    const el = targetRef.current;
+
+    if (isPressedRef.current && el) {
+      // Instant reset: disable transition, force scale 1.0
+      el.style.transition = "none";
+      el.style.transform = "scale(1) translate(0, 0)";
+      el.style.filter = "brightness(1)";
+
+      // Force browser to synchronously commit the scale(1) state
+      void el.offsetHeight;
+
+      // Re-enable transition and clear inline styles
+      // CSS sees value change: scale(1) → scale(1.05) → animates
+      el.style.transition = "";
+      el.style.transform = "";
+      el.style.filter = "";
+    }
+
+    setIsPressed(true);
+    isPressedRef.current = true;
+    setReleasedOutside(false);
+    setNudgeOffset({ x: 0, y: 0 });
+    pressStartTimeRef.current = performance.now();
+  }, [disabled, clearReleaseTimeout, targetRef]);
+
+  const handleRelease = useCallback((isOutside: boolean) => {
+    if (!isPressedRef.current) return;
+
+    const elapsed = performance.now() - pressStartTimeRef.current;
+    const remaining = PRESS_ANIMATION_DURATION - elapsed;
+
+    if (remaining > 0) {
+      // Quick click: wait for press animation to complete
+      setReleasedOutside(isOutside);
+      releaseTimeoutRef.current = setTimeout(() => {
+        setIsPressed(false);
+        isPressedRef.current = false;
+        setNudgeOffset({ x: 0, y: 0 });
+      }, remaining);
+    } else {
+      // Normal release
+      setReleasedOutside(isOutside);
+      setIsPressed(false);
+      isPressedRef.current = false;
+      setNudgeOffset({ x: 0, y: 0 });
+    }
+  }, []);
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<T>) => {
+      if (disabled) return;
+
+      // Capture pointer to receive pointerup even outside the element
+      targetRef.current?.setPointerCapture(event.pointerId);
+      pointerIdRef.current = event.pointerId;
+      handlePress();
+    },
+    [disabled, handlePress, targetRef],
+  );
+
+  const onPointerUp = useCallback(
+    (event: ReactPointerEvent<T>) => {
+      if (pointerIdRef.current !== null) {
+        targetRef.current?.releasePointerCapture(pointerIdRef.current);
+        pointerIdRef.current = null;
+      }
+      // Check actual pointer position since pointerleave doesn't fire with pointer capture
+      const rect = targetRef.current?.getBoundingClientRect();
+      const isOutside = isPointerOutside(rect, event.clientX, event.clientY);
+      releasedOutsideRef.current = isOutside; // Set synchronously before click fires
+      handleRelease(isOutside);
+    },
+    [handleRelease, targetRef],
+  );
+
+  const onPointerMove = useCallback(
+    (event: ReactPointerEvent<T>) => {
+      if (!isPressed || !targetRef.current) return;
+
+      const rect = targetRef.current.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+
+      // Check if pointer is outside the button
+      const isOutside = isPointerOutside(rect, event.clientX, event.clientY);
+
+      if (isOutside) {
+        // Calculate direction from center to pointer
+        const dx = event.clientX - centerX;
+        const dy = event.clientY - centerY;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+
+        if (distance > 0) {
+          // Normalize and scale to max offset
+          const scale = Math.min(MAX_NUDGE_OFFSET / distance, 1);
+          setNudgeOffset({
+            x: dx * scale,
+            y: dy * scale,
+          });
+        }
+      } else {
+        setNudgeOffset({ x: 0, y: 0 });
+      }
+    },
+    [isPressed, targetRef],
+  );
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent<T>) => {
+      if (disabled) return;
+      if (event.key === "Enter" || event.key === " ") {
+        // Prevent space from scrolling the page
+        if (event.key === " ") {
+          event.preventDefault();
+        }
+        handlePress();
+      }
+    },
+    [disabled, handlePress],
+  );
+
+  const onKeyUp = useCallback(
+    (event: KeyboardEvent<T>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        handleRelease(false);
+      }
+    },
+    [handleRelease],
+  );
+
+  // Prevent context menu from interrupting the press state
+  const onContextMenu = useCallback(
+    (_event: MouseEvent<T>) => {
+      if (isPressed) {
+        handleRelease(true);
+      }
+    },
+    [isPressed, handleRelease],
+  );
+
+  // Returns true if click should be allowed, resets the flag
+  const shouldAllowClick = useCallback(() => {
+    if (releasedOutsideRef.current) {
+      releasedOutsideRef.current = false;
+      return false;
+    }
+    return true;
+  }, []);
+
+  // Cleanup timeout on unmount to prevent memory leaks
+  useEffect(() => {
+    return () => {
+      if (releaseTimeoutRef.current !== null) {
+        clearTimeout(releaseTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  // Release press state when window loses focus (e.g., Alt-Tab)
+  useEffect(() => {
+    const handleWindowBlur = () => {
+      if (isPressedRef.current) {
+        handleRelease(true);
+      }
+    };
+    window.addEventListener("blur", handleWindowBlur);
+    return () => window.removeEventListener("blur", handleWindowBlur);
+  }, [handleRelease]);
+
+  return {
+    isPressed,
+    releasedOutside,
+    nudgeOffset,
+    handlers: {
+      onPointerDown,
+      onPointerUp,
+      onPointerMove,
+      onKeyDown,
+      onKeyUp,
+      onContextMenu,
+    },
+    shouldAllowClick,
+  };
+}

--- a/src/hooks/use-press-handlers.ts
+++ b/src/hooks/use-press-handlers.ts
@@ -1,0 +1,143 @@
+import {
+  useCallback,
+  type RefObject,
+  type PointerEvent as ReactPointerEvent,
+  type PointerEventHandler,
+  type KeyboardEvent,
+  type KeyboardEventHandler,
+  type MouseEvent,
+  type MouseEventHandler,
+} from "react";
+import { usePressAnimation } from "./use-press-animation";
+
+type CSSCustomProperties = Record<`--${string}`, string>;
+
+interface UsePressHandlersOptions<T extends HTMLElement> {
+  disabled?: boolean;
+  targetRef: RefObject<T | null>;
+  onPointerDown?: PointerEventHandler<T>;
+  onPointerUp?: PointerEventHandler<T>;
+  onPointerMove?: PointerEventHandler<T>;
+  onKeyDown?: KeyboardEventHandler<T>;
+  onKeyUp?: KeyboardEventHandler<T>;
+  onClick?: MouseEventHandler<T>;
+}
+
+interface UsePressHandlersReturn<T extends HTMLElement> {
+  isPressed: boolean;
+  releasedOutside: boolean;
+  pressedStyle: CSSCustomProperties | undefined;
+  handlers: {
+    onPointerDown: PointerEventHandler<T>;
+    onPointerUp: PointerEventHandler<T>;
+    onPointerMove: PointerEventHandler<T>;
+    onKeyDown: KeyboardEventHandler<T>;
+    onKeyUp: KeyboardEventHandler<T>;
+    onContextMenu: MouseEventHandler<T>;
+    onClick: MouseEventHandler<T>;
+  };
+}
+
+export function usePressHandlers<T extends HTMLElement>({
+  disabled,
+  targetRef,
+  onPointerDown,
+  onPointerUp,
+  onPointerMove,
+  onKeyDown,
+  onKeyUp,
+  onClick,
+}: UsePressHandlersOptions<T>): UsePressHandlersReturn<T> {
+  const {
+    isPressed,
+    releasedOutside,
+    nudgeOffset,
+    handlers: pressHandlers,
+    shouldAllowClick,
+  } = usePressAnimation({
+    disabled,
+    targetRef,
+  });
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<T>) => {
+      onPointerDown?.(event);
+      pressHandlers.onPointerDown(event);
+    },
+    [pressHandlers, onPointerDown],
+  );
+
+  const handlePointerUp = useCallback(
+    (event: ReactPointerEvent<T>) => {
+      onPointerUp?.(event);
+      pressHandlers.onPointerUp(event);
+    },
+    [pressHandlers, onPointerUp],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: ReactPointerEvent<T>) => {
+      onPointerMove?.(event);
+      pressHandlers.onPointerMove(event);
+    },
+    [pressHandlers, onPointerMove],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<T>) => {
+      onKeyDown?.(event);
+      pressHandlers.onKeyDown(event);
+    },
+    [pressHandlers, onKeyDown],
+  );
+
+  const handleKeyUp = useCallback(
+    (event: KeyboardEvent<T>) => {
+      onKeyUp?.(event);
+      pressHandlers.onKeyUp(event);
+    },
+    [pressHandlers, onKeyUp],
+  );
+
+  const handleContextMenu = useCallback(
+    (event: MouseEvent<T>) => {
+      pressHandlers.onContextMenu(event);
+    },
+    [pressHandlers],
+  );
+
+  const handleClick = useCallback(
+    (event: MouseEvent<T>) => {
+      if (!shouldAllowClick()) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+      onClick?.(event);
+    },
+    [onClick, shouldAllowClick],
+  );
+
+  const pressedStyle =
+    isPressed && !disabled
+      ? {
+          "--button-nudge-x": `${nudgeOffset.x}px`,
+          "--button-nudge-y": `${nudgeOffset.y}px`,
+        }
+      : undefined;
+
+  return {
+    isPressed,
+    releasedOutside,
+    pressedStyle,
+    handlers: {
+      onPointerDown: handlePointerDown,
+      onPointerUp: handlePointerUp,
+      onPointerMove: handlePointerMove,
+      onKeyDown: handleKeyDown,
+      onKeyUp: handleKeyUp,
+      onContextMenu: handleContextMenu,
+      onClick: handleClick,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Implements tactile, animated press feedback for all interactive button-like elements in the application. Buttons now visually scale up (1.05x) and brighten when pressed, providing immediate tactile feedback that makes the interface feel more responsive and polished.

## Changes

- Created `usePressAnimation` hook for core pointer/keyboard press state tracking with timing, nudge offsets, and edge case handling
- Created `usePressHandlers` hook that wraps press animation logic and composes with existing event handlers
- Extracted shared button/anchor-button styles to `button-shared.stylex.ts`, reducing duplication
- Integrated press handlers into `Button` and `AnchorButton` components
- Added ref forwarding to `Anchor` component to support pointer capture
- Added interaction tests for pointer/keyboard events

## Key Details

- **Pointer Capture API** - Uses `setPointerCapture`/`releasePointerCapture` to track pointer position even when dragged outside button boundaries
- **Magnetic nudge effect** - Buttons subtly follow the pointer direction when dragged outside, creating a playful interaction
- **Accessibility** - Completely disables transform/filter animations when `prefers-reduced-motion` is set; works with keyboard navigation (Enter/Space)
- **Edge case handling** - Handles rapid clicks, window blur, context menu interruptions, and ensures animations complete before allowing clicks
- **Performance** - Uses CSS transforms/filters for GPU-accelerated animations

## Test Plan

- [ ] Verify press animation on Button components (mouse click, hold, release)
- [ ] Verify press animation on AnchorButton components
- [ ] Test keyboard activation (Enter/Space)
- [ ] Test drag outside behavior (should cancel click, show nudge effect)
- [ ] Verify reduced motion preference disables animations
- [ ] Run existing tests: `pnpm test`