### PR TITLE
refactor: use .worktreeinclude for worktree file includes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,11 +4,7 @@
     "deny": ["Read(./.env)", "Read(./.env.*)"]
   },
   "worktree": {
-    "symlinkDirectories": [
-      "node_modules",
-      ".claude/settings.local.json",
-      ".env.local"
-    ]
+    "symlinkDirectories": ["node_modules"]
   },
   "showClearContextOnPlanAccept": true,
   "hooks": {

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+.claude/settings.local.json
+.env.local


### PR DESCRIPTION
## Summary

Move `.claude/settings.local.json` and `.env.local` from the `worktree.symlinkDirectories` config in `.claude/settings.json` to a new `.worktreeinclude` file. This separates directory symlinks (like `node_modules`) from individual file includes, using the dedicated `.worktreeinclude` mechanism for the latter.