### PR TITLE
chore: gitignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ src/_generated/i18n/
 # Claude Code
 .claude/worktrees/
 .claude/skills/*-workspace/
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary
- Add `.claude/scheduled_tasks.lock` to `.gitignore` to prevent it from being accidentally committed

## Context
This runtime lock file was accidentally included in #1820. It's created by Claude Code's scheduled tasks and should not be tracked in version control.