### PR TITLE
chore(seo): add component-library page to sitemap

### DIFF
--- a/apps/web/src/app/sitemap.xml
+++ b/apps/web/src/app/sitemap.xml
@@ -94,4 +94,15 @@
     <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/calculator" />
     <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/calculator" />
   </url>
+
+  <url>
+    <loc>https://qingqi.dev/component-library</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/component-library" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/component-library" />
+  </url>
+  <url>
+    <loc>https://qingqi.dev/zh/component-library</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/component-library" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/component-library" />
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary

The `/component-library` page exists in the app but was missing from the static sitemap (`src/app/sitemap.xml`). This adds both the English and Chinese locale URLs with their `hreflang` alternate links, matching the pattern used by all other pages in the sitemap. This ensures search engines can discover the component-library page through the sitemap for better SEO coverage.