### PR TITLE
perf: add resource priority hints to backdrop images

### DIFF
--- a/src/components/ai-chat/media-detail-content.tsx
+++ b/src/components/ai-chat/media-detail-content.tsx
@@ -268,6 +268,7 @@ function BackdropImage({
         src={src}
         srcSet={srcSet}
         sizes="600px"
+        loading="lazy"
       />
       <div role="presentation" css={styles.backdropGradient} />
     </div>

--- a/src/components/movie-database/backdrop-image.tsx
+++ b/src/components/movie-database/backdrop-image.tsx
@@ -39,6 +39,7 @@ export async function BackdropImage({ backdropPath, alt }: BackdropImageProps) {
         src={src}
         srcSet={srcSet}
         sizes="100vw"
+        fetchPriority="high"
       />
 
       <div role="presentation" css={[absoluteFill.all, styles.mask1]} />


### PR DESCRIPTION
## Summary

Adds browser resource priority hints to backdrop images based on their viewport position. The movie database page backdrop is the hero image (above the fold) and now uses `fetchPriority="high"` to ensure the browser loads it early. The AI chat media detail backdrop appears inside expandable cards (below the fold) and now uses `loading="lazy"` to defer loading until needed, reducing initial page weight.