### PR TITLE
fix: make rating elements accessible to screen readers

### DIFF
--- a/src/components/ai-chat/media-detail-content.tsx
+++ b/src/components/ai-chat/media-detail-content.tsx
@@ -142,11 +142,15 @@ export function MediaDetailContent({
           ) : null}
           <div css={styles.headerInfo}>
             {detail ? (
-              <div css={styles.ratingRow}>
-                <span css={styles.rating}>
+              <div
+                css={styles.ratingRow}
+                role="img"
+                aria-label={`${t({ en: "User rating", zh: "用户评分" })}: ${formatter.format(detail.voteAverage)}${t({ en: " out of 10", zh: "/10" })}, ${formatter.format(detail.voteCount)} ${t({ en: "votes", zh: "票" })}`}
+              >
+                <span css={styles.rating} aria-hidden="true">
                   {formatter.format(detail.voteAverage)}
                 </span>
-                <span css={styles.voteCount}>
+                <span css={styles.voteCount} aria-hidden="true">
                   ({formatter.format(detail.voteCount)})
                 </span>
               </div>

--- a/src/components/movie-database/media-poster.tsx
+++ b/src/components/movie-database/media-poster.tsx
@@ -38,9 +38,10 @@ export function MediaPoster({ media, compact }: MediaPosterProps) {
       {media.rating ? (
         <div
           css={[flex.center, styles.rating, compact && styles.ratingCompact]}
+          role="img"
           aria-label={`${t({ en: "User rating", zh: "用户评分" })}: ${formatter.format(media.rating)}`}
         >
-          {formatter.format(media.rating)}
+          <span aria-hidden="true">{formatter.format(media.rating)}</span>
         </div>
       ) : null}
     </>


### PR DESCRIPTION
## Summary

Rating elements (vote average/count in media detail and rating badge on media posters) were exposed as raw text to screen readers, producing a disjointed reading experience (e.g. separate "8.5" and "(1,234)" announcements with no context). This wraps each rating widget in `role="img"` with a descriptive `aria-label` that conveys the full meaning ("User rating: 8.5 out of 10, 1,234 votes") and marks the inner text spans as `aria-hidden="true"` so assistive technology reads only the label.

Changes in two components:
- **media-detail-content.tsx** — rating row in the AI chat media detail overlay
- **media-poster.tsx** — compact rating badge on movie/TV poster cards