### PR TITLE
fix: add aria-modal attribute to media detail overlay dialog

### DIFF
--- a/src/components/ai-chat/media-detail-overlay.test.tsx
+++ b/src/components/ai-chat/media-detail-overlay.test.tsx
@@ -44,7 +44,7 @@ function renderWithOverlay() {
 }
 
 describe("MediaDetailOverlay", () => {
-  it("opens a dialog when a media card is clicked", async () => {
+  it("opens a modal dialog when a media card is clicked", async () => {
     const user = userEvent.setup();
     renderWithOverlay();
 
@@ -52,6 +52,8 @@ describe("MediaDetailOverlay", () => {
 
     await user.click(screen.getByRole("button", { name: "Inception" }));
 
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute("aria-modal", "true");
   });
 });

--- a/src/components/ai-chat/media-detail-overlay.tsx
+++ b/src/components/ai-chat/media-detail-overlay.tsx
@@ -58,6 +58,7 @@ export function MediaDetailOverlay() {
           <div
             css={styles.card}
             role="dialog"
+            aria-modal="true"
             aria-label={focusedMedia.title ?? undefined}
           >
             <button


### PR DESCRIPTION
## Summary

The media detail overlay dialog was missing `aria-modal="true"`, which screen readers need to correctly identify the dialog as modal. Without this attribute, assistive technologies may allow users to navigate to background content while the overlay is open, breaking the expected focus-trapping behavior. This continues the accessibility improvements to AI chat components from recent PRs.