### PR TITLE
fix: use semantic main element for calculator layout

### DIFF
--- a/src/app/[locale]/calculator/layout.tsx
+++ b/src/app/[locale]/calculator/layout.tsx
@@ -31,7 +31,7 @@ export default function Layout({
   children: React.ReactNode;
   params: Promise<{ locale: string }>;
 }) {
-  return <div css={styles.container}>{children}</div>;
+  return <main css={styles.container}>{children}</main>;
 }
 
 const styles = stylex.create({


### PR DESCRIPTION
## Summary

Replace the generic `<div>` wrapper in the calculator layout with a `<main>` element to improve semantic HTML structure. This gives screen readers and assistive technologies a proper landmark for the calculator page content, consistent with accessibility best practices.