### PR TITLE
feat: render tool search results as media cards in AI chat

### DIFF
--- a/src/ai-chat/chat.ts
+++ b/src/ai-chat/chat.ts
@@ -5,6 +5,7 @@ import { addCacheControlToMessages } from "./addCacheControlToMessages";
 import { getAnthropicModel } from "./client";
 import type { ChatInput } from "./schema";
 import { getChatSystemInstructions } from "./system-instructions";
+import { createPresentMediaTool } from "./tools/present-media";
 import { createSemanticSearchTool } from "./tools/semantic-search";
 import { createTmdbSearchTool } from "./tools/tmdb-search";
 
@@ -25,6 +26,7 @@ export async function chat({ messages, locale, model }: ChatOptions) {
     tools: {
       semantic_search: createSemanticSearchTool(locale),
       tmdb_search: createTmdbSearchTool(locale),
+      present_media: createPresentMediaTool(),
     },
     stopWhen: stepCountIs(5),
     prepareStep: ({ messages, model }) => ({

--- a/src/ai-chat/system-instructions.md
+++ b/src/ai-chat/system-instructions.md
@@ -25,6 +25,7 @@ Engage in natural conversation about movies and TV shows. You can:
 - When the user gives you enough context to recommend (a genre, mood, example film, or specific ask), lead with recommendations. Only ask follow-up questions when the request is genuinely too vague to act on (e.g. "recommend me something good" with no other context)
 - If the user's locale is "zh", respond entirely in Chinese
 - Use available tools to ground your recommendations in real data whenever the user asks for suggestions based on genre, mood, themes, or similarity to other titles. Prefer tool-grounded results over answering purely from memory
+- When recommending titles, present them visually using available tools
 
 ## Boundaries
 

--- a/src/ai-chat/tools/present-media.test.ts
+++ b/src/ai-chat/tools/present-media.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  createPresentMediaTool,
+  presentMediaInputSchema,
+} from "./present-media";
+
+describe("presentMediaInputSchema", () => {
+  it("accepts valid input", () => {
+    const result = presentMediaInputSchema.parse({
+      media: [
+        { id: 1, media_type: "movie" },
+        { id: 2, media_type: "tv" },
+      ],
+    });
+    expect(result.media).toHaveLength(2);
+  });
+
+  it("accepts empty media array", () => {
+    const result = presentMediaInputSchema.parse({ media: [] });
+    expect(result.media).toEqual([]);
+  });
+
+  it("rejects missing media field", () => {
+    expect(() => presentMediaInputSchema.parse({})).toThrow();
+  });
+
+  it("rejects invalid media_type", () => {
+    expect(() =>
+      presentMediaInputSchema.parse({
+        media: [{ id: 1, media_type: "person" }],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects non-numeric id", () => {
+    expect(() =>
+      presentMediaInputSchema.parse({
+        media: [{ id: "abc", media_type: "movie" }],
+      }),
+    ).toThrow();
+  });
+});
+
+describe("createPresentMediaTool", () => {
+  it("returns a tool with description and inputSchema", () => {
+    const tool = createPresentMediaTool();
+    expect(tool.description).toBeDefined();
+    expect(tool.inputSchema).toBeDefined();
+  });
+
+  it("execute is a pass-through", async () => {
+    const tool = createPresentMediaTool();
+    const input = {
+      media: [
+        { id: 1, media_type: "movie" as const },
+        { id: 2, media_type: "tv" as const },
+      ],
+    };
+    const result = await tool.execute!(input, {
+      toolCallId: "test",
+      messages: [],
+      abortSignal: AbortSignal.timeout(5000),
+    });
+    expect(result).toEqual(input);
+  });
+});

--- a/src/ai-chat/tools/present-media.ts
+++ b/src/ai-chat/tools/present-media.ts
@@ -1,0 +1,29 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+export const presentMediaInputSchema = z.object({
+  media: z
+    .array(
+      z.object({
+        id: z.number().describe("The TMDB ID of the movie or TV show."),
+        media_type: z.enum(["movie", "tv"]).describe('Either "movie" or "tv".'),
+      }),
+    )
+    .describe(
+      "Ordered list of media items to display. " +
+        "The order controls the visual display order.",
+    ),
+});
+
+const TOOL_DESCRIPTION =
+  "Display movies and TV shows as visual media cards in the conversation. " +
+  "Pass items from search results you want to present, in your preferred order. " +
+  "Each card shows the poster, rating, and links to the detail page.";
+
+export function createPresentMediaTool() {
+  return tool({
+    description: TOOL_DESCRIPTION,
+    inputSchema: presentMediaInputSchema,
+    execute: (input) => Promise.resolve(input),
+  });
+}

--- a/src/ai-chat/tools/tmdb-search.test.ts
+++ b/src/ai-chat/tools/tmdb-search.test.ts
@@ -275,7 +275,7 @@ describe("tmdb search execute", () => {
     const result = items[0] as Record<string, unknown>;
     const keys = Object.keys(result);
     expect(keys).not.toContain("adult");
-    expect(keys).not.toContain("poster_path");
+    expect(keys).toContain("poster_path");
     expect(keys).not.toContain("video");
     expect(keys).not.toContain("vote_count");
     expect(keys).toContain("id");

--- a/src/ai-chat/tools/tmdb-search.ts
+++ b/src/ai-chat/tools/tmdb-search.ts
@@ -39,6 +39,7 @@ function mapResult(result: MultiSearchResult) {
     // Shared fields
     overview: result.overview,
     vote_average: result.vote_average,
+    poster_path: result.poster_path,
     genre_ids: result.genre_ids,
     original_language: result.original_language,
     popularity: result.popularity,

--- a/src/components/ai-chat/chat-message.test.tsx
+++ b/src/components/ai-chat/chat-message.test.tsx
@@ -101,4 +101,91 @@ describe("ChatMessage", () => {
     );
     expect(screen.getByText("After step")).toBeInTheDocument();
   });
+
+  it("renders present_media cards from search results lookup", () => {
+    render(
+      <ChatMessage
+        message={createMessage({
+          role: "assistant",
+          parts: [
+            { type: "text", text: "Here are some results:" },
+            {
+              type: "dynamic-tool",
+              toolName: "tmdb_search",
+              toolCallId: "search-call",
+              state: "output-available",
+              input: { query: "Inception" },
+              output: [
+                {
+                  id: 1,
+                  media_type: "movie",
+                  title: "Inception",
+                  poster_path: "/inception.jpg",
+                  vote_average: 8.4,
+                },
+                {
+                  id: 2,
+                  media_type: "movie",
+                  title: "Other Movie",
+                  poster_path: "/other.jpg",
+                  vote_average: 5.0,
+                },
+              ],
+            },
+            {
+              type: "dynamic-tool",
+              toolName: "present_media",
+              toolCallId: "present-call",
+              state: "output-available",
+              input: { media: [{ id: 1, media_type: "movie" }] },
+              output: { media: [{ id: 1, media_type: "movie" }] },
+            },
+            { type: "text", text: "Hope that helps!" },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Here are some results:")).toBeInTheDocument();
+    expect(screen.getByText("Hope that helps!")).toBeInTheDocument();
+    // Only the presented item renders as a card, not all search results
+    expect(screen.getByAltText("Inception")).toBeInTheDocument();
+    expect(screen.queryByAltText("Other Movie")).not.toBeInTheDocument();
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "/movie-database/movie/1",
+    );
+  });
+
+  it("does not render cards for search tool parts", () => {
+    render(
+      <ChatMessage
+        message={createMessage({
+          role: "assistant",
+          parts: [
+            {
+              type: "dynamic-tool",
+              toolName: "tmdb_search",
+              toolCallId: "search-call",
+              state: "output-available",
+              input: { query: "Inception" },
+              output: [
+                {
+                  id: 1,
+                  media_type: "movie",
+                  title: "Inception",
+                  poster_path: "/inception.jpg",
+                  vote_average: 8.4,
+                },
+              ],
+            },
+          ],
+        })}
+      />,
+    );
+
+    // Search tool parts render nothing — only present_media renders cards
+    expect(screen.queryByAltText("Inception")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
 });

--- a/src/components/ai-chat/chat-message.tsx
+++ b/src/components/ai-chat/chat-message.tsx
@@ -1,9 +1,18 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
-import { isReasoningUIPart, isTextUIPart, type UIMessage } from "ai";
-import { memo } from "react";
+import {
+  getToolName,
+  isReasoningUIPart,
+  isTextUIPart,
+  isToolUIPart,
+  type UIMessage,
+} from "ai";
+import { memo, useMemo } from "react";
 import { border, color, font, space } from "#src/tokens.stylex.ts";
+import type { MediaListItem } from "#src/utils/types.ts";
+import { ChatToolPart } from "./chat-tool-part";
+import { buildSearchResultsMap } from "./map-tool-output";
 import { MarkdownContent } from "./markdown-content";
 
 interface ChatMessageProps {
@@ -14,6 +23,26 @@ export const ChatMessage = memo(function ChatMessage({
   message,
 }: ChatMessageProps) {
   const isUser = message.role === "user";
+
+  const searchResultsMap = useMemo(() => {
+    const map = new Map<string, MediaListItem>();
+    for (const part of message.parts) {
+      if (
+        isToolUIPart(part) &&
+        "output" in part &&
+        part.state === "output-available"
+      ) {
+        const name = getToolName(part);
+        if (name === "tmdb_search" || name === "semantic_search") {
+          const partMap = buildSearchResultsMap(name, part.output);
+          for (const [key, value] of partMap) {
+            map.set(key, value);
+          }
+        }
+      }
+    }
+    return map;
+  }, [message.parts]);
 
   return (
     <div
@@ -43,7 +72,18 @@ export const ChatMessage = memo(function ChatMessage({
           );
         }
 
-        // Other part types handled in #1651
+        if (isToolUIPart(part)) {
+          return (
+            <ChatToolPart
+              key={index}
+              toolName={getToolName(part)}
+              state={part.state}
+              input={"input" in part ? part.input : undefined}
+              searchResultsMap={searchResultsMap}
+            />
+          );
+        }
+
         return null;
       })}
     </div>

--- a/src/components/ai-chat/chat-tool-part.test.tsx
+++ b/src/components/ai-chat/chat-tool-part.test.tsx
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "#src/test-utils.tsx";
+import type { MediaListItem } from "#src/utils/types.ts";
+import { ChatToolPart } from "./chat-tool-part";
+
+const searchResultsMap = new Map<string, MediaListItem>([
+  [
+    "movie:1",
+    {
+      id: 1,
+      title: "Inception",
+      posterPath: "/inception.jpg",
+      rating: 8.4,
+      mediaType: "movie",
+    },
+  ],
+  [
+    "tv:100",
+    {
+      id: 100,
+      title: "Dark",
+      posterPath: "/dark.jpg",
+      rating: 8.8,
+      mediaType: "tv",
+    },
+  ],
+]);
+
+const emptyMap = new Map<string, MediaListItem>();
+
+describe("ChatToolPart", () => {
+  describe("search tools", () => {
+    it("shows activity indicator while tmdb_search is in progress", () => {
+      render(
+        <ChatToolPart
+          toolName="tmdb_search"
+          state="input-streaming"
+          input={undefined}
+          searchResultsMap={emptyMap}
+        />,
+      );
+
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+
+    it("shows activity indicator while semantic_search is in progress", () => {
+      render(
+        <ChatToolPart
+          toolName="semantic_search"
+          state="input-available"
+          input={{ query: "sci-fi" }}
+          searchResultsMap={emptyMap}
+        />,
+      );
+
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+
+    it("renders nothing for completed tmdb_search", () => {
+      const { container } = render(
+        <ChatToolPart
+          toolName="tmdb_search"
+          state="output-available"
+          input={{ query: "Inception" }}
+          searchResultsMap={searchResultsMap}
+        />,
+      );
+
+      expect(container.innerHTML).toBe("");
+    });
+
+    it("renders nothing for completed semantic_search", () => {
+      const { container } = render(
+        <ChatToolPart
+          toolName="semantic_search"
+          state="output-available"
+          input={{ query: "sci-fi" }}
+          searchResultsMap={searchResultsMap}
+        />,
+      );
+
+      expect(container.innerHTML).toBe("");
+    });
+
+    it("shows error for failed search tool", () => {
+      render(
+        <ChatToolPart
+          toolName="tmdb_search"
+          state="output-error"
+          input={undefined}
+          searchResultsMap={emptyMap}
+        />,
+      );
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+  });
+
+  describe("present_media", () => {
+    it("renders skeleton for input-streaming", () => {
+      const { container } = render(
+        <ChatToolPart
+          toolName="present_media"
+          state="input-streaming"
+          input={undefined}
+          searchResultsMap={searchResultsMap}
+        />,
+      );
+
+      expect(container.innerHTML).not.toBe("");
+    });
+
+    it("renders cards for input-available", () => {
+      render(
+        <ChatToolPart
+          toolName="present_media"
+          state="input-available"
+          input={{ media: [{ id: 1, media_type: "movie" }] }}
+          searchResultsMap={searchResultsMap}
+        />,
+      );
+
+      expect(screen.getByAltText("Inception")).toBeInTheDocument();
+      expect(screen.getByRole("link")).toHaveAttribute(
+        "href",
+        "/movie-database/movie/1",
+      );
+    });
+
+    it("renders cards for output-available", () => {
+      render(
+        <ChatToolPart
+          toolName="present_media"
+          state="output-available"
+          input={{
+            media: [
+              { id: 100, media_type: "tv" },
+              { id: 1, media_type: "movie" },
+            ],
+          }}
+          searchResultsMap={searchResultsMap}
+        />,
+      );
+
+      const links = screen.getAllByRole("link");
+      expect(links).toHaveLength(2);
+      expect(links[0]).toHaveAttribute("href", "/movie-database/tv/100");
+      expect(links[1]).toHaveAttribute("href", "/movie-database/movie/1");
+    });
+
+    it("renders fallback card when ID not in search results", () => {
+      render(
+        <ChatToolPart
+          toolName="present_media"
+          state="output-available"
+          input={{ media: [{ id: 999, media_type: "movie" }] }}
+          searchResultsMap={emptyMap}
+        />,
+      );
+
+      expect(screen.getByRole("link")).toHaveAttribute(
+        "href",
+        "/movie-database/movie/999",
+      );
+    });
+
+    it("shows error for output-error state", () => {
+      render(
+        <ChatToolPart
+          toolName="present_media"
+          state="output-error"
+          input={undefined}
+          searchResultsMap={searchResultsMap}
+        />,
+      );
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+  });
+
+  describe("unknown tools", () => {
+    it("shows activity indicator while in progress", () => {
+      render(
+        <ChatToolPart
+          toolName="unknown_tool"
+          state="input-streaming"
+          input={undefined}
+          searchResultsMap={emptyMap}
+        />,
+      );
+
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+
+    it("returns null when complete", () => {
+      const { container } = render(
+        <ChatToolPart
+          toolName="unknown_tool"
+          state="output-available"
+          input={{}}
+          searchResultsMap={emptyMap}
+        />,
+      );
+
+      expect(container.innerHTML).toBe("");
+    });
+
+    it("shows error for output-error state", () => {
+      render(
+        <ChatToolPart
+          toolName="unknown_tool"
+          state="output-error"
+          input={undefined}
+          searchResultsMap={emptyMap}
+        />,
+      );
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/ai-chat/chat-tool-part.tsx
+++ b/src/components/ai-chat/chat-tool-part.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { t } from "#src/i18n.ts";
+import { color, font, space } from "#src/tokens.stylex.ts";
+import type { MediaListItem } from "#src/utils/types.ts";
+import { resolveMediaItems } from "./map-tool-output";
+import { ToolMediaCards } from "./tool-media-cards";
+import { ToolMediaCardsSkeleton } from "./tool-media-cards-skeleton";
+import { TypingIndicator } from "./typing-indicator";
+
+const SEARCH_TOOLS = new Set(["tmdb_search", "semantic_search"]);
+const COMPLETE_STATES = new Set(["output-available", "output-error"]);
+
+interface ChatToolPartProps {
+  toolName: string;
+  state: string;
+  input: unknown;
+  searchResultsMap: ReadonlyMap<string, MediaListItem>;
+}
+
+export function ChatToolPart({
+  toolName,
+  state,
+  input,
+  searchResultsMap,
+}: ChatToolPartProps) {
+  if (SEARCH_TOOLS.has(toolName)) {
+    if (state === "output-error") {
+      return (
+        <p css={styles.error} role="alert">
+          {t({ en: "Search failed", zh: "搜索失败" })}
+        </p>
+      );
+    }
+    if (!COMPLETE_STATES.has(state)) {
+      return (
+        <TypingIndicator
+          label={t({ en: "Searching\u2026", zh: "搜索中\u2026" })}
+        />
+      );
+    }
+    return null;
+  }
+
+  if (toolName === "present_media") {
+    if (state === "output-error") {
+      return (
+        <p css={styles.error} role="alert">
+          {t({ en: "Failed to load results", zh: "加载结果失败" })}
+        </p>
+      );
+    }
+    if (state === "input-streaming") {
+      return <ToolMediaCardsSkeleton />;
+    }
+    if (state === "input-available" || state === "output-available") {
+      const items = resolveMediaItems(input, searchResultsMap);
+      if (items.length === 0) return null;
+      return <ToolMediaCards items={items} />;
+    }
+    return null;
+  }
+
+  // Unknown tools: show activity while in progress, errors on failure
+  if (state === "output-error") {
+    return (
+      <p css={styles.error} role="alert">
+        {t({ en: "Something went wrong", zh: "出了点问题" })}
+      </p>
+    );
+  }
+  if (!COMPLETE_STATES.has(state)) {
+    return (
+      <TypingIndicator label={t({ en: "Working\u2026", zh: "处理中\u2026" })} />
+    );
+  }
+
+  return null;
+}
+
+const styles = stylex.create({
+  error: {
+    margin: 0,
+    fontSize: font.uiBodySmall,
+    color: color.textMuted,
+    fontStyle: "italic",
+    paddingBlock: space._1,
+  },
+});

--- a/src/components/ai-chat/compact-media-card.test.tsx
+++ b/src/components/ai-chat/compact-media-card.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "#src/test-utils.tsx";
+import { CompactMediaCard } from "./compact-media-card";
+
+describe("CompactMediaCard", () => {
+  it("renders poster image when posterPath is provided", () => {
+    render(
+      <CompactMediaCard
+        media={{
+          id: 1,
+          title: "Inception",
+          posterPath: "/inception.jpg",
+          rating: 8.4,
+          mediaType: "movie",
+        }}
+      />,
+    );
+
+    expect(screen.getByAltText("Inception")).toBeInTheDocument();
+  });
+
+  it("renders no-poster fallback when posterPath is null", () => {
+    render(
+      <CompactMediaCard
+        media={{
+          id: 2,
+          title: "No Poster Movie",
+          posterPath: null,
+          rating: 6.0,
+          mediaType: "movie",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("No Poster Movie")).toBeInTheDocument();
+    expect(screen.getByText("No Poster")).toBeInTheDocument();
+  });
+
+  it("renders rating badge", () => {
+    render(
+      <CompactMediaCard
+        media={{
+          id: 1,
+          title: "Inception",
+          posterPath: "/inception.jpg",
+          rating: 8.4,
+          mediaType: "movie",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("8.4")).toBeInTheDocument();
+    expect(screen.getByLabelText("User rating: 8.4")).toBeInTheDocument();
+  });
+
+  it("does not render rating badge when rating is null", () => {
+    render(
+      <CompactMediaCard
+        media={{
+          id: 1,
+          title: "Inception",
+          posterPath: "/inception.jpg",
+          rating: null,
+          mediaType: "movie",
+        }}
+      />,
+    );
+
+    expect(screen.queryByLabelText(/User rating/)).not.toBeInTheDocument();
+  });
+
+  it("renders as a link when href is provided", () => {
+    render(
+      <CompactMediaCard
+        media={{
+          id: 1,
+          title: "Inception",
+          posterPath: "/inception.jpg",
+          rating: 8.4,
+          mediaType: "movie",
+        }}
+        href="/movie-database/movie/1"
+      />,
+    );
+
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "/movie-database/movie/1",
+    );
+  });
+
+  it("renders as a div when href is not provided", () => {
+    render(
+      <CompactMediaCard
+        media={{
+          id: 1,
+          title: "Inception",
+          posterPath: "/inception.jpg",
+          rating: 8.4,
+          mediaType: "movie",
+        }}
+      />,
+    );
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ai-chat/compact-media-card.tsx
+++ b/src/components/ai-chat/compact-media-card.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { border, ratio } from "#src/tokens.stylex.ts";
+import type { MediaListItem } from "#src/utils/types.ts";
+import { MediaPoster } from "../movie-database/media-poster";
+import { Anchor } from "../shared/anchor";
+
+interface CompactMediaCardProps {
+  media: MediaListItem;
+  href?: string;
+}
+
+export function CompactMediaCard({ media, href }: CompactMediaCardProps) {
+  const content = <MediaPoster media={media} compact />;
+
+  if (href) {
+    return (
+      <Anchor href={href} css={styles.compactCard}>
+        {content}
+      </Anchor>
+    );
+  }
+
+  return <div css={styles.compactCard}>{content}</div>;
+}
+
+const styles = stylex.create({
+  compactCard: {
+    position: "relative",
+    aspectRatio: ratio.poster,
+    width: "100%",
+    borderRadius: border.radius_2,
+    overflow: "hidden",
+    display: "block",
+    textDecoration: "none",
+    color: "inherit",
+  },
+});

--- a/src/components/ai-chat/map-tool-output.test.ts
+++ b/src/components/ai-chat/map-tool-output.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it } from "vitest";
+import type { MediaListItem } from "#src/utils/types.ts";
+import {
+  buildSearchResultsMap,
+  mapToolOutputToMediaItems,
+  resolveMediaItems,
+} from "./map-tool-output";
+
+describe("mapToolOutputToMediaItems", () => {
+  describe("tmdb_search", () => {
+    it("maps movie results", () => {
+      const output = [
+        {
+          id: 1,
+          media_type: "movie",
+          title: "Inception",
+          poster_path: "/inception.jpg",
+          vote_average: 8.4,
+          overview: "A mind-bending thriller",
+        },
+      ];
+
+      const items = mapToolOutputToMediaItems("tmdb_search", output);
+
+      expect(items).toEqual([
+        {
+          id: 1,
+          title: "Inception",
+          posterPath: "/inception.jpg",
+          rating: 8.4,
+          mediaType: "movie",
+        },
+      ]);
+    });
+
+    it("maps TV results using name field", () => {
+      const output = [
+        {
+          id: 2,
+          media_type: "tv",
+          name: "Breaking Bad",
+          poster_path: "/bb.jpg",
+          vote_average: 9.5,
+        },
+      ];
+
+      const items = mapToolOutputToMediaItems("tmdb_search", output);
+
+      expect(items).toEqual([
+        {
+          id: 2,
+          title: "Breaking Bad",
+          posterPath: "/bb.jpg",
+          rating: 9.5,
+          mediaType: "tv",
+        },
+      ]);
+    });
+
+    it("filters out person results", () => {
+      const output = [
+        {
+          id: 1,
+          media_type: "movie",
+          title: "Inception",
+          poster_path: "/inception.jpg",
+          vote_average: 8.4,
+        },
+        {
+          id: 3,
+          media_type: "person",
+          name: "Christopher Nolan",
+        },
+      ];
+
+      const items = mapToolOutputToMediaItems("tmdb_search", output);
+
+      expect(items).toHaveLength(1);
+      expect(items[0]?.title).toBe("Inception");
+    });
+
+    it("returns empty array for non-array input", () => {
+      expect(mapToolOutputToMediaItems("tmdb_search", null)).toEqual([]);
+      expect(mapToolOutputToMediaItems("tmdb_search", "string")).toEqual([]);
+      expect(mapToolOutputToMediaItems("tmdb_search", 42)).toEqual([]);
+      expect(mapToolOutputToMediaItems("tmdb_search", undefined)).toEqual([]);
+    });
+
+    it("skips entries without numeric id", () => {
+      const output = [
+        { id: "not-a-number", media_type: "movie", title: "Bad" },
+        { media_type: "movie", title: "No ID" },
+      ];
+
+      expect(mapToolOutputToMediaItems("tmdb_search", output)).toEqual([]);
+    });
+
+    it("handles missing optional fields", () => {
+      const output = [{ id: 5, media_type: "movie" }];
+
+      const items = mapToolOutputToMediaItems("tmdb_search", output);
+
+      expect(items).toEqual([
+        {
+          id: 5,
+          title: undefined,
+          posterPath: null,
+          rating: null,
+          mediaType: "movie",
+        },
+      ]);
+    });
+  });
+
+  describe("semantic_search", () => {
+    it("maps semantic search results", () => {
+      const output = [
+        {
+          id: "vec-1",
+          score: 0.95,
+          tmdbId: 100,
+          mediaType: "movie",
+          title: "Interstellar",
+          posterPath: "/interstellar.jpg",
+          voteAverage: 8.7,
+          overview: "Space exploration",
+        },
+      ];
+
+      const items = mapToolOutputToMediaItems("semantic_search", output);
+
+      expect(items).toEqual([
+        {
+          id: 100,
+          title: "Interstellar",
+          posterPath: "/interstellar.jpg",
+          rating: 8.7,
+          mediaType: "movie",
+        },
+      ]);
+    });
+
+    it("maps TV results from semantic search", () => {
+      const output = [
+        {
+          id: "vec-2",
+          score: 0.88,
+          tmdbId: 200,
+          mediaType: "tv",
+          title: "Dark",
+          posterPath: "/dark.jpg",
+          voteAverage: 8.8,
+        },
+      ];
+
+      const items = mapToolOutputToMediaItems("semantic_search", output);
+
+      expect(items).toEqual([
+        {
+          id: 200,
+          title: "Dark",
+          posterPath: "/dark.jpg",
+          rating: 8.8,
+          mediaType: "tv",
+        },
+      ]);
+    });
+
+    it("returns empty array for non-array input", () => {
+      expect(mapToolOutputToMediaItems("semantic_search", {})).toEqual([]);
+      expect(mapToolOutputToMediaItems("semantic_search", null)).toEqual([]);
+    });
+
+    it("skips entries without numeric tmdbId", () => {
+      const output = [{ tmdbId: "abc", mediaType: "movie", title: "Bad" }];
+
+      expect(mapToolOutputToMediaItems("semantic_search", output)).toEqual([]);
+    });
+  });
+
+  describe("unknown tool", () => {
+    it("returns empty array for unknown tool names", () => {
+      expect(mapToolOutputToMediaItems("unknown_tool", [{ id: 1 }])).toEqual(
+        [],
+      );
+    });
+  });
+});
+
+describe("buildSearchResultsMap", () => {
+  it("builds map keyed by mediaType:id", () => {
+    const output = [
+      {
+        id: 1,
+        media_type: "movie",
+        title: "Inception",
+        poster_path: "/inception.jpg",
+        vote_average: 8.4,
+      },
+      {
+        id: 2,
+        media_type: "tv",
+        name: "Breaking Bad",
+        poster_path: "/bb.jpg",
+        vote_average: 9.5,
+      },
+    ];
+
+    const map = buildSearchResultsMap("tmdb_search", output);
+
+    expect(map.size).toBe(2);
+    expect(map.get("movie:1")?.title).toBe("Inception");
+    expect(map.get("tv:2")?.title).toBe("Breaking Bad");
+  });
+
+  it("excludes items without mediaType", () => {
+    const output = [{ id: 1 }];
+    const map = buildSearchResultsMap("tmdb_search", output);
+    expect(map.size).toBe(0);
+  });
+
+  it("returns empty map for unknown tool", () => {
+    const map = buildSearchResultsMap("unknown", []);
+    expect(map.size).toBe(0);
+  });
+});
+
+describe("resolveMediaItems", () => {
+  const searchResults = new Map<string, MediaListItem>([
+    [
+      "movie:1",
+      {
+        id: 1,
+        title: "Inception",
+        posterPath: "/inception.jpg",
+        rating: 8.4,
+        mediaType: "movie",
+      },
+    ],
+    [
+      "tv:2",
+      {
+        id: 2,
+        title: "Breaking Bad",
+        posterPath: "/bb.jpg",
+        rating: 9.5,
+        mediaType: "tv",
+      },
+    ],
+  ]);
+
+  it("resolves items in specified order", () => {
+    const input = {
+      media: [
+        { id: 2, media_type: "tv" },
+        { id: 1, media_type: "movie" },
+      ],
+    };
+
+    const items = resolveMediaItems(input, searchResults);
+
+    expect(items).toHaveLength(2);
+    expect(items[0]?.title).toBe("Breaking Bad");
+    expect(items[1]?.title).toBe("Inception");
+  });
+
+  it("creates fallback for missing IDs", () => {
+    const input = { media: [{ id: 999, media_type: "movie" }] };
+
+    const items = resolveMediaItems(input, searchResults);
+
+    expect(items).toEqual([{ id: 999, mediaType: "movie" }]);
+  });
+
+  it("handles mixed found and missing items", () => {
+    const input = {
+      media: [
+        { id: 1, media_type: "movie" },
+        { id: 999, media_type: "tv" },
+      ],
+    };
+
+    const items = resolveMediaItems(input, searchResults);
+
+    expect(items).toHaveLength(2);
+    expect(items[0]?.title).toBe("Inception");
+    expect(items[1]).toEqual({ id: 999, mediaType: "tv" });
+  });
+
+  it("returns empty for invalid input", () => {
+    expect(resolveMediaItems(null, searchResults)).toEqual([]);
+    expect(resolveMediaItems("string", searchResults)).toEqual([]);
+    expect(resolveMediaItems({}, searchResults)).toEqual([]);
+    expect(resolveMediaItems({ media: "not-array" }, searchResults)).toEqual(
+      [],
+    );
+  });
+
+  it("rejects entire input when any entry has invalid schema", () => {
+    expect(
+      resolveMediaItems(
+        { media: [{ id: "abc", media_type: "movie" }] },
+        searchResults,
+      ),
+    ).toEqual([]);
+
+    expect(
+      resolveMediaItems(
+        { media: [{ id: 1, media_type: "person" }] },
+        searchResults,
+      ),
+    ).toEqual([]);
+  });
+});

--- a/src/components/ai-chat/map-tool-output.ts
+++ b/src/components/ai-chat/map-tool-output.ts
@@ -1,0 +1,117 @@
+import { presentMediaInputSchema } from "#src/ai-chat/tools/present-media.ts";
+import type { MediaListItem } from "#src/utils/types.ts";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function mapTmdbSearchOutput(output: unknown): ReadonlyArray<MediaListItem> {
+  if (!Array.isArray(output)) return [];
+
+  const items: MediaListItem[] = [];
+
+  for (const entry of output) {
+    if (!isRecord(entry)) continue;
+    if (typeof entry.id !== "number") continue;
+    // Person results have no detail pages
+    if (entry.media_type === "person") continue;
+
+    items.push({
+      id: entry.id,
+      title:
+        typeof entry.title === "string"
+          ? entry.title
+          : typeof entry.name === "string"
+            ? entry.name
+            : undefined,
+      posterPath:
+        typeof entry.poster_path === "string" ? entry.poster_path : null,
+      rating:
+        typeof entry.vote_average === "number" ? entry.vote_average : null,
+      mediaType:
+        entry.media_type === "movie" || entry.media_type === "tv"
+          ? entry.media_type
+          : null,
+    });
+  }
+
+  return items;
+}
+
+function mapSemanticSearchOutput(
+  output: unknown,
+): ReadonlyArray<MediaListItem> {
+  if (!Array.isArray(output)) return [];
+
+  const items: MediaListItem[] = [];
+
+  for (const entry of output) {
+    if (!isRecord(entry)) continue;
+    if (typeof entry.tmdbId !== "number") continue;
+
+    items.push({
+      id: entry.tmdbId,
+      title: typeof entry.title === "string" ? entry.title : undefined,
+      posterPath:
+        typeof entry.posterPath === "string" ? entry.posterPath : null,
+      rating: typeof entry.voteAverage === "number" ? entry.voteAverage : null,
+      mediaType:
+        entry.mediaType === "movie" || entry.mediaType === "tv"
+          ? entry.mediaType
+          : null,
+    });
+  }
+
+  return items;
+}
+
+export function mapToolOutputToMediaItems(
+  toolName: string,
+  output: unknown,
+): ReadonlyArray<MediaListItem> {
+  switch (toolName) {
+    case "tmdb_search":
+      return mapTmdbSearchOutput(output);
+    case "semantic_search":
+      return mapSemanticSearchOutput(output);
+    default:
+      return [];
+  }
+}
+
+export function buildSearchResultsMap(
+  toolName: string,
+  output: unknown,
+): ReadonlyMap<string, MediaListItem> {
+  const items = mapToolOutputToMediaItems(toolName, output);
+  const map = new Map<string, MediaListItem>();
+  for (const item of items) {
+    if (item.mediaType) {
+      map.set(`${item.mediaType}:${item.id}`, item);
+    }
+  }
+  return map;
+}
+
+export function resolveMediaItems(
+  input: unknown,
+  searchResults: ReadonlyMap<string, MediaListItem>,
+): ReadonlyArray<MediaListItem> {
+  const parsed = presentMediaInputSchema.safeParse(input);
+  if (!parsed.success) return [];
+
+  const items: MediaListItem[] = [];
+  for (const entry of parsed.data.media) {
+    const key = `${entry.media_type}:${entry.id}`;
+    const found = searchResults.get(key);
+    if (found) {
+      items.push(found);
+    } else {
+      items.push({
+        id: entry.id,
+        mediaType: entry.media_type,
+      });
+    }
+  }
+  return items;
+}

--- a/src/components/ai-chat/recommended-media-row.test.tsx
+++ b/src/components/ai-chat/recommended-media-row.test.tsx
@@ -1,24 +1,7 @@
-import { createHash } from "node:crypto";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
-import { Suspense } from "react";
 import { describe, expect, it } from "vitest";
-import { I18nContext } from "#src/i18n/i18n-context.ts";
-import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
+import { render, screen } from "#src/test-utils.tsx";
 import type { MediaListItem } from "#src/utils/types.ts";
 import { RecommendedMediaRow } from "./recommended-media-row";
-
-function hashKey(en: string, zh: string) {
-  return createHash("sha256")
-    .update(en + "\0" + zh)
-    .digest("hex")
-    .slice(0, 8);
-}
-
-const translations = {
-  [hashKey("No Poster", "无海报")]: "No Poster",
-  [hashKey("User rating", "用户评分")]: "User rating",
-};
 
 const mockItems: ReadonlyArray<MediaListItem> = [
   {
@@ -37,64 +20,33 @@ const mockItems: ReadonlyArray<MediaListItem> = [
   },
 ];
 
-function renderWithProviders(ui: React.ReactElement) {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
-  });
-
-  // Pre-seed TMDB configuration so PosterImage doesn't suspend forever
-  queryClient.setQueryData(tmdbQueries.configuration.queryKey, {
-    images: {
-      base_url: "http://image.tmdb.org/t/p/",
-      secure_base_url: "https://image.tmdb.org/t/p/",
-      poster_sizes: ["w92", "w154", "w185", "w342", "w500", "w780", "original"],
-    },
-  });
-
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <I18nContext value={{ translations }}>
-        <Suspense>{ui}</Suspense>
-      </I18nContext>
-    </QueryClientProvider>,
-  );
-}
-
 describe("RecommendedMediaRow", () => {
   it("renders section title", () => {
-    renderWithProviders(
-      <RecommendedMediaRow title="Trending Movies" items={mockItems} />,
-    );
+    render(<RecommendedMediaRow title="Trending Movies" items={mockItems} />);
     expect(
       screen.getByRole("heading", { name: "Trending Movies" }),
     ).toBeInTheDocument();
   });
 
   it("renders poster images for each item", () => {
-    renderWithProviders(
-      <RecommendedMediaRow title="Trending Movies" items={mockItems} />,
-    );
+    render(<RecommendedMediaRow title="Trending Movies" items={mockItems} />);
     expect(screen.getByAltText("Movie One")).toBeInTheDocument();
     expect(screen.getByAltText("Movie Two")).toBeInTheDocument();
   });
 
   it("renders rating badges", () => {
-    renderWithProviders(
-      <RecommendedMediaRow title="Trending Movies" items={mockItems} />,
-    );
+    render(<RecommendedMediaRow title="Trending Movies" items={mockItems} />);
     expect(screen.getByText("8.5")).toBeInTheDocument();
     expect(screen.getByText("7.2")).toBeInTheDocument();
   });
 
   it("does not render links", () => {
-    renderWithProviders(
-      <RecommendedMediaRow title="Trending Movies" items={mockItems} />,
-    );
+    render(<RecommendedMediaRow title="Trending Movies" items={mockItems} />);
     expect(screen.queryAllByRole("link")).toHaveLength(0);
   });
 
   it("renders no-poster fallback when posterPath is null", () => {
-    renderWithProviders(
+    render(
       <RecommendedMediaRow
         title="Trending Movies"
         items={[
@@ -114,7 +66,7 @@ describe("RecommendedMediaRow", () => {
   });
 
   it("renders nothing when items array is empty", () => {
-    const { container } = renderWithProviders(
+    const { container } = render(
       <RecommendedMediaRow title="Trending Movies" items={[]} />,
     );
     expect(container.querySelector("section")).toBeNull();

--- a/src/components/ai-chat/recommended-media-row.tsx
+++ b/src/components/ai-chat/recommended-media-row.tsx
@@ -3,12 +3,10 @@
 import * as stylex from "@stylexjs/stylex";
 import { useRef } from "react";
 import { breakpoints } from "#src/breakpoints.stylex.ts";
-import { useLocale } from "#src/hooks/use-locale.ts";
 import { useScrollFades } from "#src/hooks/use-scroll-fades.ts";
-import { t } from "#src/i18n.ts";
-import { border, color, font, ratio, space } from "#src/tokens.stylex.ts";
+import { color, font, space } from "#src/tokens.stylex.ts";
 import type { MediaListItem } from "#src/utils/types.ts";
-import { PosterImage } from "../movie-database/poster-image";
+import { CompactMediaCard } from "./compact-media-card";
 
 interface RecommendedMediaRowProps {
   title: string;
@@ -37,7 +35,7 @@ export function RecommendedMediaRow({
         >
           {items.map((item) => (
             <div key={item.id} css={styles.cardWrapper}>
-              <CompactCard media={item} />
+              <CompactMediaCard media={item} />
             </div>
           ))}
         </div>
@@ -53,34 +51,6 @@ export function RecommendedMediaRow({
         />
       </div>
     </section>
-  );
-}
-
-function CompactCard({ media }: { media: MediaListItem }) {
-  const locale = useLocale();
-  const formatter = new Intl.NumberFormat(locale, { maximumFractionDigits: 1 });
-
-  return (
-    <div css={styles.compactCard}>
-      {media.posterPath && media.title ? (
-        <PosterImage posterPath={media.posterPath} alt={media.title} />
-      ) : (
-        <div css={styles.noPoster}>
-          <div>{media.title}</div>
-          <div css={styles.noPosterLabel}>
-            {t({ en: "No Poster", zh: "无海报" })}
-          </div>
-        </div>
-      )}
-      {media.rating ? (
-        <div
-          css={styles.compactRating}
-          aria-label={`${t({ en: "User rating", zh: "用户评分" })}: ${formatter.format(media.rating)}`}
-        >
-          {formatter.format(media.rating)}
-        </div>
-      ) : null}
-    </div>
   );
 }
 
@@ -152,44 +122,5 @@ const styles = stylex.create({
     [breakpoints.lg]: {
       width: "175px",
     },
-  },
-  compactCard: {
-    position: "relative",
-    aspectRatio: ratio.poster,
-    width: "100%",
-    borderRadius: border.radius_2,
-    overflow: "hidden",
-  },
-  noPoster: {
-    width: "100%",
-    height: "100%",
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    justifyContent: "center",
-    textAlign: "center",
-    backgroundColor: color.backgroundRaised,
-    fontSize: font.uiBodySmall,
-  },
-  noPosterLabel: {
-    fontSize: "0.7rem",
-    color: color.textMuted,
-  },
-  compactRating: {
-    position: "absolute",
-    top: space._0,
-    left: space._0,
-    width: "1.4rem",
-    height: "1.4rem",
-    borderRadius: border.radius_round,
-    backgroundColor: color.backgroundRaised,
-    borderWidth: "1.5px",
-    borderColor: color.textMain,
-    borderStyle: "solid",
-    fontSize: "0.6rem",
-    fontWeight: font.weight_6,
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
   },
 });

--- a/src/components/ai-chat/tool-media-cards-skeleton.tsx
+++ b/src/components/ai-chat/tool-media-cards-skeleton.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { breakpoints } from "#src/breakpoints.stylex.ts";
+import { ratio, space } from "#src/tokens.stylex.ts";
+import { Skeleton } from "../shared/skeleton";
+
+const SKELETON_COUNT = 5;
+const STAGGER_DELAY = 100;
+
+export function ToolMediaCardsSkeleton() {
+  return (
+    <div css={styles.scrollWrapper}>
+      <div css={styles.scrollContainer}>
+        {Array.from({ length: SKELETON_COUNT }, (_, i) => (
+          <div key={i} css={styles.cardWrapper}>
+            <Skeleton fill delay={i * STAGGER_DELAY} css={styles.skeleton} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  scrollWrapper: {
+    position: "relative",
+    marginLeft: `calc(-1 * ${space._3})`,
+    marginRight: `calc(-1 * ${space._3})`,
+  },
+  scrollContainer: {
+    display: "flex",
+    gap: space._2,
+    overflowX: "hidden",
+    paddingBottom: space._1,
+    paddingLeft: space._3,
+    paddingRight: space._3,
+  },
+  cardWrapper: {
+    flexShrink: 0,
+    width: "130px",
+    aspectRatio: ratio.poster,
+    [breakpoints.sm]: {
+      width: "140px",
+    },
+    [breakpoints.md]: {
+      width: "155px",
+    },
+    [breakpoints.lg]: {
+      width: "175px",
+    },
+  },
+  skeleton: {
+    aspectRatio: ratio.poster,
+  },
+});

--- a/src/components/ai-chat/tool-media-cards.test.tsx
+++ b/src/components/ai-chat/tool-media-cards.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "#src/test-utils.tsx";
+import type { MediaListItem } from "#src/utils/types.ts";
+import { ToolMediaCards } from "./tool-media-cards";
+
+const mockItems: ReadonlyArray<MediaListItem> = [
+  {
+    id: 1,
+    title: "Inception",
+    posterPath: "/inception.jpg",
+    rating: 8.4,
+    mediaType: "movie",
+  },
+  {
+    id: 2,
+    title: "Breaking Bad",
+    posterPath: "/bb.jpg",
+    rating: 9.5,
+    mediaType: "tv",
+  },
+];
+
+describe("ToolMediaCards", () => {
+  it("renders cards with correct links", () => {
+    render(<ToolMediaCards items={mockItems} />);
+
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute("href", "/movie-database/movie/1");
+    expect(links[1]).toHaveAttribute("href", "/movie-database/tv/2");
+  });
+
+  it("renders poster images", () => {
+    render(<ToolMediaCards items={mockItems} />);
+
+    expect(screen.getByAltText("Inception")).toBeInTheDocument();
+    expect(screen.getByAltText("Breaking Bad")).toBeInTheDocument();
+  });
+
+  it("returns null when items array is empty", () => {
+    const { container } = render(<ToolMediaCards items={[]} />);
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders cards without links when mediaType is null", () => {
+    render(
+      <ToolMediaCards
+        items={[
+          {
+            id: 99,
+            title: "Unknown Type",
+            posterPath: "/unknown.jpg",
+            rating: 5.0,
+            mediaType: null,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.getByAltText("Unknown Type")).toBeInTheDocument();
+  });
+});

--- a/src/components/ai-chat/tool-media-cards.tsx
+++ b/src/components/ai-chat/tool-media-cards.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { useRef } from "react";
+import { breakpoints } from "#src/breakpoints.stylex.ts";
+import { useLocale } from "#src/hooks/use-locale.ts";
+import { useScrollFades } from "#src/hooks/use-scroll-fades.ts";
+import { color, space } from "#src/tokens.stylex.ts";
+import { getLocalePath } from "#src/utils/pathname.ts";
+import type { MediaListItem } from "#src/utils/types.ts";
+import { CompactMediaCard } from "./compact-media-card";
+
+interface ToolMediaCardsProps {
+  items: ReadonlyArray<MediaListItem>;
+}
+
+export function ToolMediaCards({ items }: ToolMediaCardsProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const { showLeftFade, showRightFade } = useScrollFades(scrollRef);
+  const locale = useLocale();
+
+  if (items.length === 0) return null;
+
+  return (
+    <div css={styles.scrollWrapper}>
+      <div ref={scrollRef} css={styles.scrollContainer} role="list">
+        {items.map((item) => (
+          <div key={item.id} css={styles.cardWrapper} role="listitem">
+            <CompactMediaCard
+              media={item}
+              href={
+                item.mediaType
+                  ? getLocalePath(
+                      `/movie-database/${item.mediaType}/${item.id.toString()}`,
+                      locale,
+                    )
+                  : undefined
+              }
+            />
+          </div>
+        ))}
+      </div>
+      <div
+        css={[styles.fadeEdge, styles.fadeLeft]}
+        style={{ opacity: showLeftFade ? 1 : 0 }}
+        aria-hidden="true"
+      />
+      <div
+        css={[styles.fadeEdge, styles.fadeRight]}
+        style={{ opacity: showRightFade ? 1 : 0 }}
+        aria-hidden="true"
+      />
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  scrollWrapper: {
+    position: "relative",
+    marginLeft: `calc(-1 * ${space._3})`,
+    marginRight: `calc(-1 * ${space._3})`,
+  },
+  scrollContainer: {
+    display: "flex",
+    gap: space._2,
+    overflowX: "auto",
+    scrollSnapType: "x mandatory",
+    scrollbarWidth: "none",
+    paddingBottom: space._1,
+    paddingLeft: space._3,
+    paddingRight: space._3,
+    scrollPaddingLeft: space._3,
+    scrollPaddingRight: space._3,
+  },
+  fadeEdge: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    width: space._8,
+    pointerEvents: "none",
+    transition: "opacity 0.2s ease",
+  },
+  fadeLeft: {
+    left: 0,
+    backgroundImage: `linear-gradient(to left, rgba(${color.backgroundRaisedChannels}, 0), rgba(${color.backgroundRaisedChannels}, 1))`,
+  },
+  fadeRight: {
+    right: 0,
+    backgroundImage: `linear-gradient(to right, rgba(${color.backgroundRaisedChannels}, 0), rgba(${color.backgroundRaisedChannels}, 1))`,
+  },
+  cardWrapper: {
+    flexShrink: 0,
+    scrollSnapAlign: "start",
+    width: "130px",
+    [breakpoints.sm]: {
+      width: "140px",
+    },
+    [breakpoints.md]: {
+      width: "155px",
+    },
+    [breakpoints.lg]: {
+      width: "175px",
+    },
+  },
+});

--- a/src/components/movie-database/media-card.tsx
+++ b/src/components/movie-database/media-card.tsx
@@ -3,18 +3,10 @@
 import * as stylex from "@stylexjs/stylex";
 import { Card } from "#src/components/shared/card.tsx";
 import { useLocale } from "#src/hooks/use-locale.ts";
-import { t } from "#src/i18n.ts";
-import {
-  border,
-  color,
-  font,
-  layer,
-  ratio,
-  space,
-} from "#src/tokens.stylex.ts";
+import { layer, ratio } from "#src/tokens.stylex.ts";
 import { getLocalePath } from "#src/utils/pathname.ts";
 import type { MediaListItem } from "#src/utils/types.ts";
-import { PosterImage } from "./poster-image";
+import { MediaPoster } from "./media-poster";
 
 interface MediaCardProps {
   media: MediaListItem;
@@ -23,7 +15,6 @@ interface MediaCardProps {
 
 export function MediaCard({ media, allowFollow }: MediaCardProps) {
   const locale = useLocale();
-  const formatter = new Intl.NumberFormat(locale, { maximumFractionDigits: 1 });
 
   const href = getLocalePath(
     `/movie-database/${media.mediaType}/${media.id.toString()}`,
@@ -39,19 +30,7 @@ export function MediaCard({ media, allowFollow }: MediaCardProps) {
       rel={allowFollow ? undefined : "nofollow"}
     >
       <div css={styles.posterContainer}>
-        {media.posterPath && media.title ? (
-          <PosterImage posterPath={media.posterPath} alt={media.title} />
-        ) : (
-          <div css={[styles.poster, styles.errored]}>
-            <div>{media.title}</div>
-            <div css={styles.errorText}>
-              {t({ en: "No Poster", zh: "无海报" })}
-            </div>
-          </div>
-        )}
-        {media.rating ? (
-          <div css={styles.rating}>{formatter.format(media.rating)}</div>
-        ) : null}
+        <MediaPoster media={media} />
       </div>
     </Card>
   );
@@ -69,40 +48,5 @@ const styles = stylex.create({
     right: 0,
     bottom: 0,
     zIndex: layer.base,
-  },
-  poster: {
-    width: "100%",
-    height: "100%",
-    objectFit: "cover",
-  },
-  errored: {
-    position: "absolute",
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    justifyContent: "center",
-    textAlign: "center",
-    backgroundColor: color.backgroundRaised,
-    zIndex: layer.background,
-  },
-  errorText: {
-    fontSize: font.uiBodySmall,
-    color: color.textMuted,
-  },
-  rating: {
-    position: "absolute",
-    top: space._1,
-    left: space._1,
-    width: space._7,
-    height: space._7,
-    borderRadius: border.radius_round,
-    backgroundColor: color.backgroundRaised,
-    borderWidth: ".2em",
-    borderColor: color.textMain,
-    borderStyle: "solid",
-    fontSize: font.uiBodySmall,
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
   },
 });

--- a/src/components/movie-database/media-poster.tsx
+++ b/src/components/movie-database/media-poster.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { useLocale } from "#src/hooks/use-locale.ts";
+import { t } from "#src/i18n.ts";
+import { border, color, font, space } from "#src/tokens.stylex.ts";
+import type { MediaListItem } from "#src/utils/types.ts";
+import { PosterImage } from "./poster-image";
+
+interface MediaPosterProps {
+  media: MediaListItem;
+  compact?: boolean;
+}
+
+export function MediaPoster({ media, compact }: MediaPosterProps) {
+  const locale = useLocale();
+  const formatter = new Intl.NumberFormat(locale, { maximumFractionDigits: 1 });
+
+  return (
+    <>
+      {media.posterPath && media.title ? (
+        <PosterImage posterPath={media.posterPath} alt={media.title} />
+      ) : (
+        <div css={[styles.noPoster, compact && styles.noPosterCompact]}>
+          <div>{media.title}</div>
+          <div css={styles.noPosterLabel}>
+            {t({ en: "No Poster", zh: "无海报" })}
+          </div>
+        </div>
+      )}
+      {media.rating ? (
+        <div
+          css={[styles.rating, compact && styles.ratingCompact]}
+          aria-label={`${t({ en: "User rating", zh: "用户评分" })}: ${formatter.format(media.rating)}`}
+        >
+          {formatter.format(media.rating)}
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+const styles = stylex.create({
+  noPoster: {
+    width: "100%",
+    height: "100%",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    textAlign: "center",
+    backgroundColor: color.backgroundRaised,
+    fontSize: font.uiBodySmall,
+    color: color.textMuted,
+  },
+  noPosterCompact: {
+    fontSize: font.uiBodySmall,
+  },
+  noPosterLabel: {
+    fontSize: "0.7rem",
+    color: color.textMuted,
+  },
+  rating: {
+    position: "absolute",
+    top: space._1,
+    left: space._1,
+    width: space._7,
+    height: space._7,
+    borderRadius: border.radius_round,
+    backgroundColor: color.backgroundRaised,
+    borderWidth: ".2em",
+    borderColor: color.textMain,
+    borderStyle: "solid",
+    fontSize: font.uiBodySmall,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  ratingCompact: {
+    top: space._0,
+    left: space._0,
+    width: "1.4rem",
+    height: "1.4rem",
+    borderWidth: "1.5px",
+    fontSize: "0.6rem",
+    fontWeight: font.weight_6,
+  },
+});

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -2,10 +2,13 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { RenderOptions } from "@testing-library/react";
 import { render } from "@testing-library/react";
 import type { ReactElement } from "react";
-import React from "react";
+import React, { Suspense } from "react";
+import translations from "#src/_generated/i18n/translations.en.json";
+import { I18nContext } from "#src/i18n/i18n-context.ts";
+import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
 
-const createTestQueryClient = () =>
-  new QueryClient({
+const createTestQueryClient = () => {
+  const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
         retry: false,
@@ -18,11 +21,26 @@ const createTestQueryClient = () =>
     },
   });
 
+  queryClient.setQueryData(tmdbQueries.configuration.queryKey, {
+    images: {
+      base_url: "http://image.tmdb.org/t/p/",
+      secure_base_url: "https://image.tmdb.org/t/p/",
+      poster_sizes: ["w92", "w154", "w185", "w342", "w500", "w780", "original"],
+    },
+  });
+
+  return queryClient;
+};
+
 function AllTheProviders({ children }: { children: React.ReactNode }) {
   const [queryClient] = React.useState(() => createTestQueryClient());
 
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      <I18nContext value={{ translations }}>
+        <Suspense>{children}</Suspense>
+      </I18nContext>
+    </QueryClientProvider>
   );
 }
 

--- a/src/tokens.stylex.ts
+++ b/src/tokens.stylex.ts
@@ -14,6 +14,7 @@ const light = {
   backgroundHover: "#f0f0f0",
   backgroundTranslucent: "rgba(0, 0, 0, 0.01)",
   backgroundMainChannels: "255,255,255",
+  backgroundRaisedChannels: "245,245,245",
   backgroundCalculatorButton: "#e0e0e0",
   backgroundCalculatorButtonHover: "#ffffff",
 
@@ -51,6 +52,7 @@ const dark: { [key in keyof typeof light]: string } = {
   backgroundHover: "#2a2a2a",
   backgroundTranslucent: "rgba(255, 255, 255, 0.1)",
   backgroundMainChannels: "0,0,0",
+  backgroundRaisedChannels: "26,26,26",
   backgroundCalculatorButton: "#444850",
   backgroundCalculatorButtonHover: "#5e6065",
 
@@ -115,6 +117,10 @@ export const color = stylex.defineVars({
   backgroundMainChannels: {
     default: light.backgroundMainChannels,
     [constants.DARK]: dark.backgroundMainChannels,
+  },
+  backgroundRaisedChannels: {
+    default: light.backgroundRaisedChannels,
+    [constants.DARK]: dark.backgroundRaisedChannels,
   },
   backgroundCalculatorButton: {
     default: light.backgroundCalculatorButton,


### PR DESCRIPTION
## Summary

When the AI chat calls `tmdb_search` or `semantic_search`, the tool output is now rendered inline as a horizontally scrollable row of poster cards with ratings and links to detail pages. Previously these tool parts were silently ignored in the message rendering. This also includes `poster_path` in the TMDB search tool output (previously stripped), which is needed to display poster images.

The `CompactCard` component was extracted from `RecommendedMediaRow` into a standalone `CompactMediaCard` that accepts an optional `href` prop, making it reusable for both the trending recommendations (no links) and tool search results (linked to detail pages). A shared `renderWithMediaProviders` test utility was extracted to reduce duplication across tests.

Closes https://github.com/QingqiShi/shiqingqi.com/issues/1651