### PR TITLE
refactor: remove dead code and preserve error cause chain

### DIFF
--- a/src/app/[locale]/movie-database/[type]/[id]/types.ts
+++ b/src/app/[locale]/movie-database/[type]/[id]/types.ts
@@ -3,7 +3,3 @@ import type { SupportedLocale } from "#src/types.ts";
 export interface PageProps {
   params: Promise<{ locale: SupportedLocale; type: string; id: string }>;
 }
-
-export interface LayoutProps extends Pick<PageProps, "params"> {
-  children: React.ReactNode;
-}

--- a/src/app/[locale]/movie-database/ai-search/page.tsx
+++ b/src/app/[locale]/movie-database/ai-search/page.tsx
@@ -100,11 +100,6 @@ const styles = stylex.create({
     margin: 0,
   },
 
-  resultCount: {
-    color: color.textMuted,
-    fontWeight: 400,
-  },
-
   emptyState: {
     display: "flex",
     flexDirection: "column",

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,3 @@ export type SupportedTheme = "light" | "dark" | "system";
 export interface PageProps {
   params: Promise<{ locale: SupportedLocale }>;
 }
-
-export interface LayoutProps extends Pick<PageProps, "params"> {
-  children: React.ReactNode;
-}

--- a/src/utils/ai-search.ts
+++ b/src/utils/ai-search.ts
@@ -1,7 +1,6 @@
 import "server-only";
 import { z } from "zod";
 import { agent } from "#src/ai/agent.ts";
-import type { SupportedLocale } from "#src/types.ts";
 
 // Request validation schema
 const SearchParamsSchema = z.object({
@@ -40,7 +39,7 @@ export async function performAISearch(
     const { query, locale } = validatedData;
 
     // Execute AI agent
-    const result = await agent(query, locale as SupportedLocale);
+    const result = await agent(query, locale);
 
     return {
       success: true,
@@ -54,6 +53,7 @@ export async function performAISearch(
     if (error instanceof z.ZodError) {
       throw new Error(
         `Invalid parameters: ${error.errors.map((e) => e.message).join(", ")}`,
+        { cause: error },
       );
     }
 


### PR DESCRIPTION
## Summary

Remove unused `LayoutProps` type aliases from `src/types.ts` and `src/app/[locale]/movie-database/[type]/[id]/types.ts`, an unused `resultCount` style from the AI search page, and an unnecessary `SupportedLocale` import and type assertion in `ai-search.ts`. Also preserve the original `ZodError` as the `cause` when re-throwing validation errors, so the full error chain is available for debugging.