### PR TITLE
feat: add TMDB multi-search tool to AI chat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,4 +26,8 @@ pnpm test               # Run unit tests (Vitest)
 pnpm test:e2e           # Run E2E tests (Playwright) - auto-starts dev server
 pnpm codegen            # Generate TMDB API types and server functions
 pnpm codegen:tmdb       # Generate only TMDB server functions
+pnpm eval               # Run ALL AI chat evals (expensive - hits real LLM APIs)
+pnpm eval <filter>      # Run a subset of evals matching the filter, e.g. `pnpm eval tmdb-search`
 ```
+
+- **Evals are expensive** (they hit real LLM APIs). When working on a specific eval, use `pnpm eval <name>` to run only that file (e.g. `pnpm eval tmdb-search`). Only run `pnpm eval` without a filter when a full eval suite run is needed.

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "eslint-plugin-unicorn": "^62.0.0",
     "jsdom": "^27.4.0",
     "modern-normalize": "^3.0.1",
+    "msw": "^2.12.14",
     "next-i18n-router": "^5.5.6",
     "npm-run-all2": "^8.0.4",
     "openapi-typescript": "^7.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       modern-normalize:
         specifier: ^3.0.1
         version: 3.0.1
+      msw:
+        specifier: ^2.12.14
+        version: 2.12.14(@types/node@25.2.3)(typescript@5.9.3)
       next-i18n-router:
         specifier: ^5.5.6
         version: 5.5.6(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.0)(babel-plugin-react-compiler@19.0.0-beta-714736e-20250131)(react-dom@19.3.0-canary-52684925-20251110(react@19.3.0-canary-52684925-20251110))(react@19.3.0-canary-52684925-20251110))
@@ -230,7 +233,7 @@ importers:
         version: 1.4.1(@babel/core@7.29.0)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0))
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.46.0)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@27.4.0)(msw@2.12.14(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)
 
 packages:
 
@@ -1315,6 +1318,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@inquirer/ansi@1.0.2':
+    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
+    engines: {node: '>=18'}
+
   '@inquirer/ansi@2.0.2':
     resolution: {integrity: sha512-SYLX05PwJVnW+WVegZt1T4Ip1qba1ik+pNJPDiqvk6zS5Y/i8PhRzLpGEtVd7sW0G8cMtkD8t4AZYhQwm8vnww==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
@@ -1328,9 +1335,27 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/confirm@5.1.21':
+    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/confirm@6.0.3':
     resolution: {integrity: sha512-lyEvibDFL+NA5R4xl8FUmNhmu81B+LDL9L/MpKkZlQDJZXzG8InxiqYxiAlQYa9cqLLhYqKLQwZqXmSTqCLjyw==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.3.2':
+    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
+    engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1372,6 +1397,10 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
 
   '@inquirer/figures@2.0.2':
     resolution: {integrity: sha512-qXm6EVvQx/FmnSrCWCIGtMHwqeLgxABP8XgcaAoywsL0NFga9gD5kfG0gXiv80GjK9Hsoz4pgGwF/+CjygyV9A==}
@@ -1440,6 +1469,15 @@ packages:
       '@types/node':
         optional: true
 
+  '@inquirer/type@3.0.10':
+    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/type@4.0.2':
     resolution: {integrity: sha512-cae7mzluplsjSdgFA6ACLygb5jC8alO0UUnFPyu0E7tNRPrL+q/f8VcSXp+cjZQ7l5CMpDpi2G1+IQvkOiL1Lw==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
@@ -1479,6 +1517,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mswjs/interceptors@0.41.3':
+    resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
+    engines: {node: '>=18'}
 
   '@mui/types@7.4.10':
     resolution: {integrity: sha512-0+4mSjknSu218GW3isRqoxKRTOrTLd/vHi/7UC4+wZcUrOAqD9kRk7UQRL1mcrzqRoe7s3UT6rsRpbLkW5mHpQ==}
@@ -1573,6 +1615,15 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -1937,6 +1988,9 @@ packages:
 
   '@types/react@19.2.10':
     resolution: {integrity: sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==}
+
+  '@types/statuses@2.0.6':
+    resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -2597,6 +2651,10 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -2644,6 +2702,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   core-js-compat@3.46.0:
     resolution: {integrity: sha512-p9hObIIEENxSV8xIu+V68JjSeARg6UVMG5mR+JEUguG3sI6MsiS1njz2jHmyJDvA+8jX/sytkBHup6kxhM9law==}
@@ -3225,6 +3287,10 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-east-asian-width@1.4.0:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
     engines: {node: '>=18'}
@@ -3299,6 +3365,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  graphql@16.13.2:
+    resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -3331,6 +3401,9 @@ packages:
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  headers-polyfill@4.0.3:
+    resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -3512,6 +3585,9 @@ packages:
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-npm@6.1.0:
     resolution: {integrity: sha512-O2z4/kNgyjhQwVR1Wpkbfc19JIhggF97NZNCpWTnjH7kVcZMUrnut9XSN7txI7VdyIYk5ZatOq3zvSuWpU8hoA==}
@@ -3978,6 +4054,20 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msw@2.12.14:
+    resolution: {integrity: sha512-4KXa4nVBIBjbDbd7vfQNuQ25eFxug0aropCQFoI0JdOBuJWamkT1yLVIWReFI8SiTRc+H1hKzaNk+cLk2N9rtQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   mute-stream@3.0.0:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -4101,6 +4191,9 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -4172,6 +4265,9 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -4571,6 +4667,10 @@ packages:
     resolution: {integrity: sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==}
     engines: {node: '>=0.10.0'}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -4598,6 +4698,9 @@ packages:
     resolution: {integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  rettime@0.10.1:
+    resolution: {integrity: sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -4759,12 +4862,19 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
   string-ts@2.3.1:
     resolution: {integrity: sha512-xSJq+BS52SaFFAVxuStmx6n5aYZU571uYUnUrPXkPFCfdHyZMMlbP2v2Wx5sNBnAVzq/2+0+mcBLBa3Xa5ubYw==}
@@ -4895,6 +5005,10 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
@@ -5006,6 +5120,10 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
+  type-fest@5.5.0:
+    resolution: {integrity: sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==}
+    engines: {node: '>=20'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -5061,6 +5179,9 @@ packages:
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+
+  until-async@3.0.2:
+    resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -5277,6 +5398,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -5316,6 +5441,10 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -5326,9 +5455,17 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
 
   zod-to-json-schema@3.24.6:
     resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
@@ -6311,6 +6448,8 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@inquirer/ansi@1.0.2': {}
+
   '@inquirer/ansi@2.0.2': {}
 
   '@inquirer/checkbox@5.0.3(@types/node@25.2.3)':
@@ -6322,10 +6461,30 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.2.3
 
+  '@inquirer/confirm@5.1.21(@types/node@25.2.3)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.2.3)
+      '@inquirer/type': 3.0.10(@types/node@25.2.3)
+    optionalDependencies:
+      '@types/node': 25.2.3
+
   '@inquirer/confirm@6.0.3(@types/node@25.2.3)':
     dependencies:
       '@inquirer/core': 11.1.0(@types/node@25.2.3)
       '@inquirer/type': 4.0.2(@types/node@25.2.3)
+    optionalDependencies:
+      '@types/node': 25.2.3
+
+  '@inquirer/core@10.3.2(@types/node@25.2.3)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@25.2.3)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 25.2.3
 
@@ -6362,6 +6521,8 @@ snapshots:
       iconv-lite: 0.7.1
     optionalDependencies:
       '@types/node': 25.2.3
+
+  '@inquirer/figures@1.0.15': {}
 
   '@inquirer/figures@2.0.2': {}
 
@@ -6426,6 +6587,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.2.3
 
+  '@inquirer/type@3.0.10(@types/node@25.2.3)':
+    optionalDependencies:
+      '@types/node': 25.2.3
+
   '@inquirer/type@4.0.2(@types/node@25.2.3)':
     optionalDependencies:
       '@types/node': 25.2.3
@@ -6468,6 +6633,15 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mswjs/interceptors@0.41.3':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
 
   '@mui/types@7.4.10(@types/react@19.2.10)':
     dependencies:
@@ -6541,6 +6715,15 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@opentelemetry/api@1.9.0': {}
 
@@ -6915,6 +7098,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/statuses@2.0.6': {}
+
   '@types/trusted-types@2.0.7': {}
 
   '@types/unist@2.0.11': {}
@@ -7174,7 +7359,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.46.0)(tsx@4.21.0)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@27.4.0)(msw@2.12.14(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -7185,12 +7370,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.18(msw@2.12.14(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
+      msw: 2.12.14(@types/node@25.2.3)(typescript@5.9.3)
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.0.18':
@@ -7219,7 +7405,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.46.0)(tsx@4.21.0)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@27.4.0)(msw@2.12.14(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)
 
   '@vitest/utils@4.0.18':
     dependencies:
@@ -7611,6 +7797,12 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   clsx@2.1.1: {}
 
   color-convert@2.0.1:
@@ -7648,6 +7840,8 @@ snapshots:
   convert-hrtime@5.0.0: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
 
   core-js-compat@3.46.0:
     dependencies:
@@ -8463,6 +8657,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-caller-file@2.0.5: {}
+
   get-east-asian-width@1.4.0: {}
 
   get-intrinsic@1.3.0:
@@ -8542,6 +8738,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  graphql@16.13.2: {}
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -8587,6 +8785,8 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  headers-polyfill@4.0.3: {}
 
   hermes-estree@0.25.1: {}
 
@@ -8761,6 +8961,8 @@ snapshots:
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
+
+  is-node-process@1.2.0: {}
 
   is-npm@6.1.0: {}
 
@@ -9417,6 +9619,33 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msw@2.12.14(@types/node@25.2.3)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 5.1.21(@types/node@25.2.3)
+      '@mswjs/interceptors': 0.41.3
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.13.2
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.10.1
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.0
+      type-fest: 5.5.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  mute-stream@2.0.0: {}
+
   mute-stream@3.0.0: {}
 
   nanoid@3.3.11: {}
@@ -9552,6 +9781,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  outvariant@1.4.3: {}
+
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -9627,6 +9858,8 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
+
+  path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
 
@@ -10109,6 +10342,8 @@ snapshots:
 
   repeat-element@1.1.4: {}
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
 
   reselect@4.1.8: {}
@@ -10133,6 +10368,8 @@ snapshots:
       object-keys: 1.1.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  rettime@0.10.1: {}
 
   reusify@1.1.0: {}
 
@@ -10354,12 +10591,16 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  statuses@2.0.2: {}
+
   std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  strict-event-emitter@0.5.1: {}
 
   string-ts@2.3.1: {}
 
@@ -10512,6 +10753,8 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
+  tagged-tag@1.0.0: {}
+
   tapable@2.3.0: {}
 
   terser-webpack-plugin@5.3.16(esbuild@0.27.2)(webpack@5.97.1(esbuild@0.27.2)):
@@ -10606,6 +10849,10 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-fest@4.41.0: {}
+
+  type-fest@5.5.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -10719,6 +10966,8 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
+  until-async@3.0.2: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
@@ -10795,10 +11044,10 @@ snapshots:
       terser: 5.46.0
       tsx: 4.21.0
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.46.0)(tsx@4.21.0):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@27.4.0)(msw@2.12.14(@types/node@25.2.3)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.18(msw@2.12.14(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(terser@5.46.0)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -10957,6 +11206,12 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -10985,13 +11240,27 @@ snapshots:
 
   xtend@4.0.2: {}
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
 
   yaml-ast-parser@0.0.43: {}
 
   yargs-parser@21.1.1: {}
 
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
   yocto-queue@0.1.0: {}
+
+  yoctocolors-cjs@2.1.3: {}
 
   zod-to-json-schema@3.24.6(zod@3.25.76):
     dependencies:

--- a/src/_generated/tmdb-endpoints.ts
+++ b/src/_generated/tmdb-endpoints.ts
@@ -15,6 +15,7 @@ export type TMDBEndpointPaths =
   | "/3/movie/{movie_id}/recommendations"
   | "/3/movie/{movie_id}/videos"
   | "/3/search/movie"
+  | "/3/search/multi"
   | "/3/search/person"
   | "/3/search/tv"
   | "/3/trending/movie/{time_window}"
@@ -35,6 +36,7 @@ export const TMDB_ENDPOINTS = [
   "/3/movie/{movie_id}/recommendations",
   "/3/movie/{movie_id}/videos",
   "/3/search/movie",
+  "/3/search/multi",
   "/3/search/person",
   "/3/search/tv",
   "/3/trending/movie/{time_window}",

--- a/src/_generated/tmdb-server-functions.ts
+++ b/src/_generated/tmdb-server-functions.ts
@@ -147,6 +147,12 @@ export async function searchMovies(
   return tmdbGet("/3/search/movie", params);
 }
 
+export async function searchMulti(
+  params: QueryParams<"/3/search/multi", "get">,
+) {
+  return tmdbGet("/3/search/multi", params);
+}
+
 export async function searchPerson(
   params: QueryParams<"/3/search/person", "get">,
 ) {

--- a/src/ai-chat/chat.ts
+++ b/src/ai-chat/chat.ts
@@ -6,6 +6,7 @@ import { getAnthropicModel } from "./client";
 import type { ChatInput } from "./schema";
 import { getChatSystemInstructions } from "./system-instructions";
 import { createSemanticSearchTool } from "./tools/semantic-search";
+import { createTmdbSearchTool } from "./tools/tmdb-search";
 
 export { chatInputSchema, type ChatInput } from "./schema";
 
@@ -21,7 +22,10 @@ export async function chat({ messages, locale, model }: ChatOptions) {
     model: model ?? getAnthropicModel(),
     system,
     messages: modelMessages,
-    tools: { semantic_search: createSemanticSearchTool(locale) },
+    tools: {
+      semantic_search: createSemanticSearchTool(locale),
+      tmdb_search: createTmdbSearchTool(locale),
+    },
     stopWhen: stepCountIs(5),
     prepareStep: ({ messages, model }) => ({
       messages: addCacheControlToMessages({ messages, model }),

--- a/src/ai-chat/eval/tmdb-search.eval.ts
+++ b/src/ai-chat/eval/tmdb-search.eval.ts
@@ -1,0 +1,78 @@
+import { describe, it } from "vitest";
+import { runSingleTurnEval } from "./run-eval";
+import type { EvalCase } from "./types";
+
+const cases: EvalCase[] = [
+  {
+    name: "Look up a movie by title",
+    input: "Look up the movie Interstellar",
+    criteria: [
+      "Provides information about the 2014 film Interstellar directed by Christopher Nolan",
+      "Mentions key details such as genre, plot summary, or cast",
+    ],
+    requireToolCall: "tmdb_search",
+    deterministic: [
+      { type: "min-length", value: 50, label: "Response is at least 50 chars" },
+      {
+        type: "not-contains",
+        value: "http://",
+        label: "No http:// URLs in response",
+      },
+      {
+        type: "not-contains",
+        value: "https://",
+        label: "No https:// URLs in response",
+      },
+    ],
+  },
+  {
+    name: "Look up a TV show by title",
+    input: "Tell me about the TV show Breaking Bad",
+    criteria: [
+      "Provides information about the TV series Breaking Bad",
+      "Mentions key details such as genre, plot summary, or cast",
+    ],
+    requireToolCall: "tmdb_search",
+    deterministic: [
+      { type: "min-length", value: 50, label: "Response is at least 50 chars" },
+      {
+        type: "not-contains",
+        value: "http://",
+        label: "No http:// URLs in response",
+      },
+      {
+        type: "not-contains",
+        value: "https://",
+        label: "No https:// URLs in response",
+      },
+    ],
+  },
+  {
+    name: "Look up a person by name",
+    input: "Look up director Christopher Nolan",
+    criteria: [
+      "Identifies Christopher Nolan as a film director",
+      "Mentions notable films he has directed",
+    ],
+    requireToolCall: "tmdb_search",
+    deterministic: [
+      { type: "min-length", value: 50, label: "Response is at least 50 chars" },
+      {
+        type: "not-contains",
+        value: "http://",
+        label: "No http:// URLs in response",
+      },
+      {
+        type: "not-contains",
+        value: "https://",
+        label: "No https:// URLs in response",
+      },
+    ],
+  },
+];
+
+describe("Title search", () => {
+  it.each(cases)("$name", async (evalCase) => {
+    await runSingleTurnEval(evalCase);
+  });
+});

--- a/src/ai-chat/tools/tmdb-search.test.ts
+++ b/src/ai-chat/tools/tmdb-search.test.ts
@@ -1,0 +1,286 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { server } from "#src/test-msw.ts";
+import { createTmdbSearchTool, tmdbSearchInputSchema } from "./tmdb-search";
+
+const TMDB_BASE = "https://api.themoviedb.org";
+
+function movieResult(overrides: { id: number; title: string }) {
+  return {
+    adult: false,
+    id: overrides.id,
+    title: overrides.title,
+    media_type: "movie",
+    overview: "A test movie overview",
+    release_date: "2023-01-01",
+    vote_average: 7.5,
+    vote_count: 100,
+    genre_ids: [28, 878],
+    original_language: "en",
+    original_title: overrides.title,
+    popularity: 50,
+    video: false,
+  };
+}
+
+function tvResult(overrides: { id: number; name: string }) {
+  return {
+    adult: false,
+    id: overrides.id,
+    name: overrides.name,
+    media_type: "tv",
+    overview: "A test TV overview",
+    first_air_date: "2023-06-01",
+    vote_average: 8.0,
+    vote_count: 200,
+    genre_ids: [18],
+    original_language: "en",
+    original_name: overrides.name,
+    popularity: 60,
+    origin_country: ["US"],
+  };
+}
+
+function personResult(overrides: { id: number; name: string }) {
+  return {
+    adult: false,
+    id: overrides.id,
+    name: overrides.name,
+    media_type: "person",
+    popularity: 40,
+    original_name: overrides.name,
+  };
+}
+
+describe("tmdbSearchInputSchema", () => {
+  it("accepts a valid query", () => {
+    const result = tmdbSearchInputSchema.parse({ query: "Inception" });
+    expect(result.query).toBe("Inception");
+  });
+
+  it("rejects missing query", () => {
+    expect(() => tmdbSearchInputSchema.parse({})).toThrow();
+  });
+
+  it("rejects non-string query", () => {
+    expect(() => tmdbSearchInputSchema.parse({ query: 42 })).toThrow();
+  });
+});
+
+describe("createTmdbSearchTool", () => {
+  it("returns a tool with description and inputSchema", () => {
+    const tool = createTmdbSearchTool("en");
+    expect(tool.description).toBeDefined();
+    expect(tool.description).toContain("TMDB");
+    expect(tool.inputSchema).toBeDefined();
+  });
+
+  it("returns a tool with an execute function", () => {
+    const tool = createTmdbSearchTool("en");
+    expect(tool.execute).toBeDefined();
+    expect(typeof tool.execute).toBe("function");
+  });
+
+  it("creates separate tool instances per locale", () => {
+    const enTool = createTmdbSearchTool("en");
+    const zhTool = createTmdbSearchTool("zh");
+    expect(enTool).not.toBe(zhTool);
+  });
+});
+
+describe("tmdb search execute", () => {
+  it("returns movies, TV shows, and people from a single search", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/search/multi`, () =>
+        HttpResponse.json({
+          page: 1,
+          results: [
+            movieResult({ id: 1, title: "Dune" }),
+            tvResult({ id: 2, name: "Dune: Prophecy" }),
+            personResult({ id: 3, name: "Timothée Chalamet" }),
+          ],
+          total_pages: 1,
+          total_results: 3,
+        }),
+      ),
+    );
+
+    const tool = createTmdbSearchTool("en");
+    const results = await tool.execute!(
+      { query: "Dune" },
+      {
+        toolCallId: "test",
+        messages: [],
+        abortSignal: AbortSignal.timeout(5000),
+      },
+    );
+
+    expect(results).toHaveLength(3);
+    expect(results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 1,
+          title: "Dune",
+          media_type: "movie",
+        }),
+        expect.objectContaining({
+          id: 2,
+          name: "Dune: Prophecy",
+          media_type: "tv",
+        }),
+        expect.objectContaining({
+          id: 3,
+          name: "Timothée Chalamet",
+          media_type: "person",
+        }),
+      ]),
+    );
+  });
+
+  it("caps results at 10", async () => {
+    const results = Array.from({ length: 15 }, (_, i) =>
+      movieResult({ id: i + 1, title: `Movie ${i + 1}` }),
+    );
+
+    server.use(
+      http.get(`${TMDB_BASE}/3/search/multi`, () =>
+        HttpResponse.json({
+          page: 1,
+          results,
+          total_pages: 1,
+          total_results: 15,
+        }),
+      ),
+    );
+
+    const tool = createTmdbSearchTool("en");
+    const items = await tool.execute!(
+      { query: "Movie" },
+      {
+        toolCallId: "test",
+        messages: [],
+        abortSignal: AbortSignal.timeout(5000),
+      },
+    );
+
+    expect(items).toHaveLength(10);
+  });
+
+  it("returns empty array when no results", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/search/multi`, () =>
+        HttpResponse.json({
+          page: 1,
+          results: [],
+          total_pages: 0,
+          total_results: 0,
+        }),
+      ),
+    );
+
+    const tool = createTmdbSearchTool("en");
+    const results = await tool.execute!(
+      { query: "xyznonexistent" },
+      {
+        toolCallId: "test",
+        messages: [],
+        abortSignal: AbortSignal.timeout(5000),
+      },
+    );
+
+    expect(results).toEqual([]);
+  });
+
+  it("passes locale as language parameter", async () => {
+    let capturedLanguage: string | null = null;
+
+    server.use(
+      http.get(`${TMDB_BASE}/3/search/multi`, ({ request }) => {
+        const url = new URL(request.url);
+        capturedLanguage = url.searchParams.get("language");
+        return HttpResponse.json({
+          page: 1,
+          results: [movieResult({ id: 1, title: "기생충" })],
+          total_pages: 1,
+          total_results: 1,
+        });
+      }),
+    );
+
+    const tool = createTmdbSearchTool("zh");
+    await tool.execute!(
+      { query: "Parasite" },
+      {
+        toolCallId: "test",
+        messages: [],
+        abortSignal: AbortSignal.timeout(5000),
+      },
+    );
+
+    expect(capturedLanguage).toBe("zh");
+  });
+
+  it("passes query parameter correctly", async () => {
+    let capturedQuery: string | null = null;
+
+    server.use(
+      http.get(`${TMDB_BASE}/3/search/multi`, ({ request }) => {
+        const url = new URL(request.url);
+        capturedQuery = url.searchParams.get("query");
+        return HttpResponse.json({
+          page: 1,
+          results: [],
+          total_pages: 0,
+          total_results: 0,
+        });
+      }),
+    );
+
+    const tool = createTmdbSearchTool("en");
+    await tool.execute!(
+      { query: "Breaking Bad" },
+      {
+        toolCallId: "test",
+        messages: [],
+        abortSignal: AbortSignal.timeout(5000),
+      },
+    );
+
+    expect(capturedQuery).toBe("Breaking Bad");
+  });
+
+  it("strips extra fields from results", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/search/multi`, () =>
+        HttpResponse.json({
+          page: 1,
+          results: [movieResult({ id: 1, title: "Inception" })],
+          total_pages: 1,
+          total_results: 1,
+        }),
+      ),
+    );
+
+    const tool = createTmdbSearchTool("en");
+    const results = await tool.execute!(
+      { query: "Inception" },
+      {
+        toolCallId: "test",
+        messages: [],
+        abortSignal: AbortSignal.timeout(5000),
+      },
+    );
+
+    const items = results as unknown[];
+    const result = items[0] as Record<string, unknown>;
+    const keys = Object.keys(result);
+    expect(keys).not.toContain("adult");
+    expect(keys).not.toContain("poster_path");
+    expect(keys).not.toContain("video");
+    expect(keys).not.toContain("vote_count");
+    expect(keys).toContain("id");
+    expect(keys).toContain("media_type");
+    expect(keys).toContain("title");
+    expect(keys).toContain("overview");
+  });
+});

