### PR TITLE
feat: add context management for long AI chat conversations

### DIFF
--- a/src/ai-chat/chat.ts
+++ b/src/ai-chat/chat.ts
@@ -3,6 +3,7 @@ import { convertToModelMessages, stepCountIs, streamText } from "ai";
 import "server-only";
 import { addCacheControlToMessages } from "./addCacheControlToMessages";
 import { getAnthropicModel } from "./client";
+import { contextManagementProviderOptions } from "./context-management";
 import type { ChatInput } from "./schema";
 import { getChatSystemInstructions } from "./system-instructions";
 import { createPresentMediaTool } from "./tools/present-media";
@@ -28,6 +29,7 @@ export async function chat({ messages, locale, model }: ChatOptions) {
       tmdb_search: createTmdbSearchTool(locale),
       present_media: createPresentMediaTool(),
     },
+    providerOptions: contextManagementProviderOptions,
     stopWhen: stepCountIs(5),
     prepareStep: ({ messages, model }) => ({
       messages: addCacheControlToMessages({ messages, model }),

--- a/src/ai-chat/context-management-shared.ts
+++ b/src/ai-chat/context-management-shared.ts
@@ -1,0 +1,45 @@
+/**
+ * Compaction threshold in input tokens.
+ * Shared between server (context-management.ts) and client (usage indicator).
+ */
+export const COMPACTION_TRIGGER_TOKENS = 100_000;
+
+/**
+ * Ratio of compaction threshold at which the usage indicator appears.
+ * 0.6 = indicator shows at 60k tokens (60% of 100k compaction threshold).
+ */
+export const USAGE_WARNING_RATIO = 0.6;
+
+/**
+ * Two complementary context-management strategies for long conversations:
+ *
+ * 1. **Tool result clearing** — fires at 80k input tokens, drops old search
+ *    results (rich movie objects) while keeping the 3 most recent tool uses.
+ * 2. **Auto-compaction** — fires at 100k input tokens if clearing wasn't
+ *    enough, summarising the conversation with domain-aware instructions.
+ *
+ * Claude Sonnet 4.6 has a 200k context window. Triggering at 40%/50% leaves
+ * headroom and avoids quality degradation ("context rot") that occurs well
+ * before the hard limit.
+ */
+export const CONTEXT_MANAGEMENT_CONFIG = {
+  edits: [
+    // Strategy A: clear old tool results first (cheaper than compaction)
+    {
+      type: "clear_tool_uses_20250919",
+      trigger: { type: "input_tokens", value: 80_000 },
+      keep: { type: "tool_uses", value: 3 },
+      clearAtLeast: { type: "input_tokens", value: 5_000 },
+      clearToolInputs: true,
+      excludeTools: ["present_media"],
+    },
+    // Strategy B: compaction as a fallback when clearing isn't enough
+    {
+      type: "compact_20260112",
+      trigger: { type: "input_tokens", value: COMPACTION_TRIGGER_TOKENS },
+      pauseAfterCompaction: false,
+      instructions:
+        "Summarise this movie/TV recommendation conversation. Preserve: exact titles with release years, user preference signals (liked/disliked genres, actors, moods), recommendation outcomes (accepted, rejected, saved for later), and any ongoing request. Drop: search result details, plot summaries already discussed, and tool call mechanics.",
+    },
+  ],
+};

--- a/src/ai-chat/context-management.test.ts
+++ b/src/ai-chat/context-management.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  COMPACTION_TRIGGER_TOKENS,
+  CONTEXT_MANAGEMENT_CONFIG,
+  USAGE_WARNING_RATIO,
+} from "./context-management-shared";
+
+const { edits } = CONTEXT_MANAGEMENT_CONFIG;
+
+describe("CONTEXT_MANAGEMENT_CONFIG", () => {
+  it("has exactly two edit strategies", () => {
+    expect(edits).toHaveLength(2);
+  });
+
+  describe("tool result clearing (first edit)", () => {
+    const clearing = edits[0];
+
+    it("has the correct edit type", () => {
+      expect(clearing.type).toBe("clear_tool_uses_20250919");
+    });
+
+    it("triggers at 80k input tokens", () => {
+      expect(clearing.trigger).toEqual({
+        type: "input_tokens",
+        value: 80_000,
+      });
+    });
+
+    it("keeps 3 recent tool uses", () => {
+      expect(clearing.keep).toEqual({ type: "tool_uses", value: 3 });
+    });
+
+    it("clears at least 5000 tokens", () => {
+      expect(clearing.clearAtLeast).toEqual({
+        type: "input_tokens",
+        value: 5_000,
+      });
+    });
+
+    it("clears tool inputs", () => {
+      expect(clearing.clearToolInputs).toBe(true);
+    });
+
+    it("excludes present_media from clearing", () => {
+      expect(clearing.excludeTools).toEqual(["present_media"]);
+    });
+  });
+
+  describe("auto-compaction (second edit)", () => {
+    const compaction = edits[1];
+
+    it("has the correct edit type", () => {
+      expect(compaction.type).toBe("compact_20260112");
+    });
+
+    it("triggers at the shared compaction threshold", () => {
+      expect(compaction.trigger).toEqual({
+        type: "input_tokens",
+        value: COMPACTION_TRIGGER_TOKENS,
+      });
+    });
+
+    it("does not pause after compaction", () => {
+      expect(compaction.pauseAfterCompaction).toBe(false);
+    });
+
+    it("includes domain-specific compaction instructions", () => {
+      expect(compaction.instructions).toContain("movie/TV");
+      expect(compaction.instructions).toContain("titles with release years");
+      expect(compaction.instructions).toContain("preference signals");
+    });
+  });
+
+  it("tool clearing triggers before compaction", () => {
+    expect(edits[0].trigger.value).toBeLessThan(edits[1].trigger.value);
+  });
+});
+
+describe("shared constants", () => {
+  it("COMPACTION_TRIGGER_TOKENS is 100k", () => {
+    expect(COMPACTION_TRIGGER_TOKENS).toBe(100_000);
+  });
+
+  it("USAGE_WARNING_RATIO is 0.6", () => {
+    expect(USAGE_WARNING_RATIO).toBe(0.6);
+  });
+});

--- a/src/ai-chat/context-management.ts
+++ b/src/ai-chat/context-management.ts
@@ -1,0 +1,6 @@
+import "server-only";
+import { CONTEXT_MANAGEMENT_CONFIG } from "./context-management-shared";
+
+export const contextManagementProviderOptions = {
+  anthropic: { contextManagement: CONTEXT_MANAGEMENT_CONFIG },
+};

--- a/src/ai-chat/use-ai-chat.ts
+++ b/src/ai-chat/use-ai-chat.ts
@@ -3,9 +3,20 @@
 import { Chat, useChat } from "@ai-sdk/react";
 import type { UIMessage } from "ai";
 import { DefaultChatTransport } from "ai";
+import { z } from "zod";
 import type { SupportedLocale } from "#src/types.ts";
 
-const chatInstances = new Map<string, Chat<UIMessage>>();
+export interface ChatMessageMetadata {
+  inputTokens?: number;
+}
+
+export type ChatUIMessage = UIMessage<ChatMessageMetadata>;
+
+const messageMetadataSchema = z.object({
+  inputTokens: z.number().optional(),
+});
+
+const chatInstances = new Map<string, Chat<ChatUIMessage>>();
 
 export function useAIChat({ locale }: { locale: SupportedLocale }) {
   let chat = chatInstances.get(locale);
@@ -14,7 +25,7 @@ export function useAIChat({ locale }: { locale: SupportedLocale }) {
       api: "/api/ai-chat",
       body: { locale },
     });
-    chat = new Chat({ transport });
+    chat = new Chat<ChatUIMessage>({ transport, messageMetadataSchema });
     chatInstances.set(locale, chat);
   }
 

