### PR TITLE
fix: use composite key for media cards to avoid duplicate key collisions

### DIFF
--- a/src/components/ai-chat/tool-media-cards.test.tsx
+++ b/src/components/ai-chat/tool-media-cards.test.tsx
@@ -54,6 +54,34 @@ describe("ToolMediaCards", () => {
     expect(container.innerHTML).toBe("");
   });
 
+  it("renders all cards when items share the same TMDB id but differ by media type", () => {
+    render(
+      <MediaDetailProvider>
+        <ToolMediaCards
+          items={[
+            {
+              id: 123,
+              title: "Same ID Movie",
+              posterPath: "/movie.jpg",
+              rating: 7.0,
+              mediaType: "movie",
+            },
+            {
+              id: 123,
+              title: "Same ID TV Show",
+              posterPath: "/tv.jpg",
+              rating: 8.0,
+              mediaType: "tv",
+            },
+          ]}
+        />
+      </MediaDetailProvider>,
+    );
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(2);
+  });
+
   it("renders cards without buttons when mediaType is null", () => {
     render(
       <MediaDetailProvider>

--- a/src/components/ai-chat/tool-media-cards.tsx
+++ b/src/components/ai-chat/tool-media-cards.tsx
@@ -31,7 +31,11 @@ export function ToolMediaCards({ items }: ToolMediaCardsProps) {
         {items.map((item) => {
           const { mediaType } = item;
           return (
-            <div key={item.id} css={styles.cardWrapper} role="listitem">
+            <div
+              key={`${item.mediaType ?? "unknown"}-${item.id}`}
+              css={styles.cardWrapper}
+              role="listitem"
+            >
               <CompactMediaCard
                 media={item}
                 onClick={


### PR DESCRIPTION
## Summary

TMDB assigns IDs independently per media type, so a movie and a TV show can share the same numeric ID. The `ToolMediaCards` component was using `item.id` as the React `key`, which caused key collisions when search results contained a movie and TV show with the same TMDB ID. This resulted in React silently dropping one of the cards.

The fix changes the key to a composite `${mediaType}-${id}`, ensuring uniqueness across media types. A corresponding test case was added to verify both cards render when items share the same TMDB ID but differ by media type.