### PR TITLE
refactor: remove unused locale prop from BackdropImage

### DIFF
--- a/src/app/[locale]/movie-database/[type]/[id]/page.tsx
+++ b/src/app/[locale]/movie-database/[type]/[id]/page.tsx
@@ -57,7 +57,6 @@ export default async function Page({ params }: PageProps) {
                 movie.original_title ??
                 t({ en: "Untitled", zh: "佚名" })
               }
-              locale={locale}
             />
           )}
           <div css={styles.hero}>
@@ -122,7 +121,6 @@ export default async function Page({ params }: PageProps) {
                 tvShow.original_name ??
                 t({ en: "Untitled", zh: "佚名" })
               }
-              locale={locale}
             />
           )}
           <div css={styles.hero}>

--- a/src/components/movie-database/backdrop-image.tsx
+++ b/src/components/movie-database/backdrop-image.tsx
@@ -2,18 +2,16 @@ import * as stylex from "@stylexjs/stylex";
 import { getConfiguration } from "#src/_generated/tmdb-server-functions.ts";
 import { breakpoints } from "#src/breakpoints.stylex.ts";
 import { color, layer, ratio, space } from "#src/tokens.stylex.ts";
-import type { SupportedLocale } from "#src/types.ts";
 
 interface BackdropImageProps {
   backdropPath: string;
   alt: string;
-  locale: SupportedLocale;
 }
 
 /**
- * A component that renders a backdrop image with localization and responsive sizing.
- * If the required configuration is unavailable or the image fails to load, a fallback UI is displayed.
- * The component supports lazy loading and generates `srcSet` for responsive image handling.
+ * A component that renders a backdrop image with responsive sizing.
+ * If the required configuration is unavailable, nothing is rendered.
+ * The component generates `srcSet` for responsive image handling.
  */
 export async function BackdropImage({ backdropPath, alt }: BackdropImageProps) {
   const config = await getConfiguration();


### PR DESCRIPTION
## Summary

The `locale` prop on `BackdropImage` was accepted by the component interface and passed by both call sites (movie and TV show detail pages), but never actually consumed in the component body. This removes the dead prop to clean up the API surface and avoid misleading callers into thinking locale affects backdrop image rendering.