### PR TITLE
feat: add OpenGraph and Twitter Card metadata to all layout files

### DIFF
--- a/src/app/[locale]/(home)/layout.tsx
+++ b/src/app/[locale]/(home)/layout.tsx
@@ -18,15 +18,23 @@ import { glowTokens } from "./layout.stylex";
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const params = await props.params;
   validateLocale(params.locale);
+
+  const title = t({ en: "Qingqi Shi", zh: "石清琪" });
+  const description = t({
+    en: "Explore the personal website of Qingqi Shi, a software engineer who values the craftsman's spirit and specializes in React, TypeScript, and web development. Discover his professional experiences, technical skills, and educational background.",
+    zh: "探索石清琪的个人网站，他是一位信奉匠人精神并擅长 React、TypeScript 和 Web 开发的软件工程师。了解他的职业经历、技术技能和教育背景。",
+  });
+  const url =
+    params.locale === "zh"
+      ? new URL("/zh", BASE_URL).toString()
+      : new URL("/", BASE_URL).toString();
+
   return {
     title: {
-      default: t({ en: "Qingqi Shi", zh: "石清琪" }),
+      default: title,
       template: t({ en: "%s | Qingqi Shi", zh: "%s | 石清琪" }),
     },
-    description: t({
-      en: "Explore the personal website of Qingqi Shi, a software engineer who values the craftsman's spirit and specializes in React, TypeScript, and web development. Discover his professional experiences, technical skills, and educational background.",
-      zh: "探索石清琪的个人网站，他是一位信奉匠人精神并擅长 React、TypeScript 和 Web 开发的软件工程师。了解他的职业经历、技术技能和教育背景。",
-    }),
+    description,
     applicationName: t({ en: "Qingqi Shi", zh: "石清琪" }),
     alternates: {
       canonical: new URL("/", BASE_URL).toString(),
@@ -34,6 +42,19 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
         en: new URL("/", BASE_URL).toString(),
         zh: new URL("/zh", BASE_URL).toString(),
       },
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: t({ en: "Qingqi Shi", zh: "石清琪" }),
+      locale: params.locale === "zh" ? "zh_CN" : "en_US",
+      type: "website",
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
     },
   } satisfies Metadata;
 }

--- a/src/app/[locale]/calculator/layout.tsx
+++ b/src/app/[locale]/calculator/layout.tsx
@@ -9,18 +9,39 @@ import { validateLocale } from "#src/utils/validate-locale.ts";
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const params = await props.params;
   validateLocale(params.locale);
+
+  const title = t({ en: "Calculator | Qingqi Shi", zh: "计算器 | 石清琪" });
+  const description = t({
+    en: "Qingqi's simple calculator demo.",
+    zh: "一个简单的计算器演示",
+  });
+  const url =
+    params.locale === "zh"
+      ? new URL("/zh/calculator", BASE_URL).toString()
+      : new URL("/calculator", BASE_URL).toString();
+
   return {
-    title: t({ en: "Calculator | Qingqi Shi", zh: "计算器 | 石清琪" }),
-    description: t({
-      en: "Qingqi's simple calculator demo.",
-      zh: "一个简单的计算器演示",
-    }),
+    title,
+    description,
     alternates: {
       canonical: new URL("/calculator", BASE_URL).toString(),
       languages: {
         en: new URL("/calculator", BASE_URL).toString(),
         zh: new URL("/zh/calculator", BASE_URL).toString(),
       },
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: t({ en: "Qingqi Shi", zh: "石清琪" }),
+      locale: params.locale === "zh" ? "zh_CN" : "en_US",
+      type: "website",
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
     },
   } satisfies Metadata;
 }

--- a/src/app/[locale]/component-library/layout.tsx
+++ b/src/app/[locale]/component-library/layout.tsx
@@ -9,27 +9,48 @@ import { validateLocale } from "#src/utils/validate-locale.ts";
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const params = await props.params;
   validateLocale(params.locale);
+
+  const title = t({
+    en: "Component Library | Qingqi Shi",
+    zh: "组件库 | 石清琪",
+  });
+  const description = t({
+    en: "Explore Qingqi Shi's component library - a collection of beautiful, reusable components crafted with care for modern web applications.",
+    zh: "探索石清琪的组件库 - 为现代网页应用精心打造的精美、可重用组件集合。",
+  });
+  const url =
+    params.locale === "zh"
+      ? new URL("/zh/component-library", BASE_URL).toString()
+      : new URL("/component-library", BASE_URL).toString();
+
   return {
     title: {
-      default: t({
-        en: "Component Library | Qingqi Shi",
-        zh: "组件库 | 石清琪",
-      }),
+      default: title,
       template: t({
         en: "%s | Component Library | Qingqi Shi",
         zh: "%s | 组件库 | 石清琪",
       }),
     },
-    description: t({
-      en: "Explore Qingqi Shi's component library - a collection of beautiful, reusable components crafted with care for modern web applications.",
-      zh: "探索石清琪的组件库 - 为现代网页应用精心打造的精美、可重用组件集合。",
-    }),
+    description,
     alternates: {
       canonical: new URL("/component-library", BASE_URL).toString(),
       languages: {
         en: new URL("/component-library", BASE_URL).toString(),
         zh: new URL("/zh/component-library", BASE_URL).toString(),
       },
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: t({ en: "Qingqi Shi", zh: "石清琪" }),
+      locale: params.locale === "zh" ? "zh_CN" : "en_US",
+      type: "website",
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
     },
   } satisfies Metadata;
 }

