### PR TITLE
feat: delete stale vectors on TMDB 404 and add ingestion summary

### DIFF
--- a/tooling/vector-ingest/ingest.test.ts
+++ b/tooling/vector-ingest/ingest.test.ts
@@ -11,6 +11,7 @@ import {
   runIncremental,
 } from "./ingest.ts";
 import { makeMovieDetail, makeTvDetail } from "./test-fixtures.ts";
+import { TmdbApiError } from "./tmdb-client.ts";
 import type { DailyExportEntry } from "./tmdb-types.ts";
 import type { VectorRecord } from "./transform.ts";
 
@@ -24,12 +25,21 @@ function makeFakeTmdb(overrides: Partial<TmdbFetcher> = {}): TmdbFetcher {
   };
 }
 
-function makeFakeNamespace(): VectorNamespace & { upserted: VectorRecord[][] } {
+function makeFakeNamespace(): VectorNamespace & {
+  upserted: VectorRecord[][];
+  deleted: string[][];
+} {
   const upserted: VectorRecord[][] = [];
+  const deleted: string[][] = [];
   return {
     upserted,
+    deleted,
     upsert: (records) => {
       upserted.push([...records]);
+      return Promise.resolve();
+    },
+    delete: (ids) => {
+      deleted.push([...ids]);
       return Promise.resolve();
     },
   };
@@ -110,7 +120,7 @@ describe("fetchAndUpsert", () => {
     expect(result.skippedVoteCount).toBe(2);
   });
 
-  it("counts errors without stopping", async () => {
+  it("counts non-404 errors as otherErrors without stopping", async () => {
     const ns = makeFakeNamespace();
     const tmdb = makeFakeTmdb({
       fetchMovieDetail: (id, _locale) => {
@@ -122,7 +132,63 @@ describe("fetchAndUpsert", () => {
     const result = await fetchAndUpsert(tmdb, [1, 2, 3], "movie", "en", ns);
 
     expect(result.upserted).toBe(2);
-    expect(result.errors).toBe(1);
+    expect(result.otherErrors).toBe(1);
+    expect(result.deleted).toBe(0);
+  });
+
+  it("deletes vectors for 404 errors and counts as deleted", async () => {
+    const ns = makeFakeNamespace();
+    const tmdb = makeFakeTmdb({
+      fetchMovieDetail: (id, _locale) => {
+        if (id === 2)
+          return Promise.reject(
+            new TmdbApiError(404, "/3/movie/2", "Not Found"),
+          );
+        return Promise.resolve(makeMovieDetail({ id, vote_count: 500 }));
+      },
+    });
+
+    const result = await fetchAndUpsert(tmdb, [1, 2, 3], "movie", "en", ns);
+
+    expect(result.upserted).toBe(2);
+    expect(result.deleted).toBe(1);
+    expect(result.otherErrors).toBe(0);
+    expect(ns.deleted.flat()).toEqual(["movie-2"]);
+  });
+
+  it("deletes TV vectors with correct ID prefix", async () => {
+    const ns = makeFakeNamespace();
+    const tmdb = makeFakeTmdb({
+      fetchTvDetail: (id, _locale) => {
+        if (id === 5)
+          return Promise.reject(new TmdbApiError(404, "/3/tv/5", "Not Found"));
+        return Promise.resolve(makeTvDetail({ id, vote_count: 500 }));
+      },
+    });
+
+    const result = await fetchAndUpsert(tmdb, [5], "tv", "en", ns);
+
+    expect(result.deleted).toBe(1);
+    expect(ns.deleted.flat()).toEqual(["tv-5"]);
+  });
+
+  it("does not throw when all errors are 404s", async () => {
+    const ns = makeFakeNamespace();
+    const tmdb = makeFakeTmdb({
+      fetchMovieDetail: (_id, _locale) =>
+        Promise.reject(new TmdbApiError(404, "/3/movie/1", "Not Found")),
+    });
+
+    const result = await fetchAndUpsert(tmdb, [1, 2, 3, 4], "movie", "en", ns);
+
+    expect(result.deleted).toBe(4);
+    expect(result.otherErrors).toBe(0);
+    expect(ns.deleted.flat()).toEqual([
+      "movie-1",
+      "movie-2",
+      "movie-3",
+      "movie-4",
+    ]);
   });
 
   it("uses fetchTvDetail for tv mediaType", async () => {
@@ -154,23 +220,11 @@ describe("fetchAndUpsert", () => {
     expect(ids).toEqual(["movie-42", "movie-99"]);
   });
 
-  it("throws when error rate exceeds threshold", async () => {
-    const ns = makeFakeNamespace();
-    const tmdb = makeFakeTmdb({
-      fetchMovieDetail: (_id, _locale) =>
-        Promise.reject(new Error("bad token")),
-    });
-
-    await expect(
-      fetchAndUpsert(tmdb, [1, 2, 3, 4], "movie", "en", ns),
-    ).rejects.toThrow("Error rate too high");
-  });
-
-  it("does not throw when error rate is below threshold", async () => {
+  it("does not throw when error rate is high (no threshold)", async () => {
     const ns = makeFakeNamespace();
     const tmdb = makeFakeTmdb({
       fetchMovieDetail: (id, _locale) => {
-        if (id === 1) return Promise.reject(new Error("API error"));
+        if (id <= 3) return Promise.reject(new Error("bad token"));
         return Promise.resolve(makeMovieDetail({ id, vote_count: 500 }));
       },
     });
@@ -183,8 +237,8 @@ describe("fetchAndUpsert", () => {
       ns,
     );
 
-    expect(result.errors).toBe(1);
-    expect(result.upserted).toBe(4);
+    expect(result.otherErrors).toBe(3);
+    expect(result.upserted).toBe(2);
   });
 
   it("retries upsert once on failure", async () => {
@@ -195,6 +249,7 @@ describe("fetchAndUpsert", () => {
         if (upsertCalls === 1) return Promise.reject(new Error("transient"));
         return Promise.resolve();
       },
+      delete: () => Promise.resolve(),
     };
     const tmdb = makeFakeTmdb({
       fetchMovieDetail: (id, _locale) =>
@@ -209,19 +264,27 @@ describe("fetchAndUpsert", () => {
     expect(result.upserted).toBe(101);
   });
 
-  it("throws with error details when upsert fails after retry", async () => {
+  it("counts upsert retry failures as otherErrors", async () => {
     const ns: VectorNamespace = {
       upsert: () => Promise.reject(new Error("persistent failure")),
+      delete: () => Promise.resolve(),
     };
     const tmdb = makeFakeTmdb({
       fetchMovieDetail: (id, _locale) =>
         Promise.resolve(makeMovieDetail({ id, vote_count: 500 })),
     });
 
-    // 5 records — all fail at upsert, triggering error-rate threshold
-    await expect(
-      fetchAndUpsert(tmdb, [1, 2, 3, 4, 5], "movie", "en", ns),
-    ).rejects.toThrow("Error rate too high");
+    // 5 records — all fail at upsert, no threshold to trigger
+    const result = await fetchAndUpsert(
+      tmdb,
+      [1, 2, 3, 4, 5],
+      "movie",
+      "en",
+      ns,
+    );
+
+    expect(result.otherErrors).toBe(5);
+    expect(result.upserted).toBe(0);
   });
 });
 
@@ -233,7 +296,7 @@ describe("runFull", () => {
         Promise.resolve([{ id: 1, adult: false, popularity: 50 }]),
     });
 
-    await runFull(
+    const stats = await runFull(
       tmdb,
       () => {
         indexCreated = true;
@@ -243,6 +306,7 @@ describe("runFull", () => {
     );
 
     expect(indexCreated).toBe(false);
+    expect(stats).toEqual([]);
   });
 
   it("ingests into both locale namespaces", async () => {
@@ -258,7 +322,7 @@ describe("runFull", () => {
         Promise.resolve(makeTvDetail({ id, vote_count: 500 })),
     });
 
-    await runFull(tmdb, () => index, false);
+    const stats = await runFull(tmdb, () => index, false);
 
     expect(index.namespaces.has("en")).toBe(true);
     expect(index.namespaces.has("zh")).toBe(true);
@@ -267,6 +331,9 @@ describe("runFull", () => {
     const zhRecords = index.namespace("zh").upserted.flat();
     expect(enRecords).toHaveLength(2);
     expect(zhRecords).toHaveLength(2);
+
+    expect(stats).toHaveLength(4); // 2 locales × 2 media types
+    expect(stats.every((s) => s.otherErrors === 0)).toBe(true);
   });
 
   it("applies popularity filters before fetching details", async () => {
@@ -325,7 +392,7 @@ describe("runIncremental", () => {
         Promise.resolve(makeTvDetail({ id, vote_count: 500 })),
     });
 
-    await runIncremental(tmdb, () => index, 1, false);
+    const stats = await runIncremental(tmdb, () => index, 1, false);
 
     expect(index.namespaces.has("en")).toBe(true);
     expect(index.namespaces.has("zh")).toBe(true);
@@ -334,6 +401,8 @@ describe("runIncremental", () => {
     const zhRecords = index.namespace("zh").upserted.flat();
     expect(enRecords).toHaveLength(2);
     expect(zhRecords).toHaveLength(2);
+
+    expect(stats).toHaveLength(4); // 2 locales × 2 media types
   });
 
   it("does not create vector index in dry-run mode", async () => {
@@ -342,7 +411,7 @@ describe("runIncremental", () => {
       fetchChanges: () => Promise.resolve([1, 2]),
     });
 
-    await runIncremental(
+    const stats = await runIncremental(
       tmdb,
       () => {
         indexCreated = true;
@@ -353,6 +422,7 @@ describe("runIncremental", () => {
     );
 
     expect(indexCreated).toBe(false);
+    expect(stats).toEqual([]);
   });
 
   it("respects limit parameter", async () => {

--- a/tooling/vector-ingest/ingest.ts
+++ b/tooling/vector-ingest/ingest.ts
@@ -1,10 +1,11 @@
+import { appendFileSync } from "node:fs";
 import { parseArgs } from "node:util";
 import { Index } from "@upstash/vector";
 import { config } from "dotenv";
 import type { MediaMetadata } from "../../src/vector-db/types.ts";
 import { LOCALES, getRequiredEnv } from "./constants.ts";
 import { RateLimiter } from "./rate-limiter.ts";
-import { TmdbClient } from "./tmdb-client.ts";
+import { TmdbApiError, TmdbClient } from "./tmdb-client.ts";
 import type {
   DailyExportEntry,
   TmdbMovieDetail,
@@ -18,8 +19,18 @@ export const MIN_POPULARITY_MOVIE = 2;
 export const MIN_POPULARITY_TV = 7;
 export const MIN_VOTE_COUNT = 20;
 const UPSERT_BATCH_SIZE = 100;
+const DELETE_BATCH_SIZE = 100;
 const CONCURRENCY = 5;
-const ERROR_RATE_THRESHOLD = 0.5;
+
+export type IngestStats = {
+  locale: string;
+  mediaType: "movie" | "tv";
+  total: number;
+  upserted: number;
+  deleted: number;
+  skippedVoteCount: number;
+  otherErrors: number;
+};
 
 /** Subset of TmdbClient methods used by the orchestrator. */
 export type TmdbFetcher = {
@@ -38,6 +49,7 @@ export type TmdbFetcher = {
 
 export type VectorNamespace = {
   upsert: (records: VectorRecord[]) => Promise<unknown>;
+  delete: (ids: string[]) => Promise<unknown>;
 };
 
 function formatDate(date: Date): string {
@@ -89,10 +101,18 @@ async function main() {
       token: getRequiredEnv("UPSTASH_VECTOR_REST_TOKEN"),
     });
 
+  let allStats: IngestStats[];
   if (incremental) {
-    await runIncremental(tmdb, createIndex, days, dryRun, limit);
+    allStats = await runIncremental(tmdb, createIndex, days, dryRun, limit);
   } else {
-    await runFull(tmdb, createIndex, dryRun, limit);
+    allStats = await runFull(tmdb, createIndex, dryRun, limit);
+  }
+
+  writeSummary(allStats);
+
+  const hasErrors = allStats.some((s) => s.otherErrors > 0);
+  if (hasErrors) {
+    process.exit(1);
   }
 }
 
@@ -101,7 +121,7 @@ export async function runFull(
   createIndex: () => { namespace: (locale: string) => VectorNamespace },
   dryRun: boolean,
   limit?: number,
-) {
+): Promise<IngestStats[]> {
   console.log("Starting full ingestion...");
 
   // Try today first, fall back to yesterday (exports generate ~7-8 AM UTC)
@@ -142,7 +162,7 @@ export async function runFull(
 
   if (dryRun) {
     console.log("\n[DRY RUN] Stopping before API calls and upserts.");
-    return;
+    return [];
   }
 
   const vectorIndex = createIndex();
@@ -156,18 +176,21 @@ export async function runFull(
     tvIds = tvIds.slice(0, limit);
   }
 
+  const allStats: IngestStats[] = [];
+
   for (const locale of LOCALES) {
     console.log(`\nIngesting locale: ${locale}`);
     const ns = vectorIndex.namespace(locale);
 
     console.log(`  Fetching and upserting movies...`);
-    await fetchAndUpsert(tmdb, movieIds, "movie", locale, ns);
+    allStats.push(await fetchAndUpsert(tmdb, movieIds, "movie", locale, ns));
 
     console.log(`  Fetching and upserting TV shows...`);
-    await fetchAndUpsert(tmdb, tvIds, "tv", locale, ns);
+    allStats.push(await fetchAndUpsert(tmdb, tvIds, "tv", locale, ns));
   }
 
   console.log("\nFull ingestion complete.");
+  return allStats;
 }
 
 export async function runIncremental(
@@ -176,7 +199,7 @@ export async function runIncremental(
   days: number,
   dryRun: boolean,
   limit?: number,
-) {
+): Promise<IngestStats[]> {
   console.log(`Starting incremental ingestion (last ${days} day(s))...`);
 
   const endDate = new Date();
@@ -194,7 +217,7 @@ export async function runIncremental(
 
   if (dryRun) {
     console.log("\n[DRY RUN] Stopping before API calls and upserts.");
-    return;
+    return [];
   }
 
   if (limit !== undefined) {
@@ -204,6 +227,7 @@ export async function runIncremental(
   }
 
   const vectorIndex = createIndex();
+  const allStats: IngestStats[] = [];
 
   for (const locale of LOCALES) {
     console.log(`\nIngesting locale: ${locale}`);
@@ -211,16 +235,39 @@ export async function runIncremental(
 
     if (movieIds.length > 0) {
       console.log(`  Fetching and upserting ${movieIds.length} movies...`);
-      await fetchAndUpsert(tmdb, movieIds, "movie", locale, ns);
+      allStats.push(await fetchAndUpsert(tmdb, movieIds, "movie", locale, ns));
     }
 
     if (tvIds.length > 0) {
       console.log(`  Fetching and upserting ${tvIds.length} TV shows...`);
-      await fetchAndUpsert(tmdb, tvIds, "tv", locale, ns);
+      allStats.push(await fetchAndUpsert(tmdb, tvIds, "tv", locale, ns));
     }
   }
 
   console.log("\nIncremental ingestion complete.");
+  return allStats;
+}
+
+async function upsertWithRetry(
+  namespace: VectorNamespace,
+  records: VectorRecord[],
+): Promise<number> {
+  try {
+    await namespace.upsert(records);
+    return records.length;
+  } catch (firstError) {
+    console.error(`    Upsert failed, retrying: ${String(firstError)}`);
+    await sleep(1000);
+    try {
+      await namespace.upsert(records);
+      return records.length;
+    } catch (retryError) {
+      console.error(
+        `    Upsert retry failed, skipping batch of ${records.length}: ${String(retryError)}`,
+      );
+      return 0;
+    }
+  }
 }
 
 export async function fetchAndUpsert(
@@ -229,12 +276,14 @@ export async function fetchAndUpsert(
   mediaType: "movie" | "tv",
   locale: string,
   namespace: VectorNamespace,
-) {
+): Promise<IngestStats> {
   let processed = 0;
   let upserted = 0;
   let skippedVoteCount = 0;
-  let errors = 0;
+  let notFoundErrors = 0;
+  let otherErrors = 0;
   const batch: VectorRecord[] = [];
+  const toDelete: string[] = [];
 
   // Process IDs with controlled concurrency
   for (let i = 0; i < ids.length; i += CONCURRENCY) {
@@ -252,12 +301,21 @@ export async function fetchAndUpsert(
       }),
     );
 
-    for (const result of results) {
+    for (const [idx, result] of results.entries()) {
       processed++;
       if (result.status === "rejected") {
-        errors++;
-        if (errors <= 10) {
-          console.error(`    Error: ${String(result.reason)}`);
+        const id = chunk[idx];
+        if (
+          result.reason instanceof TmdbApiError &&
+          result.reason.statusCode === 404
+        ) {
+          notFoundErrors++;
+          toDelete.push(`${mediaType}-${id}`);
+        } else {
+          otherErrors++;
+          if (otherErrors <= 10) {
+            console.error(`    Error: ${String(result.reason)}`);
+          }
         }
         continue;
       }
@@ -268,67 +326,96 @@ export async function fetchAndUpsert(
       batch.push(result.value);
     }
 
-    // Flush batch when full
+    // Flush delete batch
+    if (toDelete.length >= DELETE_BATCH_SIZE) {
+      const idsToDelete = toDelete.splice(0);
+      await namespace.delete(idsToDelete);
+    }
+
+    // Flush upsert batch when full
     if (batch.length >= UPSERT_BATCH_SIZE) {
       const toUpsert = batch.splice(0);
-      try {
-        await namespace.upsert(toUpsert);
-        upserted += toUpsert.length;
-      } catch (firstError) {
-        console.error(`    Upsert failed, retrying: ${String(firstError)}`);
-        await sleep(1000);
-        try {
-          await namespace.upsert(toUpsert);
-          upserted += toUpsert.length;
-        } catch (retryError) {
-          console.error(
-            `    Upsert retry failed, skipping batch of ${toUpsert.length}: ${String(retryError)}`,
-          );
-          errors += toUpsert.length;
-        }
-      }
+      const count = await upsertWithRetry(namespace, toUpsert);
+      upserted += count;
+      otherErrors += toUpsert.length - count;
     }
 
     // Progress logging
     if (processed % 500 === 0 || processed === ids.length) {
       console.log(
-        `    Progress: ${processed}/${ids.length} processed, ${upserted + batch.length} upserted, ${skippedVoteCount} skipped (low votes), ${errors} errors`,
+        `    Progress: ${processed}/${ids.length} processed, ${upserted + batch.length} upserted, ${notFoundErrors} deleted, ${skippedVoteCount} skipped (low votes), ${otherErrors} errors`,
       );
     }
   }
 
-  // Flush remaining
+  // Flush remaining deletes
+  if (toDelete.length > 0) {
+    await namespace.delete(toDelete.splice(0));
+  }
+
+  // Flush remaining upserts
   if (batch.length > 0) {
     const toUpsert = batch.splice(0);
-    try {
-      await namespace.upsert(toUpsert);
-      upserted += toUpsert.length;
-    } catch (firstError) {
-      console.error(`    Upsert failed, retrying: ${String(firstError)}`);
-      await sleep(1000);
-      try {
-        await namespace.upsert(toUpsert);
-        upserted += toUpsert.length;
-      } catch (retryError) {
-        console.error(
-          `    Upsert retry failed, skipping batch of ${toUpsert.length}: ${String(retryError)}`,
-        );
-        errors += toUpsert.length;
-      }
-    }
+    const count = await upsertWithRetry(namespace, toUpsert);
+    upserted += count;
+    otherErrors += toUpsert.length - count;
   }
 
   console.log(
-    `    Done: ${upserted} upserted, ${skippedVoteCount} skipped, ${errors} errors`,
+    `    Done: ${upserted} upserted, ${notFoundErrors} deleted, ${skippedVoteCount} skipped, ${otherErrors} errors`,
   );
 
-  if (ids.length > 0 && errors / ids.length > ERROR_RATE_THRESHOLD) {
-    throw new Error(
-      `Error rate too high: ${errors}/${ids.length} (${((errors / ids.length) * 100).toFixed(1)}%) — aborting`,
+  return {
+    locale,
+    mediaType,
+    total: ids.length,
+    upserted,
+    deleted: notFoundErrors,
+    skippedVoteCount,
+    otherErrors,
+  };
+}
+
+export function writeSummary(allStats: IngestStats[]) {
+  if (allStats.length === 0) return;
+
+  const summaryPath = process.env["GITHUB_STEP_SUMMARY"];
+  const mdLines = summaryPath
+    ? [
+        "## Vector Ingestion Summary",
+        "",
+        "| Locale | Type | Total | Upserted | Deleted | Skipped | Errors |",
+        "|--------|------|-------|----------|---------|---------|--------|",
+      ]
+    : undefined;
+
+  console.log("\n=== Ingestion Summary ===");
+  console.log("Locale | Type  | Total | Upserted | Deleted | Skipped | Errors");
+  console.log("-------|-------|-------|----------|---------|---------|-------");
+
+  for (const s of allStats) {
+    console.log(
+      `${s.locale.padEnd(6)} | ${s.mediaType.padEnd(5)} | ${String(s.total).padStart(5)} | ${String(s.upserted).padStart(8)} | ${String(s.deleted).padStart(7)} | ${String(s.skippedVoteCount).padStart(7)} | ${String(s.otherErrors).padStart(6)}`,
+    );
+    if (s.deleted > 0) {
+      console.log(
+        `::notice::${s.locale}/${s.mediaType}: deleted ${s.deleted} stale vectors (TMDB 404)`,
+      );
+    }
+    if (s.otherErrors > 0) {
+      console.log(
+        `::warning::${s.locale}/${s.mediaType}: ${s.otherErrors} unexpected errors`,
+      );
+    }
+    mdLines?.push(
+      `| ${s.locale} | ${s.mediaType} | ${s.total} | ${s.upserted} | ${s.deleted} | ${s.skippedVoteCount} | ${s.otherErrors} |`,
     );
   }
 
-  return { upserted, skippedVoteCount, errors };
+  if (summaryPath && mdLines) {
+    mdLines.push("");
+    appendFileSync(summaryPath, mdLines.join("\n"));
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/tooling/vector-ingest/tmdb-client.ts
+++ b/tooling/vector-ingest/tmdb-client.ts
@@ -13,6 +13,15 @@ import {
 const TMDB_API_BASE = "https://api.themoviedb.org";
 const TMDB_EXPORT_BASE = "https://files.tmdb.org/p/exports";
 
+export class TmdbApiError extends Error {
+  readonly statusCode: number;
+
+  constructor(statusCode: number, path: string, statusText: string) {
+    super(`TMDB API error: ${statusCode} ${statusText} (${path})`);
+    this.statusCode = statusCode;
+  }
+}
+
 export class TmdbClient {
   apiToken: string;
   rateLimiter: RateLimiter;
@@ -136,9 +145,7 @@ export class TmdbClient {
     }
 
     if (!response.ok) {
-      throw new Error(
-        `TMDB API error: ${response.status} ${response.statusText} (${path})`,
-      );
+      throw new TmdbApiError(response.status, path, response.statusText);
     }
 
     this.rateLimiter.resetBackoff();


### PR DESCRIPTION
## Summary

When TMDB entries are removed or merged, the API returns 404 for those IDs. Previously the vector ingestion pipeline counted these as generic errors and would abort entirely if the error rate exceeded 50%. This was problematic because a large batch of TMDB removals could halt the entire ingestion.

This change introduces a `TmdbApiError` class that captures HTTP status codes, allowing the pipeline to distinguish 404s from real failures. On 404, the corresponding vector is deleted from the Upstash index, keeping search results clean. The brittle error-rate threshold is removed in favor of structured `IngestStats` reporting — a summary table is printed to stdout and optionally written to `GITHUB_STEP_SUMMARY` for CI visibility. The process exits with code 1 only if there are genuine (non-404) errors.

## Context

The `VectorNamespace` interface now includes a `delete` method alongside `upsert`. The `upsertWithRetry` logic was extracted into its own function to reduce duplication. Both `runFull` and `runIncremental` return `IngestStats[]` so callers (and CI) can inspect per-locale, per-media-type results.