### PR TITLE
refactor: unexport tmdbScope and simplify to plain object

### DIFF
--- a/src/utils/tmdb-queries.ts
+++ b/src/utils/tmdb-queries.ts
@@ -24,7 +24,7 @@ type TvResult = NonNullable<
 >[number];
 type MediaResult = MovieResult | TvResult;
 
-export const tmdbScope = [{ scope: "tmdb" }];
+const tmdbScope = { scope: "tmdb" } as const;
 
 type MovieListParams = QueryParams<"/3/discover/movie", "get"> & {
   type: "movie";


### PR DESCRIPTION
## Summary

`tmdbScope` was exported but only used internally within `tmdb-queries.ts`. This change removes the export to reduce the module's public API surface and simplifies the value from a single-element array (`[{ scope: "tmdb" }]`) to a plain object (`{ scope: "tmdb" }`). The runtime behavior is unchanged since it was always spread into query key arrays.