### PR TITLE
fix: resolve floating-point precision bug in calculator

### DIFF
--- a/src/components/calculator/calculator-logic.test.ts
+++ b/src/components/calculator/calculator-logic.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import {
+  roundResult,
+  computeBinaryOperation,
+  evaluateExpression,
+} from "./calculator-logic";
+import type { Token } from "./types";
+
+describe("roundResult", () => {
+  it("eliminates floating-point precision artifacts for 0.1 + 0.2", () => {
+    // Raw JavaScript: 0.1 + 0.2 = 0.30000000000000004
+    const rawResult = 0.1 + 0.2;
+    expect(rawResult).not.toBe(0.3); // Confirms the bug exists in raw JS
+
+    expect(roundResult(rawResult)).toBe(0.3);
+  });
+
+  it("eliminates floating-point precision artifacts for 0.1 + 0.7", () => {
+    // Raw JavaScript: 0.1 + 0.7 = 0.7999999999999999
+    const rawResult = 0.1 + 0.7;
+    expect(rawResult).not.toBe(0.8); // Confirms the bug exists in raw JS
+
+    expect(roundResult(rawResult)).toBe(0.8);
+  });
+
+  it("eliminates floating-point precision artifacts for 0.3 - 0.1", () => {
+    // Raw JavaScript: 0.3 - 0.1 = 0.19999999999999998
+    const rawResult = 0.3 - 0.1;
+    expect(rawResult).not.toBe(0.2); // Confirms the bug exists in raw JS
+
+    expect(roundResult(rawResult)).toBe(0.2);
+  });
+
+  it("preserves integers", () => {
+    expect(roundResult(42)).toBe(42);
+    expect(roundResult(0)).toBe(0);
+    expect(roundResult(-100)).toBe(-100);
+  });
+
+  it("preserves clean decimal numbers", () => {
+    expect(roundResult(3.14)).toBe(3.14);
+    expect(roundResult(0.5)).toBe(0.5);
+    expect(roundResult(-2.5)).toBe(-2.5);
+  });
+
+  it("handles special values", () => {
+    expect(roundResult(Infinity)).toBe(Infinity);
+    expect(roundResult(-Infinity)).toBe(-Infinity);
+    expect(roundResult(NaN)).toBeNaN();
+  });
+
+  it("preserves precision for numbers within 12 significant digits", () => {
+    expect(roundResult(123456789012)).toBe(123456789012);
+    expect(roundResult(0.123456789012)).toBe(0.123456789012);
+  });
+});
+
+describe("computeBinaryOperation", () => {
+  describe("addition", () => {
+    it("adds two numbers correctly", () => {
+      expect(computeBinaryOperation(2, 3, "+")).toBe(5);
+    });
+
+    it("handles floating-point precision for 0.1 + 0.2", () => {
+      expect(computeBinaryOperation(0.1, 0.2, "+")).toBe(0.3);
+    });
+
+    it("handles floating-point precision for 0.1 + 0.7", () => {
+      expect(computeBinaryOperation(0.1, 0.7, "+")).toBe(0.8);
+    });
+  });
+
+  describe("subtraction", () => {
+    it("subtracts two numbers correctly", () => {
+      expect(computeBinaryOperation(5, 3, "−")).toBe(2);
+    });
+
+    it("handles floating-point precision for 0.3 - 0.1", () => {
+      expect(computeBinaryOperation(0.3, 0.1, "−")).toBe(0.2);
+    });
+  });
+
+  describe("multiplication", () => {
+    it("multiplies two numbers correctly", () => {
+      expect(computeBinaryOperation(4, 3, "×")).toBe(12);
+    });
+
+    it("handles floating-point precision for 0.1 × 0.2", () => {
+      expect(computeBinaryOperation(0.1, 0.2, "×")).toBe(0.02);
+    });
+  });
+
+  describe("division", () => {
+    it("divides two numbers correctly", () => {
+      expect(computeBinaryOperation(12, 4, "÷")).toBe(3);
+    });
+
+    it("returns NaN for division by zero", () => {
+      expect(computeBinaryOperation(5, 0, "÷")).toBeNaN();
+    });
+
+    it("handles floating-point precision", () => {
+      expect(computeBinaryOperation(0.3, 0.1, "÷")).toBe(3);
+    });
+  });
+});
+
+describe("evaluateExpression", () => {
+  it("evaluates 0.1 + 0.2 correctly", () => {
+    const tokens: Token[] = [
+      { type: "number", value: 0.1, raw: "0.1" },
+      { type: "binaryOperator", value: "+" },
+      { type: "number", value: 0.2, raw: "0.2" },
+    ];
+    expect(evaluateExpression(tokens)).toBe(0.3);
+  });
+
+  it("evaluates chained operations with correct precision", () => {
+    // 0.1 + 0.2 + 0.3 should equal 0.6
+    const tokens: Token[] = [
+      { type: "number", value: 0.1, raw: "0.1" },
+      { type: "binaryOperator", value: "+" },
+      { type: "number", value: 0.2, raw: "0.2" },
+      { type: "binaryOperator", value: "+" },
+      { type: "number", value: 0.3, raw: "0.3" },
+    ];
+    expect(evaluateExpression(tokens)).toBe(0.6);
+  });
+});

--- a/src/components/calculator/calculator-logic.ts
+++ b/src/components/calculator/calculator-logic.ts
@@ -13,24 +13,44 @@ export function isUnaryOperator(value: string): value is "±" | "%" {
   return unaryOperatorsSet.has(value);
 }
 
+/**
+ * Round a number to eliminate floating-point precision artifacts.
+ * Uses 12 significant digits which handles common cases like 0.1 + 0.2
+ * while preserving precision for most practical calculations.
+ */
+export function roundResult(value: number): number {
+  if (!Number.isFinite(value)) {
+    return value;
+  }
+  // Round to 12 significant digits
+  const precision = 12;
+  return Number(value.toPrecision(precision));
+}
+
 export function computeBinaryOperation(
   lhs: number,
   rhs: number,
   operator: BinaryOperator,
 ): number {
+  let result: number;
   switch (operator) {
     case "+":
-      return lhs + rhs;
+      result = lhs + rhs;
+      break;
     case "−":
-      return lhs - rhs;
+      result = lhs - rhs;
+      break;
     case "×":
-      return lhs * rhs;
+      result = lhs * rhs;
+      break;
     case "÷":
       if (rhs === 0) {
         return NaN; // Division by zero produces NaN for "Error" display
       }
-      return lhs / rhs;
+      result = lhs / rhs;
+      break;
   }
+  return roundResult(result);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the classic JavaScript floating-point precision bug where operations like `0.1 + 0.2` produce `0.30000000000000004` instead of `0.3`. For a calculator widget, users expect clean results like `0.3`.

## Changes

- Added `roundResult()` function that rounds numbers to 12 significant digits
- Integrated rounding into `computeBinaryOperation()` so all arithmetic operations benefit
- Added comprehensive unit tests (19 tests) covering precision fixes and edge cases

## Key Details

- Uses 12 significant digits as the precision threshold - handles common artifacts while preserving enough precision for practical calculator use
- Edge cases (Infinity, -Infinity, NaN) pass through unchanged
- Tests explicitly verify the JavaScript floating-point bug exists before confirming the fix works

## Test Plan

- [x] `pnpm test` - 127 tests pass (19 new)
- [x] `pnpm build` - builds successfully
- [x] Manual verification: `0.1 + 0.2 = 0.3` ✓, `0.1 + 0.7 = 0.8` ✓