### PR TITLE
refactor: validate AI search POST body with Zod at route level

### DIFF
--- a/src/app/api/ai-search/route.ts
+++ b/src/app/api/ai-search/route.ts
@@ -1,15 +1,23 @@
 import type { NextRequest } from "next/server";
-import { performAISearch } from "#src/utils/ai-search.ts";
+import { z } from "zod";
+import { performAISearch, searchParamsSchema } from "#src/utils/ai-search.ts";
 import { apiRouteWrapper } from "#src/utils/api-route-wrapper.ts";
 
 export const GET = apiRouteWrapper(performAISearch);
 
 export async function POST(request: NextRequest) {
   try {
-    const body = (await request.json()) as { query: string; locale?: string };
-    const result = await performAISearch(body);
+    const body: unknown = await request.json();
+    const params = searchParamsSchema.parse(body);
+    const result = await performAISearch(params);
     return Response.json(result);
   } catch (error) {
+    if (error instanceof z.ZodError) {
+      return Response.json(
+        { success: false, error: "Invalid request body" },
+        { status: 400 },
+      );
+    }
     console.error("AI Search POST error:", error);
     return Response.json(
       {

--- a/src/utils/ai-search.ts
+++ b/src/utils/ai-search.ts
@@ -1,10 +1,9 @@
 import "server-only";
 import { z } from "zod";
 import { agent } from "#src/ai/agent.ts";
-import type { SupportedLocale } from "#src/types.ts";
 
 // Request validation schema
-const SearchParamsSchema = z.object({
+export const searchParamsSchema = z.object({
   query: z
     .string()
     .min(1, "Query cannot be empty")
@@ -13,10 +12,7 @@ const SearchParamsSchema = z.object({
   locale: z.enum(["en", "zh"]).optional().default("en"),
 });
 
-export interface AISearchParams {
-  query: string;
-  locale?: string;
-}
+export type AISearchParams = z.input<typeof searchParamsSchema>;
 
 export interface AISearchResponse {
   success: boolean;
@@ -36,11 +32,10 @@ export async function performAISearch(
 ): Promise<AISearchResponse> {
   try {
     // Validate and sanitize input parameters
-    const validatedData = SearchParamsSchema.parse(params);
-    const { query, locale } = validatedData;
+    const { query, locale } = searchParamsSchema.parse(params);
 
     // Execute AI agent
-    const result = await agent(query, locale as SupportedLocale);
+    const result = await agent(query, locale);
 
     return {
       success: true,
@@ -54,6 +49,7 @@ export async function performAISearch(
     if (error instanceof z.ZodError) {
       throw new Error(
         `Invalid parameters: ${error.errors.map((e) => e.message).join(", ")}`,
+        { cause: error },
       );
     }
 


### PR DESCRIPTION
## Summary

The AI search POST handler was casting `request.json()` with `as { query: string; locale?: string }` without any runtime validation. Malformed requests would pass through unvalidated into `performAISearch`, producing confusing 500 errors instead of a clear 400.

This change validates the POST body against the existing Zod schema at the route level, returning a proper 400 response for invalid requests. The `AISearchParams` type is now derived from the schema (`z.input<typeof searchParamsSchema>`) instead of a manually maintained interface, making the schema the single source of truth. The unnecessary `SupportedLocale` type assertion on `locale` is also removed since the Zod schema already narrows it to `"en" | "zh"`.