### PR TITLE
fix: use correct max-age attribute for locale cookie

### DIFF
--- a/src/components/shared/locale-selector.tsx
+++ b/src/components/shared/locale-selector.tsx
@@ -70,7 +70,7 @@ export function LocaleSelector({
 function setLocaleCookie(locale: SupportedLocale) {
   // set cookie for next-i18n-router
   const maxAge = 31536000; // 1 year in seconds
-  document.cookie = `${LOCALE_COOKIE_NAME}=${locale};maxAge=${maxAge};path=/;SameSite=Lax`;
+  document.cookie = `${LOCALE_COOKIE_NAME}=${locale};max-age=${maxAge};path=/;SameSite=Lax`;
 }
 
 const styles = stylex.create({


### PR DESCRIPTION
## Summary

The locale preference cookie was set with `maxAge` (camelCase), which is not a valid `Set-Cookie` attribute. Browsers ignored it, treating the cookie as a session cookie that expired when the browser closed. This fixes the attribute name to `max-age` so the locale preference persists for 1 year as intended.