### PR TITLE
fix: format vote count with locale-aware number formatter

### DIFF
--- a/src/app/[locale]/movie-database/[type]/[id]/page.tsx
+++ b/src/app/[locale]/movie-database/[type]/[id]/page.tsx
@@ -74,7 +74,7 @@ export default async function Page({ params }: PageProps) {
                 {formatter.format(movie.vote_average)}
               </div>
               <div css={styles.count} aria-hidden="true">
-                {movie.vote_count}
+                {formatter.format(movie.vote_count)}
               </div>
             </div>
             <h1 css={styles.h1}>
@@ -154,7 +154,7 @@ export default async function Page({ params }: PageProps) {
                 {formatter.format(tvShow.vote_average)}
               </div>
               <div css={styles.count} aria-hidden="true">
-                {tvShow.vote_count}
+                {formatter.format(tvShow.vote_count)}
               </div>
             </div>
             <h1 css={styles.h1}>


### PR DESCRIPTION
## Summary

The `vote_count` on movie and TV show detail pages was rendered as a raw number without locale-aware formatting, while the adjacent `vote_average` already used `formatter.format()`. This wraps `vote_count` with the same formatter so large numbers display with proper grouping separators (e.g., "12,345" in English).