### PR TITLE
feat: stream AI chat responses with multi-turn support

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.58",
+    "@ai-sdk/react": "^3.0.135",
     "@mui/utils": "^7.3.7",
     "@phosphor-icons/react": "^2.1.10",
     "@serwist/next": "^9.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: ^3.0.58
         version: 3.0.58(zod@3.25.76)
+      '@ai-sdk/react':
+        specifier: ^3.0.135
+        version: 3.0.135(react@19.3.0-canary-52684925-20251110)(zod@3.25.76)
       '@mui/utils':
         specifier: ^7.3.7
         version: 7.3.7(@types/react@19.2.10)(react@19.3.0-canary-52684925-20251110)
@@ -237,8 +240,20 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@3.0.77':
+    resolution: {integrity: sha512-UdwIG2H2YMuntJQ5L+EmED5XiwnlvDT3HOmKfVFxR4Nq/RSLFA/HcchhwfNXHZ5UJjyuL2VO0huLbWSZ9ijemQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@4.0.19':
     resolution: {integrity: sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.21':
+    resolution: {integrity: sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -246,6 +261,12 @@ packages:
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
+
+  '@ai-sdk/react@3.0.135':
+    resolution: {integrity: sha512-FX044uUYP0prAV+ViC/Xagy36Too2pDj+/kpo/JSM4x6KLVVuZdqxkq7X+uF80L9r/TZtyppCmdec716sQnOzg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
 
   '@asamuzakjp/css-color@4.1.1':
     resolution: {integrity: sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==}
@@ -2175,6 +2196,12 @@ packages:
 
   ai@6.0.116:
     resolution: {integrity: sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@6.0.133:
+    resolution: {integrity: sha512-8YBTQdRtIpa7gLKWLvUHLnKxI5lEyV1z9o20+8uDjMs4EOGuv62fQivHD/Yi7SBidzEhAORjCBcQrQ5Lu2V0Vw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -4422,6 +4449,11 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swr@2.4.1:
+    resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -4449,6 +4481,10 @@ packages:
     resolution: {integrity: sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==}
     engines: {node: '>=10'}
     hasBin: true
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   time-span@5.1.0:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
@@ -4596,6 +4632,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -4858,7 +4899,21 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 3.25.76
 
+  '@ai-sdk/gateway@3.0.77(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.21(zod@3.25.76)
+      '@vercel/oidc': 3.1.0
+      zod: 3.25.76
+
   '@ai-sdk/provider-utils@4.0.19(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@4.0.21(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
@@ -4868,6 +4923,16 @@ snapshots:
   '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
+
+  '@ai-sdk/react@3.0.135(react@19.3.0-canary-52684925-20251110)(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider-utils': 4.0.21(zod@3.25.76)
+      ai: 6.0.133(zod@3.25.76)
+      react: 19.3.0-canary-52684925-20251110
+      swr: 2.4.1(react@19.3.0-canary-52684925-20251110)
+      throttleit: 2.1.0
+    transitivePeerDependencies:
+      - zod
 
   '@asamuzakjp/css-color@4.1.1':
     dependencies:
@@ -6620,6 +6685,14 @@ snapshots:
       '@ai-sdk/gateway': 3.0.66(zod@3.25.76)
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.19(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      zod: 3.25.76
+
+  ai@6.0.133(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.77(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.21(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 
@@ -9227,6 +9300,12 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swr@2.4.1(react@19.3.0-canary-52684925-20251110):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.3.0-canary-52684925-20251110
+      use-sync-external-store: 1.6.0(react@19.3.0-canary-52684925-20251110)
+
   symbol-tree@3.2.4: {}
 
   tapable@2.3.0: {}
@@ -9248,6 +9327,8 @@ snapshots:
       acorn: 8.15.0
       commander: 2.20.3
       source-map-support: 0.5.21
+
+  throttleit@2.1.0: {}
 
   time-span@5.1.0:
     dependencies:
@@ -9434,6 +9515,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.10
+
+  use-sync-external-store@1.6.0(react@19.3.0-canary-52684925-20251110):
+    dependencies:
+      react: 19.3.0-canary-52684925-20251110
 
   util-deprecate@1.0.2: {}
 

--- a/src/ai-chat/chat.ts
+++ b/src/ai-chat/chat.ts
@@ -1,4 +1,4 @@
-import { generateText } from "ai";
+import { convertToModelMessages, streamText } from "ai";
 import "server-only";
 import { getAnthropicModel } from "./client";
 import type { ChatInput } from "./schema";
@@ -6,14 +6,13 @@ import { getChatSystemInstructions } from "./system-instructions";
 
 export { chatInputSchema, type ChatInput } from "./schema";
 
-export async function chat({ message, locale }: ChatInput) {
+export async function chat({ messages, locale }: ChatInput) {
   const system = getChatSystemInstructions(locale);
+  const modelMessages = await convertToModelMessages(messages);
 
-  const result = await generateText({
+  return streamText({
     model: getAnthropicModel(),
     system,
-    messages: [{ role: "user", content: message }],
+    messages: modelMessages,
   });
-
-  return { text: result.text };
 }

--- a/src/ai-chat/schema.ts
+++ b/src/ai-chat/schema.ts
@@ -1,7 +1,20 @@
+import type { UIMessage } from "ai";
 import { z } from "zod";
 
+function isUIMessage(val: unknown): val is UIMessage {
+  if (typeof val !== "object" || val === null) return false;
+  return (
+    "id" in val &&
+    typeof val.id === "string" &&
+    "role" in val &&
+    typeof val.role === "string" &&
+    "parts" in val &&
+    Array.isArray(val.parts)
+  );
+}
+
 export const chatInputSchema = z.object({
-  message: z.string().min(1).max(2000),
+  messages: z.array(z.custom<UIMessage>(isUIMessage)).min(1),
   locale: z.enum(["en", "zh"]).default("en"),
 });
 

--- a/src/ai-chat/use-ai-chat.ts
+++ b/src/ai-chat/use-ai-chat.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { useChat } from "@ai-sdk/react";
+import { DefaultChatTransport } from "ai";
+import type { SupportedLocale } from "#src/types.ts";
+
+export function useAIChat({ locale }: { locale: SupportedLocale }) {
+  const transport = new DefaultChatTransport({
+    api: "/api/ai-chat",
+    body: { locale },
+  });
+
+  return useChat({ transport });
+}

--- a/src/app/api/ai-chat/route.test.ts
+++ b/src/app/api/ai-chat/route.test.ts
@@ -1,3 +1,5 @@
+import { simulateReadableStream, streamText } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
 import { NextRequest } from "next/server";
 import { describe, expect, it, vi } from "vitest";
 import { chatInputSchema } from "#src/ai-chat/schema.ts";
@@ -17,23 +19,50 @@ function chatRequest(body: unknown) {
   });
 }
 
-describe("POST /api/ai-chat", () => {
-  it("returns 200 with valid message", async () => {
-    const { chat } = await import("#src/ai-chat/chat.ts");
-    vi.mocked(chat).mockResolvedValueOnce({ text: "Great movie!" });
+function validMessages() {
+  return [
+    {
+      id: "msg-1",
+      role: "user",
+      parts: [{ type: "text", text: "recommend a sci-fi movie" }],
+    },
+  ];
+}
 
-    const response = await POST(
-      chatRequest({ message: "recommend a sci-fi movie" }),
-    );
+describe("POST /api/ai-chat", () => {
+  it("returns a streaming response with valid messages", async () => {
+    const { chat } = await import("#src/ai-chat/chat.ts");
+    const result = streamText({
+      model: new MockLanguageModelV3({
+        doStream: {
+          stream: simulateReadableStream({
+            chunks: [
+              { type: "text-start", id: "t1" },
+              { type: "text-delta", id: "t1", delta: "Great " },
+              { type: "text-delta", id: "t1", delta: "movie!" },
+              { type: "text-end", id: "t1" },
+            ],
+            initialDelayInMs: 0,
+            chunkDelayInMs: 0,
+          }),
+        },
+      }),
+      messages: [{ role: "user", content: "test" }],
+    });
+    vi.mocked(chat).mockResolvedValueOnce(result);
+
+    const response = await POST(chatRequest({ messages: validMessages() }));
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({
-      success: true,
-      text: "Great movie!",
-    });
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    expect(response.body).not.toBeNull();
+
+    const text = await response.text();
+    expect(text).toContain("Great ");
+    expect(text).toContain("movie!");
   });
 
-  it("returns 400 for missing message", async () => {
+  it("returns 400 for missing messages", async () => {
     const response = await POST(chatRequest({}));
 
     expect(response.status).toBe(400);
@@ -43,8 +72,18 @@ describe("POST /api/ai-chat", () => {
     });
   });
 
-  it("returns 400 for empty message", async () => {
-    const response = await POST(chatRequest({ message: "" }));
+  it("returns 400 for empty messages array", async () => {
+    const response = await POST(chatRequest({ messages: [] }));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Invalid request body",
+    });
+  });
+
+  it("returns 400 for invalid message format", async () => {
+    const response = await POST(chatRequest({ messages: [{ text: "hello" }] }));
 
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({
@@ -55,7 +94,7 @@ describe("POST /api/ai-chat", () => {
 
   it("returns 400 for invalid locale", async () => {
     const response = await POST(
-      chatRequest({ message: "hello", locale: "fr" }),
+      chatRequest({ messages: validMessages(), locale: "fr" }),
     );
 
     expect(response.status).toBe(400);
@@ -69,7 +108,7 @@ describe("POST /api/ai-chat", () => {
     const { chat } = await import("#src/ai-chat/chat.ts");
     vi.mocked(chat).mockRejectedValueOnce(new Error("API key invalid"));
 
-    const response = await POST(chatRequest({ message: "hello" }));
+    const response = await POST(chatRequest({ messages: validMessages() }));
 
     expect(response.status).toBe(500);
     expect(await response.json()).toEqual({

--- a/src/app/api/ai-chat/route.ts
+++ b/src/app/api/ai-chat/route.ts
@@ -5,8 +5,9 @@ import { chat, chatInputSchema } from "#src/ai-chat/chat.ts";
 export async function POST(request: NextRequest) {
   try {
     const body: unknown = await request.json();
-    const result = await chat(chatInputSchema.parse(body));
-    return Response.json({ success: true, text: result.text });
+    const input = chatInputSchema.parse(body);
+    const result = await chat(input);
+    return result.toUIMessageStreamResponse();
   } catch (error) {
     if (error instanceof z.ZodError) {
       return Response.json(


### PR DESCRIPTION
## Summary

Convert the AI chat endpoint from a synchronous request-response pattern to server-sent event streaming, enabling real-time token delivery to the client. The API now also accepts full conversation history (`UIMessage[]`) instead of a single message string, supporting multi-turn conversations.

Adds a `useAIChat` client hook (wrapping `@ai-sdk/react`) that manages chat state and connects to the streaming endpoint via `DefaultChatTransport`.

## Context

The previous implementation buffered the entire Anthropic response before sending it back as JSON. Streaming significantly improves perceived latency for users. Accepting `UIMessage[]` is required by the AI SDK's streaming protocol and also enables multi-turn conversations where the model has access to prior context.

Closes #1646