### PR TITLE
feat: add ESLint rule to prevent t() calls outside render scope

### DIFF
--- a/.claude/skills/i18n-patterns/SKILL.md
+++ b/.claude/skills/i18n-patterns/SKILL.md
@@ -180,3 +180,4 @@ The parent page/layout must be in the manifest for client translations to work. 
 - Manually adding `setLocale` to page files — the Babel plugin does this automatically
 - Creating separate `translations.json` files — translations live inline in the component
 - Using `getTranslations()` or `useTranslations()` — these no longer exist; use `t()` everywhere
+- Calling `t()` outside render scope — `t()` must be called directly in a React component body, custom hook, or `generateMetadata()`. It cannot be used in `useEffect`, event handlers, callbacks (`.map()`, `.then()`), `setTimeout`, module scope, or exported non-component functions. The ESLint rule `i18n/no-t-outside-render` enforces this. Non-exported helper functions are allowed only if every call site is in render scope.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,11 @@ import nextConfig from "eslint-config-next";
 import importPlugin from "eslint-plugin-import-x";
 import eslintPluginUnicorn from "eslint-plugin-unicorn";
 import { defineConfig } from "eslint/config";
+import { createRequire } from "node:module";
 import tsEslint from "typescript-eslint";
+
+const require = createRequire(import.meta.url);
+const i18nPlugin = require("./tooling/eslint-plugin-i18n/index.js");
 
 export default defineConfig([
   {
@@ -32,6 +36,7 @@ export default defineConfig([
       "import-x": importPlugin,
       "@stylexjs": stylexjs,
       unicorn: eslintPluginUnicorn,
+      i18n: i18nPlugin,
     },
     languageOptions: {
       ecmaVersion: "latest",
@@ -94,6 +99,7 @@ export default defineConfig([
       "one-var": ["error", "never"],
       "@eslint-react/set-state-in-effect": "off",
       "unicorn/no-unused-properties": "error",
+      "i18n/no-t-outside-render": "error",
       "@typescript-eslint/no-unused-vars": [
         "error",
         {
@@ -106,6 +112,13 @@ export default defineConfig([
           ignoreRestSiblings: true,
         },
       ],
+    },
+  },
+  // Test files may call t() outside render scope for unit testing purposes.
+  {
+    files: ["**/*.test.{ts,tsx,js,mjs}", "**/*.spec.{ts,tsx,js,mjs}"],
+    rules: {
+      "i18n/no-t-outside-render": "off",
     },
   },
   // Tooling JS files are CJS and not covered by tsconfig, so disable

--- a/tooling/eslint-plugin-i18n/index.js
+++ b/tooling/eslint-plugin-i18n/index.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const noTOutsideRender = require("./no-t-outside-render");
+
+module.exports = {
+  rules: {
+    "no-t-outside-render": noTOutsideRender,
+  },
+};

--- a/tooling/eslint-plugin-i18n/no-t-outside-render.js
+++ b/tooling/eslint-plugin-i18n/no-t-outside-render.js
@@ -1,0 +1,330 @@
+/**
+ * ESLint rule: no-t-outside-render
+ *
+ * Prevents t() calls (from #src/i18n) outside React render scope.
+ *
+ * The i18n Babel plugin transforms client-side t() into useI18nLookup(),
+ * which is a React hook and must run during render. Even in server components,
+ * t() at module scope can read the wrong locale. This rule enforces that t()
+ * only appears where React keeps it reactive.
+ */
+
+"use strict";
+
+/** @param {string} name */
+function isComponentName(name) {
+  return /^[A-Z]/.test(name);
+}
+
+/** @param {string} name */
+function isHookName(name) {
+  return /^use[A-Z]/.test(name);
+}
+
+/**
+ * Walk up from a node to find the nearest enclosing function.
+ * @param {import("eslint").Rule.Node} node
+ * @returns {import("eslint").Rule.Node | null}
+ */
+function getEnclosingFunction(node) {
+  let current = node.parent;
+  while (current) {
+    if (
+      current.type === "FunctionDeclaration" ||
+      current.type === "FunctionExpression" ||
+      current.type === "ArrowFunctionExpression"
+    ) {
+      return current;
+    }
+    current = current.parent;
+  }
+  return null;
+}
+
+/**
+ * Check if a function node is a callback argument or assigned to a JSX event attribute.
+ * This catches useEffect(() => ...), onClick={() => ...}, arr.map(() => ...), etc.
+ * @param {import("eslint").Rule.Node} fnNode
+ * @returns {boolean}
+ */
+function isCallbackOrEventHandler(fnNode) {
+  const parent = fnNode.parent;
+
+  // Arrow/function expression passed as argument to a call: foo(() => ...)
+  if (parent.type === "CallExpression" && parent.arguments.includes(fnNode)) {
+    return true;
+  }
+
+  // Arrow/function expression in JSX expression container for event attribute: onClick={() => ...}
+  if (parent.type === "JSXExpressionContainer") {
+    const attr = parent.parent;
+    if (attr.type === "JSXAttribute") {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Get the name of a function node, if it has one.
+ * @param {import("eslint").Rule.Node} fnNode
+ * @returns {string | null}
+ */
+function getFunctionName(fnNode) {
+  if (fnNode.type === "FunctionDeclaration" && fnNode.id) {
+    return fnNode.id.name;
+  }
+  // Variable declarator: const foo = () => {} or const foo = function() {}
+  if (
+    fnNode.parent.type === "VariableDeclarator" &&
+    fnNode.parent.id.type === "Identifier"
+  ) {
+    return fnNode.parent.id.name;
+  }
+  return null;
+}
+
+/**
+ * Check if a function node is exported.
+ * @param {import("eslint").Rule.Node} fnNode
+ * @returns {boolean}
+ */
+function isExported(fnNode) {
+  if (fnNode.type === "FunctionDeclaration") {
+    const parent = fnNode.parent;
+    return (
+      parent.type === "ExportNamedDeclaration" ||
+      parent.type === "ExportDefaultDeclaration"
+    );
+  }
+  // Variable: export const foo = () => {}
+  if (
+    fnNode.parent.type === "VariableDeclarator" &&
+    fnNode.parent.parent.type === "VariableDeclaration"
+  ) {
+    return fnNode.parent.parent.parent.type === "ExportNamedDeclaration";
+  }
+  return false;
+}
+
+/**
+ * Check if a function is a render-scope function (component, hook, or generateMetadata).
+ * @param {import("eslint").Rule.Node} fnNode
+ * @returns {boolean}
+ */
+function isRenderScopeFunction(fnNode) {
+  const name = getFunctionName(fnNode);
+  if (!name) {
+    // export default function() {} — anonymous default export is a component
+    if (
+      fnNode.type === "FunctionDeclaration" &&
+      fnNode.parent.type === "ExportDefaultDeclaration"
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  if (isComponentName(name) || isHookName(name)) {
+    return true;
+  }
+
+  // generateMetadata is whitelisted
+  if (name === "generateMetadata" && isExported(fnNode)) {
+    return true;
+  }
+
+  return false;
+}
+
+/** @type {import("eslint").Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow t() calls outside React render scope (components, hooks, generateMetadata)",
+    },
+    messages: {
+      outsideRender:
+        "t() used outside render scope. t() must be called directly in a React component body, custom hook, or generateMetadata(). Move the translation to render scope so it stays reactive when the locale changes.",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    let tImported = false;
+    let tLocalName = "t";
+
+    // t() calls that need deferred resolution (in non-exported helper functions)
+    // Key: helper function name, Value: array of t() call nodes
+    /** @type {Map<string, import("eslint").Rule.Node[]>} */
+    const deferredTCalls = new Map();
+
+    // All call sites of helper functions
+    // Key: function name, Value: array of call-site nodes
+    /** @type {Map<string, import("eslint").Rule.Node[]>} */
+    const helperCallSites = new Map();
+
+    // t() calls that are definitely errors
+    /** @type {import("eslint").Rule.Node[]} */
+    const errorCalls = [];
+
+    // Set of helper function names we need to track
+    /** @type {Set<string>} */
+    const helperNames = new Set();
+
+    /**
+     * Classify a t() call. Returns "allowed", "error", or the helper function name for deferred resolution.
+     * @param {import("eslint").Rule.Node} callNode
+     * @returns {"allowed" | "error" | string}
+     */
+    function classifyTCall(callNode) {
+      const enclosingFn = getEnclosingFunction(callNode);
+
+      // Module scope — no enclosing function
+      if (!enclosingFn) {
+        return "error";
+      }
+
+      // If the immediate enclosing function is a callback/event handler, error
+      if (
+        (enclosingFn.type === "ArrowFunctionExpression" ||
+          enclosingFn.type === "FunctionExpression") &&
+        isCallbackOrEventHandler(enclosingFn)
+      ) {
+        return "error";
+      }
+
+      // Check if the enclosing function is itself a render-scope function
+      if (isRenderScopeFunction(enclosingFn)) {
+        return "allowed";
+      }
+
+      const name = getFunctionName(enclosingFn);
+
+      // Anonymous function that's not a callback and not render-scope — error
+      if (!name) {
+        return "error";
+      }
+
+      // Exported non-component/non-hook function — error
+      if (isExported(enclosingFn)) {
+        return "error";
+      }
+
+      // Non-exported, non-component, non-hook named function — defer
+      return name;
+    }
+
+    return {
+      ImportDeclaration(node) {
+        const source = node.source.value;
+        if (
+          source === "#src/i18n" ||
+          source === "#src/i18n.ts" ||
+          (typeof source === "string" && /\/i18n(?:\.ts)?$/.test(source))
+        ) {
+          for (const specifier of node.specifiers) {
+            if (
+              specifier.type === "ImportSpecifier" &&
+              specifier.imported.type === "Identifier" &&
+              specifier.imported.name === "t"
+            ) {
+              tImported = true;
+              tLocalName = specifier.local.name;
+            }
+          }
+        }
+      },
+
+      CallExpression(node) {
+        if (!tImported) return;
+
+        // Check if this is a t() call
+        if (
+          node.callee.type === "Identifier" &&
+          node.callee.name === tLocalName
+        ) {
+          const result = classifyTCall(node);
+          if (result === "error") {
+            errorCalls.push(node);
+          } else if (result !== "allowed") {
+            // Deferred — result is the helper function name
+            helperNames.add(result);
+            if (!deferredTCalls.has(result)) {
+              deferredTCalls.set(result, []);
+            }
+            deferredTCalls.get(result).push(node);
+          }
+          return;
+        }
+
+        // Track call sites of helper functions: helperName()
+        if (
+          node.callee.type === "Identifier" &&
+          node.callee.name !== tLocalName
+        ) {
+          const calleeName = node.callee.name;
+          if (!helperCallSites.has(calleeName)) {
+            helperCallSites.set(calleeName, []);
+          }
+          helperCallSites.get(calleeName).push(node);
+        }
+      },
+
+      "Program:exit"() {
+        // Report definite errors
+        for (const node of errorCalls) {
+          context.report({ node, messageId: "outsideRender" });
+        }
+
+        // Resolve deferred calls
+        for (const [helperName, tCallNodes] of deferredTCalls) {
+          const callSites = helperCallSites.get(helperName);
+
+          if (!callSites || callSites.length === 0) {
+            // No call sites found — can't verify it's called from render scope
+            for (const node of tCallNodes) {
+              context.report({ node, messageId: "outsideRender" });
+            }
+            continue;
+          }
+
+          // Check if every call site is a direct call in render scope
+          let allInRenderScope = true;
+          for (const callSite of callSites) {
+            const callSiteFn = getEnclosingFunction(callSite);
+
+            if (!callSiteFn) {
+              allInRenderScope = false;
+              break;
+            }
+
+            // If the call site's enclosing function is a callback, not render scope
+            if (
+              (callSiteFn.type === "ArrowFunctionExpression" ||
+                callSiteFn.type === "FunctionExpression") &&
+              isCallbackOrEventHandler(callSiteFn)
+            ) {
+              allInRenderScope = false;
+              break;
+            }
+
+            if (!isRenderScopeFunction(callSiteFn)) {
+              allInRenderScope = false;
+              break;
+            }
+          }
+
+          if (!allInRenderScope) {
+            for (const node of tCallNodes) {
+              context.report({ node, messageId: "outsideRender" });
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/tooling/eslint-plugin-i18n/no-t-outside-render.test.mjs
+++ b/tooling/eslint-plugin-i18n/no-t-outside-render.test.mjs
@@ -1,0 +1,340 @@
+import { createRequire } from "node:module";
+import { RuleTester } from "eslint";
+
+const require = createRequire(import.meta.url);
+const rule = require("./no-t-outside-render");
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
+
+// RuleTester.run registers its own describe/it blocks,
+// so call it at the top level (not inside an it() block).
+ruleTester.run("no-t-outside-render", rule, {
+  valid: [
+    // V1: Direct in component render body
+    {
+      code: `
+            import { t } from "#src/i18n";
+            function MyComponent() {
+              const label = t({ en: "Hello", zh: "你好" });
+              return <div>{label}</div>;
+            }
+          `,
+    },
+    // V2: In JSX children
+    {
+      code: `
+            import { t } from "#src/i18n";
+            function MyComponent() {
+              return <div>{t({ en: "Hello", zh: "你好" })}</div>;
+            }
+          `,
+    },
+    // V3: In JSX attribute
+    {
+      code: `
+            import { t } from "#src/i18n";
+            function MyComponent() {
+              return <button aria-label={t({ en: "Close", zh: "关闭" })} />;
+            }
+          `,
+    },
+    // V4: In template literal in render scope
+    {
+      code: `
+            import { t } from "#src/i18n";
+            function MyComponent() {
+              return <div aria-label={\`\${t({ en: "Rating:", zh: "评分:" })} \${value}\`} />;
+            }
+          `,
+    },
+    // V5: In ternary/conditional in render scope
+    {
+      code: `
+            import { t } from "#src/i18n";
+            function MyComponent() {
+              const label = isActive ? t({ en: "Active", zh: "活跃" }) : t({ en: "Inactive", zh: "不活跃" });
+              return <div>{label}</div>;
+            }
+          `,
+    },
+    // V6: Non-exported helper function called only from render scope
+    {
+      code: `
+            import { t } from "#src/i18n";
+            function formatRuntime(mins) {
+              return \`\${mins}\${t({ en: "m", zh: " 分钟" })}\`;
+            }
+            function MyComponent() {
+              return <div>{formatRuntime(120)}</div>;
+            }
+          `,
+    },
+    // V7: Non-exported local component (uppercase name)
+    {
+      code: `
+            import { t } from "#src/i18n";
+            function HelperButton() {
+              return <button>{t({ en: "Click", zh: "点击" })}</button>;
+            }
+            export function MyComponent() {
+              return <HelperButton />;
+            }
+          `,
+    },
+    // V8: Inside a custom hook
+    {
+      code: `
+            import { t } from "#src/i18n";
+            function useMyLabel() {
+              return t({ en: "Hello", zh: "你好" });
+            }
+          `,
+    },
+    // V9: export default function (component)
+    {
+      code: `
+            import { t } from "#src/i18n";
+            export default function Page() {
+              return <div>{t({ en: "Welcome", zh: "欢迎" })}</div>;
+            }
+          `,
+    },
+    // V10: Helper called from multiple components (all render scope)
+    {
+      code: `
+            import { t } from "#src/i18n";
+            function getLabel() {
+              return t({ en: "Label", zh: "标签" });
+            }
+            function ComponentA() {
+              return <div>{getLabel()}</div>;
+            }
+            function ComponentB() {
+              return <span>{getLabel()}</span>;
+            }
+          `,
+    },
+    // V11: generateMetadata (whitelisted)
+    {
+      code: `
+            import { t } from "#src/i18n.ts";
+            export function generateMetadata() {
+              return { title: t({ en: "My Page", zh: "我的页面" }) };
+            }
+          `,
+    },
+    // V12: Server component — t() in component body
+    {
+      code: `
+            import { t } from "#src/i18n.ts";
+            export default function Page() {
+              return <div>{t({ en: "Hello", zh: "你好" })}</div>;
+            }
+          `,
+    },
+    // V13: Server component — helper function called from render scope
+    {
+      code: `
+            import { t } from "#src/i18n.ts";
+            function formatLabel(name) {
+              return \`\${t({ en: "Name:", zh: "名称:" })} \${name}\`;
+            }
+            export default function Page() {
+              return <div>{formatLabel("test")}</div>;
+            }
+          `,
+    },
+    // No t import — t() calls should be ignored
+    {
+      code: `
+            function t(obj) { return obj.en; }
+            const label = t({ en: "Hello", zh: "你好" });
+          `,
+    },
+    // Anonymous default export component
+    {
+      code: `
+            import { t } from "#src/i18n";
+            export default function() {
+              return <div>{t({ en: "Hello", zh: "你好" })}</div>;
+            }
+          `,
+    },
+  ],
+
+  invalid: [
+    // I1: Inside useEffect callback
+    {
+      code: `
+            import { t } from "#src/i18n";
+            function MyComponent() {
+              useEffect(() => {
+                document.title = t({ en: "Hello", zh: "你好" });
+              }, []);
+              return <div />;
+            }
+          `,
+      errors: [{ messageId: "outsideRender" }],
+    },
+    // I2: Inside useLayoutEffect callback
+    {
+      code: `
+            import { t } from "#src/i18n";
+            function MyComponent() {
+              useLayoutEffect(() => {
+                ref.current.textContent = t({ en: "Hello", zh: "你好" });
+              }, []);
+              return <div ref={ref} />;
+            }
+          `,
+      errors: [{ messageId: "outsideRender" }],
+    },
+    // I3: Inside inline event handler
+    {
+      code: `
+            import { t } from "#src/i18n";
+            function MyComponent() {
+              return <button onClick={() => alert(t({ en: "Clicked", zh: "已点击" }))}>Click</button>;
+            }
+          `,
+      errors: [{ messageId: "outsideRender" }],
+    },
+    // I4: Inside named event handler function defined in component
+    {
+      code: `
+            import { t } from "#src/i18n";
+            function MyComponent() {
+              function handleClick() {
+                alert(t({ en: "Clicked", zh: "已点击" }));
+              }
+              return <button onClick={handleClick}>Click</button>;
+            }
+          `,
+      errors: [{ messageId: "outsideRender" }],
+    },
+    // I5: Inside setTimeout callback
+    {
+      code: `
+            import { t } from "#src/i18n";
+            function MyComponent() {
+              setTimeout(() => {
+                console.log(t({ en: "Timeout", zh: "超时" }));
+              }, 1000);
+              return <div />;
+            }
+          `,
+      errors: [{ messageId: "outsideRender" }],
+    },
+    // I6: Exported non-component function
+    {
+      code: `
+            import { t } from "#src/i18n";
+            export function getLabel() {
+              return t({ en: "Label", zh: "标签" });
+            }
+          `,
+      errors: [{ messageId: "outsideRender" }],
+    },
+    // I7: Function passed as callback to .map()
+    {
+      code: `
+            import { t } from "#src/i18n";
+            function MyComponent() {
+              const labels = items.map(() => t({ en: "Item", zh: "项目" }));
+              return <div>{labels}</div>;
+            }
+          `,
+      errors: [{ messageId: "outsideRender" }],
+    },
+    // I8: Inside .then() callback
+    {
+      code: `
+            import { t } from "#src/i18n";
+            function MyComponent() {
+              fetch("/api").then(() => {
+                console.log(t({ en: "Done", zh: "完成" }));
+              });
+              return <div />;
+            }
+          `,
+      errors: [{ messageId: "outsideRender" }],
+    },
+    // I9: At module scope
+    {
+      code: `
+            import { t } from "#src/i18n.ts";
+            const LABEL = t({ en: "Hello", zh: "你好" });
+          `,
+      errors: [{ messageId: "outsideRender" }],
+    },
+    // I10: Helper function that is also passed as callback
+    {
+      code: `
+            import { t } from "#src/i18n";
+            function getLabel() {
+              return t({ en: "Label", zh: "标签" });
+            }
+            function MyComponent() {
+              const label = getLabel();
+              return <button onClick={() => setLabel(getLabel())}>{label}</button>;
+            }
+          `,
+      errors: [{ messageId: "outsideRender" }],
+    },
+    // I11: Helper function that is exported
+    {
+      code: `
+            import { t } from "#src/i18n";
+            export function getLabel() {
+              return t({ en: "Label", zh: "标签" });
+            }
+            function MyComponent() {
+              return <div>{getLabel()}</div>;
+            }
+          `,
+      errors: [{ messageId: "outsideRender" }],
+    },
+    // I12: Function expression assigned to variable and used as event handler
+    {
+      code: `
+            import { t } from "#src/i18n";
+            function MyComponent() {
+              const handler = () => {
+                alert(t({ en: "Hello", zh: "你好" }));
+              };
+              return <button onClick={handler}>Click</button>;
+            }
+          `,
+      errors: [{ messageId: "outsideRender" }],
+    },
+    // I13: Server component — module scope (even with component below)
+    {
+      code: `
+            import { t } from "#src/i18n.ts";
+            const LABEL = t({ en: "Hello", zh: "你好" });
+            export default function Page() {
+              return <div>{LABEL}</div>;
+            }
+          `,
+      errors: [{ messageId: "outsideRender" }],
+    },
+    // I14: Server component — exported non-component function
+    {
+      code: `
+            import { t } from "#src/i18n.ts";
+            export function getLabel() {
+              return t({ en: "Label", zh: "标签" });
+            }
+          `,
+      errors: [{ messageId: "outsideRender" }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

The i18n Babel plugin transforms client-side `t()` calls into `useI18nLookup()`, a React hook that must run during render. Calling `t()` outside render scope (in `useEffect`, event handlers, callbacks, `setTimeout`, module scope, or exported non-component functions) violates the Rules of Hooks and causes runtime errors. This adds a custom ESLint rule (`i18n/no-t-outside-render`) to catch these misuses at lint time.

The rule supports deferred resolution for non-exported helper functions — if every call site is in render scope, the helper is allowed. Test files are exempted since they may call `t()` outside render for unit testing purposes.

## Context

The previous commit (6cc807d) fixed an instance of `t()` called outside render scope in media detail. This rule prevents similar issues from recurring. The rule is implemented as a local ESLint plugin under `tooling/eslint-plugin-i18n/` and includes a comprehensive test suite with 14 valid and 14 invalid cases covering components, hooks, `generateMetadata`, callbacks, event handlers, module scope, and helper function resolution.