### PR TITLE
feat: link recommended media cards to detail pages

### DIFF
--- a/src/components/ai-chat/recommended-media-row.test.tsx
+++ b/src/components/ai-chat/recommended-media-row.test.tsx
@@ -40,8 +40,48 @@ describe("RecommendedMediaRow", () => {
     expect(screen.getByText("7.2")).toBeInTheDocument();
   });
 
-  it("does not render links", () => {
+  it("renders links to detail pages", () => {
     render(<RecommendedMediaRow title="Trending Movies" items={mockItems} />);
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute("href", "/movie-database/movie/1");
+    expect(links[1]).toHaveAttribute("href", "/movie-database/movie/2");
+  });
+
+  it("renders links for TV items with correct type", () => {
+    render(
+      <RecommendedMediaRow
+        title="Trending TV Shows"
+        items={[
+          {
+            id: 10,
+            title: "TV Show One",
+            posterPath: "/tv1.jpg",
+            rating: 9.0,
+            mediaType: "tv",
+          },
+        ]}
+      />,
+    );
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveAttribute("href", "/movie-database/tv/10");
+  });
+
+  it("does not render link when mediaType is missing", () => {
+    render(
+      <RecommendedMediaRow
+        title="Trending"
+        items={[
+          {
+            id: 5,
+            title: "Unknown Type",
+            posterPath: "/unknown.jpg",
+            rating: 7.0,
+          },
+        ]}
+      />,
+    );
     expect(screen.queryAllByRole("link")).toHaveLength(0);
   });
 

--- a/src/components/ai-chat/recommended-media-row.tsx
+++ b/src/components/ai-chat/recommended-media-row.tsx
@@ -3,8 +3,10 @@
 import * as stylex from "@stylexjs/stylex";
 import { useRef } from "react";
 import { breakpoints } from "#src/breakpoints.stylex.ts";
+import { useLocale } from "#src/hooks/use-locale.ts";
 import { useScrollFades } from "#src/hooks/use-scroll-fades.ts";
 import { color, font, space } from "#src/tokens.stylex.ts";
+import { getLocalePath } from "#src/utils/pathname.ts";
 import type { MediaListItem } from "#src/utils/types.ts";
 import { CompactMediaCard } from "./compact-media-card";
 
@@ -19,6 +21,7 @@ export function RecommendedMediaRow({
 }: RecommendedMediaRowProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const { showLeftFade, showRightFade } = useScrollFades(scrollRef);
+  const locale = useLocale();
 
   if (items.length === 0) return null;
 
@@ -35,7 +38,17 @@ export function RecommendedMediaRow({
         >
           {items.map((item) => (
             <div key={item.id} css={styles.cardWrapper}>
-              <CompactMediaCard media={item} />
+              <CompactMediaCard
+                media={item}
+                href={
+                  item.mediaType
+                    ? getLocalePath(
+                        `/movie-database/${item.mediaType}/${item.id.toString()}`,
+                        locale,
+                      )
+                    : undefined
+                }
+              />
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary

Recommended media cards in the AI chat were not clickable, so users could see recommendations but had no way to navigate to the detail page. This wraps each `CompactMediaCard` in a link to `/movie-database/{type}/{id}` when `mediaType` is present, using locale-aware paths. When `mediaType` is absent the card renders without a link, preserving backward compatibility.