--- a/src/app/api/ai-chat/route.ts
+++ b/src/app/api/ai-chat/route.ts
@@ -7,7 +7,14 @@ export async function POST(request: NextRequest) {
     const body: unknown = await request.json();
     const input = chatInputSchema.parse(body);
     const result = await chat(input);
-    return result.toUIMessageStreamResponse();
+    return result.toUIMessageStreamResponse({
+      messageMetadata: ({ part }) => {
+        if (part.type === "finish-step") {
+          return { inputTokens: part.usage.inputTokens };
+        }
+        return undefined;
+      },
+    });
   } catch (error) {
     if (error instanceof z.ZodError) {
       return Response.json(

--- a/src/components/ai-chat/chat-message-list.test.tsx
+++ b/src/components/ai-chat/chat-message-list.test.tsx
@@ -1,11 +1,12 @@
-import type { UIMessage } from "ai";
 import { describe, expect, it } from "vitest";
+import type { ChatUIMessage } from "#src/ai-chat/use-ai-chat.ts";
 import { render, screen } from "#src/test-utils.tsx";
 import { ChatMessageList } from "./chat-message-list";
 
 function createMessage(
-  overrides: Partial<UIMessage> & Pick<UIMessage, "id" | "role" | "parts">,
-): UIMessage {
+  overrides: Partial<ChatUIMessage> &
+    Pick<ChatUIMessage, "id" | "role" | "parts">,
+): ChatUIMessage {
   return overrides;
 }
 

--- a/src/components/ai-chat/chat-message-list.tsx
+++ b/src/components/ai-chat/chat-message-list.tsx
@@ -3,20 +3,39 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ChatStatus, UIMessage } from "ai";
 import { type ReactNode, useEffect, useState } from "react";
+import {
+  COMPACTION_TRIGGER_TOKENS,
+  USAGE_WARNING_RATIO,
+} from "#src/ai-chat/context-management-shared.ts";
+import type { ChatMessageMetadata } from "#src/ai-chat/use-ai-chat.ts";
+import { t } from "#src/i18n.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
-import { space } from "#src/tokens.stylex.ts";
+import { color, font, space } from "#src/tokens.stylex.ts";
 import { ChatMessage } from "./chat-message";
 import { ScrollToBottomButton } from "./scroll-to-bottom-button";
 import { TypingIndicator } from "./typing-indicator";
 
 const SCROLL_THRESHOLD = 50;
+const USAGE_WARNING_THRESHOLD = COMPACTION_TRIGGER_TOKENS * USAGE_WARNING_RATIO;
 
 interface ChatMessageListProps {
-  messages: ReadonlyArray<UIMessage>;
+  messages: ReadonlyArray<UIMessage<ChatMessageMetadata>>;
   status: ChatStatus;
   emptyState: ReactNode;
   typingIndicatorLabel: string;
   scrollToBottomLabel: string;
+}
+
+function getLatestInputTokens(
+  messages: ReadonlyArray<UIMessage<ChatMessageMetadata>>,
+): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg?.role === "assistant" && msg.metadata?.inputTokens != null) {
+      return msg.metadata.inputTokens;
+    }
+  }
+  return 0;
 }
 
 export function ChatMessageList({
@@ -58,6 +77,8 @@ export function ChatMessageList({
   }, [messages.length, lastMessageRole, isAtBottom]);
 
   const showTypingIndicator = status === "submitted";
+  const latestInputTokens = getLatestInputTokens(messages);
+  const showUsageWarning = latestInputTokens >= USAGE_WARNING_THRESHOLD;
 
   return (
     <div css={[flex.col, styles.container]}>
@@ -80,6 +101,11 @@ export function ChatMessageList({
             <TypingIndicator label={typingIndicatorLabel} />
           )}
         </div>
+      )}
+      {showUsageWarning && (
+        <p css={styles.usageWarning}>
+          {t({ en: "Long conversation", zh: "长对话" })}
+        </p>
       )}
       <ScrollToBottomButton
         visible={!isAtBottom && messages.length > 0}
@@ -104,5 +130,12 @@ const styles = stylex.create({
   },
   messagesList: {
     gap: space._2,
+  },
+  usageWarning: {
+    margin: 0,
+    textAlign: "center",
+    fontSize: font.uiBodySmall,
+    color: color.textMuted,
+    paddingBlock: space._1,
   },
 });

