### PR TITLE
fix: use relatedTarget instead of currentTarget in MenuButton onBlur

### DIFF
--- a/src/components/shared/menu-button.tsx
+++ b/src/components/shared/menu-button.tsx
@@ -77,7 +77,7 @@ export function MenuButton({
         onBlur={(e) => {
           if (
             isMenuShown &&
-            !containerRef.current?.contains(e.currentTarget) &&
+            !containerRef.current?.contains(e.relatedTarget) &&
             !outsideClicked.current
           ) {
             setIsMenuShown(false);


### PR DESCRIPTION
## Summary

The `onBlur` handler in `MenuButton` was using `e.currentTarget` to check whether focus moved outside the menu container. Since `currentTarget` always refers to the element the handler is attached to (the container `<div>` itself), `containerRef.current?.contains(e.currentTarget)` was always `true`, preventing the menu from closing when focus left the container via keyboard navigation.

This fix uses `e.relatedTarget` instead, which correctly refers to the element *receiving* focus, allowing the `contains()` check to determine whether focus moved outside the menu.