### PR TITLE
fix: add prefers-reduced-motion support for view transition animations

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -61,6 +61,19 @@
   }
 }
 
+/* Reduced-motion alternatives: fade instead of slide */
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes fade-out {
+  to {
+    opacity: 0;
+  }
+}
+
 ::view-transition-old(.slide-out) {
   animation: slide-out 250ms cubic-bezier(0.32, 0.72, 0, 1);
   animation-fill-mode: forwards;
@@ -69,6 +82,18 @@
 ::view-transition-new(.slide-in) {
   animation: slide-in 250ms cubic-bezier(0.32, 0.72, 0, 1);
   animation-fill-mode: forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(.slide-out) {
+    animation: fade-out 150ms ease;
+    animation-fill-mode: forwards;
+  }
+
+  ::view-transition-new(.slide-in) {
+    animation: fade-in 150ms ease;
+    animation-fill-mode: forwards;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Users who prefer reduced motion currently see the full slide-in/slide-out view transition animations, which can cause discomfort or accessibility issues. This adds a `prefers-reduced-motion: reduce` media query that replaces the sliding animations with a shorter, subtler fade-in/fade-out alternative, respecting the user's OS-level motion preference.