### PR TITLE
feat: add ai-mode page to sitemap

### DIFF
--- a/src/app/sitemap.xml
+++ b/src/app/sitemap.xml
@@ -94,4 +94,15 @@
     <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/calculator" />
     <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/calculator" />
   </url>
+
+  <url>
+    <loc>https://qingqi.dev/movie-database/ai-mode</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/movie-database/ai-mode" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/movie-database/ai-mode" />
+  </url>
+  <url>
+    <loc>https://qingqi.dev/zh/movie-database/ai-mode</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/movie-database/ai-mode" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/movie-database/ai-mode" />
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary

The movie database AI mode page (`/movie-database/ai-mode`) was missing from the sitemap despite being a prerendered route. This adds both locale variants (English and Chinese) with proper `hreflang` alternate links so search engines can discover and index the page correctly.