### PR TITLE
chore: disallow API routes in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Allow: /
+Disallow: /api/
 Sitemap: https://qingqi.dev/sitemap.xml


### PR DESCRIPTION
## Summary

Adds a `Disallow: /api/` rule to `robots.txt` to prevent search engine crawlers from indexing internal API endpoints. These routes serve JSON responses for the frontend and are not meant to appear in search results.