--- a/src/ai-chat/tools/tmdb-search.ts
+++ b/src/ai-chat/tools/tmdb-search.ts
@@ -1,0 +1,57 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { searchMulti } from "#src/_generated/tmdb-server-functions.ts";
+import type { SupportedLocale } from "#src/types.ts";
+import type { ResponseType } from "#src/utils/tmdb-client.ts";
+
+type MultiSearchResult = NonNullable<
+  ResponseType<"/3/search/multi", "get">["results"]
+>[number];
+
+export const tmdbSearchInputSchema = z.object({
+  query: z
+    .string()
+    .describe(
+      "The title or person name to search for. " +
+        "Searches across movies, TV shows, and people. " +
+        'Examples: "Inception", "Breaking Bad", "Christopher Nolan".',
+    ),
+});
+
+const TOOL_DESCRIPTION =
+  "Search TMDB for movies, TV shows, and people by name. " +
+  "Use this tool when the user mentions a specific movie, TV show, or person by name, " +
+  "or wants to look up a particular title or actor/director. " +
+  "Results include a media_type field (movie, tv, or person) to distinguish result types. " +
+  "For thematic or mood-based queries, use semantic_search instead.";
+
+const MAX_RESULTS = 10;
+
+function mapResult(result: MultiSearchResult) {
+  return {
+    id: result.id,
+    media_type: result.media_type,
+    // Movie fields
+    title: result.title,
+    release_date: result.release_date,
+    // TV / Person fields
+    name: result.name,
+    // Shared fields
+    overview: result.overview,
+    vote_average: result.vote_average,
+    genre_ids: result.genre_ids,
+    original_language: result.original_language,
+    popularity: result.popularity,
+  };
+}
+
+export function createTmdbSearchTool(locale: SupportedLocale) {
+  return tool({
+    description: TOOL_DESCRIPTION,
+    inputSchema: tmdbSearchInputSchema,
+    execute: async ({ query }) => {
+      const response = await searchMulti({ query, language: locale });
+      return response.results?.slice(0, MAX_RESULTS).map(mapResult) ?? [];
+    },
+  });
+}

