### PR TITLE
feat: add styled GFM table rendering to AI chat markdown

### DIFF
--- a/src/components/ai-chat/markdown-content.test.tsx
+++ b/src/components/ai-chat/markdown-content.test.tsx
@@ -93,4 +93,31 @@ describe("MarkdownContent", () => {
     expect(screen.getByText("First paragraph")).toBeInTheDocument();
     expect(screen.getByText("Second paragraph")).toBeInTheDocument();
   });
+
+  it("renders GFM tables with header and data rows", () => {
+    const table = [
+      "| Title | Year | Rating |",
+      "| --- | --- | --- |",
+      "| Inception | 2010 | 8.8 |",
+      "| Interstellar | 2014 | 8.7 |",
+    ].join("\n");
+
+    render(<MarkdownContent content={table} />);
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getAllByRole("columnheader")).toHaveLength(3);
+    expect(screen.getByText("Title").tagName).toBe("TH");
+    expect(screen.getByText("Inception").tagName).toBe("TD");
+    expect(screen.getByText("Interstellar").tagName).toBe("TD");
+    expect(screen.getAllByRole("row")).toHaveLength(3);
+  });
+
+  it("wraps tables in a scrollable container", () => {
+    const table = ["| A | B |", "| --- | --- |", "| 1 | 2 |"].join("\n");
+
+    const { container } = render(<MarkdownContent content={table} />);
+
+    const tableEl = container.querySelector("table");
+    expect(tableEl?.parentElement?.tagName).toBe("DIV");
+  });
 });

--- a/src/components/ai-chat/markdown-content.tsx
+++ b/src/components/ai-chat/markdown-content.tsx
@@ -74,6 +74,32 @@ const styles = stylex.create({
     paddingInline: space._00,
     paddingBlock: space._00,
   },
+  tableWrapper: {
+    overflowX: "auto",
+    marginBlock: 0,
+  },
+  table: {
+    borderCollapse: "collapse",
+    width: "100%",
+    fontSize: font.uiBodySmall,
+  },
+  th: {
+    textAlign: "left",
+    fontWeight: font.weight_6,
+    paddingBlock: space._1,
+    paddingInline: space._2,
+    borderBottomWidth: border.size_2,
+    borderBottomStyle: "solid",
+    borderBottomColor: color.controlTrack,
+    whiteSpace: "nowrap",
+  },
+  td: {
+    paddingBlock: space._1,
+    paddingInline: space._2,
+    borderBottomWidth: border.size_1,
+    borderBottomStyle: "solid",
+    borderBottomColor: color.controlTrack,
+  },
   wrapper: {
     gap: space._2,
   },
@@ -102,6 +128,13 @@ const components: Components = {
     }
     return <code css={styles.codeInline} {...props} />;
   },
+  table: ({ node, ...props }) => (
+    <div css={styles.tableWrapper}>
+      <table css={styles.table} {...props} />
+    </div>
+  ),
+  th: ({ node, ...props }) => <th css={styles.th} {...props} />,
+  td: ({ node, ...props }) => <td css={styles.td} {...props} />,
 };
 
 const remarkPlugins = [remarkGfm];


### PR DESCRIPTION
## Summary

The AI chat markdown renderer previously did not style GFM (GitHub Flavored Markdown) tables, so when the LLM returned tabular data (e.g. movie comparisons), tables rendered with default browser styling that looked out of place. This adds custom `table`, `th`, and `td` component overrides to `react-markdown` with StyleX styles — collapsed borders, proper padding, header weight and bottom border, and a horizontally scrollable wrapper for narrow viewports.

Two new tests verify that GFM tables render with the correct semantic HTML structure (table/th/td/rows) and that the table is wrapped in a scrollable container div.