### PR TITLE
fix: add prefers-reduced-motion support to media detail overlay animation

### DIFF
--- a/src/components/ai-chat/media-detail-overlay.tsx
+++ b/src/components/ai-chat/media-detail-overlay.tsx
@@ -10,6 +10,7 @@ import { usePortalTarget } from "#src/contexts/portal-context.tsx";
 import { t } from "#src/i18n.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { fixedFill } from "#src/primitives/layout.stylex.ts";
+import { motionConstants } from "#src/primitives/motion.stylex.ts";
 import { buttonReset } from "#src/primitives/reset.stylex.ts";
 import { border, color, layer, space } from "#src/tokens.stylex.ts";
 import { MediaDetailContent } from "./media-detail-content";
@@ -160,7 +161,10 @@ const styles = stylex.create({
     overflow: "hidden",
     overflowY: "auto",
     pointerEvents: "all",
-    animationName: slideUp,
+    animationName: {
+      default: slideUp,
+      [motionConstants.REDUCED_MOTION]: "none",
+    },
     animationDuration: "300ms",
     animationTimingFunction: easing,
     animationFillMode: "backwards",


### PR DESCRIPTION
## Summary

The media detail overlay's slide-up animation did not respect the user's `prefers-reduced-motion` preference. This adds a conditional `animationName` that disables the slide-up animation when reduced motion is preferred, consistent with the approach already used elsewhere in the codebase (e.g. chat loading animations in #1834, view transitions in #1830).