### PR TITLE
fix: preserve falsy query param values in apiRequestWrapper

### DIFF
--- a/src/utils/api-request-wrapper.test.ts
+++ b/src/utils/api-request-wrapper.test.ts
@@ -1,0 +1,146 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { server } from "#src/test-msw.ts";
+import { apiRequestWrapper } from "./api-request-wrapper";
+
+type TestServerFn = (params: {
+  page?: number;
+  enabled?: boolean;
+  name?: string;
+  tags?: string[];
+}) => Promise<{ ok: boolean }>;
+
+function captureSearchParams(
+  path: string,
+  handler: (params: URLSearchParams) => void,
+) {
+  server.use(
+    http.get(`*${path}`, ({ request }) => {
+      handler(new URL(request.url).searchParams);
+      return HttpResponse.json({ ok: true });
+    }),
+  );
+}
+
+describe("apiRequestWrapper", () => {
+  describe("parameter serialization", () => {
+    it("includes numeric 0 in query params", async () => {
+      let captured: URLSearchParams | undefined;
+      captureSearchParams("/api/test", (params) => {
+        captured = params;
+      });
+
+      await apiRequestWrapper<TestServerFn>("/api/test", { page: 0 });
+
+      expect(captured?.get("page")).toBe("0");
+    });
+
+    it("includes boolean false in query params", async () => {
+      let captured: URLSearchParams | undefined;
+      captureSearchParams("/api/test", (params) => {
+        captured = params;
+      });
+
+      await apiRequestWrapper<TestServerFn>("/api/test", { enabled: false });
+
+      expect(captured?.get("enabled")).toBe("false");
+    });
+
+    it("includes empty string in query params", async () => {
+      let captured: URLSearchParams | undefined;
+      captureSearchParams("/api/test", (params) => {
+        captured = params;
+      });
+
+      await apiRequestWrapper<TestServerFn>("/api/test", { name: "" });
+
+      expect(captured?.get("name")).toBe("");
+    });
+
+    it("omits null values", async () => {
+      let captured: URLSearchParams | undefined;
+      captureSearchParams("/api/test", (params) => {
+        captured = params;
+      });
+
+      await apiRequestWrapper<TestServerFn>("/api/test", {
+        page: 1,
+        name: null as unknown as string,
+      });
+
+      expect(captured?.get("page")).toBe("1");
+      expect(captured?.has("name")).toBe(false);
+    });
+
+    it("omits undefined values", async () => {
+      let captured: URLSearchParams | undefined;
+      captureSearchParams("/api/test", (params) => {
+        captured = params;
+      });
+
+      await apiRequestWrapper<TestServerFn>("/api/test", {
+        page: 1,
+        name: undefined,
+      });
+
+      expect(captured?.get("page")).toBe("1");
+      expect(captured?.has("name")).toBe(false);
+    });
+
+    it("appends array values as repeated params", async () => {
+      let captured: URLSearchParams | undefined;
+      captureSearchParams("/api/test", (params) => {
+        captured = params;
+      });
+
+      await apiRequestWrapper<TestServerFn>("/api/test", {
+        tags: ["a", "b", "c"],
+      });
+
+      expect(captured?.getAll("tags")).toEqual(["a", "b", "c"]);
+    });
+
+    it("serializes string and number params correctly", async () => {
+      let captured: URLSearchParams | undefined;
+      captureSearchParams("/api/test", (params) => {
+        captured = params;
+      });
+
+      await apiRequestWrapper<TestServerFn>("/api/test", {
+        page: 3,
+        name: "hello",
+      });
+
+      expect(captured?.get("page")).toBe("3");
+      expect(captured?.get("name")).toBe("hello");
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws on non-ok responses", async () => {
+      server.use(
+        http.get("*/api/test", () =>
+          HttpResponse.json({ error: "Not found" }, { status: 404 }),
+        ),
+      );
+
+      await expect(
+        apiRequestWrapper<TestServerFn>("/api/test", {}),
+      ).rejects.toThrow();
+    });
+
+    it("throws when called during SSR", async () => {
+      const originalWindow = globalThis.window;
+      // @ts-expect-error -- simulating SSR by removing window
+      delete globalThis.window;
+
+      try {
+        await expect(
+          apiRequestWrapper<TestServerFn>("/api/test", {}),
+        ).rejects.toThrow("apiRequestWrapper called during SSR");
+      } finally {
+        globalThis.window = originalWindow;
+      }
+    });
+  });
+});

--- a/src/utils/api-request-wrapper.ts
+++ b/src/utils/api-request-wrapper.ts
@@ -11,15 +11,19 @@ export async function apiRequestWrapper<
   }
   const baseUrl = window.location.origin;
   const url = new URL(`${baseUrl}${apiRoute}`);
-  for (const entry of Object.entries(params)) {
-    if (entry[1]) {
-      if (Array.isArray(entry[1])) {
-        entry[1].forEach((value) => {
-          url.searchParams.append(entry[0], String(value));
-        });
-      } else {
-        url.searchParams.set(entry[0], String(entry[1] as unknown));
+  for (const [key, value] of Object.entries(params)) {
+    if (value == null) continue;
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        url.searchParams.append(key, `${item}`);
       }
+    } else if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      url.searchParams.set(key, `${value}`);
     }
   }
   const response = await fetch(url.toString(), {


### PR DESCRIPTION
## Summary

The `apiRequestWrapper` used a truthiness check (`if (entry[1])`) to decide whether to include query parameters, which silently dropped valid falsy values like `0`, `false`, and `""`. This fix replaces the truthiness check with an explicit `== null` guard so only `null` and `undefined` are skipped, and adds `typeof` narrowing for string/number/boolean instead of an unsafe `as unknown` cast.

Unit tests are added covering all edge cases: numeric zero, boolean false, empty string, null, undefined, arrays, and error handling.