### PR TITLE
fix: include first_air_date in TMDB multi-search TV results

### DIFF
--- a/src/ai-chat/tools/tmdb-search.test.ts
+++ b/src/ai-chat/tools/tmdb-search.test.ts
@@ -283,4 +283,37 @@ describe("tmdb search execute", () => {
     expect(keys).toContain("title");
     expect(keys).toContain("overview");
   });
+
+  it("includes first_air_date for TV results", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/search/multi`, () =>
+        HttpResponse.json({
+          page: 1,
+          results: [tvResult({ id: 1, name: "Breaking Bad" })],
+          total_pages: 1,
+          total_results: 1,
+        }),
+      ),
+    );
+
+    const tool = createTmdbSearchTool("en");
+    const results = await tool.execute!(
+      { query: "Breaking Bad" },
+      {
+        toolCallId: "test",
+        messages: [],
+        abortSignal: AbortSignal.timeout(5000),
+      },
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual(
+      expect.objectContaining({
+        id: 1,
+        name: "Breaking Bad",
+        media_type: "tv",
+        first_air_date: "2023-06-01",
+      }),
+    );
+  });
 });

--- a/src/ai-chat/tools/tmdb-search.ts
+++ b/src/ai-chat/tools/tmdb-search.ts
@@ -4,9 +4,12 @@ import { searchMulti } from "#src/_generated/tmdb-server-functions.ts";
 import type { SupportedLocale } from "#src/types.ts";
 import type { ResponseType } from "#src/utils/tmdb-client.ts";
 
+// The TMDB OpenAPI spec omits first_air_date from the multi-search union type,
+// but the API returns it for TV results at runtime (verified against the live
+// API on 2026-03-28). Extend the generated type to include the missing field.
 type MultiSearchResult = NonNullable<
   ResponseType<"/3/search/multi", "get">["results"]
->[number];
+>[number] & { first_air_date?: string };
 
 export const tmdbSearchInputSchema = z.object({
   query: z
@@ -37,6 +40,7 @@ function mapResult(result: MultiSearchResult) {
     release_date: result.release_date,
     // TV / Person fields
     name: result.name,
+    first_air_date: result.first_air_date,
     // Shared fields
     overview: result.overview,
     vote_average: result.vote_average,


### PR DESCRIPTION
## Summary

The TMDB multi-search API returns `first_air_date` for TV results at runtime, but the auto-generated OpenAPI type omits this field. This means the AI chat search tool was silently dropping the air date for TV shows, preventing it from being displayed in search result cards. This fix extends the generated type with the missing field and maps it through in `mapResult`, along with a test to verify the behavior.