--- a/src/app/[locale]/movie-database/[type]/[id]/layout.tsx
+++ b/src/app/[locale]/movie-database/[type]/[id]/layout.tsx
@@ -13,6 +13,20 @@ import type { SupportedLocale } from "#src/types.ts";
 import { validateLocale } from "#src/utils/validate-locale.ts";
 import type { PageProps } from "./types";
 
+const TMDB_IMAGE_BASE = "https://image.tmdb.org/t/p/";
+
+function buildOgImages(backdropPath: string | null | undefined, title: string) {
+  if (!backdropPath) return undefined;
+  return [
+    {
+      url: `${TMDB_IMAGE_BASE}w1280${backdropPath}`,
+      width: 1280,
+      height: 720,
+      alt: title,
+    },
+  ];
+}
+
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
@@ -29,12 +43,19 @@ export async function generateMetadata({
       movie_id: id,
       language: validatedLocale,
     });
+    const title =
+      movieDetails.title ??
+      movieDetails.original_title ??
+      t({ en: "Untitled", zh: "佚名" });
+    const description = movieDetails.overview || movieDetails.tagline;
+    const url =
+      locale === "zh"
+        ? new URL(`/zh/movie-database/movie/${id}`, BASE_URL).toString()
+        : new URL(`/movie-database/movie/${id}`, BASE_URL).toString();
+
     return {
-      title:
-        movieDetails.title ??
-        movieDetails.original_title ??
-        t({ en: "Untitled", zh: "佚名" }),
-      description: movieDetails.overview || movieDetails.tagline,
+      title,
+      description,
       alternates: {
         canonical: new URL(`/movie-database/movie/${id}`, BASE_URL).toString(),
         languages: {
@@ -42,24 +63,65 @@ export async function generateMetadata({
           zh: new URL(`/zh/movie-database/movie/${id}`, BASE_URL).toString(),
         },
       },
+      openGraph: {
+        title,
+        description: description ?? undefined,
+        url,
+        siteName: t({ en: "Qingqi Shi", zh: "石清琪" }),
+        locale: locale === "zh" ? "zh_CN" : "en_US",
+        type: "website",
+        images: buildOgImages(movieDetails.backdrop_path, title),
+      },
+      twitter: {
+        card: movieDetails.backdrop_path ? "summary_large_image" : "summary",
+        title,
+        description: description ?? undefined,
+        images: movieDetails.backdrop_path
+          ? [`${TMDB_IMAGE_BASE}w1280${movieDetails.backdrop_path}`]
+          : undefined,
+      },
     } satisfies Metadata;
   } else {
     const tvShowDetails = await getTvShowDetails({
       series_id: id,
       language: validatedLocale,
     });
+    const title =
+      tvShowDetails.name ??
+      tvShowDetails.original_name ??
+      t({ en: "Untitled", zh: "佚名" });
+    const description = tvShowDetails.overview || tvShowDetails.tagline;
+    const url =
+      locale === "zh"
+        ? new URL(`/zh/movie-database/tv/${id}`, BASE_URL).toString()
+        : new URL(`/movie-database/tv/${id}`, BASE_URL).toString();
+
     return {
-      title:
-        tvShowDetails.name ??
-        tvShowDetails.original_name ??
-        t({ en: "Untitled", zh: "佚名" }),
-      description: tvShowDetails.overview || tvShowDetails.tagline,
+      title,
+      description,
       alternates: {
         canonical: new URL(`/movie-database/tv/${id}`, BASE_URL).toString(),
         languages: {
           en: new URL(`/movie-database/tv/${id}`, BASE_URL).toString(),
           zh: new URL(`/zh/movie-database/tv/${id}`, BASE_URL).toString(),
         },
+      },
+      openGraph: {
+        title,
+        description: description ?? undefined,
+        url,
+        siteName: t({ en: "Qingqi Shi", zh: "石清琪" }),
+        locale: locale === "zh" ? "zh_CN" : "en_US",
+        type: "website",
+        images: buildOgImages(tvShowDetails.backdrop_path, title),
+      },
+      twitter: {
+        card: tvShowDetails.backdrop_path ? "summary_large_image" : "summary",
+        title,
+        description: description ?? undefined,
+        images: tvShowDetails.backdrop_path
+          ? [`${TMDB_IMAGE_BASE}w1280${tvShowDetails.backdrop_path}`]
+          : undefined,
       },
     } satisfies Metadata;
   }

--- a/src/app/[locale]/movie-database/ai-mode/layout.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/layout.tsx
@@ -5,21 +5,43 @@ import { BASE_URL } from "#src/constants.ts";
 import { t } from "#src/i18n.ts";
 import { color, font, space } from "#src/tokens.stylex.ts";
 
-export function generateMetadata(_props: {
+export async function generateMetadata(props: {
   params: Promise<{ locale: string }>;
-}): Metadata {
+}): Promise<Metadata> {
+  const { locale } = await props.params;
+
+  const title = t({ en: "AI Mode", zh: "AI 模式" });
+  const description = t({
+    en: "Chat with AI about movies and TV shows",
+    zh: "与 AI 聊电影和电视剧",
+  });
+  const url =
+    locale === "zh"
+      ? new URL("/zh/movie-database/ai-mode", BASE_URL).toString()
+      : new URL("/movie-database/ai-mode", BASE_URL).toString();
+
   return {
-    title: t({ en: "AI Mode", zh: "AI 模式" }),
-    description: t({
-      en: "Chat with AI about movies and TV shows",
-      zh: "与 AI 聊电影和电视剧",
-    }),
+    title,
+    description,
     alternates: {
       canonical: new URL("/movie-database/ai-mode", BASE_URL).toString(),
       languages: {
         en: new URL("/movie-database/ai-mode", BASE_URL).toString(),
         zh: new URL("/zh/movie-database/ai-mode", BASE_URL).toString(),
       },
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: t({ en: "Qingqi Shi", zh: "石清琪" }),
+      locale: locale === "zh" ? "zh_CN" : "en_US",
+      type: "website",
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
     },
   } satisfies Metadata;
 }

--- a/src/app/[locale]/movie-database/layout.tsx
+++ b/src/app/[locale]/movie-database/layout.tsx
@@ -6,28 +6,50 @@ import { t } from "#src/i18n.ts";
 import { space } from "#src/tokens.stylex.ts";
 import type { PageProps } from "#src/types.ts";
 
-export function generateMetadata(_props: PageProps): Metadata {
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const params = await props.params;
+
+  const title = t({
+    en: "Movie Database | Qingqi Shi",
+    zh: "影视数据库 | 石清琪",
+  });
+  const description = t({
+    en: "Qingqi's Movie Database (QMDB) is a tool to help you find ratings and reviews for the newest movie and TV shows.",
+    zh: "石清琪的影视数据库 (QMDB) 是一个帮助您查找最新电影和电视剧评分与影评的工具。",
+  });
+  const url =
+    params.locale === "zh"
+      ? new URL("/zh/movie-database", BASE_URL).toString()
+      : new URL("/movie-database", BASE_URL).toString();
+
   return {
     title: {
-      default: t({
-        en: "Movie Database | Qingqi Shi",
-        zh: "影视数据库 | 石清琪",
-      }),
+      default: title,
       template: t({
         en: "%s | Movie Database | Qingqi Shi",
         zh: "%s | 影视数据库 | 石清琪",
       }),
     },
-    description: t({
-      en: "Qingqi's Movie Database (QMDB) is a tool to help you find ratings and reviews for the newest movie and TV shows.",
-      zh: "石清琪的影视数据库 (QMDB) 是一个帮助您查找最新电影和电视剧评分与影评的工具。",
-    }),
+    description,
     alternates: {
       canonical: new URL("/movie-database", BASE_URL).toString(),
       languages: {
         en: new URL("/movie-database", BASE_URL).toString(),
         zh: new URL("/zh/movie-database", BASE_URL).toString(),
       },
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: t({ en: "Qingqi Shi", zh: "石清琪" }),
+      locale: params.locale === "zh" ? "zh_CN" : "en_US",
+      type: "website",
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
     },
   } satisfies Metadata;
 }


### PR DESCRIPTION
## Summary

Adds OpenGraph and Twitter Card metadata to all page layout files so that links shared on social media (Facebook, Twitter/X, Slack, iMessage, etc.) render rich previews with titles, descriptions, and — for movie/TV detail pages — TMDB backdrop images. Previously, shared links only had basic `<title>` and `<meta name="description">` tags, which many platforms ignore in favour of `og:` and `twitter:` tags.

Changes cover the home page, calculator, component library, movie database (index, detail, and AI mode) layouts. The movie/TV detail layout additionally includes `summary_large_image` cards with TMDB backdrop images when available. A couple of `generateMetadata` functions were also converted from synchronous to async to access `params` for locale-aware URL generation.