--- a/src/app/api/ai-chat/route.test.ts
+++ b/src/app/api/ai-chat/route.test.ts
@@ -4,6 +4,7 @@ import { NextRequest } from "next/server";
 import { describe, expect, it, vi } from "vitest";
 import { chatInputSchema } from "#src/ai-chat/schema.ts";
 import { createSemanticSearchTool } from "#src/ai-chat/tools/semantic-search.ts";
+import { createTmdbSearchTool } from "#src/ai-chat/tools/tmdb-search.ts";
 
 vi.mock("#src/ai-chat/chat.ts", () => ({
   chatInputSchema,
@@ -49,7 +50,10 @@ describe("POST /api/ai-chat", () => {
         },
       }),
       messages: [{ role: "user", content: "test" }],
-      tools: { semantic_search: createSemanticSearchTool("en") },
+      tools: {
+        semantic_search: createSemanticSearchTool("en"),
+        tmdb_search: createTmdbSearchTool("en"),
+      },
       stopWhen: stepCountIs(5),
     });
     vi.mocked(chat).mockResolvedValueOnce(result);

--- a/src/test-msw.ts
+++ b/src/test-msw.ts
@@ -1,0 +1,8 @@
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll } from "vitest";
+
+export const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());

--- a/tooling/tmdb-codegen/endpoints-config.js
+++ b/tooling/tmdb-codegen/endpoints-config.js
@@ -80,6 +80,11 @@ export const endpoints = [
     requiredParams: true,
     needsZodSchema: true, // Required for AI tools
   },
