### PR TITLE
refactor: replace type assertions with runtime type guards in media filters

### DIFF
--- a/src/app/[locale]/movie-database/(list)/page.tsx
+++ b/src/app/[locale]/movie-database/(list)/page.tsx
@@ -15,10 +15,7 @@ import { MediaList } from "#src/components/movie-database/media-list.tsx";
 import { t } from "#src/i18n.ts";
 import type { PageProps } from "#src/types.ts";
 import { getQueryClient } from "#src/utils/get-query-client.ts";
-import type {
-  GenreFilterType,
-  Sort,
-} from "#src/utils/media-filters-context.ts";
+import { isGenreFilterType, isSort } from "#src/utils/media-filter-types.ts";
 import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
 
 export default async function Page(
@@ -30,23 +27,25 @@ export default async function Page(
   const params = await props.params;
   const searchParams = await props.searchParams;
 
-  const type = (
-    Array.isArray(searchParams.type) ? searchParams.type[0] : searchParams.type
-  ) as "movie" | "tv" | undefined;
-  const mediaType = type === "tv" ? "tv" : "movie";
+  const rawType = Array.isArray(searchParams.type)
+    ? searchParams.type[0]
+    : searchParams.type;
+  const mediaType = rawType === "tv" ? "tv" : "movie";
 
   const genres =
     typeof searchParams.genre === "string"
       ? [searchParams.genre]
       : searchParams.genre;
-  const genreFilterType = (
-    Array.isArray(searchParams.genreFilterType)
-      ? searchParams.genreFilterType[0]
-      : searchParams.genreFilterType
-  ) as GenreFilterType | undefined;
-  const sort = (
-    Array.isArray(searchParams.sort) ? searchParams.sort[0] : searchParams.sort
-  ) as Sort | undefined;
+  const rawGenreFilterType = Array.isArray(searchParams.genreFilterType)
+    ? searchParams.genreFilterType[0]
+    : searchParams.genreFilterType;
+  const genreFilterType = isGenreFilterType(rawGenreFilterType)
+    ? rawGenreFilterType
+    : undefined;
+  const rawSort = Array.isArray(searchParams.sort)
+    ? searchParams.sort[0]
+    : searchParams.sort;
+  const sort = isSort(rawSort) ? rawSort : undefined;
 
   // Fetch config, genres, and initial page
   const queryClient = getQueryClient();

--- a/src/components/movie-database/media-filters-provider.tsx
+++ b/src/components/movie-database/media-filters-provider.tsx
@@ -10,9 +10,13 @@ import type {
 import { MediaFiltersContext } from "#src/utils/media-filters-context.ts";
 
 const emptyFilters = {
-  genreFilterType: "all" as GenreFilterType,
-  sort: "popularity.desc" as Sort,
-  mediaType: "movie" as MediaType,
+  genreFilterType: "all",
+  sort: "popularity.desc",
+  mediaType: "movie",
+} satisfies {
+  genreFilterType: GenreFilterType;
+  sort: Sort;
+  mediaType: MediaType;
 };
 
 interface MediaFiltersProviderProps {

--- a/src/utils/media-filter-types.ts
+++ b/src/utils/media-filter-types.ts
@@ -1,0 +1,30 @@
+export type GenreFilterType = "all" | "any";
+export type Sort =
+  | "popularity.asc"
+  | "popularity.desc"
+  | "vote_average.asc"
+  | "vote_average.desc";
+export type MediaType = "movie" | "tv";
+
+const genreFilterTypes: ReadonlySet<string> = new Set<GenreFilterType>([
+  "all",
+  "any",
+]);
+export function isGenreFilterType(value: unknown): value is GenreFilterType {
+  return typeof value === "string" && genreFilterTypes.has(value);
+}
+
+const sorts: ReadonlySet<string> = new Set<Sort>([
+  "popularity.asc",
+  "popularity.desc",
+  "vote_average.asc",
+  "vote_average.desc",
+]);
+export function isSort(value: unknown): value is Sort {
+  return typeof value === "string" && sorts.has(value);
+}
+
+const mediaTypes: ReadonlySet<string> = new Set<MediaType>(["movie", "tv"]);
+export function isMediaType(value: unknown): value is MediaType {
+  return typeof value === "string" && mediaTypes.has(value);
+}

--- a/src/utils/media-filters-context.ts
+++ b/src/utils/media-filters-context.ts
@@ -1,12 +1,7 @@
 import { createContext } from "react";
+import type { GenreFilterType, MediaType, Sort } from "./media-filter-types";
 
-export type GenreFilterType = "all" | "any";
-export type Sort =
-  | "popularity.asc"
-  | "popularity.desc"
-  | "vote_average.asc"
-  | "vote_average.desc";
-export type MediaType = "movie" | "tv";
+export type { GenreFilterType, MediaType, Sort } from "./media-filter-types";
 
 export const MediaFiltersContext = createContext<{
   genres: Set<string>;


### PR DESCRIPTION
## Summary

Removes unsafe `as Type` assertions from the media filter code path. URL search parameters (genreFilterType, sort) were being cast directly to union types without validation — if a user passed an invalid query string value, it would silently flow through as an unexpected type. This introduces runtime type guard functions (`isGenreFilterType`, `isSort`) that validate search param values before narrowing, and uses `satisfies` instead of `as` for the known-good `emptyFilters` constant.

The type definitions and their guards are extracted into a new `media-filter-types.ts` module so they can be imported independently of the React context.