### PR TITLE
fix: respect caller's prefetch prop in Anchor component

### DIFF
--- a/src/components/shared/anchor.tsx
+++ b/src/components/shared/anchor.tsx
@@ -9,16 +9,16 @@ import { anchorTokens } from "./anchor.stylex";
 export const Anchor = forwardRef<
   HTMLAnchorElement,
   React.ComponentProps<typeof Link>
->(function Anchor({ className, style, onMouseEnter, ...props }, ref) {
-  const [prefetch, setPrefetch] = useState(false);
+>(function Anchor({ className, style, prefetch, onMouseEnter, ...props }, ref) {
+  const [hovered, setHovered] = useState(false);
 
   return (
     <Link
       {...props}
       ref={ref}
-      prefetch={prefetch ? null : false}
+      prefetch={prefetch === false ? false : hovered ? null : false}
       onMouseEnter={(e) => {
-        setPrefetch(true);
+        setHovered(true);
         onMouseEnter?.(e);
       }}
       className={className}


### PR DESCRIPTION
## Summary

The `Anchor` component previously managed prefetch as internal-only state, always enabling hover-based prefetching regardless of what the caller passed. This change accepts `prefetch` as a prop so callers can opt out of prefetching entirely by passing `prefetch={false}`. The internal state variable is also renamed from `prefetch` to `hovered` for clarity, since it tracks hover state rather than prefetch intent.