### PR TITLE
fix: hardcode trailer video language to English for reliable results

### DIFF
--- a/src/app/[locale]/movie-database/[type]/[id]/page.tsx
+++ b/src/app/[locale]/movie-database/[type]/[id]/page.tsx
@@ -39,8 +39,8 @@ export default async function Page({ params }: PageProps) {
       language: locale,
     });
 
-    // Pre-fetch
-    void getMovieVideos({ movie_id: id, language: locale });
+    // Pre-fetch (hardcode to English — trailers are often only available in English)
+    void getMovieVideos({ movie_id: id, language: "en" });
 
     const movie = await movieDetailsPromise;
     const hours = Math.floor(movie.runtime / 60);
@@ -111,8 +111,8 @@ export default async function Page({ params }: PageProps) {
       language: locale,
     });
 
-    // Pre-fetch
-    void getTvShowVideos({ series_id: id, language: locale });
+    // Pre-fetch (hardcode to English — trailers are often only available in English)
+    void getTvShowVideos({ series_id: id, language: "en" });
 
     const tvShow = await tvShowDetailsPromise;
 

--- a/src/components/movie-database/tv-show-trailer.tsx
+++ b/src/components/movie-database/tv-show-trailer.tsx
@@ -13,7 +13,8 @@ interface TvShowTrailerProps {
 export async function TvShowTrailer({ tvShowId, locale }: TvShowTrailerProps) {
   const trailers = await getTvShowVideos({
     series_id: tvShowId,
-    language: locale,
+    // Hardcode to English as trailers are often only available in English
+    language: "en",
   });
 
   const trailer = trailers.results?.find(


### PR DESCRIPTION
## Summary

TMDB often only has trailer videos available in English. When fetching trailers using the user's locale (e.g., Chinese), the API frequently returns no results, meaning users in non-English locales see no trailers at all. The movie `Trailer` component already hardcoded the language to English; this change applies the same fix to the TV show trailer component and aligns the pre-fetch calls on the detail page to match.