### PR TITLE
refactor: remove type assertion in apiRequestWrapper param serialization

### DIFF
--- a/src/utils/api-request-wrapper.ts
+++ b/src/utils/api-request-wrapper.ts
@@ -1,3 +1,9 @@
+type ParamValue = string | number | boolean;
+
+function toSearchParamString(value: ParamValue): string {
+  return value.toString();
+}
+
 /**
  * Makes it easier to call a route handler API that was mapped from a server function.
  */
@@ -11,15 +17,24 @@ export async function apiRequestWrapper<
   }
   const baseUrl = window.location.origin;
   const url = new URL(`${baseUrl}${apiRoute}`);
-  for (const entry of Object.entries(params)) {
-    if (entry[1]) {
-      if (Array.isArray(entry[1])) {
-        entry[1].forEach((value) => {
-          url.searchParams.append(entry[0], String(value));
-        });
-      } else {
-        url.searchParams.set(entry[0], String(entry[1] as unknown));
+  for (const [key, value] of Object.entries(params)) {
+    if (value == null) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (
+          typeof item === "string" ||
+          typeof item === "number" ||
+          typeof item === "boolean"
+        ) {
+          url.searchParams.append(key, toSearchParamString(item));
+        }
       }
+    } else if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      url.searchParams.set(key, toSearchParamString(value));
     }
   }
   const response = await fetch(url.toString(), {


### PR DESCRIPTION
## Summary

Replace the `as unknown` type assertion in `apiRequestWrapper` with explicit `typeof` narrowing for search param serialization. The old code relied on `String(entry[1] as unknown)` to coerce param values, which violates the project's no-type-assertions rule. The new approach introduces a `ParamValue` type and `toSearchParamString` helper, using runtime type checks to ensure only `string`, `number`, and `boolean` values are serialized.

This also fixes a subtle bug: the old truthiness check (`if (entry[1])`) would skip falsy-but-valid param values like `false` and `0`. The new code uses `== null` to skip only `null`/`undefined`.