### PR TITLE
refactor: remove tool-result clearing strategy from context management

### DIFF
--- a/src/ai-chat/context-management-shared.ts
+++ b/src/ai-chat/context-management-shared.ts
@@ -6,34 +6,24 @@ export const COMPACTION_TRIGGER_TOKENS = 100_000;
 
 /**
  * Ratio of compaction threshold at which the usage indicator appears.
- * 0.6 = indicator shows at 60k tokens (60% of 100k compaction threshold).
+ * 0.6 = indicator shows at 60% of compaction threshold.
  */
 export const USAGE_WARNING_RATIO = 0.6;
 
 /**
- * Two complementary context-management strategies for long conversations:
+ * Auto-compaction for long conversations.
  *
- * 1. **Tool result clearing** — fires at 80k input tokens, drops old search
- *    results (rich movie objects) while keeping the 3 most recent tool uses.
- * 2. **Auto-compaction** — fires at 100k input tokens if clearing wasn't
- *    enough, summarising the conversation with domain-aware instructions.
+ * Fires when input tokens reach the compaction threshold, summarising the
+ * conversation with domain-aware instructions. Prompt caching keeps
+ * per-message costs low until that point, so no intermediate clearing is
+ * needed.
  *
- * Claude Sonnet 4.6 has a 200k context window. Triggering at 40%/50% leaves
- * headroom and avoids quality degradation ("context rot") that occurs well
- * before the hard limit.
+ * Claude Sonnet 4.6 has a 200k context window. The production threshold
+ * (100k) leaves headroom and avoids quality degradation ("context rot")
+ * that occurs well before the hard limit.
  */
 export const CONTEXT_MANAGEMENT_CONFIG = {
   edits: [
-    // Strategy A: clear old tool results first (cheaper than compaction)
-    {
-      type: "clear_tool_uses_20250919",
-      trigger: { type: "input_tokens", value: 80_000 },
-      keep: { type: "tool_uses", value: 3 },
-      clearAtLeast: { type: "input_tokens", value: 5_000 },
-      clearToolInputs: true,
-      excludeTools: ["present_media"],
-    },
-    // Strategy B: compaction as a fallback when clearing isn't enough
     {
       type: "compact_20260112",
       trigger: { type: "input_tokens", value: COMPACTION_TRIGGER_TOKENS },

--- a/src/ai-chat/context-management.test.ts
+++ b/src/ai-chat/context-management.test.ts
@@ -8,46 +8,12 @@ import {
 const { edits } = CONTEXT_MANAGEMENT_CONFIG;
 
 describe("CONTEXT_MANAGEMENT_CONFIG", () => {
-  it("has exactly two edit strategies", () => {
-    expect(edits).toHaveLength(2);
+  it("has exactly one edit strategy", () => {
+    expect(edits).toHaveLength(1);
   });
 
-  describe("tool result clearing (first edit)", () => {
-    const clearing = edits[0];
-
-    it("has the correct edit type", () => {
-      expect(clearing.type).toBe("clear_tool_uses_20250919");
-    });
-
-    it("triggers at 80k input tokens", () => {
-      expect(clearing.trigger).toEqual({
-        type: "input_tokens",
-        value: 80_000,
-      });
-    });
-
-    it("keeps 3 recent tool uses", () => {
-      expect(clearing.keep).toEqual({ type: "tool_uses", value: 3 });
-    });
-
-    it("clears at least 5000 tokens", () => {
-      expect(clearing.clearAtLeast).toEqual({
-        type: "input_tokens",
-        value: 5_000,
-      });
-    });
-
-    it("clears tool inputs", () => {
-      expect(clearing.clearToolInputs).toBe(true);
-    });
-
-    it("excludes present_media from clearing", () => {
-      expect(clearing.excludeTools).toEqual(["present_media"]);
-    });
-  });
-
-  describe("auto-compaction (second edit)", () => {
-    const compaction = edits[1];
+  describe("auto-compaction", () => {
+    const compaction = edits[0];
 
     it("has the correct edit type", () => {
       expect(compaction.type).toBe("compact_20260112");
@@ -69,10 +35,6 @@ describe("CONTEXT_MANAGEMENT_CONFIG", () => {
       expect(compaction.instructions).toContain("titles with release years");
       expect(compaction.instructions).toContain("preference signals");
     });
-  });
-
-  it("tool clearing triggers before compaction", () => {
-    expect(edits[0].trigger.value).toBeLessThan(edits[1].trigger.value);
   });
 });
 

--- a/src/components/ai-chat/chat-message-list.tsx
+++ b/src/components/ai-chat/chat-message-list.tsx
@@ -104,7 +104,10 @@ export function ChatMessageList({
       )}
       {showUsageWarning && (
         <p css={styles.usageWarning}>
-          {t({ en: "Long conversation", zh: "长对话" })}
+          {t({
+            en: "The conversation is getting lengthy",
+            zh: "对话越来越长",
+          })}
         </p>
       )}
       <ScrollToBottomButton


### PR DESCRIPTION
## Summary

Removes the `clear_tool_uses` strategy from the two-step context management pipeline, leaving only the compaction strategy. Prompt caching keeps per-message costs low until compaction fires, so the intermediate clearing step adds complexity without meaningful benefit. The usage indicator now shows the raw token count instead of a localized label, giving more actionable information during long conversations.

Closes #1690