### PR TITLE
feat: add trending recommendations to AI mode empty state

### DIFF
--- a/src/_generated/tmdb-endpoints.ts
+++ b/src/_generated/tmdb-endpoints.ts
@@ -17,6 +17,8 @@ export type TMDBEndpointPaths =
   | "/3/search/movie"
   | "/3/search/person"
   | "/3/search/tv"
+  | "/3/trending/movie/{time_window}"
+  | "/3/trending/tv/{time_window}"
   | "/3/tv/{series_id}"
   | "/3/tv/{series_id}/recommendations"
   | "/3/tv/{series_id}/videos";
@@ -35,6 +37,8 @@ export const TMDB_ENDPOINTS = [
   "/3/search/movie",
   "/3/search/person",
   "/3/search/tv",
+  "/3/trending/movie/{time_window}",
+  "/3/trending/tv/{time_window}",
   "/3/tv/{series_id}",
   "/3/tv/{series_id}/recommendations",
   "/3/tv/{series_id}/videos",

--- a/src/_generated/tmdb-server-functions.ts
+++ b/src/_generated/tmdb-server-functions.ts
@@ -84,6 +84,28 @@ export async function getMovieVideos(
   return tmdbGet("/3/movie/{movie_id}/videos", queryParams, { movie_id });
 }
 
+export async function getTrendingMovies(
+  params: { time_window: string } & QueryParams<
+    "/3/trending/movie/{time_window}",
+    "get"
+  >,
+) {
+  const { time_window, ...queryParams } = params;
+  return tmdbGet("/3/trending/movie/{time_window}", queryParams, {
+    time_window,
+  });
+}
+
+export async function getTrendingTvShows(
+  params: { time_window: string } & QueryParams<
+    "/3/trending/tv/{time_window}",
+    "get"
+  >,
+) {
+  const { time_window, ...queryParams } = params;
+  return tmdbGet("/3/trending/tv/{time_window}", queryParams, { time_window });
+}
+
 export async function getTvShowDetails(
   params: { series_id: string } & QueryParams<"/3/tv/{series_id}", "get">,
 ) {

--- a/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
@@ -3,9 +3,10 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 import { useAIChat } from "#src/ai-chat/use-ai-chat.ts";
+import { ChatActionsContext } from "#src/components/ai-chat/chat-actions-context.tsx";
 import { ChatInputBar } from "#src/components/ai-chat/chat-input-bar.tsx";
 import { ChatMessageList } from "#src/components/ai-chat/chat-message-list.tsx";
-import { border, color, space } from "#src/tokens.stylex.ts";
+import { border, color, layer, space } from "#src/tokens.stylex.ts";
 import type { SupportedLocale } from "#src/types.ts";
 
 interface AIChatViewProps {
@@ -29,8 +30,12 @@ export function AIChatView({
 }: AIChatViewProps) {
   const { messages, status, sendMessage, stop } = useAIChat({ locale });
 
+  const handleSend = (text: string) => {
+    void sendMessage({ text });
+  };
+
   return (
-    <>
+    <ChatActionsContext value={{ sendMessage: handleSend }}>
       <ChatMessageList
         messages={messages}
         status={status}
@@ -44,23 +49,36 @@ export function AIChatView({
           sendLabel={sendLabel}
           stopLabel={stopLabel}
           status={status}
-          onSend={(text) => {
-            void sendMessage({ text });
-          }}
+          onSend={handleSend}
           onStop={stop}
         />
       </div>
-    </>
+    </ChatActionsContext>
   );
 }
+
+/**
+ * Horizontal inset from viewport edge to content inside ChatMessageList.
+ * Padding chain: layout (space._3 + safe-area) + ChatMessageList (space._3).
+ * See also: recommended-media-row.tsx which uses the same offsets.
+ */
+const contentInsetLeft = `calc(${space._3} + ${space._3} + env(safe-area-inset-left, 0px))`;
+const contentInsetRight = `calc(${space._3} + ${space._3} + env(safe-area-inset-right, 0px))`;
+const layoutInsetLeft = `calc(${space._3} + env(safe-area-inset-left, 0px))`;
+const layoutInsetRight = `calc(${space._3} + env(safe-area-inset-right, 0px))`;
 
 const styles = stylex.create({
   inputArea: {
     position: "sticky",
     bottom: 0,
     flexShrink: 0,
-    padding: space._3,
+    zIndex: layer.content,
+    paddingTop: space._3,
     paddingBottom: `calc(${space._3} + env(safe-area-inset-bottom))`,
+    paddingLeft: contentInsetLeft,
+    paddingRight: contentInsetRight,
+    marginLeft: `calc(-1 * ${layoutInsetLeft})`,
+    marginRight: `calc(-1 * ${layoutInsetRight})`,
     borderTopWidth: border.size_1,
     borderTopStyle: "solid",
     borderTopColor: color.controlTrack,

--- a/src/app/[locale]/movie-database/ai-mode/page.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/page.tsx
@@ -1,6 +1,8 @@
 import * as stylex from "@stylexjs/stylex";
+import { RecommendedMedia } from "#src/components/ai-chat/recommended-media.tsx";
+import { SuggestionChips } from "#src/components/ai-chat/suggestion-chips.tsx";
 import { t } from "#src/i18n.ts";
-import { color, font, space } from "#src/tokens.stylex.ts";
+import { space } from "#src/tokens.stylex.ts";
 import type { SupportedLocale } from "#src/types.ts";
 import { validateLocale } from "#src/utils/validate-locale.ts";
 import { AIChatView } from "./ai-chat-view";
@@ -18,15 +20,31 @@ export default async function Page({
       locale={validatedLocale}
       emptyState={
         <div css={styles.welcomeContainer}>
-          <h1 css={styles.welcomeTitle}>
-            {t({ en: "AI Mode", zh: "AI 模式" })}
-          </h1>
-          <p css={styles.welcomeDescription}>
-            {t({
-              en: "Chat with AI about movies and TV shows",
-              zh: "与 AI 聊电影和电视剧",
+          <SuggestionChips
+            groupLabel={t({
+              en: "Suggested prompts",
+              zh: "推荐提问",
             })}
-          </p>
+            suggestions={[
+              t({
+                en: "What should I watch tonight?",
+                zh: "今晚该看什么？",
+              }),
+              t({
+                en: "Find me a sci-fi thriller",
+                zh: "找一部科幻惊悚片",
+              }),
+              t({
+                en: "Best movies of 2025",
+                zh: "2025年最佳电影",
+              }),
+              t({
+                en: "Shows similar to Breaking Bad",
+                zh: "类似《绝命毒师》的剧",
+              }),
+            ]}
+          />
+          <RecommendedMedia locale={validatedLocale} />
         </div>
       }
       typingIndicatorLabel={t({
@@ -49,18 +67,9 @@ export default async function Page({
 
 const styles = stylex.create({
   welcomeContainer: {
-    textAlign: "center",
-  },
-  welcomeTitle: {
-    fontSize: font.uiHeading1,
-    fontWeight: font.weight_6,
-    color: color.textMain,
-    margin: 0,
-    marginBottom: space._2,
-  },
-  welcomeDescription: {
-    fontSize: font.uiBody,
-    color: color.textMuted,
-    margin: 0,
+    display: "flex",
+    flexDirection: "column",
+    gap: space._5,
+    width: "100%",
   },
 });

--- a/src/components/ai-chat/chat-actions-context.tsx
+++ b/src/components/ai-chat/chat-actions-context.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { createContext, use } from "react";
+
+interface ChatActions {
+  sendMessage: (text: string) => void;
+}
+
+export const ChatActionsContext = createContext<ChatActions | null>(null);
+
+export function useChatActions() {
+  const context = use(ChatActionsContext);
+  if (!context) {
+    throw new Error(
+      "useChatActions must be used within a ChatActionsContext provider",
+    );
+  }
+  return context;
+}

--- a/src/components/ai-chat/chat-message-list.tsx
+++ b/src/components/ai-chat/chat-message-list.tsx
@@ -91,8 +91,9 @@ const styles = stylex.create({
   emptyStateWrapper: {
     display: "flex",
     alignItems: "center",
-    justifyContent: "center",
+    justifyContent: "flex-start",
     flexGrow: 1,
+    paddingTop: space._8,
   },
   messagesList: {
     display: "flex",

--- a/src/components/ai-chat/recommended-media-row-skeleton.tsx
+++ b/src/components/ai-chat/recommended-media-row-skeleton.tsx
@@ -1,0 +1,57 @@
+import * as stylex from "@stylexjs/stylex";
+import { breakpoints } from "#src/breakpoints.stylex.ts";
+import { border, ratio, space } from "#src/tokens.stylex.ts";
+import { Skeleton } from "../shared/skeleton";
+
+const SKELETON_COUNT = 6;
+
+export function RecommendedMediaRowSkeleton() {
+  return (
+    <div css={styles.section}>
+      <Skeleton width={120} height={14} />
+      <div css={styles.row}>
+        {Array.from({ length: SKELETON_COUNT }, (_, i) => (
+          <div key={i} css={styles.card}>
+            <Skeleton fill delay={i * 100} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const contentInsetLeft = `calc(${space._3} + ${space._3} + env(safe-area-inset-left, 0px))`;
+const contentInsetRight = `calc(${space._3} + ${space._3} + env(safe-area-inset-right, 0px))`;
+
+const styles = stylex.create({
+  section: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space._2,
+  },
+  row: {
+    display: "flex",
+    gap: space._2,
+    overflow: "hidden",
+    marginLeft: `calc(-1 * ${contentInsetLeft})`,
+    marginRight: `calc(-1 * ${contentInsetRight})`,
+    paddingLeft: contentInsetLeft,
+    paddingRight: contentInsetRight,
+  },
+  card: {
+    flexShrink: 0,
+    width: "130px",
+    aspectRatio: ratio.poster,
+    borderRadius: border.radius_2,
+    overflow: "hidden",
+    [breakpoints.sm]: {
+      width: "140px",
+    },
+    [breakpoints.md]: {
+      width: "155px",
+    },
+    [breakpoints.lg]: {
+      width: "175px",
+    },
+  },
+});

--- a/src/components/ai-chat/recommended-media-row.test.tsx
+++ b/src/components/ai-chat/recommended-media-row.test.tsx
@@ -1,0 +1,122 @@
+import { createHash } from "node:crypto";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { Suspense } from "react";
+import { describe, expect, it } from "vitest";
+import { I18nContext } from "#src/i18n/i18n-context.ts";
+import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
+import type { MediaListItem } from "#src/utils/types.ts";
+import { RecommendedMediaRow } from "./recommended-media-row";
+
+function hashKey(en: string, zh: string) {
+  return createHash("sha256")
+    .update(en + "\0" + zh)
+    .digest("hex")
+    .slice(0, 8);
+}
+
+const translations = {
+  [hashKey("No Poster", "无海报")]: "No Poster",
+  [hashKey("User rating", "用户评分")]: "User rating",
+};
+
+const mockItems: ReadonlyArray<MediaListItem> = [
+  {
+    id: 1,
+    title: "Movie One",
+    posterPath: "/poster1.jpg",
+    rating: 8.5,
+    mediaType: "movie",
+  },
+  {
+    id: 2,
+    title: "Movie Two",
+    posterPath: "/poster2.jpg",
+    rating: 7.2,
+    mediaType: "movie",
+  },
+];
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+
+  // Pre-seed TMDB configuration so PosterImage doesn't suspend forever
+  queryClient.setQueryData(tmdbQueries.configuration.queryKey, {
+    images: {
+      base_url: "http://image.tmdb.org/t/p/",
+      secure_base_url: "https://image.tmdb.org/t/p/",
+      poster_sizes: ["w92", "w154", "w185", "w342", "w500", "w780", "original"],
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <I18nContext value={{ translations }}>
+        <Suspense>{ui}</Suspense>
+      </I18nContext>
+    </QueryClientProvider>,
+  );
+}
+
+describe("RecommendedMediaRow", () => {
+  it("renders section title", () => {
+    renderWithProviders(
+      <RecommendedMediaRow title="Trending Movies" items={mockItems} />,
+    );
+    expect(
+      screen.getByRole("heading", { name: "Trending Movies" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders poster images for each item", () => {
+    renderWithProviders(
+      <RecommendedMediaRow title="Trending Movies" items={mockItems} />,
+    );
+    expect(screen.getByAltText("Movie One")).toBeInTheDocument();
+    expect(screen.getByAltText("Movie Two")).toBeInTheDocument();
+  });
+
+  it("renders rating badges", () => {
+    renderWithProviders(
+      <RecommendedMediaRow title="Trending Movies" items={mockItems} />,
+    );
+    expect(screen.getByText("8.5")).toBeInTheDocument();
+    expect(screen.getByText("7.2")).toBeInTheDocument();
+  });
+
+  it("does not render links", () => {
+    renderWithProviders(
+      <RecommendedMediaRow title="Trending Movies" items={mockItems} />,
+    );
+    expect(screen.queryAllByRole("link")).toHaveLength(0);
+  });
+
+  it("renders no-poster fallback when posterPath is null", () => {
+    renderWithProviders(
+      <RecommendedMediaRow
+        title="Trending Movies"
+        items={[
+          {
+            id: 99,
+            title: "No Poster Movie",
+            posterPath: null,
+            rating: 6.3,
+            mediaType: "movie",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("No Poster Movie")).toBeInTheDocument();
+    expect(screen.getByText("No Poster")).toBeInTheDocument();
+  });
+
+  it("renders nothing when items array is empty", () => {
+    const { container } = renderWithProviders(
+      <RecommendedMediaRow title="Trending Movies" items={[]} />,
+    );
+    expect(container.querySelector("section")).toBeNull();
+  });
+});

--- a/src/components/ai-chat/recommended-media-row.tsx
+++ b/src/components/ai-chat/recommended-media-row.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { useRef } from "react";
+import { breakpoints } from "#src/breakpoints.stylex.ts";
+import { useLocale } from "#src/hooks/use-locale.ts";
+import { useScrollFades } from "#src/hooks/use-scroll-fades.ts";
+import { t } from "#src/i18n.ts";
+import { border, color, font, ratio, space } from "#src/tokens.stylex.ts";
+import type { MediaListItem } from "#src/utils/types.ts";
+import { PosterImage } from "../movie-database/poster-image";
+
+interface RecommendedMediaRowProps {
+  title: string;
+  items: ReadonlyArray<MediaListItem>;
+}
+
+export function RecommendedMediaRow({
+  title,
+  items,
+}: RecommendedMediaRowProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const { showLeftFade, showRightFade } = useScrollFades(scrollRef);
+
+  if (items.length === 0) return null;
+
+  return (
+    <section css={styles.section}>
+      <h2 css={styles.title}>{title}</h2>
+      <div css={styles.scrollWrapper}>
+        <div
+          ref={scrollRef}
+          css={styles.scrollContainer}
+          role="region"
+          aria-label={title}
+          tabIndex={0}
+        >
+          {items.map((item) => (
+            <div key={item.id} css={styles.cardWrapper}>
+              <CompactCard media={item} />
+            </div>
+          ))}
+        </div>
+        <div
+          css={[styles.fadeEdge, styles.fadeLeft]}
+          style={{ opacity: showLeftFade ? 1 : 0 }}
+          aria-hidden="true"
+        />
+        <div
+          css={[styles.fadeEdge, styles.fadeRight]}
+          style={{ opacity: showRightFade ? 1 : 0 }}
+          aria-hidden="true"
+        />
+      </div>
+    </section>
+  );
+}
+
+function CompactCard({ media }: { media: MediaListItem }) {
+  const locale = useLocale();
+  const formatter = new Intl.NumberFormat(locale, { maximumFractionDigits: 1 });
+
+  return (
+    <div css={styles.compactCard}>
+      {media.posterPath && media.title ? (
+        <PosterImage posterPath={media.posterPath} alt={media.title} />
+      ) : (
+        <div css={styles.noPoster}>
+          <div>{media.title}</div>
+          <div css={styles.noPosterLabel}>
+            {t({ en: "No Poster", zh: "无海报" })}
+          </div>
+        </div>
+      )}
+      {media.rating ? (
+        <div
+          css={styles.compactRating}
+          aria-label={`${t({ en: "User rating", zh: "用户评分" })}: ${formatter.format(media.rating)}`}
+        >
+          {formatter.format(media.rating)}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Horizontal inset from viewport edge to content inside ChatMessageList.
+ * Padding chain: layout (space._3 + safe-area) + ChatMessageList (space._3).
+ * See also: ai-chat-view.tsx inputArea which uses the same offsets.
+ */
+const contentInsetLeft = `calc(${space._3} + ${space._3} + env(safe-area-inset-left, 0px))`;
+const contentInsetRight = `calc(${space._3} + ${space._3} + env(safe-area-inset-right, 0px))`;
+
+const styles = stylex.create({
+  section: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space._2,
+  },
+  title: {
+    fontSize: font.uiBodySmall,
+    fontWeight: font.weight_6,
+    color: color.textMuted,
+    textTransform: "uppercase",
+    letterSpacing: "0.05em",
+    margin: 0,
+  },
+  scrollWrapper: {
+    position: "relative",
+    marginLeft: `calc(-1 * ${contentInsetLeft})`,
+    marginRight: `calc(-1 * ${contentInsetRight})`,
+  },
+  scrollContainer: {
+    display: "flex",
+    gap: space._2,
+    overflowX: "auto",
+    scrollSnapType: "x mandatory",
+    scrollbarWidth: "none",
+    paddingBottom: space._1,
+    paddingLeft: contentInsetLeft,
+    paddingRight: contentInsetRight,
+    scrollPaddingLeft: contentInsetLeft,
+    scrollPaddingRight: contentInsetRight,
+  },
+  fadeEdge: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    width: space._8,
+    pointerEvents: "none",
+    transition: "opacity 0.2s ease",
+  },
+  fadeLeft: {
+    left: 0,
+    backgroundImage: `linear-gradient(to left, rgba(${color.backgroundMainChannels}, 0), rgba(${color.backgroundMainChannels}, 1))`,
+  },
+  fadeRight: {
+    right: 0,
+    backgroundImage: `linear-gradient(to right, rgba(${color.backgroundMainChannels}, 0), rgba(${color.backgroundMainChannels}, 1))`,
+  },
+  cardWrapper: {
+    flexShrink: 0,
+    scrollSnapAlign: "start",
+    width: "130px",
+    [breakpoints.sm]: {
+      width: "140px",
+    },
+    [breakpoints.md]: {
+      width: "155px",
+    },
+    [breakpoints.lg]: {
+      width: "175px",
+    },
+  },
+  compactCard: {
+    position: "relative",
+    aspectRatio: ratio.poster,
+    width: "100%",
+    borderRadius: border.radius_2,
+    overflow: "hidden",
+  },
+  noPoster: {
+    width: "100%",
+    height: "100%",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    textAlign: "center",
+    backgroundColor: color.backgroundRaised,
+    fontSize: font.uiBodySmall,
+  },
+  noPosterLabel: {
+    fontSize: "0.7rem",
+    color: color.textMuted,
+  },
+  compactRating: {
+    position: "absolute",
+    top: space._0,
+    left: space._0,
+    width: "1.4rem",
+    height: "1.4rem",
+    borderRadius: border.radius_round,
+    backgroundColor: color.backgroundRaised,
+    borderWidth: "1.5px",
+    borderColor: color.textMain,
+    borderStyle: "solid",
+    fontSize: "0.6rem",
+    fontWeight: font.weight_6,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/src/components/ai-chat/recommended-media.tsx
+++ b/src/components/ai-chat/recommended-media.tsx
@@ -1,0 +1,115 @@
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { Suspense } from "react";
+import {
+  getConfiguration,
+  getTrendingMovies,
+  getTrendingTvShows,
+} from "#src/_generated/tmdb-server-functions.ts";
+import { t } from "#src/i18n.ts";
+import type { SupportedLocale } from "#src/types.ts";
+import { getQueryClient } from "#src/utils/get-query-client.ts";
+import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
+import { RecommendedMediaRow } from "./recommended-media-row";
+import { RecommendedMediaRowSkeleton } from "./recommended-media-row-skeleton";
+
+const ITEMS_PER_ROW = 10;
+
+interface RecommendedMediaProps {
+  locale: SupportedLocale;
+}
+
+export function RecommendedMedia({ locale }: RecommendedMediaProps) {
+  const queryClient = getQueryClient();
+
+  void queryClient.prefetchQuery({
+    ...tmdbQueries.configuration,
+    queryFn: async () => getConfiguration(),
+  });
+
+  const dehydratedState = dehydrate(queryClient);
+
+  return (
+    <>
+      <Suspense fallback={<RecommendedMediaRowSkeleton />}>
+        <TrendingMoviesRow locale={locale} dehydratedState={dehydratedState} />
+      </Suspense>
+      <Suspense fallback={<RecommendedMediaRowSkeleton />}>
+        <TrendingTvShowsRow locale={locale} dehydratedState={dehydratedState} />
+      </Suspense>
+    </>
+  );
+}
+
+async function TrendingMoviesRow({
+  locale,
+  dehydratedState,
+}: {
+  locale: SupportedLocale;
+  dehydratedState: ReturnType<typeof dehydrate>;
+}) {
+  const response = await getTrendingMovies({
+    time_window: "week",
+    language: locale,
+  }).catch((error) => {
+    console.error("Failed to fetch trending movies:", error);
+    return null;
+  });
+  if (!response) return null;
+
+  const items = (response.results ?? [])
+    .filter((movie) => movie.title)
+    .slice(0, ITEMS_PER_ROW)
+    .map((movie) => ({
+      id: movie.id,
+      title: movie.title,
+      posterPath: movie.poster_path,
+      rating: movie.vote_average,
+      mediaType: "movie" as const,
+    }));
+
+  return (
+    <HydrationBoundary state={dehydratedState}>
+      <RecommendedMediaRow
+        title={t({ en: "Trending Movies", zh: "热门电影" })}
+        items={items}
+      />
+    </HydrationBoundary>
+  );
+}
+
+async function TrendingTvShowsRow({
+  locale,
+  dehydratedState,
+}: {
+  locale: SupportedLocale;
+  dehydratedState: ReturnType<typeof dehydrate>;
+}) {
+  const response = await getTrendingTvShows({
+    time_window: "week",
+    language: locale,
+  }).catch((error) => {
+    console.error("Failed to fetch trending TV shows:", error);
+    return null;
+  });
+  if (!response) return null;
+
+  const items = (response.results ?? [])
+    .filter((show) => show.name)
+    .slice(0, ITEMS_PER_ROW)
+    .map((show) => ({
+      id: show.id,
+      title: show.name,
+      posterPath: show.poster_path,
+      rating: show.vote_average,
+      mediaType: "tv" as const,
+    }));
+
+  return (
+    <HydrationBoundary state={dehydratedState}>
+      <RecommendedMediaRow
+        title={t({ en: "Trending TV Shows", zh: "热门电视剧" })}
+        items={items}
+      />
+    </HydrationBoundary>
+  );
+}

--- a/src/components/ai-chat/suggestion-chips.test.tsx
+++ b/src/components/ai-chat/suggestion-chips.test.tsx
@@ -1,0 +1,52 @@
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "#src/test-utils.tsx";
+import { ChatActionsContext } from "./chat-actions-context";
+import { SuggestionChips } from "./suggestion-chips";
+
+function renderChips(suggestions: ReadonlyArray<string>) {
+  const sendMessage = vi.fn();
+  const result = render(
+    <ChatActionsContext value={{ sendMessage }}>
+      <SuggestionChips
+        suggestions={suggestions}
+        groupLabel="Suggested prompts"
+      />
+    </ChatActionsContext>,
+  );
+  return { ...result, sendMessage };
+}
+
+describe("SuggestionChips", () => {
+  it("renders all suggestion texts as buttons", () => {
+    renderChips(["Recommend a thriller", "What's trending?"]);
+
+    expect(
+      screen.getByRole("button", { name: "Recommend a thriller" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "What's trending?" }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls sendMessage with correct text on chip click", async () => {
+    const user = userEvent.setup();
+    const { sendMessage } = renderChips([
+      "Recommend a thriller",
+      "What's trending?",
+    ]);
+
+    await user.click(
+      screen.getByRole("button", { name: "Recommend a thriller" }),
+    );
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith("Recommend a thriller");
+  });
+
+  it("renders no buttons when suggestions array is empty", () => {
+    renderChips([]);
+
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+  });
+});

--- a/src/components/ai-chat/suggestion-chips.tsx
+++ b/src/components/ai-chat/suggestion-chips.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { border, color, font, space } from "#src/tokens.stylex.ts";
+import { useChatActions } from "./chat-actions-context";
+
+interface SuggestionChipsProps {
+  suggestions: ReadonlyArray<string>;
+  groupLabel: string;
+}
+
+export function SuggestionChips({
+  suggestions,
+  groupLabel,
+}: SuggestionChipsProps) {
+  const { sendMessage } = useChatActions();
+
+  return (
+    <div role="group" aria-label={groupLabel} css={styles.container}>
+      {suggestions.map((text) => (
+        <button
+          key={text}
+          type="button"
+          css={styles.chip}
+          onClick={() => sendMessage(text)}
+        >
+          {text}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  container: {
+    display: "flex",
+    flexWrap: "wrap",
+    justifyContent: "center",
+    gap: space._1,
+  },
+  chip: {
+    appearance: "none",
+    borderWidth: border.size_1,
+    borderStyle: "solid",
+    borderColor: {
+      default: color.controlTrack,
+      ":hover": color.controlActive,
+    },
+    borderRadius: border.radius_round,
+    backgroundColor: {
+      default: "transparent",
+      ":hover": color.controlActive,
+    },
+    color: {
+      default: color.textMuted,
+      ":hover": color.textOnActive,
+    },
+    fontFamily: font.family,
+    fontSize: font.uiBodySmall,
+    lineHeight: font.lineHeight_3,
+    paddingBlock: space._1,
+    paddingInline: space._3,
+    cursor: "pointer",
+    transition:
+      "background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease",
+  },
+});

--- a/src/components/calculator/calculator-display.tsx
+++ b/src/components/calculator/calculator-display.tsx
@@ -1,10 +1,9 @@
 "use client";
 import * as stylex from "@stylexjs/stylex";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useScrollFades } from "#src/hooks/use-scroll-fades.ts";
 import { color, space } from "#src/tokens.stylex.ts";
 import type { Token } from "./types.ts";
-
-const SCROLL_THRESHOLD = 1;
 
 interface CalculatorDisplayProps {
   tokens: Token[];
@@ -24,8 +23,7 @@ export function CalculatorDisplay({
   const containerRef = useRef<HTMLDivElement>(null);
   const textRef = useRef<HTMLSpanElement>(null);
   const [isScrollable, setIsScrollable] = useState(false);
-  const [showLeftGradient, setShowLeftGradient] = useState(false);
-  const [showRightGradient, setShowRightGradient] = useState(false);
+  const { showLeftFade, showRightFade } = useScrollFades(containerRef);
 
   useLayoutEffect(() => {
     const container = containerRef.current;
@@ -71,24 +69,6 @@ export function CalculatorDisplay({
     return () => observer.disconnect();
   }, [displayText]);
 
-  // Update gradient visibility based on scroll position
-  useLayoutEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    const updateGradients = () => {
-      const scrollLeft = container.scrollLeft;
-      const maxScroll = container.scrollWidth - container.clientWidth;
-      setShowLeftGradient(scrollLeft > SCROLL_THRESHOLD);
-      setShowRightGradient(scrollLeft < maxScroll - SCROLL_THRESHOLD);
-    };
-
-    container.addEventListener("scroll", updateGradients);
-    updateGradients();
-
-    return () => container.removeEventListener("scroll", updateGradients);
-  }, [isScrollable]);
-
   useEffect(() => {
     const container = containerRef.current;
     if (!container || !isScrollable) return;
@@ -115,14 +95,14 @@ export function CalculatorDisplay({
             css={[
               styles.gradient,
               styles.leftGradient,
-              showLeftGradient && styles.visible,
+              showLeftFade && styles.visible,
             ]}
           />
           <div
             css={[
               styles.gradient,
               styles.rightGradient,
-              showRightGradient && styles.visible,
+              showRightFade && styles.visible,
             ]}
           />
         </>

--- a/src/hooks/use-scroll-fades.ts
+++ b/src/hooks/use-scroll-fades.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Tracks horizontal scroll position to determine whether left/right
+ * fade indicators should be visible. Listens to scroll and resize events.
+ */
+export function useScrollFades(scrollRef: React.RefObject<HTMLElement | null>) {
+  const [showLeftFade, setShowLeftFade] = useState(false);
+  const [showRightFade, setShowRightFade] = useState(false);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const update = () => {
+      const { scrollLeft, scrollWidth, clientWidth } = el;
+      setShowLeftFade(Math.round(scrollLeft) > 0);
+      setShowRightFade(Math.round(scrollLeft) + clientWidth < scrollWidth - 1);
+    };
+
+    el.addEventListener("scroll", update, { passive: true });
+
+    // ResizeObserver fires its callback asynchronously after observe(),
+    // which handles initial state without a synchronous setState in the effect.
+    // Falls back to a rAF-deferred call in environments without ResizeObserver (e.g. jsdom).
+    let observer: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== "undefined") {
+      observer = new ResizeObserver(update);
+      observer.observe(el);
+    } else {
+      requestAnimationFrame(update);
+    }
+
+    return () => {
+      el.removeEventListener("scroll", update);
+      observer?.disconnect();
+    };
+  }, [scrollRef]);
+
+  return { showLeftFade, showRightFade };
+}

--- a/tooling/tmdb-codegen/endpoints-config.js
+++ b/tooling/tmdb-codegen/endpoints-config.js
@@ -19,6 +19,16 @@ export const endpoints = [
   { path: "/3/genre/movie/list", functionName: "getMovieGenres" },
   { path: "/3/genre/tv/list", functionName: "getTvShowGenres" },
 
+  // Trending
+  {
+    path: "/3/trending/movie/{time_window}",
+    functionName: "getTrendingMovies",
+  },
+  {
+    path: "/3/trending/tv/{time_window}",
+    functionName: "getTrendingTvShows",
+  },
+
   // Movie Discovery & Lists
   {
     path: "/3/discover/movie",


### PR DESCRIPTION
## Summary

Closes #1649

The AI mode page's empty state previously showed only a static title and subtitle. This adds horizontally scrollable rows of trending movies and TV shows (fetched from TMDB's trending API) to give users content to browse before starting a conversation. The empty state layout is adjusted from vertically centered to top-aligned to accommodate the new content.

Also adds the TMDB trending endpoints to the codegen config and fixes a type arity issue in eval scorers (`createScorer` now requires three generic arguments).