### PR TITLE
fix: add onLoad handler to poster image to dismiss skeleton reliably

### DIFF
--- a/src/components/movie-database/poster-image.tsx
+++ b/src/components/movie-database/poster-image.tsx
@@ -57,6 +57,7 @@ export function PosterImage({ posterPath, alt }: PosterImageProps) {
         srcSet={srcSet}
         sizes="auto,(max-width: 326px) 100vw,(max-width: 485px) 50vw,(max-width: 644px) 33.3vw,(max-width: 767px) 25vw,(max-width: 969px) 33.3vw,(max-width: 1079px) 25vw,(max-width: 1259px) 33.3vw,(max-width: 1571px) 25vw,362px"
         loading="lazy"
+        onLoad={() => setImgLoaded(true)}
         ref={(el) => {
           if (el && el.complete) {
             setImgLoaded(true);


### PR DESCRIPTION
## Summary

The poster image component relied solely on a `ref` callback checking `el.complete` to dismiss the loading skeleton. This misses the case where the image finishes loading asynchronously after the ref runs but before the next render, leaving the skeleton visible indefinitely. Adding an `onLoad` handler ensures the skeleton is always dismissed once the image loads, regardless of timing.