### PR TITLE
fix: add server-only guard to OpenAI client module

### DIFF
--- a/src/ai/client.ts
+++ b/src/ai/client.ts
@@ -1,4 +1,5 @@
 import OpenAI from "openai";
+import "server-only";
 
 let _openaiClient: OpenAI | null = null;
 let _openaiModel: string | null = null;


### PR DESCRIPTION
## Summary

The `src/ai/client.ts` module creates and exports an OpenAI API client that holds sensitive credentials. Adding the `server-only` import ensures Next.js will throw a build-time error if any client component accidentally imports this module, preventing API keys from being bundled into the client-side JavaScript.