### PR TITLE
fix: use overview instead of tagline for movie/TV meta description

### DIFF
--- a/src/app/[locale]/movie-database/[type]/[id]/layout.tsx
+++ b/src/app/[locale]/movie-database/[type]/[id]/layout.tsx
@@ -34,7 +34,7 @@ export async function generateMetadata({
         movieDetails.title ??
         movieDetails.original_title ??
         t({ en: "Untitled", zh: "佚名" }),
-      description: movieDetails.tagline,
+      description: movieDetails.overview || movieDetails.tagline,
       alternates: {
         canonical: new URL(`/movie-database/movie/${id}`, BASE_URL).toString(),
         languages: {
@@ -53,7 +53,7 @@ export async function generateMetadata({
         tvShowDetails.name ??
         tvShowDetails.original_name ??
         t({ en: "Untitled", zh: "佚名" }),
-      description: tvShowDetails.tagline,
+      description: tvShowDetails.overview || tvShowDetails.tagline,
       alternates: {
         canonical: new URL(`/movie-database/tv/${id}`, BASE_URL).toString(),
         languages: {


### PR DESCRIPTION
## Summary

The movie and TV show detail pages were using the `tagline` field as the HTML meta description. Taglines are typically short marketing phrases (e.g., "Just when you thought it was safe to go back in the water...") that don't describe the content well for search engines or social sharing previews. This changes the meta description to prefer the `overview` field, which contains the actual plot synopsis, falling back to `tagline` when no overview is available.