### PR TITLE
fix: add server-only guard to AI chat system instructions

### DIFF
--- a/src/ai-chat/system-instructions.ts
+++ b/src/ai-chat/system-instructions.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "fs";
 import { join } from "path";
+import "server-only";
 import type { SupportedLocale } from "#src/types.ts";
 
 let template: string | null = null;


### PR DESCRIPTION
## Summary

The `system-instructions.ts` module uses `readFileSync` and contains server-side system prompt logic, but lacked a `server-only` import guard. This adds the `"server-only"` import to ensure a build-time error if the module is ever accidentally imported from a client component, following Next.js best practices for enforcing the server boundary.