### PR TITLE
fix: localize hardcoded aria-labels in AI chat components

### DIFF
--- a/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
@@ -22,6 +22,7 @@ interface AIChatViewProps {
   placeholder: string;
   sendLabel: string;
   stopLabel: string;
+  removeAttachmentLabel: string;
 }
 
 export function AIChatView({
@@ -32,6 +33,7 @@ export function AIChatView({
   placeholder,
   sendLabel,
   stopLabel,
+  removeAttachmentLabel,
 }: AIChatViewProps) {
   const { messages, status, sendMessage, stop } = useAIChat({ locale });
   const [attachedMedia, setAttachedMedia] = useState<AttachedMedia | null>(
@@ -67,6 +69,7 @@ export function AIChatView({
             placeholder={placeholder}
             sendLabel={sendLabel}
             stopLabel={stopLabel}
+            removeAttachmentLabel={removeAttachmentLabel}
             status={status}
             attachedMedia={attachedMedia}
             onSend={handleSend}

--- a/src/app/[locale]/movie-database/ai-mode/page.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/page.tsx
@@ -61,6 +61,7 @@ export default async function Page({
       })}
       sendLabel={t({ en: "Send message", zh: "发送消息" })}
       stopLabel={t({ en: "Stop generating", zh: "停止生成" })}
+      removeAttachmentLabel={t({ en: "Remove attachment", zh: "移除附件" })}
     />
   );
 }

--- a/src/components/ai-chat/chat-input-bar.test.tsx
+++ b/src/components/ai-chat/chat-input-bar.test.tsx
@@ -18,6 +18,7 @@ function renderInputBar(
       placeholder="Ask about movies..."
       sendLabel="Send message"
       stopLabel="Stop generating"
+      removeAttachmentLabel="Remove attachment"
       status={overrides.status ?? "ready"}
       attachedMedia={overrides.attachedMedia ?? null}
       onSend={onSend}

--- a/src/components/ai-chat/chat-input-bar.tsx
+++ b/src/components/ai-chat/chat-input-bar.tsx
@@ -15,6 +15,7 @@ interface ChatInputBarProps {
   placeholder: string;
   sendLabel: string;
   stopLabel: string;
+  removeAttachmentLabel: string;
   status: "submitted" | "streaming" | "ready" | "error";
   attachedMedia: AttachedMedia | null;
   onSend: (text: string) => void;
@@ -26,6 +27,7 @@ export function ChatInputBar({
   placeholder,
   sendLabel,
   stopLabel,
+  removeAttachmentLabel,
   status,
   attachedMedia,
   onSend,
@@ -84,7 +86,7 @@ export function ChatInputBar({
             {attachedMedia.title}
             <button
               type="button"
-              aria-label="Remove attachment"
+              aria-label={removeAttachmentLabel}
               onClick={onClearAttachment}
               css={[
                 flex.inlineCenter,

--- a/src/components/ai-chat/media-detail-overlay.tsx
+++ b/src/components/ai-chat/media-detail-overlay.tsx
@@ -7,6 +7,7 @@ import { createPortal } from "react-dom";
 import { RemoveScroll } from "react-remove-scroll";
 import { breakpoints } from "#src/breakpoints.stylex.ts";
 import { usePortalTarget } from "#src/contexts/portal-context.tsx";
+import { t } from "#src/i18n.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { fixedFill } from "#src/primitives/layout.stylex.ts";
 import { buttonReset } from "#src/primitives/reset.stylex.ts";
@@ -64,7 +65,7 @@ export function MediaDetailOverlay() {
               type="button"
               css={[buttonReset.base, flex.inlineCenter, styles.closeButton]}
               onClick={() => setFocusedMedia(null)}
-              aria-label="Close"
+              aria-label={t({ en: "Close", zh: "关闭" })}
             >
               <XIcon size={20} />
             </button>


### PR DESCRIPTION
## Summary

The "Remove attachment" button in the chat input bar and the "Close" button in the media detail overlay had hardcoded English `aria-label` strings, making them inaccessible for Chinese-locale users relying on screen readers. This change threads a translated `removeAttachmentLabel` prop through the component tree and uses an inline `t()` call for the close button, ensuring both aria-labels are properly localized.