### PR TITLE
fix: add fallback aria-labels for media cards when title is missing

### DIFF
--- a/src/components/ai-chat/compact-media-card.test.tsx
+++ b/src/components/ai-chat/compact-media-card.test.tsx
@@ -123,4 +123,70 @@ describe("CompactMediaCard", () => {
 
     expect(onClick).toHaveBeenCalledTimes(1);
   });
+
+  it("uses title as button aria-label when available", () => {
+    render(
+      <CompactMediaCard
+        media={{
+          id: 1,
+          title: "Inception",
+          posterPath: "/inception.jpg",
+          rating: 8.4,
+          mediaType: "movie",
+        }}
+        onClick={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Inception" }),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to 'Movie' aria-label when title is missing for movie", () => {
+    render(
+      <CompactMediaCard
+        media={{
+          id: 1,
+          posterPath: "/inception.jpg",
+          rating: 8.4,
+          mediaType: "movie",
+        }}
+        onClick={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Movie" })).toBeInTheDocument();
+  });
+
+  it("falls back to 'TV show' aria-label when title is missing for tv", () => {
+    render(
+      <CompactMediaCard
+        media={{
+          id: 1,
+          posterPath: "/show.jpg",
+          rating: 7.0,
+          mediaType: "tv",
+        }}
+        onClick={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "TV show" })).toBeInTheDocument();
+  });
+
+  it("falls back to 'Media' aria-label when title and mediaType are missing", () => {
+    render(
+      <CompactMediaCard
+        media={{
+          id: 1,
+          posterPath: "/unknown.jpg",
+          rating: 5.0,
+        }}
+        onClick={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Media" })).toBeInTheDocument();
+  });
 });

--- a/src/components/ai-chat/compact-media-card.tsx
+++ b/src/components/ai-chat/compact-media-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
+import { t } from "#src/i18n.ts";
 import { buttonReset } from "#src/primitives/reset.stylex.ts";
 import { border, ratio } from "#src/tokens.stylex.ts";
 import type { MediaListItem } from "#src/utils/types.ts";
@@ -9,6 +10,13 @@ import { MediaPoster } from "../movie-database/media-poster";
 interface CompactMediaCardProps {
   media: MediaListItem;
   onClick?: () => void;
+}
+
+function getMediaLabel(media: MediaListItem): string {
+  if (media.title) return media.title;
+  if (media.mediaType === "movie") return t({ en: "Movie", zh: "电影" });
+  if (media.mediaType === "tv") return t({ en: "TV show", zh: "电视剧" });
+  return t({ en: "Media", zh: "媒体" });
 }
 
 export function CompactMediaCard({ media, onClick }: CompactMediaCardProps) {
@@ -20,7 +28,7 @@ export function CompactMediaCard({ media, onClick }: CompactMediaCardProps) {
         type="button"
         css={[buttonReset.base, styles.compactCard]}
         onClick={onClick}
-        aria-label={media.title ?? undefined}
+        aria-label={getMediaLabel(media)}
       >
         {content}
       </button>

--- a/src/components/ai-chat/media-detail-overlay.test.tsx
+++ b/src/components/ai-chat/media-detail-overlay.test.tsx
@@ -25,6 +25,15 @@ const mockItems: ReadonlyArray<MediaListItem> = [
   },
 ];
 
+const mockItemsWithMissingTitle: ReadonlyArray<MediaListItem> = [
+  {
+    id: 789,
+    posterPath: "/unknown.jpg",
+    rating: 6.0,
+    mediaType: "movie",
+  },
+];
+
 function renderWithOverlay() {
   return render(
     <PortalTargetProvider>
@@ -145,5 +154,42 @@ describe("MediaDetailOverlay", () => {
 
     // Focus should wrap to the last focusable element
     expect(lastFocusable).toHaveFocus();
+  });
+
+  it("labels dialog with media title when available", async () => {
+    const user = userEvent.setup();
+    renderWithOverlay();
+
+    await user.click(screen.getByRole("button", { name: "Inception" }));
+
+    expect(
+      screen.getByRole("dialog", { name: "Inception" }),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to media type label when title is missing", async () => {
+    const user = userEvent.setup();
+    render(
+      <PortalTargetProvider>
+        <MediaDetailProvider>
+          <ChatActionsContext
+            value={{
+              sendMessage: vi.fn(),
+              attachedMedia: null,
+              setAttachedMedia: vi.fn(),
+            }}
+          >
+            <ToolMediaCards items={mockItemsWithMissingTitle} />
+            <MediaDetailOverlay />
+          </ChatActionsContext>
+        </MediaDetailProvider>
+      </PortalTargetProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Movie" }));
+
+    expect(
+      screen.getByRole("dialog", { name: "Movie details" }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/ai-chat/media-detail-overlay.tsx
+++ b/src/components/ai-chat/media-detail-overlay.tsx
@@ -13,10 +13,17 @@ import { fixedFill } from "#src/primitives/layout.stylex.ts";
 import { buttonReset } from "#src/primitives/reset.stylex.ts";
 import { border, color, layer, space } from "#src/tokens.stylex.ts";
 import { MediaDetailContent } from "./media-detail-content";
-import { useMediaDetail } from "./media-detail-context";
+import { useMediaDetail, type FocusedMedia } from "./media-detail-context";
 
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function getDialogLabel(media: FocusedMedia): string {
+  if (media.title) return media.title;
+  if (media.mediaType === "movie")
+    return t({ en: "Movie details", zh: "电影详情" });
+  return t({ en: "TV show details", zh: "电视剧详情" });
+}
 
 export function MediaDetailOverlay() {
   const { focusedMedia, setFocusedMedia } = useMediaDetail();
@@ -86,7 +93,7 @@ export function MediaDetailOverlay() {
             css={styles.card}
             role="dialog"
             aria-modal="true"
-            aria-label={focusedMedia.title ?? undefined}
+            aria-label={getDialogLabel(focusedMedia)}
           >
             <button
               ref={closeButtonRef}

--- a/src/components/movie-database/media-card.tsx
+++ b/src/components/movie-database/media-card.tsx
@@ -3,6 +3,7 @@
 import * as stylex from "@stylexjs/stylex";
 import { Card } from "#src/components/shared/card.tsx";
 import { useLocale } from "#src/hooks/use-locale.ts";
+import { t } from "#src/i18n.ts";
 import { absoluteFill } from "#src/primitives/layout.stylex.ts";
 import { layer, ratio } from "#src/tokens.stylex.ts";
 import { getLocalePath } from "#src/utils/pathname.ts";
@@ -12,6 +13,13 @@ import { MediaPoster } from "./media-poster";
 interface MediaCardProps {
   media: MediaListItem;
   allowFollow?: boolean;
+}
+
+function getMediaLabel(media: MediaListItem): string {
+  if (media.title) return media.title;
+  if (media.mediaType === "movie") return t({ en: "Movie", zh: "电影" });
+  if (media.mediaType === "tv") return t({ en: "TV show", zh: "电视剧" });
+  return t({ en: "Media", zh: "媒体" });
 }
 
 export function MediaCard({ media, allowFollow }: MediaCardProps) {
@@ -27,7 +35,7 @@ export function MediaCard({ media, allowFollow }: MediaCardProps) {
       href={href}
       prefetch={false}
       css={styles.card}
-      aria-label={media.title ?? undefined}
+      aria-label={getMediaLabel(media)}
       rel={allowFollow ? undefined : "nofollow"}
     >
       <div css={[absoluteFill.all, styles.posterContainer]}>


### PR DESCRIPTION
## Summary

Media cards and the detail overlay previously passed `undefined` as their `aria-label` when the media title was missing, making them invisible to screen readers. This adds `getMediaLabel` / `getDialogLabel` helper functions that fall back to a localized media-type string ("Movie", "TV show", or "Media") so every interactive element always has a meaningful accessible name.

Tests added for `CompactMediaCard` and `MediaDetailOverlay` to cover the title-present, title-missing-with-type, and title-and-type-missing scenarios.