### PR TITLE
fix: add aria-label to chat messages log container

### DIFF
--- a/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
@@ -17,6 +17,7 @@ import type { SupportedLocale } from "#src/types.ts";
 interface AIChatViewProps {
   locale: SupportedLocale;
   emptyState: ReactNode;
+  messagesLabel: string;
   typingIndicatorLabel: string;
   scrollToBottomLabel: string;
   placeholder: string;
@@ -28,6 +29,7 @@ interface AIChatViewProps {
 export function AIChatView({
   locale,
   emptyState,
+  messagesLabel,
   typingIndicatorLabel,
   scrollToBottomLabel,
   placeholder,
@@ -61,6 +63,7 @@ export function AIChatView({
           messages={messages}
           status={status}
           emptyState={emptyState}
+          messagesLabel={messagesLabel}
           typingIndicatorLabel={typingIndicatorLabel}
           scrollToBottomLabel={scrollToBottomLabel}
         />

--- a/src/app/[locale]/movie-database/ai-mode/page.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/page.tsx
@@ -47,6 +47,10 @@ export default async function Page({
           <RecommendedMedia locale={validatedLocale} />
         </div>
       }
+      messagesLabel={t({
+        en: "Chat messages",
+        zh: "聊天消息",
+      })}
       typingIndicatorLabel={t({
         en: "AI is thinking…",
         zh: "AI 正在思考…",

--- a/src/components/ai-chat/chat-message-list.test.tsx
+++ b/src/components/ai-chat/chat-message-list.test.tsx
@@ -11,6 +11,7 @@ function createMessage(
 
 const defaultProps = {
   emptyState: <div>Welcome to AI Mode</div>,
+  messagesLabel: "Chat messages",
   typingIndicatorLabel: "AI is thinking…",
   scrollToBottomLabel: "Scroll to bottom",
 };
@@ -99,7 +100,7 @@ describe("ChatMessageList", () => {
     ).toBeInTheDocument();
   });
 
-  it("uses log role on messages container for screen reader announcements", () => {
+  it("uses log role with accessible label on messages container", () => {
     const messages = [
       createMessage({
         id: "1",
@@ -111,7 +112,9 @@ describe("ChatMessageList", () => {
     render(
       <ChatMessageList messages={messages} status="ready" {...defaultProps} />,
     );
-    expect(screen.getByRole("log")).toBeInTheDocument();
+    expect(
+      screen.getByRole("log", { name: "Chat messages" }),
+    ).toBeInTheDocument();
   });
 
   it("does not render log role when messages list is empty", () => {

--- a/src/components/ai-chat/chat-message-list.tsx
+++ b/src/components/ai-chat/chat-message-list.tsx
@@ -15,6 +15,7 @@ interface ChatMessageListProps {
   messages: ReadonlyArray<UIMessage>;
   status: ChatStatus;
   emptyState: ReactNode;
+  messagesLabel: string;
   typingIndicatorLabel: string;
   scrollToBottomLabel: string;
 }
@@ -23,6 +24,7 @@ export function ChatMessageList({
   messages,
   status,
   emptyState,
+  messagesLabel,
   typingIndicatorLabel,
   scrollToBottomLabel,
 }: ChatMessageListProps) {
@@ -64,7 +66,11 @@ export function ChatMessageList({
       {messages.length === 0 ? (
         <div css={styles.emptyStateWrapper}>{emptyState}</div>
       ) : (
-        <div role="log" css={[flex.col, styles.messagesList]}>
+        <div
+          role="log"
+          aria-label={messagesLabel}
+          css={[flex.col, styles.messagesList]}
+        >
           {messages.map((message, index) => (
             <ChatMessage
               key={message.id}


### PR DESCRIPTION
## Summary

The chat messages `role="log"` container lacked an accessible name, making it indistinguishable from other log regions for screen reader users. This adds a localized `aria-label` ("Chat messages" / "聊天消息") to the log container so assistive technology can clearly announce its purpose.