### PR TITLE
fix: hide scroll-to-bottom button from a11y tree and tab order when invisible

### DIFF
--- a/src/components/ai-chat/chat-message-list.test.tsx
+++ b/src/components/ai-chat/chat-message-list.test.tsx
@@ -94,11 +94,19 @@ describe("ChatMessageList", () => {
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });
 
-  it("renders scroll-to-bottom button", () => {
-    render(<ChatMessageList messages={[]} status="ready" {...defaultProps} />);
+  it("renders scroll-to-bottom button hidden when there are no messages", () => {
+    const { container } = render(
+      <ChatMessageList messages={[]} status="ready" {...defaultProps} />,
+    );
+    // The button exists in the DOM but is hidden from the accessibility tree
     expect(
-      screen.getByRole("button", { name: "Scroll to bottom" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: "Scroll to bottom" }),
+    ).not.toBeInTheDocument();
+    const button = container.querySelector(
+      'button[aria-label="Scroll to bottom"]',
+    );
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute("aria-hidden", "true");
   });
 
   it("uses log role with accessible label on messages container", () => {

--- a/src/components/ai-chat/scroll-to-bottom-button.test.tsx
+++ b/src/components/ai-chat/scroll-to-bottom-button.test.tsx
@@ -32,4 +32,46 @@ describe("ScrollToBottomButton", () => {
 
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
+
+  it("is hidden from accessibility tree when not visible", () => {
+    render(
+      <ScrollToBottomButton
+        visible={false}
+        label="Scroll to bottom"
+        onClick={() => {}}
+      />,
+    );
+
+    // aria-hidden removes it from the accessible role query
+    expect(
+      screen.queryByRole("button", { name: "Scroll to bottom" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("is removed from tab order when not visible", () => {
+    const { container } = render(
+      <ScrollToBottomButton
+        visible={false}
+        label="Scroll to bottom"
+        onClick={() => {}}
+      />,
+    );
+
+    const button = container.querySelector("button");
+    expect(button).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("is in the tab order when visible", () => {
+    const { container } = render(
+      <ScrollToBottomButton
+        visible={true}
+        label="Scroll to bottom"
+        onClick={() => {}}
+      />,
+    );
+
+    const button = container.querySelector("button");
+    expect(button).toHaveAttribute("tabindex", "0");
+    expect(button).toHaveAttribute("aria-hidden", "false");
+  });
 });

--- a/src/components/ai-chat/scroll-to-bottom-button.tsx
+++ b/src/components/ai-chat/scroll-to-bottom-button.tsx
@@ -21,6 +21,8 @@ export function ScrollToBottomButton({
     <button
       type="button"
       aria-label={label}
+      aria-hidden={!visible}
+      tabIndex={visible ? 0 : -1}
       onClick={onClick}
       css={[
         buttonReset.base,


### PR DESCRIPTION
## Summary

The scroll-to-bottom button in the AI chat was still exposed to the accessibility tree and keyboard tab order when visually hidden (i.e., when `visible={false}`). This meant screen reader users would encounter a phantom button and keyboard users could tab to an invisible element. This adds `aria-hidden` and `tabIndex` attributes that toggle based on visibility, and updates tests to verify the correct behaviour.