### PR TITLE
a11y: add aria-label to TMDB credit info button

### DIFF
--- a/src/components/movie-database/tmdb-credit.tsx
+++ b/src/components/movie-database/tmdb-credit.tsx
@@ -16,7 +16,10 @@ export function TmdbCredit({ position }: TmdbCreditProps) {
   return (
     <MenuButton
       position={position}
-      buttonProps={{ icon: <InfoIcon /> }}
+      buttonProps={{
+        icon: <InfoIcon />,
+        "aria-label": t({ en: "TMDB attribution info", zh: "TMDB 版权信息" }),
+      }}
       menuContent={
         <div
           css={[


### PR DESCRIPTION
## Summary

The TMDB credit info button uses only an icon (`InfoIcon`) with no text content, making it inaccessible to screen readers. This adds a bilingual `aria-label` ("TMDB attribution info" / "TMDB 版权信息") so assistive technology users can identify the button's purpose.