### PR TITLE
chore: simplify worktree config and add sandbox/permissions settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,18 @@
 {
+  "sandbox": {
+    "enabled": true
+  },
+  "permissions": {
+    "defaultMode": "bypassPermissions",
+    "deny": ["Read(./.env)", "Read(./.env.*)"]
+  },
+  "worktree": {
+    "symlinkDirectories": [
+      "node_modules",
+      ".claude/settings.local.json",
+      ".env.local"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {
@@ -25,26 +39,6 @@
           {
             "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/.claude/hooks/worktree-guard.sh\""
-          }
-        ]
-      }
-    ],
-    "WorktreeCreate": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash -c 'NAME=$(jq -r .name) && REPO=$(git rev-parse --show-toplevel) && DIR=\"$REPO/.claude/worktrees/$NAME\" && git worktree add \"$DIR\" >&2 && cd \"$DIR\" && pnpm install >&2 && SRC=\"$REPO/.claude/settings.local.json\" && if [ -f \"$SRC\" ]; then cp \"$SRC\" \"$DIR/.claude/settings.local.json\" >&2; fi && ENV=\"$REPO/.env.local\" && if [ -f \"$ENV\" ]; then cp \"$ENV\" \"$DIR/.env.local\" >&2; fi && echo \"$DIR\"'"
-          }
-        ]
-      }
-    ],
-    "WorktreeRemove": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash -c 'WORKTREE_PATH=$(jq -r .worktree_path) && git worktree remove \"$WORKTREE_PATH\" --force >&2'"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Replace custom `WorktreeCreate` and `WorktreeRemove` hooks with the built-in `worktree.symlinkDirectories` declarative config, and add top-level `sandbox` and `permissions` settings. This simplifies worktree setup by leveraging Claude Code's native symlink support instead of manually scripting directory creation, pnpm install, and file copying in bash hooks.

## Context

The previous worktree hooks used a long bash one-liner to create worktrees, run `pnpm install`, and copy config files. Claude Code now supports `worktree.symlinkDirectories` which handles this declaratively by symlinking `node_modules`, `.claude/settings.local.json`, and `.env.local` into new worktrees. The `sandbox` and `permissions` fields configure sandbox mode and deny access to `.env` files respectively.