### PR TITLE
refactor: remove unused type aliases and dead style

### DIFF
--- a/src/components/shared/locale-selector.tsx
+++ b/src/components/shared/locale-selector.tsx
@@ -81,9 +81,4 @@ const styles = stylex.create({
     overflow: "hidden",
     padding: controlSize._1,
   },
-  menuShown: {
-    opacity: 1,
-    pointerEvents: "all",
-    transform: "scale(1, 1)",
-  },
 });

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,8 +1,3 @@
-import type { paths } from "#src/_generated/tmdbV3.d.ts";
-
-export type Configuration =
-  paths["/3/configuration"]["get"]["responses"]["200"]["content"]["application/json"];
-
 export type MediaListItem = {
   id: number;
   title?: string | null;
@@ -10,37 +5,3 @@ export type MediaListItem = {
   rating?: number | null;
   mediaType?: "movie" | "tv" | null;
 };
-
-export type Genre = NonNullable<
-  paths["/3/genre/movie/list"]["get"]["responses"]["200"]["content"]["application/json"]["genres"]
->[number];
-
-export type MovieDetails = NonNullable<
-  paths["/3/movie/{movie_id}"]["get"]["responses"]["200"]["content"]["application/json"]
->;
-
-export type MovieVideos = NonNullable<
-  paths["/3/movie/{movie_id}/videos"]["get"]["responses"]["200"]["content"]["application/json"]
->;
-
-export type TvShowSort =
-  | "first_air_date.asc"
-  | "first_air_date.desc"
-  | "name.asc"
-  | "name.desc"
-  | "original_name.asc"
-  | "original_name.desc"
-  | "popularity.asc"
-  | "popularity.desc"
-  | "vote_average.asc"
-  | "vote_average.desc"
-  | "vote_count.asc"
-  | "vote_count.desc";
-
-export type TvShowDetails = NonNullable<
-  paths["/3/tv/{series_id}"]["get"]["responses"]["200"]["content"]["application/json"]
->;
-
-export type TvShowVideos = NonNullable<
-  paths["/3/tv/{series_id}/videos"]["get"]["responses"]["200"]["content"]["application/json"]
->;


### PR DESCRIPTION
## Summary

Remove dead code: 7 unused TMDB type aliases from `src/utils/types.ts` and an unreferenced `menuShown` StyleX style from the locale selector. The type aliases (`Configuration`, `Genre`, `MovieDetails`, `MovieVideos`, `TvShowSort`, `TvShowDetails`, `TvShowVideos`) were superseded by the auto-generated TMDB server functions which carry their own inferred types, making these manual wrappers unnecessary.