### PR TITLE
build: add pnpm-workspace.yaml for native dependency control

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+ignoredBuiltDependencies:
+  - esbuild
+  - sharp
+  - unrs-resolver
+
+onlyBuiltDependencies:
+  - better-sqlite3


### PR DESCRIPTION
## Summary

Add `pnpm-workspace.yaml` to skip unnecessary native dependency builds (esbuild, sharp, unrs-resolver) during `pnpm install` while explicitly allowing `better-sqlite3` which is required by the vector database layer. This reduces install time and avoids platform-specific compilation noise for dependencies that ship prebuilt binaries.