### PR TITLE
refactor: replace forwardRef with ref prop in Anchor component

### DIFF
--- a/src/components/shared/anchor.tsx
+++ b/src/components/shared/anchor.tsx
@@ -2,14 +2,18 @@
 
 import * as stylex from "@stylexjs/stylex";
 import Link from "next/link";
-import { forwardRef, useState } from "react";
+import { useState } from "react";
 import { border } from "#src/tokens.stylex.ts";
 import { anchorTokens } from "./anchor.stylex";
 
-export const Anchor = forwardRef<
-  HTMLAnchorElement,
-  React.ComponentProps<typeof Link>
->(function Anchor({ className, style, prefetch, onMouseEnter, ...props }, ref) {
+export function Anchor({
+  className,
+  style,
+  prefetch,
+  onMouseEnter,
+  ref,
+  ...props
+}: React.ComponentProps<typeof Link>) {
   const [hovered, setHovered] = useState(false);
 
   return (
@@ -26,7 +30,7 @@ export const Anchor = forwardRef<
       css={styles.a}
     />
   );
-});
+}
 
 const styles = stylex.create({
   a: {


### PR DESCRIPTION
## Summary

React 19 supports `ref` as a regular prop on function components, making `forwardRef` unnecessary. This refactors the `Anchor` component to accept `ref` directly via `React.ComponentProps<typeof Link>`, removing the `forwardRef` wrapper and simplifying the component definition.