### PR TITLE
fix: add accessible label and keyboard focus to media cards list

### DIFF
--- a/src/components/ai-chat/tool-media-cards.test.tsx
+++ b/src/components/ai-chat/tool-media-cards.test.tsx
@@ -22,6 +22,17 @@ const mockItems: ReadonlyArray<MediaListItem> = [
 ];
 
 describe("ToolMediaCards", () => {
+  it("renders a labeled, keyboard-focusable list", () => {
+    render(
+      <MediaDetailProvider>
+        <ToolMediaCards items={mockItems} />
+      </MediaDetailProvider>,
+    );
+
+    const list = screen.getByRole("list", { name: "Search results" });
+    expect(list).toHaveAttribute("tabindex", "0");
+  });
+
   it("renders cards as buttons", () => {
     render(
       <MediaDetailProvider>

--- a/src/components/ai-chat/tool-media-cards.tsx
+++ b/src/components/ai-chat/tool-media-cards.tsx
@@ -4,6 +4,7 @@ import * as stylex from "@stylexjs/stylex";
 import { useRef } from "react";
 import { breakpoints } from "#src/breakpoints.stylex.ts";
 import { useScrollFades } from "#src/hooks/use-scroll-fades.ts";
+import { t } from "#src/i18n.ts";
 import { scrollX } from "#src/primitives/layout.stylex.ts";
 import { color, space } from "#src/tokens.stylex.ts";
 import type { MediaListItem } from "#src/utils/types.ts";
@@ -27,6 +28,8 @@ export function ToolMediaCards({ items }: ToolMediaCardsProps) {
         ref={scrollRef}
         css={[scrollX.base, styles.scrollContainer]}
         role="list"
+        aria-label={t({ en: "Search results", zh: "搜索结果" })}
+        tabIndex={0}
       >
         {items.map((item) => {
           const { mediaType } = item;


### PR DESCRIPTION
## Summary

The horizontally scrollable media cards list in AI chat had no accessible name and was not reachable via keyboard navigation. This adds an `aria-label` ("Search results" / "搜索结果") and `tabIndex={0}` to the scroll container so screen readers can identify the list and keyboard users can scroll through it. A corresponding test verifies both attributes.