### PR TITLE
style: internationalize AI search loading page and use design tokens

### DIFF
--- a/src/app/[locale]/movie-database/ai-search/loading.tsx
+++ b/src/app/[locale]/movie-database/ai-search/loading.tsx
@@ -1,6 +1,7 @@
 import { SparkleIcon } from "@phosphor-icons/react/dist/ssr/Sparkle";
 import * as stylex from "@stylexjs/stylex";
-import { color, space } from "#src/tokens.stylex.ts";
+import { t } from "#src/i18n.ts";
+import { color, font, space } from "#src/tokens.stylex.ts";
 
 export default function Loading() {
   return (
@@ -14,8 +15,15 @@ export default function Loading() {
             role="presentation"
           />
         </div>
-        <p css={styles.text}>AI is thinking...</p>
-        <p css={styles.subtext}>Searching movies and TV shows for you</p>
+        <p css={styles.text}>
+          {t({ en: "AI is thinking...", zh: "AI 正在思考..." })}
+        </p>
+        <p css={styles.subtext}>
+          {t({
+            en: "Searching movies and TV shows for you",
+            zh: "正在为你搜索电影和电视剧",
+          })}
+        </p>
       </div>
     </div>
   );
@@ -65,15 +73,15 @@ const styles = stylex.create({
   },
 
   text: {
-    fontSize: "20px",
-    fontWeight: 600,
+    fontSize: font.uiHeading2,
+    fontWeight: font.weight_6,
     color: color.textMain,
     marginBottom: space._2,
     margin: 0,
   },
 
   subtext: {
-    fontSize: "16px",
+    fontSize: font.uiBody,
     color: color.textMuted,
     margin: 0,
   },


### PR DESCRIPTION
## Summary

The AI search loading page had hardcoded English strings and pixel-based font sizes, making it the only page in the locale-aware `[locale]` route tree without i18n support. This replaces the hardcoded text with `t()` calls (English + Chinese) and swaps the raw `fontSize`/`fontWeight` values for the project's design tokens (`font.uiHeading2`, `font.weight_6`, `font.uiBody`), aligning the loading page with the conventions used across the rest of the codebase.