+  {
+    path: "/3/search/multi",
+    functionName: "searchMulti",
+    requiredParams: true,
+  },
 ];
 
 // API routes to generate (maps function names to route paths)


### PR DESCRIPTION
## Summary

Add a `tmdb_search` tool to the AI chat that lets the model look up movies, TV shows, and people by name via TMDB's `/search/multi` endpoint. This replaces the originally planned discover tools (#1715) because title/name search better serves the primary use case: users mention a specific title or person and want to find it.

A single `searchMulti` call covers all three media types (movie, tv, person), reducing tool count and system prompt tokens compared to separate search endpoints.

## Changes

- **`tmdb-search.ts`** — new tool using TMDB multi-search, with result mapping that strips unnecessary fields
- **`tmdb-search.test.ts`** — unit tests using MSW for network-level mocking (mixed results, capping, empty results, locale/query passthrough, field stripping)
- **`test-msw.ts`** — shared MSW server setup for all tests
- **`chat.ts`** — registers `tmdb_search` tool alongside `semantic_search`
- **`tmdb-search.eval.ts`** — LLM evals for movie, TV show, and person lookups
- **`endpoints-config.js`** — added `searchMulti` endpoint to TMDB codegen
- **`CLAUDE.md`** — documented eval commands and filtering guidance

## Context

The issue (#1715) originally called for `discover_movies` and `discover_tv_shows` tools. Title/name search was chosen instead because:

- **Discover requires genre IDs**: The LLM would need a separate lookup step or hardcoded mapping to translate "horror" into genre ID 27.
- **Discover filters are rigid**: Parameters like `vote_average.gte` and `sort_by` require exact TMDB API values the model would need to guess.
- **Title search matches user intent better**: Most conversational queries reference specific titles or people, which map directly to a text search.
- **Semantic search already covers thematic queries**: The existing `semantic_search` tool handles mood/theme-based discovery, making discover tools partially redundant.

Closes #1715
Closes #1714