### PR TITLE
fix: prevent chat form submission during IME composition

### DIFF
--- a/src/components/ai-chat/chat-input-bar.test.tsx
+++ b/src/components/ai-chat/chat-input-bar.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "#src/test-utils.tsx";
@@ -116,6 +117,19 @@ describe("ChatInputBar typing and sending", () => {
     const textarea = screen.getByPlaceholderText("Ask about movies...");
     await user.type(textarea, "   ");
     await user.keyboard("{Enter}");
+
+    expect(props.onSend).not.toHaveBeenCalled();
+  });
+
+  it("does not send when Enter is pressed during IME composition", async () => {
+    const user = userEvent.setup();
+    const { props } = renderInputBar();
+
+    const textarea = screen.getByPlaceholderText("Ask about movies...");
+    await user.type(textarea, "hello");
+
+    // Simulate Enter during IME composition (e.g. confirming a Chinese character)
+    fireEvent.keyDown(textarea, { key: "Enter", isComposing: true });
 
     expect(props.onSend).not.toHaveBeenCalled();
   });

--- a/src/components/ai-chat/chat-input-bar.tsx
+++ b/src/components/ai-chat/chat-input-bar.tsx
@@ -67,6 +67,10 @@ export function ChatInputBar({
   }
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
+    // Skip during IME composition (e.g. Chinese/Japanese/Korean input) —
+    // Enter should confirm the composed characters, not submit the message.
+    if (event.nativeEvent.isComposing) return;
+
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
       send();


### PR DESCRIPTION
## Summary

The site supports Chinese (zh) locale, but the AI chat input was unusable for CJK (Chinese/Japanese/Korean) input users. Pressing Enter during IME composition to confirm a composed character would simultaneously submit the message. This adds an `isComposing` guard to the keydown handler so that Enter during composition is ignored, allowing users to confirm characters without triggering form submission.