### PR TITLE
a11y: add accessible label to AI search input

### DIFF
--- a/src/components/movie-database/search-button.tsx
+++ b/src/components/movie-database/search-button.tsx
@@ -88,6 +88,10 @@ export function SearchButton() {
                 en: "Search with AI: 'best sci-fi movies from 2023' or 'funny Korean dramas'...",
                 zh: "AI 搜索：'2023年最佳科幻电影'或'搞笑韩剧'...",
               })}
+              aria-label={t({
+                en: "AI search query",
+                zh: "AI 搜索查询",
+              })}
               css={styles.input}
               autoComplete="off"
               spellCheck={false}


### PR DESCRIPTION
## Summary

The AI search input in the movie database search dialog had a `placeholder` but no `aria-label`, making it difficult for screen readers to identify the input's purpose. This adds a localized `aria-label` (English and Chinese) so assistive technology users can understand the input without relying on placeholder text, which is not consistently announced by screen readers.