### PR TITLE
fix: add prefers-reduced-motion support to chat loading animations

### DIFF
--- a/src/components/ai-chat/tool-activity-line.tsx
+++ b/src/components/ai-chat/tool-activity-line.tsx
@@ -6,6 +6,7 @@ import * as stylex from "@stylexjs/stylex";
 import { t } from "#src/i18n.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { truncate } from "#src/primitives/layout.stylex.ts";
+import { motionConstants } from "#src/primitives/motion.stylex.ts";
 import { border, color, font, space } from "#src/tokens.stylex.ts";
 import { isRecord } from "./map-tool-output";
 
@@ -114,6 +115,11 @@ const pulse = stylex.keyframes({
   "50%": { opacity: 1, transform: "scale(1)" },
 });
 
+const pulseReduced = stylex.keyframes({
+  "0%, 100%": { opacity: 0.4 },
+  "50%": { opacity: 1 },
+});
+
 const styles = stylex.create({
   line: {
     gap: space._1,
@@ -132,7 +138,10 @@ const styles = stylex.create({
     height: "0.375rem",
     borderRadius: border.radius_round,
     backgroundColor: color.textMuted,
-    animationName: pulse,
+    animationName: {
+      default: pulse,
+      [motionConstants.REDUCED_MOTION]: pulseReduced,
+    },
     animationDuration: "1.4s",
     animationTimingFunction: "ease-in-out",
     animationIterationCount: "infinite",

--- a/src/components/ai-chat/typing-indicator.tsx
+++ b/src/components/ai-chat/typing-indicator.tsx
@@ -2,6 +2,7 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { flex } from "#src/primitives/flex.stylex.ts";
+import { motionConstants } from "#src/primitives/motion.stylex.ts";
 import { border, color, font, space } from "#src/tokens.stylex.ts";
 
 const DOT_COUNT = 3;
@@ -31,6 +32,11 @@ const bounce = stylex.keyframes({
   "40%": { opacity: 1, transform: "scale(1)" },
 });
 
+const bounceReduced = stylex.keyframes({
+  "0%, 80%, 100%": { opacity: 0.3 },
+  "40%": { opacity: 1 },
+});
+
 const styles = stylex.create({
   container: {
     gap: space._1,
@@ -41,7 +47,10 @@ const styles = stylex.create({
     height: "0.375rem",
     borderRadius: border.radius_round,
     backgroundColor: color.textMuted,
-    animationName: bounce,
+    animationName: {
+      default: bounce,
+      [motionConstants.REDUCED_MOTION]: bounceReduced,
+    },
     animationDuration: "1.4s",
     animationTimingFunction: "ease-in-out",
     animationIterationCount: "infinite",


### PR DESCRIPTION
## Summary

- Add `prefers-reduced-motion` support to `TypingIndicator` and `ToolActivityLine` components
- When reduced motion is preferred, infinite bounce/pulse animations switch to opacity-only keyframes (removing `transform: scale()`) to avoid causing discomfort for users with vestibular disorders
- Follows the existing `motionConstants.REDUCED_MOTION` conditional pattern established in `motion.stylex.ts`

## Test plan

- [x] `pnpm lint:changed` passes
- [x] `pnpm format:changed` passes (unchanged)
- [x] `pnpm test` passes (572 tests)
- [x] `pnpm build` succeeds
- [ ] Visually verify in browser with `prefers-reduced-motion: reduce` enabled that dots still pulse (opacity) without scaling