### PR TITLE
fix: set locale cookie when switching to Chinese locale

### DIFF
--- a/src/components/shared/locale-selector.tsx
+++ b/src/components/shared/locale-selector.tsx
@@ -43,8 +43,8 @@ export function LocaleSelector({
             isActive={locale === "en"}
             autoFocus={locale !== "en"}
             onBeforeNavigation={() => {
-              // next-i18n-router will always respect the locale cookie when navigating to a path without prefix
-              // to avoid switching language on reload, we need to set the cookie to "en" manually.
+              // next-i18n-router respects the locale cookie, so we must keep
+              // it in sync to avoid reverting locale on reload or root navigation.
               setLocaleCookie("en");
             }}
           >
@@ -56,6 +56,9 @@ export function LocaleSelector({
             href={`${getLocalePath(pathname, "zh")}${searchString}`}
             isActive={locale === "zh"}
             autoFocus={locale === "en"}
+            onBeforeNavigation={() => {
+              setLocaleCookie("zh");
+            }}
           >
             <span>中文</span>
             <span>🇨🇳</span>


### PR DESCRIPTION
## Summary

The English locale `MenuItem` in `LocaleSelector` already called `setLocaleCookie("en")` before navigation to keep the `next-i18n-router` locale cookie in sync. The Chinese locale `MenuItem` was missing this call, so switching to Chinese wouldn't update the cookie. On reload or root navigation, `next-i18n-router` would read the stale cookie and revert to the previous locale. This adds the matching `setLocaleCookie("zh")` call to fix the persistence issue.