### PR TITLE
fix: replace deprecated frameBorder with CSS and add allow attribute on trailer iframe

### DIFF
--- a/src/components/movie-database/trailer-button.tsx
+++ b/src/components/movie-database/trailer-button.tsx
@@ -38,7 +38,7 @@ export function TrailerButton({
           height="405"
           src={`https://www.youtube.com/embed/${trailerId}?hl=${locale}`}
           title={iframeTitle}
-          frameBorder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           allowFullScreen
         />
       </Overlay>
@@ -50,5 +50,6 @@ const styles = stylex.create({
   video: {
     width: "100%",
     height: "100%",
+    borderWidth: 0,
   },
 });


### PR DESCRIPTION
## Summary

The YouTube trailer embed iframe used the deprecated HTML `frameBorder` attribute. This replaces it with the CSS equivalent (`borderWidth: 0`) via StyleX and adds the standard `allow` attribute that YouTube embeds use to enable features like picture-in-picture, autoplay, and encrypted media playback.