### PR TITLE
feat: add chat message display components for AI mode

### DIFF
--- a/src/app/[locale]/movie-database/ai-mode/chat-messages-section.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/chat-messages-section.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import type { UIMessage } from "ai";
+import type { ReactNode } from "react";
+import { ChatMessageList } from "#src/components/ai-chat/chat-message-list.tsx";
+
+interface ChatMessagesSectionProps {
+  emptyState: ReactNode;
+  typingIndicatorLabel: string;
+  scrollToBottomLabel: string;
+}
+
+// TODO(#1662): remove demo data — replace with useAIChat
+const demoMessages: ReadonlyArray<UIMessage> = [
+  {
+    id: "demo-1",
+    role: "user",
+    parts: [{ type: "text", text: "Can you recommend a good sci-fi movie?" }],
+  },
+  {
+    id: "demo-2",
+    role: "assistant",
+    parts: [
+      {
+        type: "text",
+        text: "I'd recommend Arrival (2016)! It's a thought-provoking sci-fi film directed by Denis Villeneuve. The story follows a linguist recruited by the military to communicate with extraterrestrial visitors. It beautifully explores themes of language, time, and human connection.\n\nThe cinematography is stunning and Amy Adams delivers an incredible performance. It's the kind of film that stays with you long after watching.",
+      },
+    ],
+  },
+  {
+    id: "demo-3",
+    role: "user",
+    parts: [
+      { type: "text", text: "What about something more action-oriented?" },
+    ],
+  },
+  {
+    id: "demo-4",
+    role: "assistant",
+    parts: [
+      {
+        type: "reasoning",
+        text: "The user wants action sci-fi. Let me think of movies with great action sequences that are also well-regarded critically...",
+      },
+      {
+        type: "text",
+        text: "For action sci-fi, check out Edge of Tomorrow (2014) starring Tom Cruise and Emily Blunt! It's a thrilling time-loop movie where a soldier relives the same battle against alien invaders, getting better each time.\n\nThink Groundhog Day meets intense military sci-fi. The action sequences are fantastic and it has a great sense of humor too.",
+      },
+    ],
+  },
+];
+
+export function ChatMessagesSection({
+  emptyState,
+  typingIndicatorLabel,
+  scrollToBottomLabel,
+}: ChatMessagesSectionProps) {
+  return (
+    <ChatMessageList
+      messages={demoMessages}
+      status="submitted"
+      emptyState={emptyState}
+      typingIndicatorLabel={typingIndicatorLabel}
+      scrollToBottomLabel={scrollToBottomLabel}
+    />
+  );
+}

--- a/src/app/[locale]/movie-database/ai-mode/page.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/page.tsx
@@ -4,6 +4,7 @@ import type { SupportedLocale } from "#src/types.ts";
 import { getTranslations } from "#src/utils/get-translations.ts";
 import { validateLocale } from "#src/utils/validate-locale.ts";
 import { ChatInputSection } from "./chat-input-section";
