### PR TITLE
refactor: standardize skill names to kebab-case identifiers

### DIFF
--- a/.claude/skills/data-fetching/SKILL.md
+++ b/.claude/skills/data-fetching/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Fetching Data
+name: data-fetching
 description: Data fetching patterns for server/client components using fetch API, TanStack Query, useSuspenseQuery, apiRouteWrapper, and apiRequestWrapper. Use when implementing data loading, API calls, server functions, queries, mutations, API routes, or when the user mentions TanStack Query, useSuspenseQuery, apiRouteWrapper, apiRequestWrapper, tmdb-server-functions, or data fetching.
 ---
 

--- a/.claude/skills/i18n-patterns/SKILL.md
+++ b/.claude/skills/i18n-patterns/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Internationalizing Components
+name: i18n-patterns
 description: Internationalization (i18n) patterns for server and client components using getTranslations and useTranslations. Use when working with translations, locales, multilingual content, translation files, TranslationContextProvider, locale switching, or when the user mentions i18n, translations, getTranslations, useTranslations, or translation.json files.
 ---
 

--- a/.claude/skills/package-management/SKILL.md
+++ b/.claude/skills/package-management/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Managing Packages
+name: package-management
 description: Package management using pnpm and corepack with packageManager field in package.json. This skill should be used when installing dependencies, upgrading packages, troubleshooting package manager issues, or working with pnpm commands. Explicit triggers include "upgrade pnpm", "update pnpm", "pnpm version", "pnpm install", "pnpm add", "corepack", "package installation", "dependency updates", or "packageManager field".
 ---
 

--- a/.claude/skills/playwright-e2e/SKILL.md
+++ b/.claude/skills/playwright-e2e/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Testing with Playwright
+name: playwright-e2e
 description: Playwright end-to-end (e2e) testing best practices for user-centric testing using semantic locators. Use when writing E2E tests, integration tests, user flow tests, Playwright tests, test specs, or when the user mentions Playwright, e2e tests, getByRole, test flows, or user testing.
 ---
 

--- a/.claude/skills/react19-patterns/SKILL.md
+++ b/.claude/skills/react19-patterns/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Using React 19 Patterns
+name: react19-patterns
 description: React 19 patterns and React Compiler behavior with Context shorthand syntax and use() hook. Use when working with Context, useContext, use() hook, Provider components, optimization patterns like useMemo, useCallback, memo, memoization, or when the user mentions React 19, React Compiler, Context.Provider, or manual optimization.
 ---
 

--- a/.claude/skills/stylex-styling/SKILL.md
+++ b/.claude/skills/stylex-styling/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Styling with StyleX
+name: stylex-styling
 description: StyleX styling patterns using design tokens, breakpoints, and custom css prop. Use when working with styles, CSS, design tokens, breakpoints, responsive design, themes, styling components, css prop, stylex.create, or when the user mentions StyleX, tokens.stylex, controlSize, color tokens, or breakpoints.
 ---
 

--- a/.claude/skills/tmdb-codegen/SKILL.md
+++ b/.claude/skills/tmdb-codegen/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Generating TMDB Code
+name: tmdb-codegen
 description: TMDB API code generation workflow with selective Zod schemas using pnpm codegen:tmdb. Use when working with TMDB endpoints, regenerating types, adding TMDB API functionality, modifying endpoints-config.js, tmdb-server-functions.ts, Zod schemas, or when the user mentions TMDB codegen, endpoints-config, pnpm codegen:tmdb, needsZodSchema, or auto-generated TMDB files.
 ---
 


### PR DESCRIPTION
## Summary

Standardizes skill identifiers to use machine-friendly kebab-case naming instead of human-friendly display names. This establishes a consistent naming convention for programmatic skill references.

## Changes

- Updated `data-fetching` skill name from "Fetching Data"
- Updated `i18n-patterns` skill name from "Internationalizing Components"
- Updated `package-management` skill name from "Managing Packages"
- Updated `playwright-e2e` skill name from "Testing with Playwright"
- Updated `react19-patterns` skill name from "Using React 19 Patterns"
- Updated `stylex-styling` skill name from "Styling with StyleX"
- Updated `tmdb-codegen` skill name from "Generating TMDB Code"

## Key Details

- All 7 project-specific skills updated consistently
- Pattern follows kebab-case convention (lowercase with hyphens)
- Description fields and content remain unchanged
- No functional code changes, only skill metadata