### PR TITLE
refactor: extract shared sanitizeParams utility for AI tool params

### DIFF
--- a/src/ai/agent.ts
+++ b/src/ai/agent.ts
@@ -169,18 +169,17 @@ export async function agent(
     }> = [];
 
     for (const outputItem of response.output) {
-      const item = outputItem;
-      fullConversation.push(item);
+      fullConversation.push(outputItem);
 
-      if (item.type === "function_call") {
-        console.log("tool call: ", item.name);
+      if (outputItem.type === "function_call") {
+        console.log("tool call: ", outputItem.name);
         // Check if this is the completion call
-        if (item.name === "complete_phase_1") {
+        if (outputItem.name === "complete_phase_1") {
           hasCompletionCall = true;
         }
 
         // Auto-inject language parameter based on locale
-        const toolArgs = JSON.parse(item.arguments || "{}") as Record<
+        const toolArgs = JSON.parse(outputItem.arguments || "{}") as Record<
           string,
           unknown
         >;
@@ -191,9 +190,9 @@ export async function agent(
 
         // Collect for parallel execution
         toolCalls.push({
-          name: item.name,
+          name: outputItem.name,
           arguments: JSON.stringify(toolArgs),
-          call_id: item.call_id,
+          call_id: outputItem.call_id,
         });
       }
     }
@@ -265,10 +264,9 @@ export async function agent(
     throw new Error("No parsed output available from final processing");
   }
 
-  finalResponse.output.forEach((output) => fullConversation.push(output));
-
   // Save conversation for debugging in development only
   if (process.env.NODE_ENV === "development") {
+    finalResponse.output.forEach((output) => fullConversation.push(output));
     try {
       const logFile = `/tmp/ai-conversation-${Date.now()}.json`;
       writeFileSync(logFile, JSON.stringify(fullConversation, null, 2));

--- a/src/ai/movie-search-tool.ts
+++ b/src/ai/movie-search-tool.ts
@@ -3,6 +3,7 @@ import { zodResponsesFunction } from "openai/helpers/zod";
 import { searchMovies } from "#src/_generated/tmdb-server-functions.ts";
 import { operationsSchema } from "#src/_generated/tmdb-zod.ts";
 import type { paths } from "#src/_generated/tmdbV3.d.ts";
+import { sanitizeParams } from "./sanitize-params";
 
 // Extract Zod schema from generated schemas (backward compatible)
 const movieSearchSchema =
@@ -31,20 +32,13 @@ export async function executeMovieSearchToolCall(toolCall: {
     throw new Error(`Unknown tool: ${toolCall.name}`);
   }
 
-  const args = JSON.parse(toolCall.arguments) as Record<string, unknown>;
+  const validatedParams = movieSearchSchema.parse(
+    JSON.parse(toolCall.arguments || "{}"),
+  );
 
-  // Parse and validate with Zod schema
-  const validatedParams = movieSearchSchema.parse(args);
-
-  // Remove undefined values to avoid issues with the API
-  const strippedParams = { ...validatedParams };
-  Object.keys(strippedParams).forEach((key) => {
-    if (!strippedParams[key as keyof MovieSearchParams]) {
-      delete strippedParams[key as keyof MovieSearchParams];
-    }
-  });
-
-  const movieResults = await searchMovies(strippedParams as MovieSearchParams);
+  const movieResults = await searchMovies(
+    sanitizeParams(validatedParams) as MovieSearchParams,
+  );
 
   return {
     call_id: toolCall.call_id,

--- a/src/ai/movie-tool.ts
+++ b/src/ai/movie-tool.ts
@@ -3,6 +3,7 @@ import { zodResponsesFunction } from "openai/helpers/zod";
 import { discoverMovies } from "#src/_generated/tmdb-server-functions.ts";
 import { operationsSchema } from "#src/_generated/tmdb-zod.ts";
 import type { paths } from "#src/_generated/tmdbV3.d.ts";
+import { sanitizeParams } from "./sanitize-params";
 
 // Extract Zod schema from generated schemas and make it required
 const movieDiscoverySchema = operationsSchema.shape[
@@ -34,31 +35,14 @@ export async function executeMovieToolCall(toolCall: {
     throw new Error(`Unknown tool: ${toolCall.name}`);
   }
 
-  const args = JSON.parse(toolCall.arguments) as Record<string, unknown>;
-
-  // Parse and validate with Zod schema
-  const validatedParams = movieDiscoverySchema.parse(args);
-
-  // Remove undefined values to avoid issues with the API
-  const strippedParams = { ...validatedParams };
-  Object.keys(strippedParams).forEach((key) => {
-    if (!strippedParams[key as keyof MovieDiscoveryParams]) {
-      delete strippedParams[key as keyof MovieDiscoveryParams];
-    }
-  });
-
-  // Convert null values to undefined for TMDB API compatibility
-  const sanitizedParams = Object.fromEntries(
-    Object.entries(strippedParams).map(([key, value]) => [
-      key,
-      value === null ? undefined : value,
-    ]),
+  const validatedParams = movieDiscoverySchema.parse(
+    JSON.parse(toolCall.arguments || "{}"),
   );
 
   const movieResults = await discoverMovies({
     "vote_count.gte": 300,
     "vote_average.gte": 3,
-    ...sanitizedParams,
+    ...sanitizeParams(validatedParams),
   } as MovieDiscoveryParams);
 
   return {

--- a/src/ai/person-search-tool.ts
+++ b/src/ai/person-search-tool.ts
@@ -3,6 +3,7 @@ import { zodResponsesFunction } from "openai/helpers/zod";
 import { searchPerson } from "#src/_generated/tmdb-server-functions.ts";
 import { operationsSchema } from "#src/_generated/tmdb-zod.ts";
 import type { paths } from "#src/_generated/tmdbV3.d.ts";
+import { sanitizeParams } from "./sanitize-params";
 
 // Extract Zod schema from generated schemas
 const personSearchSchema =
@@ -31,21 +32,12 @@ export async function executePersonSearchToolCall(toolCall: {
     throw new Error(`Unknown tool: ${toolCall.name}`);
   }
 
-  const args = JSON.parse(toolCall.arguments) as Record<string, unknown>;
-
-  // Parse and validate with Zod schema
-  const validatedParams = personSearchSchema.parse(args);
-
-  // Remove undefined values to avoid issues with the API
-  const strippedParams = { ...validatedParams };
-  Object.keys(strippedParams).forEach((key) => {
-    if (!strippedParams[key as keyof PersonSearchParams]) {
-      delete strippedParams[key as keyof PersonSearchParams];
-    }
-  });
+  const validatedParams = personSearchSchema.parse(
+    JSON.parse(toolCall.arguments || "{}"),
+  );
 
   const personResults = await searchPerson(
-    strippedParams as PersonSearchParams,
+    sanitizeParams(validatedParams) as PersonSearchParams,
   );
 
   return {

--- a/src/ai/sanitize-params.test.ts
+++ b/src/ai/sanitize-params.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeParams } from "./sanitize-params";
+
+describe("sanitizeParams", () => {
+  it("removes null values", () => {
+    expect(sanitizeParams({ a: 1, b: null })).toEqual({ a: 1 });
+  });
+
+  it("removes undefined values", () => {
+    expect(sanitizeParams({ a: 1, b: undefined })).toEqual({ a: 1 });
+  });
+
+  it("preserves 0", () => {
+    expect(sanitizeParams({ page: 0 })).toEqual({ page: 0 });
+  });
+
+  it("preserves false", () => {
+    expect(sanitizeParams({ include_adult: false })).toEqual({
+      include_adult: false,
+    });
+  });
+
+  it("preserves empty string", () => {
+    expect(sanitizeParams({ query: "" })).toEqual({ query: "" });
+  });
+
+  it("preserves truthy values", () => {
+    expect(sanitizeParams({ query: "hello", page: 1 })).toEqual({
+      query: "hello",
+      page: 1,
+    });
+  });
+
+  it("returns empty object when all values are null or undefined", () => {
+    expect(sanitizeParams({ a: null, b: undefined })).toEqual({});
+  });
+
+  it("returns empty object for empty input", () => {
+    expect(sanitizeParams({})).toEqual({});
+  });
+
+  it("filters mixed valid and nullish values", () => {
+    expect(
+      sanitizeParams({ a: 0, b: null, c: "x", d: undefined, e: false }),
+    ).toEqual({ a: 0, c: "x", e: false });
+  });
+});

--- a/src/ai/sanitize-params.ts
+++ b/src/ai/sanitize-params.ts
@@ -1,0 +1,7 @@
+export function sanitizeParams(
+  params: Record<string, unknown>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(params).filter(([, value]) => value != null),
+  );
+}

--- a/src/ai/tv-search-tool.ts
+++ b/src/ai/tv-search-tool.ts
@@ -3,6 +3,7 @@ import { zodResponsesFunction } from "openai/helpers/zod";
 import { searchTvShows } from "#src/_generated/tmdb-server-functions.ts";
 import { operationsSchema } from "#src/_generated/tmdb-zod.ts";
 import type { paths } from "#src/_generated/tmdbV3.d.ts";
+import { sanitizeParams } from "./sanitize-params";
 
 // Extract Zod schema from generated schemas
 const tvSearchSchema =
@@ -31,20 +32,13 @@ export async function executeTvSearchToolCall(toolCall: {
     throw new Error(`Unknown tool: ${toolCall.name}`);
   }
 
-  const args = JSON.parse(toolCall.arguments) as Record<string, unknown>;
+  const validatedParams = tvSearchSchema.parse(
+    JSON.parse(toolCall.arguments || "{}"),
+  );
 
-  // Parse and validate with Zod schema
-  const validatedParams = tvSearchSchema.parse(args);
-
-  // Remove undefined values to avoid issues with the API
-  const strippedParams = { ...validatedParams };
-  Object.keys(strippedParams).forEach((key) => {
-    if (!strippedParams[key as keyof TvSearchParams]) {
-      delete strippedParams[key as keyof TvSearchParams];
-    }
-  });
-
-  const tvResults = await searchTvShows(strippedParams as TvSearchParams);
+  const tvResults = await searchTvShows(
+    sanitizeParams(validatedParams) as TvSearchParams,
+  );
 
   return {
     call_id: toolCall.call_id,

--- a/src/ai/tv-tool.ts
+++ b/src/ai/tv-tool.ts
@@ -3,6 +3,7 @@ import { zodResponsesFunction } from "openai/helpers/zod";
 import { discoverTvShows } from "#src/_generated/tmdb-server-functions.ts";
 import { operationsSchema } from "#src/_generated/tmdb-zod.ts";
 import type { paths } from "#src/_generated/tmdbV3.d.ts";
+import { sanitizeParams } from "./sanitize-params";
 // Extract Zod schema from generated schemas
 const tvDiscoverySchema = operationsSchema.shape[
   "discover-tv"
@@ -33,31 +34,14 @@ export async function executeTvToolCall(toolCall: {
     throw new Error(`Unknown tool: ${toolCall.name}`);
   }
 
-  const args = JSON.parse(toolCall.arguments) as Record<string, unknown>;
-
-  // Parse and validate with Zod schema
-  const validatedParams = tvDiscoverySchema.parse(args);
-
-  // Remove undefined values to avoid issues with the API
-  const strippedParams = { ...validatedParams };
-  Object.keys(strippedParams).forEach((key) => {
-    if (!strippedParams[key as keyof TvDiscoveryParams]) {
-      delete strippedParams[key as keyof TvDiscoveryParams];
-    }
-  });
-
-  // Convert null values to undefined for TMDB API compatibility
-  const sanitizedParams = Object.fromEntries(
-    Object.entries(strippedParams).map(([key, value]) => [
-      key,
-      value === null ? undefined : value,
-    ]),
+  const validatedParams = tvDiscoverySchema.parse(
+    JSON.parse(toolCall.arguments || "{}"),
   );
 
   const tvResults = await discoverTvShows({
     "vote_count.gte": 300,
     "vote_average.gte": 3,
-    ...sanitizedParams,
+    ...sanitizeParams(validatedParams),
   } as TvDiscoveryParams);
 
   return {


### PR DESCRIPTION
## Summary

Extracts duplicated parameter-sanitization logic from five AI tool files into a single shared `sanitizeParams` utility. The old inline code used truthiness checks to strip params, which incorrectly removed valid falsy values like `0` and `false`. The new utility only removes `null` and `undefined`, preserving all other values.

Also cleans up `agent.ts` by removing an unnecessary variable alias and scoping the debug conversation logging to development-only.

## Context

Each tool file (movie-search, movie-discover, tv-search, tv-discover, person-search) had its own copy of param-stripping logic with slightly different approaches — some also converted `null` to `undefined`. The shared `sanitizeParams` function handles both cases uniformly with `value != null`. Nine unit tests cover edge cases including `0`, `false`, empty strings, and mixed inputs.