### PR TITLE
fix: add focus trapping to shared Overlay dialog component

### DIFF
--- a/src/components/shared/overlay.tsx
+++ b/src/components/shared/overlay.tsx
@@ -17,6 +17,9 @@ import { t } from "#src/i18n.ts";
 import { border, color, layer, space } from "#src/tokens.stylex.ts";
 import { Button } from "./button";
 
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), iframe, [tabindex]:not([tabindex="-1"])';
+
 interface OverlayProps {
   isOpen: boolean;
   onClose: () => void;
@@ -45,15 +48,33 @@ export function Overlay({
 
     // Move focus into the dialog once the portal renders
     requestAnimationFrame(() => {
-      const firstFocusable = dialogRef.current?.querySelector<HTMLElement>(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-      );
+      const firstFocusable =
+        dialogRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
       firstFocusable?.focus();
     });
 
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
         onClose();
+        return;
+      }
+
+      // Trap focus within the dialog
+      if (event.key === "Tab" && dialogRef.current) {
+        const focusableElements =
+          dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+        if (focusableElements.length === 0) return;
+
+        const first = focusableElements[0];
+        const last = focusableElements[focusableElements.length - 1];
+
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

When the Overlay dialog is open, pressing Tab can move focus to elements behind the overlay backdrop, making the dialog unusable for keyboard-only users and violating WCAG 2.4.3 (Focus Order). This adds focus trapping so that Tab and Shift+Tab cycle through only the focusable elements within the dialog. The focusable element selector is also extracted into a shared constant to keep the initial-focus and trap logic consistent.