### PR TITLE
fix: validate phase completion tool args with Zod schema

### DIFF
--- a/src/ai/phase-completion-tool.ts
+++ b/src/ai/phase-completion-tool.ts
@@ -18,9 +18,9 @@ export function executePhaseCompletionToolCall(toolCall: {
   arguments: string;
   call_id: string;
 }) {
-  const args = JSON.parse(toolCall.arguments) as z.infer<
-    typeof phaseCompletionSchema
-  >;
+  const args = phaseCompletionSchema.parse(
+    JSON.parse(toolCall.arguments || "{}"),
+  );
 
   return {
     success: true,


### PR DESCRIPTION
## Summary

Replaces an unsafe `as z.infer<typeof phaseCompletionSchema>` type assertion with runtime Zod validation (`phaseCompletionSchema.parse(...)`) in the phase completion tool. This ensures malformed tool call arguments are caught at runtime with a clear validation error instead of silently passing through as invalid data. Also adds a fallback to `"{}"` for empty argument strings to prevent `JSON.parse` from throwing on undefined input.