### PR TITLE
fix: show fallback UI when poster image fails to load

### DIFF
--- a/src/components/movie-database/poster-image.tsx
+++ b/src/components/movie-database/poster-image.tsx
@@ -22,8 +22,9 @@ export function PosterImage({ posterPath, alt }: PosterImageProps) {
   const { data: config } = useSuspenseQuery(tmdbQueries.configuration);
 
   const [imgLoaded, setImgLoaded] = useState(false);
+  const [imgErrored, setImgErrored] = useState(false);
 
-  if (!config.images?.base_url || !config.images?.poster_sizes) {
+  if (!config.images?.base_url || !config.images?.poster_sizes || imgErrored) {
     return (
       <div css={[styles.poster, styles.errored]}>
         <div>{alt}</div>
@@ -58,6 +59,7 @@ export function PosterImage({ posterPath, alt }: PosterImageProps) {
         sizes="auto,(max-width: 326px) 100vw,(max-width: 485px) 50vw,(max-width: 644px) 33.3vw,(max-width: 767px) 25vw,(max-width: 969px) 33.3vw,(max-width: 1079px) 25vw,(max-width: 1259px) 33.3vw,(max-width: 1571px) 25vw,362px"
         loading="lazy"
         onLoad={() => setImgLoaded(true)}
+        onError={() => setImgErrored(true)}
         ref={(el) => {
           if (el && el.complete) {
             setImgLoaded(true);


### PR DESCRIPTION
## Summary

Poster images can fail to load when TMDB returns a 404 for a stale poster path or the CDN is unreachable. Without error handling, users see a broken image icon. This adds an `onError` handler to the poster `<img>` element so the component gracefully falls back to the same text-based UI that is shown when TMDB configuration is missing.