### PR TITLE
fix: use Chinese enumeration comma for genre separator in zh locale

### DIFF
--- a/src/utils/tmdb-queries.test.ts
+++ b/src/utils/tmdb-queries.test.ts
@@ -158,6 +158,30 @@ describe("mediaDetail", () => {
       expect(result.genreText).toBe("Drama, Thriller");
     });
 
+    it("joins genres with Chinese separator when language is zh", async () => {
+      server.use(
+        http.get("*/api/tmdb/get-movie-details", () =>
+          HttpResponse.json(
+            movieDetailsResponse({
+              genres: [
+                { id: 18, name: "剧情" },
+                { id: 53, name: "惊悚" },
+              ],
+            }),
+          ),
+        ),
+      );
+
+      const options = mediaDetail({
+        type: "movie",
+        id: "550",
+        language: "zh",
+      });
+      const result = await options.queryFn!({} as never);
+
+      expect(result.genreText).toBe("剧情、惊悚");
+    });
+
     it("passes movie_id and language as query params", async () => {
       let requestUrl = "";
       server.use(
@@ -231,6 +255,30 @@ describe("mediaDetail", () => {
       const result = await options.queryFn!({} as never);
 
       expect(result.duration).toBe("");
+    });
+
+    it("joins genres with Chinese separator when language is zh", async () => {
+      server.use(
+        http.get("*/api/tmdb/get-tv-show-details", () =>
+          HttpResponse.json(
+            tvDetailsResponse({
+              genres: [
+                { id: 10765, name: "科幻" },
+                { id: 18, name: "剧情" },
+              ],
+            }),
+          ),
+        ),
+      );
+
+      const options = mediaDetail({
+        type: "tv",
+        id: "1399",
+        language: "zh",
+      });
+      const result = await options.queryFn!({} as never);
+
+      expect(result.genreText).toBe("科幻、剧情");
     });
 
     it("formats seasons in Chinese when language is zh", async () => {

--- a/src/utils/tmdb-queries.ts
+++ b/src/utils/tmdb-queries.ts
@@ -223,6 +223,7 @@ export const mediaDetail = (params: MediaDetailParams) =>
   queryOptions({
     queryKey: [{ query: "mediaDetail", ...tmdbScope, ...params }],
     queryFn: async (): Promise<NormalizedMediaDetail> => {
+      const genreSeparator = params.language === "zh" ? "、" : ", ";
       if (params.type === "tv") {
         const { type, id, ...queryParams } = params;
         const data = await apiRequestWrapper<typeof getTvShowDetails>(
@@ -241,7 +242,7 @@ export const mediaDetail = (params: MediaDetailParams) =>
             data.genres
               ?.map((g) => g.name)
               .filter((n): n is string => n !== undefined)
-              .join(", ") ?? "",
+              .join(genreSeparator) ?? "",
           overview: data.overview ?? null,
           tagline: data.tagline ?? null,
           voteAverage: data.vote_average,
@@ -263,7 +264,7 @@ export const mediaDetail = (params: MediaDetailParams) =>
           data.genres
             ?.map((g) => g.name)
             .filter((n): n is string => n !== undefined)
-            .join(", ") ?? "",
+            .join(genreSeparator) ?? "",
         overview: data.overview ?? null,
         tagline: data.tagline ?? null,
         voteAverage: data.vote_average,


### PR DESCRIPTION
## Summary

Genre lists in media details (both movies and TV shows) were using the Western comma separator (`, `) for all locales, including Chinese. Chinese punctuation convention uses the enumeration comma (`、`) to separate list items. This fixes the genre text to use the correct locale-appropriate separator when the language is `zh`, e.g. `"剧情、惊悚"` instead of `"剧情, 惊悚"`.