### PR TITLE
fix: enforce subdomain boundary in Vercel referer allowlist

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,5 +3,5 @@ export const LOCALE_COOKIE_NAME = "NEXT_LOCALE";
 export const ALLOWED_REFERER = [
   BASE_URL,
   "http://localhost:3000",
-  "vercel.app",
+  ".vercel.app",
 ];

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -45,4 +45,21 @@ describe("proxy referer validation for API routes", () => {
     expect(response.status).toBe(403);
     expect(await response.json()).toEqual({ error: "Unauthorized" });
   });
+
+  it("allows requests from Vercel preview deployments", () => {
+    const response = proxy(
+      apiRequest("/api/ai-chat", "https://my-app-abc123.vercel.app/search"),
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("rejects requests from domains ending in vercel.app that are not subdomains", async () => {
+    const response = proxy(
+      apiRequest("/api/ai-chat", "https://evilvercel.app/search"),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "Unauthorized" });
+  });
 });


### PR DESCRIPTION
## Summary

The referer allowlist entry `"vercel.app"` matched any domain ending in those characters (e.g. `evilvercel.app`), not just legitimate Vercel preview deployment subdomains. This changes the entry to `".vercel.app"` so the proxy's substring check enforces a subdomain boundary, only allowing URLs like `my-app-abc123.vercel.app`.

Two new tests cover the fix: one confirming Vercel preview deployments are allowed, and one confirming look-alike domains like `evilvercel.app` are rejected.