### PR TITLE
fix: auto-add noopener noreferrer for target=_blank Anchor links

### DIFF
--- a/src/components/shared/anchor.test.tsx
+++ b/src/components/shared/anchor.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "#src/test-utils.tsx";
+import { Anchor } from "./anchor";
+
+describe("Anchor", () => {
+  it("renders a link with the given href", () => {
+    render(<Anchor href="/about">About</Anchor>);
+
+    const link = screen.getByRole("link", { name: "About" });
+    expect(link).toHaveAttribute("href", "/about");
+  });
+
+  it("adds rel='noopener noreferrer' when target is _blank", () => {
+    render(
+      <Anchor href="https://example.com" target="_blank">
+        External
+      </Anchor>,
+    );
+
+    const link = screen.getByRole("link", { name: "External" });
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("merges noopener noreferrer into existing rel for _blank links", () => {
+    render(
+      <Anchor href="https://example.com" target="_blank" rel="nofollow me">
+        External
+      </Anchor>,
+    );
+
+    const link = screen.getByRole("link", { name: "External" });
+    const rel = link.getAttribute("rel");
+    expect(rel).toContain("nofollow");
+    expect(rel).toContain("me");
+    expect(rel).toContain("noopener");
+    expect(rel).toContain("noreferrer");
+  });
+
+  it("does not duplicate tokens when rel already includes noopener noreferrer", () => {
+    render(
+      <Anchor
+        href="https://example.com"
+        target="_blank"
+        rel="nofollow me noopener noreferrer"
+      >
+        External
+      </Anchor>,
+    );
+
+    const link = screen.getByRole("link", { name: "External" });
+    const rel = link.getAttribute("rel")!;
+    const tokens = rel.split(/\s+/);
+    expect(tokens.filter((t) => t === "noopener")).toHaveLength(1);
+    expect(tokens.filter((t) => t === "noreferrer")).toHaveLength(1);
+  });
+
+  it("does not add rel when target is not _blank", () => {
+    render(<Anchor href="/local-page">Local</Anchor>);
+
+    const link = screen.getByRole("link", { name: "Local" });
+    expect(link).not.toHaveAttribute("rel");
+  });
+});

--- a/src/components/shared/anchor.tsx
+++ b/src/components/shared/anchor.tsx
@@ -11,14 +11,22 @@ export function Anchor({
   style,
   prefetch,
   onMouseEnter,
+  rel,
+  target,
   ref,
   ...props
 }: React.ComponentProps<typeof Link>) {
   const [hovered, setHovered] = useState(false);
 
+  // Automatically ensure noopener and noreferrer are present for _blank links
+  const resolvedRel =
+    target === "_blank" ? mergeRel(rel, "noopener noreferrer") : rel;
+
   return (
     <Link
       {...props}
+      target={target}
+      rel={resolvedRel}
       ref={ref}
       prefetch={prefetch === false ? false : hovered ? null : false}
       onMouseEnter={(e) => {
@@ -30,6 +38,18 @@ export function Anchor({
       css={styles.a}
     />
   );
+}
+
+/**
+ * Merges rel tokens, deduplicating any that already exist.
+ */
+function mergeRel(existing: string | undefined, required: string): string {
+  if (!existing) return required;
+  const tokens = new Set(existing.split(/\s+/));
+  for (const token of required.split(/\s+/)) {
+    tokens.add(token);
+  }
+  return [...tokens].join(" ");
 }
 
 const styles = stylex.create({


### PR DESCRIPTION
## Summary

Links opened with `target="_blank"` without `rel="noopener"` allow the opened page to access `window.opener`, which is a security concern. This change makes the shared `Anchor` component automatically inject `noopener noreferrer` into the `rel` attribute whenever `target="_blank"` is set, so individual callsites don't need to remember to add it. A `mergeRel` helper deduplicates tokens when a custom `rel` is also provided. Includes 5 unit tests covering the new behavior.