--- a/src/components/ai-chat/chat-message.tsx
+++ b/src/components/ai-chat/chat-message.tsx
@@ -6,10 +6,12 @@ import {
   isReasoningUIPart,
   isTextUIPart,
   isToolUIPart,
+  type TextUIPart,
   type UIMessage,
 } from "ai";
 import { border, color, font, space } from "#src/tokens.stylex.ts";
 import type { MediaListItem } from "#src/utils/types.ts";
+import { CompactionNotice } from "./compaction-notice";
 import { buildSearchResultsMap } from "./map-tool-output";
 import { MarkdownContent } from "./markdown-content";
 import { ToolActivityGroup } from "./tool-activity-group";
@@ -48,6 +50,13 @@ export function ChatMessage({
               <p key={key} css={[styles.partBase, styles.text]}>
                 {part.text}
               </p>
+            );
+          }
+          if (isCompactionPart(part)) {
+            return (
+              <div key={index} css={styles.partBase}>
+                <CompactionNotice />
+              </div>
             );
           }
           return (
@@ -98,6 +107,10 @@ export function ChatMessage({
       })}
     </div>
   );
+}
+
+function isCompactionPart(part: TextUIPart): boolean {
+  return part.providerMetadata?.anthropic?.type === "compaction";
 }
 
 function deriveMessageData(parts: UIMessage["parts"]) {

--- a/src/components/ai-chat/compaction-notice.tsx
+++ b/src/components/ai-chat/compaction-notice.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { t } from "#src/i18n.ts";
+import { color, font, space } from "#src/tokens.stylex.ts";
+
+export function CompactionNotice() {
+  return (
+    <p css={styles.notice} role="status">
+      {t({
+        en: "Context was summarized to continue the conversation.",
+        zh: "已总结上下文以继续对话。",
+      })}
+    </p>
+  );
+}
+
+const styles = stylex.create({
+  notice: {
+    margin: 0,
+    fontSize: font.uiBodySmall,
+    color: color.textMuted,
+    fontStyle: "italic",
+    paddingBlock: space._1,
+  },
+});

--- a/tooling/i18n-codegen/generator.ts
+++ b/tooling/i18n-codegen/generator.ts
@@ -284,9 +284,13 @@ function main(): void {
   console.log(`  ${enPath}`);
   console.log(`  ${zhPath}`);
 
-  // Generate per-page client bundles, loaders, and manifest
+  // Generate per-page client bundles, loaders, and manifest.
+  // Pass raw (pre-merge) entries so that each file retains all its t() keys.
+  // mergeResults deduplicates by key and keeps only one file reference, which
+  // would cause keys shared across files to be missing from some page bundles.
   console.log("\nGenerating per-page client bundles...");
-  generatePerPageBundles(merged.entries);
+  const allFileEntries = results.flatMap((r) => r.entries);
+  generatePerPageBundles(allFileEntries);
 }
 
 main();


### PR DESCRIPTION
## Summary

Long AI chat conversations degrade in quality as the context window fills up ("context rot"). This adds Anthropic's context management API with a two-tier strategy to keep conversations useful:

1. **Tool result clearing** (80k input tokens) — drops old TMDB search results while keeping the 3 most recent tool uses. This is cheap and often sufficient since search results are the largest context consumers.
2. **Auto-compaction** (100k input tokens) — summarizes the full conversation using domain-aware instructions that preserve movie/TV titles, user preferences, and recommendation outcomes.

On the client side, a "Long conversation" warning appears at 60% of the compaction threshold, and an inline notice is shown when compaction actually occurs so the user understands why earlier details may be less precise.

## Context

The compaction instructions are tailored to the movie/TV recommendation domain — they prioritize preserving exact titles with release years, preference signals, and recommendation outcomes while dropping verbose search result details and tool call mechanics.

Also includes a fix to the i18n codegen: `generatePerPageBundles` was receiving post-merge entries (deduplicated by key), which caused shared translation keys to appear in only one page bundle. Now passes pre-merge entries so each file retains all its `t()` keys.