+import { ChatMessagesSection } from "./chat-messages-section";
 import translations from "./translations.json";
 
 export default async function Page({
@@ -17,12 +18,16 @@ export default async function Page({
 
   return (
     <>
-      <div css={styles.messagesArea}>
-        <div css={styles.welcomeContainer}>
-          <h1 css={styles.welcomeTitle}>{t("title")}</h1>
-          <p css={styles.welcomeDescription}>{t("description")}</p>
-        </div>
-      </div>
+      <ChatMessagesSection
+        emptyState={
+          <div css={styles.welcomeContainer}>
+            <h1 css={styles.welcomeTitle}>{t("title")}</h1>
+            <p css={styles.welcomeDescription}>{t("description")}</p>
+          </div>
+        }
+        typingIndicatorLabel={t("typingIndicator")}
+        scrollToBottomLabel={t("scrollToBottom")}
+      />
       <div css={styles.inputArea}>
         <ChatInputSection
           placeholder={t("placeholder")}
@@ -35,14 +40,6 @@ export default async function Page({
 }
 
 const styles = stylex.create({
-  messagesArea: {
-    flexGrow: 1,
-    overflowY: "auto",
-    padding: space._3,
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-  },
   welcomeContainer: {
     textAlign: "center",
   },
@@ -59,11 +56,14 @@ const styles = stylex.create({
     margin: 0,
   },
   inputArea: {
+    position: "sticky",
+    bottom: 0,
     flexShrink: 0,
     padding: space._3,
     paddingBottom: `calc(${space._3} + env(safe-area-inset-bottom))`,
     borderTopWidth: border.size_1,
     borderTopStyle: "solid",
     borderTopColor: color.controlTrack,
+    backgroundColor: color.backgroundMain,
   },
 });

--- a/src/app/[locale]/movie-database/ai-mode/translations.json
+++ b/src/app/[locale]/movie-database/ai-mode/translations.json
@@ -22,5 +22,13 @@
   "stopLabel": {
     "en": "Stop generating",
     "zh": "停止生成"
+  },
+  "typingIndicator": {
+    "en": "AI is thinking…",
+    "zh": "AI 正在思考…"
+  },
+  "scrollToBottom": {
+    "en": "Scroll to bottom",
+    "zh": "滚动到底部"
   }
 }

--- a/src/components/ai-chat/chat-message-list.test.tsx
+++ b/src/components/ai-chat/chat-message-list.test.tsx
@@ -1,0 +1,101 @@
+import type { UIMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { render, screen } from "#src/test-utils.tsx";
+import { ChatMessageList } from "./chat-message-list";
+
+function createMessage(
+  overrides: Partial<UIMessage> & Pick<UIMessage, "id" | "role" | "parts">,
+): UIMessage {
+  return overrides;
+}
+
+const defaultProps = {
+  emptyState: <div>Welcome to AI Mode</div>,
+  typingIndicatorLabel: "AI is thinking…",
+  scrollToBottomLabel: "Scroll to bottom",
+};
+
+describe("ChatMessageList", () => {
+  it("renders empty state when messages is empty", () => {
+    render(<ChatMessageList messages={[]} status="ready" {...defaultProps} />);
+    expect(screen.getByText("Welcome to AI Mode")).toBeInTheDocument();
+  });
+
+  it("renders messages when provided", () => {
+    const messages = [
+      createMessage({
+        id: "1",
+        role: "user",
+        parts: [{ type: "text", text: "Recommend a movie" }],
+      }),
+      createMessage({
+        id: "2",
+        role: "assistant",
+        parts: [{ type: "text", text: "Try Inception!" }],
+      }),
+    ];
+
+    render(
+      <ChatMessageList messages={messages} status="ready" {...defaultProps} />,
+    );
+    expect(screen.getByText("Recommend a movie")).toBeInTheDocument();
+    expect(screen.getByText("Try Inception!")).toBeInTheDocument();
+  });
+
+  it("does not show empty state when messages exist", () => {
+    const messages = [
+      createMessage({
+        id: "1",
+        role: "user",
+        parts: [{ type: "text", text: "Hello" }],
+      }),
+    ];
+
+    render(
+      <ChatMessageList messages={messages} status="ready" {...defaultProps} />,
+    );
+    expect(screen.queryByText("Welcome to AI Mode")).not.toBeInTheDocument();
+  });
+
+  it("shows typing indicator when status is submitted", () => {
+    const messages = [
+      createMessage({
+        id: "1",
+        role: "user",
+        parts: [{ type: "text", text: "Hello" }],
+      }),
+    ];
+
+    render(
+      <ChatMessageList
+        messages={messages}
+        status="submitted"
+        {...defaultProps}
+      />,
+    );
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByText("AI is thinking…")).toBeInTheDocument();
+  });
+
+  it("hides typing indicator when status is ready", () => {
+    const messages = [
+      createMessage({
+        id: "1",
+        role: "user",
+        parts: [{ type: "text", text: "Hello" }],
+      }),
+    ];
+
+    render(
+      <ChatMessageList messages={messages} status="ready" {...defaultProps} />,
+    );
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("renders scroll-to-bottom button", () => {
+    render(<ChatMessageList messages={[]} status="ready" {...defaultProps} />);
+    expect(
+      screen.getByRole("button", { name: "Scroll to bottom" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/ai-chat/chat-message-list.tsx
+++ b/src/components/ai-chat/chat-message-list.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import type { ChatStatus, UIMessage } from "ai";
+import { type ReactNode, useEffect, useState } from "react";
+import { space } from "#src/tokens.stylex.ts";
+import { ChatMessage } from "./chat-message";
+import { ScrollToBottomButton } from "./scroll-to-bottom-button";
+import { TypingIndicator } from "./typing-indicator";
+
+const SCROLL_THRESHOLD = 50;
+
+interface ChatMessageListProps {
+  messages: ReadonlyArray<UIMessage>;
+  status: ChatStatus;
+  emptyState: ReactNode;
+  typingIndicatorLabel: string;
+  scrollToBottomLabel: string;
+}
+
+export function ChatMessageList({
+  messages,
+  status,
+  emptyState,
+  typingIndicatorLabel,
+  scrollToBottomLabel,
+}: ChatMessageListProps) {
+  const [isAtBottom, setIsAtBottom] = useState(true);
+
+  const scrollToBottom = () => {
+    window.scrollTo({
+      top: document.documentElement.scrollHeight,
+      behavior: "smooth",
+    });
+    setIsAtBottom(true);
+  };
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const { scrollHeight } = document.documentElement;
+      const atBottom =
+        scrollHeight - window.scrollY - window.innerHeight < SCROLL_THRESHOLD;
+      setIsAtBottom(atBottom);
+    };
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  const lastMessageRole =
+    messages.length > 0 ? messages[messages.length - 1]?.role : undefined;
+
+  useEffect(() => {
+    if (messages.length === 0) return;
+    if (isAtBottom || lastMessageRole === "user") {
+      window.scrollTo({ top: document.documentElement.scrollHeight });
+    }
+  }, [messages.length, lastMessageRole, isAtBottom]);
+
+  const showTypingIndicator = status === "submitted";
+
+  return (
+    <div css={styles.container}>
+      {messages.length === 0 ? (
+        <div css={styles.emptyStateWrapper}>{emptyState}</div>
+      ) : (
+        <div css={styles.messagesList}>
+          {messages.map((message) => (
+            <ChatMessage key={message.id} message={message} />
+          ))}
+          {showTypingIndicator && (
+            <TypingIndicator label={typingIndicatorLabel} />
+          )}
+        </div>
+      )}
+      <ScrollToBottomButton
+        visible={!isAtBottom && messages.length > 0}
+        label={scrollToBottomLabel}
+        onClick={scrollToBottom}
+      />
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  container: {
+    flexGrow: 1,
+    display: "flex",
+    flexDirection: "column",
+    padding: space._3,
+  },
+  emptyStateWrapper: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexGrow: 1,
+  },
+  messagesList: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space._2,
+  },
+});

--- a/src/components/ai-chat/chat-message.test.tsx
+++ b/src/components/ai-chat/chat-message.test.tsx
@@ -1,0 +1,79 @@
+import type { UIMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { render, screen } from "#src/test-utils.tsx";
+import { ChatMessage } from "./chat-message";
+
+function createMessage(
+  overrides: Partial<UIMessage> & Pick<UIMessage, "role" | "parts">,
+): UIMessage {
+  return {
+    id: "test-message",
+    ...overrides,
+  };
+}
+
+describe("ChatMessage", () => {
+  it("renders user message text", () => {
+    render(
+      <ChatMessage
+        message={createMessage({
+          role: "user",
+          parts: [{ type: "text", text: "Hello there" }],
+        })}
+      />,
+    );
+    expect(screen.getByText("Hello there")).toBeInTheDocument();
+  });
+
+  it("renders assistant message text", () => {
+    render(
+      <ChatMessage
+        message={createMessage({
+          role: "assistant",
+          parts: [{ type: "text", text: "Hi! How can I help?" }],
+        })}
+      />,
+    );
+    expect(screen.getByText("Hi! How can I help?")).toBeInTheDocument();
+  });
+
+  it("renders multiple text parts", () => {
+    render(
+      <ChatMessage
+        message={createMessage({
+          role: "assistant",
+          parts: [
+            { type: "text", text: "First paragraph" },
+            { type: "text", text: "Second paragraph" },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText("First paragraph")).toBeInTheDocument();
+    expect(screen.getByText("Second paragraph")).toBeInTheDocument();
+  });
+
+  it("renders reasoning parts", () => {
+    render(
+      <ChatMessage
+        message={createMessage({
+          role: "assistant",
+          parts: [{ type: "reasoning", text: "Thinking about this..." }],
+        })}
+      />,
+    );
+    expect(screen.getByText("Thinking about this...")).toBeInTheDocument();
+  });
+
+  it("does not crash on step-start parts", () => {
+    render(
+      <ChatMessage
+        message={createMessage({
+          role: "assistant",
+          parts: [{ type: "step-start" }, { type: "text", text: "After step" }],
+        })}
+      />,
+    );
+    expect(screen.getByText("After step")).toBeInTheDocument();
+  });
+});

--- a/src/components/ai-chat/chat-message.tsx
+++ b/src/components/ai-chat/chat-message.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { isReasoningUIPart, isTextUIPart, type UIMessage } from "ai";
+import { memo } from "react";
+import { border, color, font, space } from "#src/tokens.stylex.ts";
+
+interface ChatMessageProps {
+  message: UIMessage;
+}
+
+export const ChatMessage = memo(function ChatMessage({
+  message,
+}: ChatMessageProps) {
+  const isUser = message.role === "user";
+
+  return (
+    <div
+      css={[styles.bubble, isUser ? styles.userBubble : styles.assistantBubble]}
+    >
+      {message.parts.map((part, index) => {
+        if (isTextUIPart(part)) {
+          return (
+            <p key={index} css={[styles.partBase, styles.text]}>
+              {part.text}
+            </p>
+          );
+        }
+
+        if (isReasoningUIPart(part)) {
+          return (
+            <p key={index} css={[styles.partBase, styles.reasoning]}>
+              {part.text}
+            </p>
+          );
+        }
+
+        // Other part types handled in #1651
+        return null;
+      })}
+    </div>
+  );
+});
+
+const styles = stylex.create({
+  bubble: {
+    maxWidth: "85%",
+    paddingBlock: space._2,
+    paddingInline: space._3,
+  },
+  userBubble: {
+    marginLeft: "auto",
+    backgroundColor: color.controlActive,
+    color: color.textOnActive,
+    borderRadius: border.radius_3,
+    borderBottomRightRadius: border.radius_1,
+  },
+  assistantBubble: {
+    marginRight: "auto",
+    backgroundColor: color.backgroundRaised,
+    color: color.textMain,
+    borderRadius: border.radius_3,
+    borderBottomLeftRadius: border.radius_1,
+  },
+  partBase: {
+    margin: 0,
+    whiteSpace: "pre-wrap",
+    wordBreak: "break-word",
+    lineHeight: font.lineHeight_4,
+  },
+  text: {
+    fontSize: font.uiBody,
+  },
+  reasoning: {
+    fontSize: font.uiBodySmall,
+    color: color.textMuted,
+    fontStyle: "italic",
+  },
+});

--- a/src/components/ai-chat/scroll-to-bottom-button.test.tsx
+++ b/src/components/ai-chat/scroll-to-bottom-button.test.tsx
@@ -1,0 +1,35 @@
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "#src/test-utils.tsx";
+import { ScrollToBottomButton } from "./scroll-to-bottom-button";
+
+describe("ScrollToBottomButton", () => {
+  it("renders button with correct aria-label", () => {
+    render(
+      <ScrollToBottomButton
+        visible={true}
+        label="Scroll to bottom"
+        onClick={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Scroll to bottom" }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onClick when clicked", async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(
+      <ScrollToBottomButton
+        visible={true}
+        label="Scroll to bottom"
+        onClick={handleClick}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Scroll to bottom" }));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ai-chat/scroll-to-bottom-button.tsx
+++ b/src/components/ai-chat/scroll-to-bottom-button.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { ArrowDownIcon } from "@phosphor-icons/react/dist/ssr/ArrowDown";
+import * as stylex from "@stylexjs/stylex";
+import { border, color, shadow, space } from "#src/tokens.stylex.ts";
+
+const REDUCED_MOTION = "@media (prefers-reduced-motion: reduce)";
+
+interface ScrollToBottomButtonProps {
+  visible: boolean;
+  label: string;
+  onClick: () => void;
+}
+
+export function ScrollToBottomButton({
+  visible,
+  label,
+  onClick,
+}: ScrollToBottomButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={onClick}
+      css={[styles.button, visible ? styles.visible : styles.hidden]}
+    >
+      <ArrowDownIcon weight="bold" role="presentation" />
+    </button>
+  );
+}
+
+const styles = stylex.create({
+  button: {
+    position: "fixed",
+    bottom: `calc(${space._10} + env(safe-area-inset-bottom))`,
+    left: "50%",
+    transform: "translateX(-50%)",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "2rem",
+    height: "2rem",
+    borderRadius: border.radius_round,
+    borderWidth: 0,
+    borderStyle: "none",
+    appearance: "none",
+    cursor: "pointer",
+    padding: 0,
+    backgroundColor: color.backgroundRaised,
+    color: {
+      default: color.textMuted,
+      ":hover": color.textMain,
+    },
+    boxShadow: shadow._2,
+    transition: {
+      default: "opacity 0.2s ease, transform 0.2s ease",
+      [REDUCED_MOTION]: "opacity 0.2s ease",
+    },
+  },
+  visible: {
+    opacity: 1,
+    pointerEvents: "auto",
+  },
+  hidden: {
+    opacity: 0,
+    pointerEvents: "none",
+  },
+});

--- a/src/components/ai-chat/typing-indicator.test.tsx
+++ b/src/components/ai-chat/typing-indicator.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "#src/test-utils.tsx";
+import { TypingIndicator } from "./typing-indicator";
+
+describe("TypingIndicator", () => {
+  it("renders with role status", () => {
+    render(<TypingIndicator label="AI is thinking…" />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("displays the label text", () => {
+    render(<TypingIndicator label="AI is thinking…" />);
+    expect(screen.getByText("AI is thinking…")).toBeInTheDocument();
+  });
+
+  it("has aria-label matching the label prop", () => {
+    render(<TypingIndicator label="AI is thinking…" />);
+    expect(screen.getByRole("status")).toHaveAttribute(
+      "aria-label",
+      "AI is thinking…",
+    );
+  });
+});

--- a/src/components/ai-chat/typing-indicator.tsx
+++ b/src/components/ai-chat/typing-indicator.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { color, font, space } from "#src/tokens.stylex.ts";
+
+const DOT_COUNT = 3;
+const DOT_DELAY_MS = 160;
+
+interface TypingIndicatorProps {
+  label: string;
+}
+
+export function TypingIndicator({ label }: TypingIndicatorProps) {
+  return (
+    <div role="status" aria-label={label} css={styles.container}>
+      {Array.from({ length: DOT_COUNT }, (_, i) => (
+        <span
+          key={i}
+          css={styles.dot}
+          style={{ animationDelay: `${i * DOT_DELAY_MS}ms` }}
+        />
+      ))}
+      <span css={styles.label}>{label}</span>
+    </div>
+  );
+}
+
+const bounce = stylex.keyframes({
+  "0%, 80%, 100%": { opacity: 0.3, transform: "scale(0.8)" },
+  "40%": { opacity: 1, transform: "scale(1)" },
+});
+
+const styles = stylex.create({
+  container: {
+    display: "flex",
+    alignItems: "center",
+    gap: space._1,
+    paddingBlock: space._1,
+  },
+  dot: {
+    width: "0.375rem",
+    height: "0.375rem",
+    borderRadius: "50%",
+    backgroundColor: color.textMuted,
+    animationName: bounce,
+    animationDuration: "1.4s",
+    animationTimingFunction: "ease-in-out",
+    animationIterationCount: "infinite",
+    animationFillMode: "both",
+  },
+  label: {
+    fontSize: font.uiBodySmall,
+    color: color.textMuted,
+    marginLeft: space._1,
+  },
+});


### PR DESCRIPTION
## Summary

Adds the core message display components for the AI chat interface in movie database AI mode. This includes chat message bubbles (user and assistant variants), a scrollable message list with auto-scroll behavior, an animated typing indicator for when the AI is processing, and a floating scroll-to-bottom button. The AI mode layout is also adjusted to properly fill the full viewport height for a chat-style interface.

These components build on the page scaffold (#1691) and input bar (#1694), providing the visual layer needed before wiring up actual AI message streaming.

Closes #1660