### PR TITLE
fix: avoid leaking internal error details in ai-search API response

### DIFF
--- a/src/app/api/ai-search/route.ts
+++ b/src/app/api/ai-search/route.ts
@@ -12,10 +12,7 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error("AI Search POST error:", error);
     return Response.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : "Internal server error",
-      },
+      { success: false, error: "Internal server error" },
       { status: 500 },
     );
   }


### PR DESCRIPTION
## Summary

The POST handler in `/api/ai-search` previously returned `error.message` to the client when an `Error` was caught, which could expose internal implementation details (database errors, service names, stack information). This change replaces the conditional error message with a static "Internal server error" string. The actual error is still logged server-side via `console.error` so debugging is unaffected.