### PR TITLE
chore: add Claude Code hooks and settings

### DIFF
--- a/.claude/hooks/worktree-guard.sh
+++ b/.claude/hooks/worktree-guard.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Pre-tool-use hook: blocks tool calls that reach outside the current worktree
+# into the main repository. Only activates when running inside a worktree
+# created under .claude/worktrees/.
+#
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Determine current git root (worktree root when inside a worktree)
+WORKTREE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# Only activate when inside a .claude/worktrees/ directory
+case "$WORKTREE_ROOT" in
+  */.claude/worktrees/*) ;;
+  *) exit 0 ;;
+esac
+
+# Derive the main repository root by stripping /.claude/worktrees/<name>
+MAIN_REPO="${WORKTREE_ROOT%%/.claude/worktrees/*}"
+
+TOOL=$(echo "$INPUT" | jq -r '.tool_name')
+
+# Check whether a path escapes the worktree into the main repo
+check_path() {
+  local p="$1"
+  [ -z "$p" ] && return 0
+
+  # Make absolute
+  [[ "$p" != /* ]] && p="$WORKTREE_ROOT/$p"
+
+  # Normalize (resolve . and ..)
+  p=$(python3 -c "import os.path, sys; print(os.path.normpath(sys.argv[1]))" "$p")
+
+  # Block if path is under the main repo but NOT under the worktree
+  if [[ "$p" == "$MAIN_REPO"* && "$p" != "$WORKTREE_ROOT"* ]]; then
+    echo "Blocked: path '$p' is outside worktree '$WORKTREE_ROOT'" >&2
+    exit 2
+  fi
+}
+
+case "$TOOL" in
+  Read|Write|Edit|MultiEdit|NotebookEdit)
+    check_path "$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty')"
+    ;;
+  Glob|Grep)
+    check_path "$(echo "$INPUT" | jq -r '.tool_input.path // empty')"
+    ;;
+  Bash)
+    CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+    # Remove worktree path references, then check if the main repo path remains
+    CLEANED=$(python3 -c "import sys; print(sys.argv[1].replace(sys.argv[2], ''))" "$CMD" "$WORKTREE_ROOT")
+    if echo "$CLEANED" | grep -qF "$MAIN_REPO"; then
+      echo "Blocked: command references main repo '$MAIN_REPO' from within worktree" >&2
+      exit 2
+    fi
+    ;;
+esac

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,44 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'CMD=$(jq -r .tool_input.command) && if echo \"$CMD\" | grep -qE \"\\bnpm\\b|\\bnpx\\b\"; then echo \"Use pnpm/pnpx instead of npm/npx. This project uses pnpm.\" >&2; exit 2; fi'"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash|Read|Write|Edit|MultiEdit|Glob|Grep|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.claude/hooks/worktree-guard.sh\""
+          }
+        ]
+      }
+    ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'NAME=$(jq -r .name) && REPO=$(git rev-parse --show-toplevel) && DIR=\"$REPO/.claude/worktrees/$NAME\" && git worktree add \"$DIR\" >&2 && cd \"$DIR\" && pnpm install >&2 && echo \"$DIR\"'"
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'WORKTREE_PATH=$(jq -r .worktree_path) && git worktree remove \"$WORKTREE_PATH\" --force >&2'"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Add Claude Code project-level hooks and settings to enforce development conventions and enable safe worktree usage. This ensures pnpm is always used instead of other package managers, and prevents tools from accidentally modifying the main repository when operating inside a worktree.

## Context

The settings configure three hook types: a pre-tool-use hook that blocks non-pnpm package manager commands, a worktree guard script that prevents file operations from escaping the worktree boundary into the main repo, and lifecycle hooks for worktree creation/removal that handle setup (pnpm install) and cleanup automatically.