### PR TITLE
chore: add .playwright-cli to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
+
+# Playwright CLI
+.playwright-cli


### PR DESCRIPTION
## Summary

Adds the `.playwright-cli` directory to `.gitignore` to prevent Playwright CLI artifacts from being tracked in version control.