### PR TITLE
fix: defer TMDB_API_TOKEN read to request time

### DIFF
--- a/src/ai-chat/tools/tmdb-search.test.ts
+++ b/src/ai-chat/tools/tmdb-search.test.ts
@@ -1,7 +1,11 @@
 import { http, HttpResponse } from "msw";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { server } from "#src/test-msw.ts";
 import { createTmdbSearchTool, tmdbSearchInputSchema } from "./tmdb-search";
+
+beforeAll(() => {
+  process.env.TMDB_API_TOKEN = "test-token";
+});
 
 const TMDB_BASE = "https://api.themoviedb.org";
 

--- a/src/utils/tmdb-client.ts
+++ b/src/utils/tmdb-client.ts
@@ -6,7 +6,14 @@ import type { paths } from "#src/_generated/tmdbV3.d.ts";
 import { buildTmdbUrl } from "./build-tmdb-url";
 
 const BASE_URL = "https://api.themoviedb.org";
-const API = process.env.TMDB_API_TOKEN;
+
+function getApiToken(): string {
+  const token = process.env.TMDB_API_TOKEN;
+  if (!token) {
+    throw new Error("TMDB_API_TOKEN is not set");
+  }
+  return token;
+}
 
 /** Extract path parameters from a path string */
 export type PathParams<T extends string> =
@@ -40,7 +47,7 @@ async function tmdbFetch<T>(url: string, errorMessage: string): Promise<T> {
     method: "GET",
     headers: {
       accept: "application/json",
-      Authorization: `Bearer ${API}`,
+      Authorization: `Bearer ${getApiToken()}`,
     },
     cache: "force-cache",
     next: { revalidate: 86400 },


### PR DESCRIPTION
## Summary

The TMDB API token was previously captured at module evaluation time (`const API = process.env.TMDB_API_TOKEN`), which meant it was `undefined` for the entire process lifetime if the env var wasn't set when the module was first imported — as happens in test environments. This changes the token read to a lazy `getApiToken()` function that fetches the token at request time, fixing test reliability and adding a clear error when the token is missing.

The TMDB search test is updated to set the env var in a `beforeAll` hook so the lazy reader succeeds during test runs.