### PR TITLE
fix: add error handling to apiRouteWrapper

### DIFF
--- a/src/utils/api-route-wrapper.ts
+++ b/src/utils/api-route-wrapper.ts
@@ -15,10 +15,18 @@ export function apiRouteWrapper(
   ) => Promise<unknown>,
 ) {
   return async function routeHandler(request: NextRequest) {
-    const result = await serverFunction(
-      Object.fromEntries(request.nextUrl.searchParams.entries()),
-    );
+    try {
+      const result = await serverFunction(
+        Object.fromEntries(request.nextUrl.searchParams.entries()),
+      );
 
-    return NextResponse.json(result);
+      return NextResponse.json(result);
+    } catch (error) {
+      console.error("API route error:", error);
+      return NextResponse.json(
+        { error: "Internal server error" },
+        { status: 500 },
+      );
+    }
   };
 }


### PR DESCRIPTION
## Summary

Wraps the server function invocation inside `apiRouteWrapper` in a try/catch block so that unhandled exceptions are caught, logged to the console, and returned as a structured `{ error: "Internal server error" }` JSON response with a 500 status code. Previously, any exception thrown by a wrapped server function would propagate unhandled, potentially resulting in opaque error pages rather than a consistent API error response.