### PR TITLE
fix: add .claude to eslint ignores and use stable key for compaction part

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,7 @@ export default defineConfig([
       "next.config.js",
       "postcss.config.js",
       "src/_generated/**/*",
+      ".claude/**/*",
       ".next/**/*",
       "next-env.d.ts",
       "public/sw.js",

--- a/src/components/ai-chat/chat-message.tsx
+++ b/src/components/ai-chat/chat-message.tsx
@@ -54,7 +54,7 @@ export function ChatMessage({
           }
           if (isCompactionPart(part)) {
             return (
-              <div key={index} css={styles.partBase}>
+              <div key={key} css={styles.partBase}>
                 <CompactionNotice />
               </div>
             );


### PR DESCRIPTION
## Summary

Adds the `.claude/` directory to the ESLint ignore list so that Claude Code skill and configuration files are not linted, consistent with how other non-source directories (`.next/`, `src/_generated/`) are already excluded.

Also fixes the compaction notice part in the chat message component to use the stable `key` variable instead of the array `index`. All other parts in the same `map` already use the stable key — this one was missed, which could cause React reconciliation issues when the message parts list changes.