### PR TITLE
a11y: add title attribute to YouTube trailer iframes

### DIFF
--- a/src/components/movie-database/trailer-button.tsx
+++ b/src/components/movie-database/trailer-button.tsx
@@ -11,12 +11,14 @@ import { Overlay } from "../shared/overlay";
 interface TrailerButtonProps {
   trailerId: string;
   locale: SupportedLocale;
+  iframeTitle: string;
 }
 
 export function TrailerButton({
   children,
   trailerId,
   locale,
+  iframeTitle,
 }: PropsWithChildren<TrailerButtonProps>) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -35,6 +37,7 @@ export function TrailerButton({
           width="720"
           height="405"
           src={`https://www.youtube.com/embed/${trailerId}?hl=${locale}`}
+          title={iframeTitle}
           frameBorder="0"
           allowFullScreen
         />

--- a/src/components/movie-database/trailer.tsx
+++ b/src/components/movie-database/trailer.tsx
@@ -24,7 +24,13 @@ export async function Trailer({ movieId, locale }: TrailerProps) {
 
   return (
     <div css={styles.container}>
-      <TrailerButton trailerId={trailer.key} locale={locale}>
+      <TrailerButton
+        trailerId={trailer.key}
+        locale={locale}
+        iframeTitle={
+          trailer.name ?? t({ en: "Movie trailer", zh: "电影预告片" })
+        }
+      >
         {t({ en: "Play trailer", zh: "播放预告" })}
       </TrailerButton>
     </div>

--- a/src/components/movie-database/tv-show-trailer.tsx
+++ b/src/components/movie-database/tv-show-trailer.tsx
@@ -23,7 +23,13 @@ export async function TvShowTrailer({ tvShowId, locale }: TvShowTrailerProps) {
 
   return (
     <div css={styles.container}>
-      <TrailerButton trailerId={trailer.key} locale={locale}>
+      <TrailerButton
+        trailerId={trailer.key}
+        locale={locale}
+        iframeTitle={
+          trailer.name ?? t({ en: "TV show trailer", zh: "电视剧预告片" })
+        }
+      >
         {t({ en: "Play trailer", zh: "播放预告" })}
       </TrailerButton>
     </div>


### PR DESCRIPTION
## Summary

The YouTube embed iframes in the movie and TV show trailer components were missing a `title` attribute, which is required for accessibility (WCAG 2.4.1 / 4.1.2). Screen readers rely on iframe titles to describe embedded content to users.

Added an `iframeTitle` prop to `TrailerButton` that gets set as the iframe's `title` attribute, using the trailer name from TMDB with localized fallbacks ("Movie trailer" / "TV show trailer").