### PR TITLE
style: replace hard-coded values with design tokens

### DIFF
--- a/src/app/[locale]/movie-database/ai-mode/layout.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { ErrorBoundary } from "react-error-boundary";
 import { BASE_URL } from "#src/constants.ts";
 import { t } from "#src/i18n.ts";
-import { color, space } from "#src/tokens.stylex.ts";
+import { color, font, space } from "#src/tokens.stylex.ts";
 
 export function generateMetadata(_props: {
   params: Promise<{ locale: string }>;
@@ -63,7 +63,7 @@ const styles = stylex.create({
     padding: space._6,
   },
   errorText: {
-    fontSize: "18px",
+    fontSize: font.uiHeading3,
     color: color.textMuted,
     margin: 0,
   },

--- a/src/components/ai-chat/tool-activity-line.tsx
+++ b/src/components/ai-chat/tool-activity-line.tsx
@@ -6,7 +6,7 @@ import * as stylex from "@stylexjs/stylex";
 import { t } from "#src/i18n.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { truncate } from "#src/primitives/layout.stylex.ts";
-import { color, font, space } from "#src/tokens.stylex.ts";
+import { border, color, font, space } from "#src/tokens.stylex.ts";
 import { isRecord } from "./map-tool-output";
 
 export const TERMINAL_STATES = new Set([
@@ -130,7 +130,7 @@ const styles = stylex.create({
   pulsingDot: {
     width: "0.375rem",
     height: "0.375rem",
-    borderRadius: "50%",
+    borderRadius: border.radius_round,
     backgroundColor: color.textMuted,
     animationName: pulse,
     animationDuration: "1.4s",
@@ -138,7 +138,7 @@ const styles = stylex.create({
     animationIterationCount: "infinite",
   },
   label: {
-    fontWeight: 500,
+    fontWeight: font.weight_5,
     whiteSpace: "nowrap",
   },
   separator: {

--- a/src/components/ai-chat/typing-indicator.tsx
+++ b/src/components/ai-chat/typing-indicator.tsx
@@ -2,7 +2,7 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { flex } from "#src/primitives/flex.stylex.ts";
-import { color, font, space } from "#src/tokens.stylex.ts";
+import { border, color, font, space } from "#src/tokens.stylex.ts";
 
 const DOT_COUNT = 3;
 const DOT_DELAY_MS = 160;
@@ -39,7 +39,7 @@ const styles = stylex.create({
   dot: {
     width: "0.375rem",
     height: "0.375rem",
-    borderRadius: "50%",
+    borderRadius: border.radius_round,
     backgroundColor: color.textMuted,
     animationName: bounce,
     animationDuration: "1.4s",


### PR DESCRIPTION
## Summary

Replace scattered hard-coded CSS values (`"18px"`, `"50%"`, `500`, `1.5`, `"1px"`) with their corresponding StyleX design tokens (`font.uiHeading3`, `border.radius_round`, `font.weight_5`, `font.lineHeight_4`, `border.size_1`). This improves consistency across components and ensures future theme changes propagate automatically through the token system rather than requiring manual find-and-replace of magic values.

Files changed:
- `layout.tsx` (ai-mode): `fontSize: "18px"` → `font.uiHeading3`
- `tool-activity-line.tsx`: `borderRadius: "50%"` → `border.radius_round`, `fontWeight: 500` → `font.weight_5`
- `typing-indicator.tsx`: `borderRadius: "50%"` → `border.radius_round`
- `search-button.tsx`: `lineHeight: 1.5` → `font.lineHeight_4`, `borderTopWidth: "1px"` → `border.size_1`