### PR TITLE
a11y: add log role to chat messages container for screen readers

### DIFF
--- a/src/components/ai-chat/chat-message-list.test.tsx
+++ b/src/components/ai-chat/chat-message-list.test.tsx
@@ -98,4 +98,24 @@ describe("ChatMessageList", () => {
       screen.getByRole("button", { name: "Scroll to bottom" }),
     ).toBeInTheDocument();
   });
+
+  it("uses log role on messages container for screen reader announcements", () => {
+    const messages = [
+      createMessage({
+        id: "1",
+        role: "user",
+        parts: [{ type: "text", text: "Hello" }],
+      }),
+    ];
+
+    render(
+      <ChatMessageList messages={messages} status="ready" {...defaultProps} />,
+    );
+    expect(screen.getByRole("log")).toBeInTheDocument();
+  });
+
+  it("does not render log role when messages list is empty", () => {
+    render(<ChatMessageList messages={[]} status="ready" {...defaultProps} />);
+    expect(screen.queryByRole("log")).not.toBeInTheDocument();
+  });
 });

--- a/src/components/ai-chat/chat-message-list.tsx
+++ b/src/components/ai-chat/chat-message-list.tsx
@@ -63,7 +63,7 @@ export function ChatMessageList({
       {messages.length === 0 ? (
         <div css={styles.emptyStateWrapper}>{emptyState}</div>
       ) : (
-        <div css={styles.messagesList}>
+        <div role="log" css={styles.messagesList}>
           {messages.map((message, index) => (
             <ChatMessage
               key={message.id}


### PR DESCRIPTION
## Summary

Add `role="log"` to the AI chat messages container so screen readers announce new messages as they arrive. The `log` ARIA role designates a live region where new content is appended in a meaningful order, which is exactly the behavior of a chat message list. The role is only rendered when there are messages present, keeping the empty state free of unnecessary ARIA landmarks. Two tests verify both behaviors.