### PR TITLE
chore: ignore Windows Zone.Identifier metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+*:Zone.Identifier
 *.pem
 
 # local env files

--- a/public/InterVariable.woff2:Zone.Identifier
+++ b/public/InterVariable.woff2:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\Qingqi\Downloads\Inter-4.0.zip


### PR DESCRIPTION
## Summary

Windows creates `Zone.Identifier` alternate data stream files to track the download origin of files (marking them as "from the internet"). One such file (`InterVariable.woff2:Zone.Identifier`) was already committed to the repo. This removes it and adds a gitignore rule (`*:Zone.Identifier`) to prevent any future instances from being tracked.