### PR TITLE
a11y: add Escape key dismissal and dialog role to overlay

### DIFF
--- a/src/components/shared/overlay.tsx
+++ b/src/components/shared/overlay.tsx
@@ -3,6 +3,7 @@
 import { XIcon } from "@phosphor-icons/react/X";
 import * as stylex from "@stylexjs/stylex";
 import {
+  useEffect,
   useDeferredValue,
   ViewTransition,
   type PropsWithChildren,
@@ -28,6 +29,19 @@ export function Overlay({
   const portalTarget = usePortalTarget();
   const deferredIsOpen = useDeferredValue(isOpen);
 
+  useEffect(() => {
+    if (!deferredIsOpen) return;
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [deferredIsOpen, onClose]);
+
   if (!deferredIsOpen || !portalTarget) {
     return null;
   }
@@ -39,7 +53,7 @@ export function Overlay({
       </ViewTransition>
       <ViewTransition enter="slide-in" exit="slide-out">
         <RemoveScroll enabled={deferredIsOpen} allowPinchZoom forwardProps>
-          <div css={styles.content}>
+          <div css={styles.content} role="dialog" aria-modal="true">
             <Button
               css={styles.closeButton}
               icon={<XIcon role="presentation" />}


### PR DESCRIPTION
## Summary

The shared Overlay component previously could only be dismissed by clicking the close button or the backdrop. This adds two standard accessibility improvements: an Escape keydown listener that closes the overlay when it is open, and `role="dialog"` with `aria-modal="true"` on the content container so assistive technologies correctly identify it as a modal dialog. These changes align with WCAG expectations for modal overlays.