### PR TITLE
fix: rename misnamed setIsMenuShown to setTheme in useTheme hook

### DIFF
--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -10,7 +10,7 @@ function subscribe(onStoreChange: () => void) {
 }
 
 let themeSingleton: string | null = null;
-function setIsMenuShown(newTheme: SupportedTheme) {
+function setTheme(newTheme: SupportedTheme) {
   themeSingleton = newTheme;
   localStorage.setItem(STORAGE_KEY, newTheme);
   listeners.forEach((listener) => listener());
@@ -28,5 +28,5 @@ export function useTheme() {
     () => themeSingleton ?? localStorage.getItem(STORAGE_KEY),
     () => "system",
   );
-  return [getSupportedTheme(theme), setIsMenuShown] as const;
+  return [getSupportedTheme(theme), setTheme] as const;
 }


### PR DESCRIPTION
## Summary

The `setIsMenuShown` function in the `useTheme` hook was incorrectly named — it sets the theme, not menu visibility. This was likely left over from a copy-paste when the hook was originally created. Renamed to `setTheme` at both the definition and return site to accurately reflect its purpose.