### PR TITLE
fix: display error message in AI chat when API call fails

### DIFF
--- a/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
@@ -20,6 +20,7 @@ interface AIChatViewProps {
   messagesLabel: string;
   typingIndicatorLabel: string;
   scrollToBottomLabel: string;
+  errorLabel: string;
   placeholder: string;
   sendLabel: string;
   stopLabel: string;
@@ -32,12 +33,13 @@ export function AIChatView({
   messagesLabel,
   typingIndicatorLabel,
   scrollToBottomLabel,
+  errorLabel,
   placeholder,
   sendLabel,
   stopLabel,
   removeAttachmentLabel,
 }: AIChatViewProps) {
-  const { messages, status, sendMessage, stop } = useAIChat({ locale });
+  const { messages, status, error, sendMessage, stop } = useAIChat({ locale });
   const [attachedMedia, setAttachedMedia] = useState<AttachedMedia | null>(
     null,
   );
@@ -62,10 +64,12 @@ export function AIChatView({
         <ChatMessageList
           messages={messages}
           status={status}
+          error={error}
           emptyState={emptyState}
           messagesLabel={messagesLabel}
           typingIndicatorLabel={typingIndicatorLabel}
           scrollToBottomLabel={scrollToBottomLabel}
+          errorLabel={errorLabel}
         />
         <div css={styles.inputArea}>
           <ChatInputBar

--- a/src/app/[locale]/movie-database/ai-mode/page.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/page.tsx
@@ -59,6 +59,10 @@ export default async function Page({
         en: "Scroll to bottom",
         zh: "滚动到底部",
       })}
+      errorLabel={t({
+        en: "Something went wrong. Please try again.",
+        zh: "出了点问题，请重试。",
+      })}
       placeholder={t({
         en: "Ask about movies and TV shows...",
         zh: "询问关于电影和电视剧的问题...",

--- a/src/components/ai-chat/chat-message-list.test.tsx
+++ b/src/components/ai-chat/chat-message-list.test.tsx
@@ -15,6 +15,8 @@ const defaultProps = {
   messagesLabel: "Chat messages",
   typingIndicatorLabel: "AI is thinking…",
   scrollToBottomLabel: "Scroll to bottom",
+  errorLabel: "Something went wrong. Please try again.",
+  error: undefined,
 };
 
 describe("ChatMessageList", () => {
@@ -121,5 +123,62 @@ describe("ChatMessageList", () => {
   it("does not render log role when messages list is empty", () => {
     render(<ChatMessageList messages={[]} status="ready" {...defaultProps} />);
     expect(screen.queryByRole("log")).not.toBeInTheDocument();
+  });
+
+  it("shows error message when status is error and error is present", () => {
+    const messages = [
+      createMessage({
+        id: "1",
+        role: "user",
+        parts: [{ type: "text", text: "Hello" }],
+      }),
+    ];
+
+    render(
+      <ChatMessageList
+        {...defaultProps}
+        messages={messages}
+        status="error"
+        error={new Error("Network failure")}
+      />,
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Something went wrong. Please try again.",
+    );
+  });
+
+  it("does not show error message when status is ready", () => {
+    const messages = [
+      createMessage({
+        id: "1",
+        role: "user",
+        parts: [{ type: "text", text: "Hello" }],
+      }),
+    ];
+
+    render(
+      <ChatMessageList {...defaultProps} messages={messages} status="ready" />,
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("does not show error message when status is error but error is undefined", () => {
+    const messages = [
+      createMessage({
+        id: "1",
+        role: "user",
+        parts: [{ type: "text", text: "Hello" }],
+      }),
+    ];
+
+    render(
+      <ChatMessageList
+        {...defaultProps}
+        messages={messages}
+        status="error"
+        error={undefined}
+      />,
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 });

--- a/src/components/ai-chat/chat-message-list.tsx
+++ b/src/components/ai-chat/chat-message-list.tsx
@@ -21,10 +21,12 @@ const USAGE_WARNING_THRESHOLD = COMPACTION_TRIGGER_TOKENS * USAGE_WARNING_RATIO;
 interface ChatMessageListProps {
   messages: ReadonlyArray<UIMessage<ChatMessageMetadata>>;
   status: ChatStatus;
+  error: Error | undefined;
   emptyState: ReactNode;
   messagesLabel: string;
   typingIndicatorLabel: string;
   scrollToBottomLabel: string;
+  errorLabel: string;
 }
 
 function getLatestInputTokens(
@@ -42,10 +44,12 @@ function getLatestInputTokens(
 export function ChatMessageList({
   messages,
   status,
+  error,
   emptyState,
   messagesLabel,
   typingIndicatorLabel,
   scrollToBottomLabel,
+  errorLabel,
 }: ChatMessageListProps) {
   const [isAtBottom, setIsAtBottom] = useState(true);
 
@@ -79,6 +83,7 @@ export function ChatMessageList({
   }, [messages.length, lastMessageRole, isAtBottom]);
 
   const showTypingIndicator = status === "submitted";
+  const showError = status === "error" && error != null;
   const latestInputTokens = getLatestInputTokens(messages);
   const showUsageWarning = latestInputTokens >= USAGE_WARNING_THRESHOLD;
 
@@ -105,6 +110,11 @@ export function ChatMessageList({
           ))}
           {showTypingIndicator && (
             <TypingIndicator label={typingIndicatorLabel} />
+          )}
+          {showError && (
+            <p css={styles.errorMessage} role="alert">
+              {errorLabel}
+            </p>
           )}
         </div>
       )}
@@ -146,5 +156,13 @@ const styles = stylex.create({
     fontSize: font.uiBodySmall,
     color: color.textMuted,
     paddingBlock: space._1,
+  },
+  errorMessage: {
+    margin: 0,
+    textAlign: "center",
+    fontSize: font.uiBodySmall,
+    color: color.textMuted,
+    fontStyle: "italic",
+    paddingBlock: space._2,
   },
 });


### PR DESCRIPTION
## Summary

Previously, when an AI chat API call failed, the chat UI silently swallowed the error — the user had no indication that something went wrong. This adds an inline error message that appears at the bottom of the message list when the chat status is `error`, giving users clear feedback to retry.

Changes:
- Expose the `error` field from `useAIChat` by explicitly destructuring the return value of `useChat`
- Thread `error` and a localized `errorLabel` prop through `AIChatView` into `ChatMessageList`
- Render a styled `role="alert"` error message when `status === "error"` and `error` is defined
- Add three test cases covering error display, no-error-when-ready, and no-error-when-undefined