### PR TITLE
refactor: extract shared formatRuntime utility

### DIFF
--- a/src/app/[locale]/movie-database/[type]/[id]/page.tsx
+++ b/src/app/[locale]/movie-database/[type]/[id]/page.tsx
@@ -17,14 +17,8 @@ import { skeletonTokens } from "#src/components/shared/skeleton.stylex.ts";
 import { Skeleton } from "#src/components/shared/skeleton.tsx";
 import { t } from "#src/i18n.ts";
 import { border, color, controlSize, font, space } from "#src/tokens.stylex.ts";
+import { formatRuntime } from "#src/utils/format-runtime.ts";
 import type { PageProps } from "./types";
-
-function formatRuntime(runtime: number) {
-  if (!runtime) return "";
-  const hours = Math.floor(runtime / 60);
-  const minutes = runtime % 60;
-  return `${hours > 0 ? `${hours}${t({ en: "h", zh: " 小时" })} ` : ""}${minutes}${t({ en: "m", zh: " 分钟" })}`;
-}
 
 export default async function Page({ params }: PageProps) {
   const { type, id, locale } = await params;
@@ -85,7 +79,11 @@ export default async function Page({ params }: PageProps) {
             <div css={styles.meta}>
               {[
                 movie.release_date?.split("-")[0],
-                formatRuntime(movie.runtime),
+                formatRuntime(
+                  movie.runtime,
+                  t({ en: "h", zh: " 小时" }),
+                  t({ en: "m", zh: " 分钟" }),
+                ),
                 movie.genres
                   ?.map((genre) => genre.name)
                   .filter(Boolean)

--- a/src/components/ai-chat/media-detail-content.tsx
+++ b/src/components/ai-chat/media-detail-content.tsx
@@ -16,19 +16,13 @@ import {
   shadow,
   space,
 } from "#src/tokens.stylex.ts";
+import { formatRuntime } from "#src/utils/format-runtime.ts";
 import { buildSrcSet } from "#src/utils/tmdb-image.ts";
 import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
 import { Button } from "../shared/button";
 import { Skeleton } from "../shared/skeleton";
 import { useChatActions } from "./chat-actions-context";
 import { useMediaDetail, type FocusedMedia } from "./media-detail-context";
-
-function formatMovieRuntime(minutes: number) {
-  if (!minutes) return "";
-  const hours = Math.floor(minutes / 60);
-  const mins = minutes % 60;
-  return `${hours > 0 ? `${hours}${t({ en: "h", zh: " 小时" })} ` : ""}${mins}${t({ en: "m", zh: " 分钟" })}`;
-}
 
 export function MediaDetailContent({
   id,
@@ -82,7 +76,11 @@ export function MediaDetailContent({
                   : t({ en: "seasons", zh: "季" })
               }`
             : ""
-          : formatMovieRuntime(detail.runtime),
+          : formatRuntime(
+              detail.runtime,
+              t({ en: "h", zh: " 小时" }),
+              t({ en: "m", zh: " 分钟" }),
+            ),
         detail.genres.join(t({ en: ", ", zh: "、" })),
       ]
         .filter(Boolean)

--- a/src/utils/format-runtime.test.ts
+++ b/src/utils/format-runtime.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { formatRuntime } from "./format-runtime";
+
+describe("formatRuntime", () => {
+  it("formats hours and minutes", () => {
+    expect(formatRuntime(148, "h", "m")).toBe("2h 28m");
+  });
+
+  it("formats minutes only when less than an hour", () => {
+    expect(formatRuntime(45, "h", "m")).toBe("45m");
+  });
+
+  it("formats exactly one hour", () => {
+    expect(formatRuntime(60, "h", "m")).toBe("1h 0m");
+  });
+
+  it("returns empty string for zero", () => {
+    expect(formatRuntime(0, "h", "m")).toBe("");
+  });
+
+  it("returns empty string for NaN", () => {
+    expect(formatRuntime(NaN, "h", "m")).toBe("");
+  });
+
+  it("formats large values", () => {
+    expect(formatRuntime(240, "h", "m")).toBe("4h 0m");
+  });
+
+  it("formats single-digit minutes", () => {
+    expect(formatRuntime(65, "h", "m")).toBe("1h 5m");
+  });
+
+  it("uses the provided locale labels", () => {
+    expect(formatRuntime(148, " 小时", " 分钟")).toBe("2 小时 28 分钟");
+  });
+});

--- a/src/utils/format-runtime.ts
+++ b/src/utils/format-runtime.ts
@@ -1,0 +1,20 @@
+/**
+ * Formats a movie/TV runtime in minutes into a human-readable string
+ * with the given hour and minute labels.
+ *
+ * Returns an empty string for falsy values (0, NaN, etc.)
+ * to avoid showing "0m" for entries without runtime data.
+ *
+ * @example formatRuntime(148, "h", "m") → "2h 28m"
+ * @example formatRuntime(45, "h", "m")  → "45m"
+ */
+export function formatRuntime(
+  minutes: number,
+  hourLabel: string,
+  minuteLabel: string,
+) {
+  if (!minutes) return "";
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  return `${hours > 0 ? `${hours}${hourLabel} ` : ""}${mins}${minuteLabel}`;
+}


### PR DESCRIPTION
## Summary
- Extracted duplicated `formatRuntime` / `formatMovieRuntime` functions from the SSR movie detail page (`src/app/[locale]/movie-database/[type]/[id]/page.tsx`) and the client-side AI chat media detail overlay (`src/components/ai-chat/media-detail-content.tsx`) into a shared utility at `src/utils/format-runtime.ts`.
- The shared function accepts locale-specific hour/minute labels as parameters so `t()` calls remain at the call site, complying with the `i18n/no-t-outside-render` ESLint rule.
- Added 8 unit tests covering edge cases (zero, NaN, hours-only, minutes-only, large values, locale labels).

## Test plan
- [x] `pnpm lint:changed` passes
- [x] `pnpm format:changed` passes
- [x] `pnpm test` passes (580/580)
- [x] `pnpm build` succeeds
- [x] New test file `src/utils/format-runtime.test.ts` covers formatting behavior