### PR TITLE
test: remove unnecessary card.stylex mock from card tests

### DIFF
--- a/src/components/shared/card.test.tsx
+++ b/src/components/shared/card.test.tsx
@@ -1,16 +1,8 @@
 import { createHash } from "node:crypto";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { I18nContext } from "#src/i18n/i18n-context.ts";
 import { render, screen } from "#src/test-utils.tsx";
 import { Card } from "./card";
-
-vi.mock("./card.stylex", () => ({
-  cardTokens: {
-    detailsIndicatorOpacity: "detailsIndicatorOpacity",
-    detailsIndicatorTransform: "detailsIndicatorTransform",
-    imageFilter: "imageFilter",
-  },
-}));
 
 function hashKey(en: string, zh: string) {
   return createHash("sha256")


### PR DESCRIPTION
## Summary

Remove the `vi.mock` of `./card.stylex` from the Card component tests. The mock was faking `cardTokens` values but was unnecessary — all 4 tests pass without it. This aligns with the project convention of avoiding mocks in tests unless explicitly needed.