### PR TITLE
fix: localize calculator error label for i18n support

### DIFF
--- a/src/components/calculator/calculator-display.tsx
+++ b/src/components/calculator/calculator-display.tsx
@@ -2,6 +2,7 @@
 import * as stylex from "@stylexjs/stylex";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useScrollFades } from "#src/hooks/use-scroll-fades.ts";
+import { t } from "#src/i18n.ts";
 import { color, space } from "#src/tokens.stylex.ts";
 import type { Token } from "./types.ts";
 
@@ -10,15 +11,18 @@ interface CalculatorDisplayProps {
   currentToken: Token;
 }
 
-function formatTokenValue(token: Token): string {
-  return Number.isNaN(token.value) ? "Error" : String(token.value);
+function formatTokenValue(token: Token, errorLabel: string): string {
+  return Number.isNaN(token.value) ? errorLabel : String(token.value);
 }
 
 export function CalculatorDisplay({
   tokens,
   currentToken,
 }: CalculatorDisplayProps) {
-  const displayText = [...tokens, currentToken].map(formatTokenValue).join(" ");
+  const errorLabel = t({ en: "Error", zh: "错误" });
+  const displayText = [...tokens, currentToken]
+    .map((token) => formatTokenValue(token, errorLabel))
+    .join(" ");
 
   const containerRef = useRef<HTMLDivElement>(null);
   const textRef = useRef<HTMLSpanElement>(null);


### PR DESCRIPTION
## Summary

The calculator display hardcoded the "Error" string shown when a computation results in NaN. This meant Chinese-locale users saw an English-only error message. This change uses the `t()` i18n function to display "错误" for Chinese users and "Error" for English users, keeping the calculator display consistent with the rest of the site's localization.