### PR TITLE
feat: add server-side session management for AI chat

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@serwist/next": "^9.5.0",
     "@stylexjs/stylex": "^0.18.2",
     "@tanstack/react-query": "5.90.20",
+    "@upstash/redis": "^1.37.0",
     "@upstash/vector": "^1.2.3",
     "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "1.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@tanstack/react-query':
         specifier: 5.90.20
         version: 5.90.20(react@19.3.0-canary-52684925-20251110)
+      '@upstash/redis':
+        specifier: ^1.37.0
+        version: 1.37.0
       '@upstash/vector':
         specifier: ^1.2.3
         version: 1.2.3
@@ -2657,6 +2660,9 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@upstash/redis@1.37.0':
+    resolution: {integrity: sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==}
 
   '@upstash/vector@1.2.3':
     resolution: {integrity: sha512-yXsWKeuHNYyH72BcSZd3bV5ZD5MybAoTvKxkMaeV2UzuGfNzbHBVh5eO+ysTWTFAf8I9XcOueF4tZfAGjCa4Iw==}
@@ -5677,6 +5683,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -8444,6 +8453,10 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
+
+  '@upstash/redis@1.37.0':
+    dependencies:
+      uncrypto: 0.1.3
 
   '@upstash/vector@1.2.3': {}
 
@@ -12068,6 +12081,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  uncrypto@0.1.3: {}
 
   undici-types@7.16.0: {}
 

--- a/src/ai-chat/chat.ts
+++ b/src/ai-chat/chat.ts
@@ -10,7 +10,7 @@ import { createPresentMediaTool } from "./tools/present-media";
 import { createSemanticSearchTool } from "./tools/semantic-search";
 import { createTmdbSearchTool } from "./tools/tmdb-search";
 
-export { chatInputSchema, type ChatInput } from "./schema";
+export type { ChatInput } from "./schema";
 
 interface ChatOptions extends ChatInput {
   model?: LanguageModel;

--- a/src/ai-chat/is-ui-message.ts
+++ b/src/ai-chat/is-ui-message.ts
@@ -1,0 +1,13 @@
+import type { UIMessage } from "ai";
+
+export function isUIMessage(val: unknown): val is UIMessage {
+  if (typeof val !== "object" || val === null) return false;
+  return (
+    "id" in val &&
+    typeof val.id === "string" &&
+    "role" in val &&
+    typeof val.role === "string" &&
+    "parts" in val &&
+    Array.isArray(val.parts)
+  );
+}

--- a/src/ai-chat/schema.ts
+++ b/src/ai-chat/schema.ts
@@ -1,17 +1,6 @@
 import type { UIMessage } from "ai";
 import { z } from "zod";
-
-function isUIMessage(val: unknown): val is UIMessage {
-  if (typeof val !== "object" || val === null) return false;
-  return (
-    "id" in val &&
-    typeof val.id === "string" &&
-    "role" in val &&
-    typeof val.role === "string" &&
-    "parts" in val &&
-    Array.isArray(val.parts)
-  );
-}
+import { isUIMessage } from "./is-ui-message";
 
 export const chatInputSchema = z.object({
   messages: z.array(z.custom<UIMessage>(isUIMessage)).min(1),

--- a/src/ai-chat/session-schema.ts
+++ b/src/ai-chat/session-schema.ts
@@ -1,0 +1,24 @@
+import type { UIMessage } from "ai";
+import { z } from "zod";
+import { isUIMessage } from "./is-ui-message";
+
+const sharedFields = {
+  sessionId: z.string().uuid().optional(),
+  locale: z.enum(["en", "zh"]).default("en"),
+};
+
+export const sessionChatInputSchema = z.discriminatedUnion("trigger", [
+  z.object({
+    ...sharedFields,
+    trigger: z.literal("submit-message"),
+    message: z.custom<UIMessage>(isUIMessage),
+  }),
+  z.object({
+    ...sharedFields,
+    trigger: z.literal("regenerate-message"),
+  }),
+]);
+
+export type SessionChatInput = z.infer<typeof sessionChatInputSchema>;
+
+export const sessionIdSchema = z.string().uuid();

--- a/src/ai-chat/use-ai-chat.ts
+++ b/src/ai-chat/use-ai-chat.ts
@@ -3,31 +3,168 @@
 import { Chat, useChat } from "@ai-sdk/react";
 import type { UIMessage } from "ai";
 import { DefaultChatTransport } from "ai";
+import { useState } from "react";
 import { z } from "zod";
+import { isUIMessage } from "#src/ai-chat/is-ui-message.ts";
 import type { SupportedLocale } from "#src/types.ts";
 
 export interface ChatMessageMetadata {
   inputTokens?: number;
+  sessionId?: string;
 }
 
 export type ChatUIMessage = UIMessage<ChatMessageMetadata>;
 
 const messageMetadataSchema = z.object({
   inputTokens: z.number().optional(),
+  sessionId: z.string().optional(),
 });
+
+function findSessionIdFromMessages(
+  messages: ChatUIMessage[],
+): string | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const metadata = messages[i].metadata;
+    if (metadata?.sessionId) {
+      return metadata.sessionId;
+    }
+  }
+  return undefined;
+}
+
+const STORAGE_KEY_PREFIX = "ai-chat-session:";
+
+function getStoredSessionId(locale: SupportedLocale): string | null {
+  try {
+    return localStorage.getItem(`${STORAGE_KEY_PREFIX}${locale}`);
+  } catch {
+    return null;
+  }
+}
+
+function setStoredSessionId(locale: SupportedLocale, sessionId: string) {
+  try {
+    localStorage.setItem(`${STORAGE_KEY_PREFIX}${locale}`, sessionId);
+  } catch {
+    // May throw in SSR or when storage quota is exceeded
+  }
+}
+
+function clearStoredSessionId(locale: SupportedLocale) {
+  try {
+    localStorage.removeItem(`${STORAGE_KEY_PREFIX}${locale}`);
+  } catch {
+    // Intentionally ignored — localStorage may be unavailable
+  }
+}
+
+const sessionResponseSchema = z.object({
+  messages: z.array(z.custom<ChatUIMessage>(isUIMessage)),
+  sessionId: z.string(),
+});
+
+async function fetchSession(
+  sessionId: string,
+): Promise<{ messages: ChatUIMessage[]; sessionId: string } | null> {
+  const response = await fetch("/api/ai-chat/session", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ sessionId }),
+  });
+  if (response.ok) {
+    return sessionResponseSchema.parse(await response.json());
+  }
+  if (response.status === 404) {
+    return null;
+  }
+  throw new Error(`Failed to fetch session: ${response.status}`);
+}
 
 const chatInstances = new Map<string, Chat<ChatUIMessage>>();
 
+function getOrCreateChat(locale: SupportedLocale): Chat<ChatUIMessage> {
+  const existing = chatInstances.get(locale);
+  if (existing) return existing;
+
+  const transport = new DefaultChatTransport<ChatUIMessage>({
+    api: "/api/ai-chat",
+    prepareSendMessagesRequest: ({ messages, trigger }) => {
+      const sessionId = findSessionIdFromMessages(messages);
+      if (trigger === "regenerate-message") {
+        return { body: { sessionId, locale, trigger } };
+      }
+      const lastMessage = messages[messages.length - 1];
+      return { body: { sessionId, message: lastMessage, locale, trigger } };
+    },
+  });
+
+  const chat = new Chat<ChatUIMessage>({
+    transport,
+    messageMetadataSchema,
+    onFinish: ({ messages }) => {
+      const sessionId = findSessionIdFromMessages(messages);
+      if (sessionId) {
+        setStoredSessionId(locale, sessionId);
+      }
+    },
+    onError: () => {
+      const storedSessionId = getStoredSessionId(locale);
+      if (!storedSessionId) return;
+
+      const chatInstance = chatInstances.get(locale);
+      if (!chatInstance) return;
+
+      fetchSession(storedSessionId)
+        .then((result) => {
+          const ci = chatInstances.get(locale);
+          if (!ci) return;
+
+          if (result) {
+            ci.messages = result.messages;
+            ci.clearError();
+          }
+        })
+        .catch(console.error);
+    },
+  });
+
+  chatInstances.set(locale, chat);
+
+  return chat;
+}
+
 export function useAIChat({ locale }: { locale: SupportedLocale }) {
-  let chat = chatInstances.get(locale);
-  if (!chat) {
-    const transport = new DefaultChatTransport({
-      api: "/api/ai-chat",
-      body: { locale },
-    });
-    chat = new Chat<ChatUIMessage>({ transport, messageMetadataSchema });
-    chatInstances.set(locale, chat);
+  const chat = getOrCreateChat(locale);
+  const chatResult = useChat({ chat });
+
+  const [previousSessionId, setPreviousSessionId] = useState(() => {
+    if (chat.messages.length > 0) return null;
+    return getStoredSessionId(locale);
+  });
+
+  // Dismiss banner when user starts a new conversation
+  if (previousSessionId && chatResult.messages.length > 0) {
+    setPreviousSessionId(null);
   }
 
-  return useChat({ chat });
+  const continueSession = () => {
+    if (!previousSessionId) return;
+    fetchSession(previousSessionId)
+      .then((result) => {
+        if (!result) {
+          clearStoredSessionId(locale);
+          setPreviousSessionId(null);
+          return;
+        }
+        chat.messages = result.messages;
+        setPreviousSessionId(null);
+      })
+      .catch(console.error);
+  };
+
+  return {
+    ...chatResult,
+    previousSessionId,
+    continueSession,
+  };
 }

--- a/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
@@ -11,6 +11,7 @@ import { ChatInputBar } from "#src/components/ai-chat/chat-input-bar.tsx";
 import { ChatMessageList } from "#src/components/ai-chat/chat-message-list.tsx";
 import { MediaDetailProvider } from "#src/components/ai-chat/media-detail-context.tsx";
 import { MediaDetailOverlay } from "#src/components/ai-chat/media-detail-overlay.tsx";
+import { SessionRestoreBanner } from "#src/components/ai-chat/session-restore-banner.tsx";
 import { border, color, layer, space } from "#src/tokens.stylex.ts";
 import type { SupportedLocale } from "#src/types.ts";
 
@@ -39,7 +40,15 @@ export function AIChatView({
   stopLabel,
   removeAttachmentLabel,
 }: AIChatViewProps) {
-  const { messages, status, error, sendMessage, stop } = useAIChat({ locale });
+  const {
+    messages,
+    status,
+    error,
+    sendMessage,
+    stop,
+    previousSessionId,
+    continueSession,
+  } = useAIChat({ locale });
   const [attachedMedia, setAttachedMedia] = useState<AttachedMedia | null>(
     null,
   );
@@ -61,6 +70,9 @@ export function AIChatView({
           setAttachedMedia,
         }}
       >
+        {previousSessionId && messages.length === 0 && (
+          <SessionRestoreBanner onContinue={continueSession} />
+        )}
         <ChatMessageList
           messages={messages}
           status={status}

--- a/src/app/api/ai-chat/route.test.ts
+++ b/src/app/api/ai-chat/route.test.ts
@@ -1,15 +1,28 @@
+import type { UIMessage } from "ai";
 import { simulateReadableStream, stepCountIs, streamText } from "ai";
 import { MockLanguageModelV3 } from "ai/test";
 import { NextRequest } from "next/server";
-import { describe, expect, it, vi } from "vitest";
-import { chatInputSchema } from "#src/ai-chat/schema.ts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createPresentMediaTool } from "#src/ai-chat/tools/present-media.ts";
 import { createSemanticSearchTool } from "#src/ai-chat/tools/semantic-search.ts";
 import { createTmdbSearchTool } from "#src/ai-chat/tools/tmdb-search.ts";
 
 vi.mock("#src/ai-chat/chat.ts", () => ({
-  chatInputSchema,
   chat: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+
+const mockStore = new Map<string, UIMessage[]>();
+
+vi.mock("#src/session-store/session-store.ts", () => ({
+  generateSessionId: vi.fn(() => "generated-session-id"),
+  getSessionMessages: vi.fn((sessionId: string) => {
+    return mockStore.get(sessionId) ?? null;
+  }),
+  saveSessionMessages: vi.fn((sessionId: string, messages: UIMessage[]) => {
+    mockStore.set(sessionId, messages);
+  }),
 }));
 
 import { POST } from "./route";
@@ -22,57 +35,164 @@ function chatRequest(body: unknown) {
   });
 }
 
-function validMessages() {
-  return [
-    {
-      id: "msg-1",
-      role: "user",
-      parts: [{ type: "text", text: "recommend a sci-fi movie" }],
+function validMessage(): UIMessage {
+  return {
+    id: "msg-1",
+    role: "user",
+    parts: [{ type: "text", text: "recommend a sci-fi movie" }],
+  };
+}
+
+function mockStreamResult() {
+  return streamText({
+    model: new MockLanguageModelV3({
+      doStream: {
+        stream: simulateReadableStream({
+          chunks: [
+            { type: "text-start", id: "t1" },
+            { type: "text-delta", id: "t1", delta: "Great " },
+            { type: "text-delta", id: "t1", delta: "movie!" },
+            { type: "text-end", id: "t1" },
+          ],
+          initialDelayInMs: 0,
+          chunkDelayInMs: 0,
+        }),
+      },
+    }),
+    messages: [{ role: "user", content: "test" }],
+    tools: {
+      semantic_search: createSemanticSearchTool("en"),
+      tmdb_search: createTmdbSearchTool("en"),
+      present_media: createPresentMediaTool(),
     },
-  ];
+    stopWhen: stepCountIs(5),
+  });
 }
 
 describe("POST /api/ai-chat", () => {
-  it("returns a streaming response with valid messages", async () => {
+  beforeEach(async () => {
+    mockStore.clear();
     const { chat } = await import("#src/ai-chat/chat.ts");
-    const result = streamText({
-      model: new MockLanguageModelV3({
-        doStream: {
-          stream: simulateReadableStream({
-            chunks: [
-              { type: "text-start", id: "t1" },
-              { type: "text-delta", id: "t1", delta: "Great " },
-              { type: "text-delta", id: "t1", delta: "movie!" },
-              { type: "text-end", id: "t1" },
-            ],
-            initialDelayInMs: 0,
-            chunkDelayInMs: 0,
-          }),
-        },
-      }),
-      messages: [{ role: "user", content: "test" }],
-      tools: {
-        semantic_search: createSemanticSearchTool("en"),
-        tmdb_search: createTmdbSearchTool("en"),
-        present_media: createPresentMediaTool(),
+    vi.mocked(chat).mockReset();
+    const { saveSessionMessages } =
+      await import("#src/session-store/session-store.ts");
+    vi.mocked(saveSessionMessages).mockImplementation(
+      (sessionId: string, messages: UIMessage[]) => {
+        mockStore.set(sessionId, messages);
+        return Promise.resolve();
       },
-      stopWhen: stepCountIs(5),
+    );
+    const { getSessionMessages } =
+      await import("#src/session-store/session-store.ts");
+    vi.mocked(getSessionMessages).mockImplementation((sessionId: string) => {
+      return Promise.resolve(mockStore.get(sessionId) ?? null);
     });
-    vi.mocked(chat).mockResolvedValueOnce(result);
+  });
 
-    const response = await POST(chatRequest({ messages: validMessages() }));
+  it("creates a new session when no sessionId is provided", async () => {
+    const { chat } = await import("#src/ai-chat/chat.ts");
+    vi.mocked(chat).mockResolvedValueOnce(mockStreamResult());
+
+    const response = await POST(
+      chatRequest({
+        message: validMessage(),
+        trigger: "submit-message",
+      }),
+    );
 
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toContain("text/event-stream");
-    expect(response.body).not.toBeNull();
 
     const text = await response.text();
     expect(text).toContain("Great ");
     expect(text).toContain("movie!");
   });
 
-  it("returns 400 for missing messages", async () => {
-    const response = await POST(chatRequest({}));
+  it("loads existing session when sessionId is provided", async () => {
+    const { chat } = await import("#src/ai-chat/chat.ts");
+    vi.mocked(chat).mockResolvedValueOnce(mockStreamResult());
+
+    const existingMessages: UIMessage[] = [
+      {
+        id: "msg-0",
+        role: "user",
+        parts: [{ type: "text", text: "hello" }],
+      },
+      {
+        id: "msg-0-resp",
+        role: "assistant",
+        parts: [{ type: "text", text: "hi there" }],
+      },
+    ];
+    mockStore.set("a0000000-0000-4000-8000-000000000001", existingMessages);
+
+    const response = await POST(
+      chatRequest({
+        sessionId: "a0000000-0000-4000-8000-000000000001",
+        message: validMessage(),
+        trigger: "submit-message",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+
+    const { chat: chatFn } = await import("#src/ai-chat/chat.ts");
+    expect(vi.mocked(chatFn)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [...existingMessages, validMessage()],
+      }),
+    );
+  });
+
+  it("returns 404 when session is not found", async () => {
+    const response = await POST(
+      chatRequest({
+        sessionId: "00000000-0000-0000-0000-000000000000",
+        message: validMessage(),
+        trigger: "submit-message",
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "session-not-found" });
+  });
+
+  it("truncates messages after last user message on regenerate", async () => {
+    const { chat } = await import("#src/ai-chat/chat.ts");
+    vi.mocked(chat).mockResolvedValueOnce(mockStreamResult());
+
+    const storedMessages: UIMessage[] = [
+      {
+        id: "msg-u1",
+        role: "user",
+        parts: [{ type: "text", text: "hello" }],
+      },
+      {
+        id: "msg-a1",
+        role: "assistant",
+        parts: [{ type: "text", text: "hi" }],
+      },
+    ];
+    mockStore.set("b0000000-0000-4000-8000-000000000002", storedMessages);
+
+    const response = await POST(
+      chatRequest({
+        sessionId: "b0000000-0000-4000-8000-000000000002",
+        trigger: "regenerate-message",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+
+    expect(vi.mocked(chat)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [storedMessages[0]],
+      }),
+    );
+  });
+
+  it("returns 400 for missing message on submit-message trigger", async () => {
+    const response = await POST(chatRequest({ trigger: "submit-message" }));
 
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({
@@ -81,18 +201,14 @@ describe("POST /api/ai-chat", () => {
     });
   });
 
-  it("returns 400 for empty messages array", async () => {
-    const response = await POST(chatRequest({ messages: [] }));
-
-    expect(response.status).toBe(400);
-    expect(await response.json()).toEqual({
-      success: false,
-      error: "Invalid request body",
-    });
-  });
-
-  it("returns 400 for invalid message format", async () => {
-    const response = await POST(chatRequest({ messages: [{ text: "hello" }] }));
+  it("returns 400 for invalid sessionId format", async () => {
+    const response = await POST(
+      chatRequest({
+        sessionId: "not-a-uuid",
+        message: validMessage(),
+        trigger: "submit-message",
+      }),
+    );
 
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({
@@ -103,7 +219,11 @@ describe("POST /api/ai-chat", () => {
 
   it("returns 400 for invalid locale", async () => {
     const response = await POST(
-      chatRequest({ messages: validMessages(), locale: "fr" }),
+      chatRequest({
+        message: validMessage(),
+        locale: "fr",
+        trigger: "submit-message",
+      }),
     );
 
     expect(response.status).toBe(400);
@@ -113,16 +233,128 @@ describe("POST /api/ai-chat", () => {
     });
   });
 
+  it("saves user messages pre-stream", async () => {
+    const { chat } = await import("#src/ai-chat/chat.ts");
+    vi.mocked(chat).mockResolvedValueOnce(mockStreamResult());
+    const { saveSessionMessages } =
+      await import("#src/session-store/session-store.ts");
+
+    await POST(
+      chatRequest({
+        message: validMessage(),
+        trigger: "submit-message",
+      }),
+    );
+
+    // First call is the pre-stream save with user messages
+    expect(vi.mocked(saveSessionMessages).mock.calls[0]).toEqual([
+      "generated-session-id",
+      [validMessage()],
+    ]);
+  });
+
   it("returns 500 when chat throws", async () => {
     const { chat } = await import("#src/ai-chat/chat.ts");
     vi.mocked(chat).mockRejectedValueOnce(new Error("API key invalid"));
 
-    const response = await POST(chatRequest({ messages: validMessages() }));
+    const response = await POST(
+      chatRequest({
+        message: validMessage(),
+        trigger: "submit-message",
+      }),
+    );
 
     expect(response.status).toBe(500);
     expect(await response.json()).toEqual({
       success: false,
       error: "Internal server error",
     });
+  });
+
+  it("streams error event when post-stream save fails", async () => {
+    const { chat } = await import("#src/ai-chat/chat.ts");
+    vi.mocked(chat).mockResolvedValueOnce(mockStreamResult());
+    const { saveSessionMessages } =
+      await import("#src/session-store/session-store.ts");
+
+    let callCount = 0;
+    vi.mocked(saveSessionMessages).mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // Pre-stream save succeeds
+        return Promise.resolve();
+      }
+      // Post-stream save fails
+      return Promise.reject(new Error("Redis connection lost"));
+    });
+
+    const response = await POST(
+      chatRequest({
+        message: validMessage(),
+        trigger: "submit-message",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const text = await response.text();
+    expect(text).toContain("Failed to save session");
+  });
+
+  it("returns 500 when pre-stream save fails", async () => {
+    const { saveSessionMessages } =
+      await import("#src/session-store/session-store.ts");
+    vi.mocked(saveSessionMessages).mockRejectedValueOnce(
+      new Error("Redis down"),
+    );
+
+    const response = await POST(
+      chatRequest({
+        message: validMessage(),
+        trigger: "submit-message",
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Internal server error",
+    });
+  });
+
+  it("returns 500 when Redis read fails", async () => {
+    const { getSessionMessages } =
+      await import("#src/session-store/session-store.ts");
+    vi.mocked(getSessionMessages).mockRejectedValueOnce(
+      new Error("Redis timeout"),
+    );
+
+    const response = await POST(
+      chatRequest({
+        sessionId: "a0000000-0000-4000-8000-000000000001",
+        message: validMessage(),
+        trigger: "submit-message",
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Internal server error",
+    });
+  });
+
+  it("includes sessionId in stream metadata", async () => {
+    const { chat } = await import("#src/ai-chat/chat.ts");
+    vi.mocked(chat).mockResolvedValueOnce(mockStreamResult());
+
+    const response = await POST(
+      chatRequest({
+        message: validMessage(),
+        trigger: "submit-message",
+      }),
+    );
+
+    const text = await response.text();
+    expect(text).toContain("generated-session-id");
   });
 });

--- a/src/app/api/ai-chat/route.ts
+++ b/src/app/api/ai-chat/route.ts
@@ -1,20 +1,109 @@
+import type { UIMessage } from "ai";
+import { createUIMessageStream, createUIMessageStreamResponse } from "ai";
 import type { NextRequest } from "next/server";
 import { z } from "zod";
-import { chat, chatInputSchema } from "#src/ai-chat/chat.ts";
+import { chat } from "#src/ai-chat/chat.ts";
+import { sessionChatInputSchema } from "#src/ai-chat/session-schema.ts";
+import {
+  generateSessionId,
+  getSessionMessages,
+  saveSessionMessages,
+} from "#src/session-store/session-store.ts";
 
 export async function POST(request: NextRequest) {
   try {
     const body: unknown = await request.json();
-    const input = chatInputSchema.parse(body);
-    const result = await chat(input);
-    return result.toUIMessageStreamResponse({
-      messageMetadata: ({ part }) => {
-        if (part.type === "finish-step") {
-          return { inputTokens: part.usage.inputTokens };
+    const input = sessionChatInputSchema.parse(body);
+
+    let sessionId: string;
+    let messages: UIMessage[];
+
+    if (input.trigger === "submit-message") {
+      if (input.sessionId) {
+        const stored = await getSessionMessages(input.sessionId);
+        if (!stored) {
+          return Response.json({ error: "session-not-found" }, { status: 404 });
         }
-        return undefined;
+        sessionId = input.sessionId;
+        messages = [...stored, input.message];
+      } else {
+        sessionId = generateSessionId();
+        messages = [input.message];
+      }
+    } else {
+      if (!input.sessionId) {
+        return Response.json(
+          { success: false, error: "Invalid request body" },
+          { status: 400 },
+        );
+      }
+      const stored = await getSessionMessages(input.sessionId);
+      if (!stored) {
+        return Response.json({ error: "session-not-found" }, { status: 404 });
+      }
+      sessionId = input.sessionId;
+      const lastUserIndex = stored.findLastIndex((m) => m.role === "user");
+      messages =
+        lastUserIndex >= 0 ? stored.slice(0, lastUserIndex + 1) : stored;
+    }
+
+    // Pre-stream checkpoint: save user messages while LLM initializes
+    const [, result] = await Promise.all([
+      saveSessionMessages(sessionId, messages),
+      chat({ messages, locale: input.locale }),
+    ]);
+
+    let finishedMessages: UIMessage[] | undefined;
+
+    const stream = createUIMessageStream({
+      execute: async ({ writer }) => {
+        const innerStream = result.toUIMessageStream({
+          originalMessages: messages,
+          messageMetadata: ({ part }) => {
+            if (part.type === "finish-step") {
+              return { inputTokens: part.usage.inputTokens, sessionId };
+            }
+            return undefined;
+          },
+          onFinish: ({ messages: updatedMessages }) => {
+            finishedMessages = updatedMessages;
+          },
+        });
+
+        const reader = innerStream.getReader();
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            writer.write(value);
+          }
+        } catch (error) {
+          writer.write({
+            type: "error",
+            errorText: error instanceof Error ? error.message : "Stream error",
+          });
+          return;
+        }
+
+        if (finishedMessages) {
+          try {
+            await saveSessionMessages(sessionId, finishedMessages);
+          } catch (error) {
+            console.error("Failed to save session messages on finish:", error);
+            writer.write({
+              type: "error",
+              errorText: "Failed to save session",
+            });
+          }
+        }
+      },
+      onError: (error) => {
+        console.error("AI Chat stream error:", error);
+        return error instanceof Error ? error.message : "Internal server error";
       },
     });
+
+    return createUIMessageStreamResponse({ stream });
   } catch (error) {
     if (error instanceof z.ZodError) {
       return Response.json(

--- a/src/app/api/ai-chat/session/route.test.ts
+++ b/src/app/api/ai-chat/session/route.test.ts
@@ -1,0 +1,89 @@
+import type { UIMessage } from "ai";
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mockStore = new Map<string, UIMessage[]>();
+
+vi.mock("#src/session-store/session-store.ts", () => ({
+  getSessionMessages: vi.fn((sessionId: string) => {
+    return mockStore.get(sessionId) ?? null;
+  }),
+}));
+
+import { POST } from "./route";
+
+function sessionRequest(body: unknown) {
+  return new NextRequest("http://localhost:3000/api/ai-chat/session", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/ai-chat/session", () => {
+  beforeEach(async () => {
+    mockStore.clear();
+    const { getSessionMessages } =
+      await import("#src/session-store/session-store.ts");
+    vi.mocked(getSessionMessages).mockImplementation((sessionId: string) => {
+      return Promise.resolve(mockStore.get(sessionId) ?? null);
+    });
+  });
+
+  it("returns messages for valid sessionId", async () => {
+    const storedMessages: UIMessage[] = [
+      {
+        id: "msg-1",
+        role: "user",
+        parts: [{ type: "text", text: "hello" }],
+      },
+    ];
+    mockStore.set("a0000000-0000-4000-8000-000000000001", storedMessages);
+
+    const response = await POST(
+      sessionRequest({ sessionId: "a0000000-0000-4000-8000-000000000001" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      messages: storedMessages,
+      sessionId: "a0000000-0000-4000-8000-000000000001",
+    });
+  });
+
+  it("returns 404 for missing session", async () => {
+    const response = await POST(
+      sessionRequest({ sessionId: "a0000000-0000-4000-8000-000000000001" }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "session-not-found" });
+  });
+
+  it("returns 400 when sessionId is missing", async () => {
+    const response = await POST(sessionRequest({}));
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when sessionId is invalid", async () => {
+    const response = await POST(sessionRequest({ sessionId: "not-a-uuid" }));
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 500 when Redis read fails", async () => {
+    const { getSessionMessages } =
+      await import("#src/session-store/session-store.ts");
+    vi.mocked(getSessionMessages).mockRejectedValueOnce(
+      new Error("Redis timeout"),
+    );
+
+    const response = await POST(
+      sessionRequest({ sessionId: "a0000000-0000-4000-8000-000000000001" }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "Internal server error" });
+  });
+});

--- a/src/app/api/ai-chat/session/route.ts
+++ b/src/app/api/ai-chat/session/route.ts
@@ -1,0 +1,29 @@
+import type { NextRequest } from "next/server";
+import { z } from "zod";
+import { sessionIdSchema } from "#src/ai-chat/session-schema.ts";
+import { getSessionMessages } from "#src/session-store/session-store.ts";
+
+const bodySchema = z.object({ sessionId: sessionIdSchema });
+
+export async function POST(request: NextRequest) {
+  try {
+    const body: unknown = await request.json();
+    const parsed = bodySchema.safeParse(body);
+    if (!parsed.success) {
+      return Response.json(
+        { error: "Missing or invalid sessionId" },
+        { status: 400 },
+      );
+    }
+
+    const messages = await getSessionMessages(parsed.data.sessionId);
+    if (!messages) {
+      return Response.json({ error: "session-not-found" }, { status: 404 });
+    }
+
+    return Response.json({ messages, sessionId: parsed.data.sessionId });
+  } catch (error) {
+    console.error("AI Chat session POST error:", error);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/components/ai-chat/session-restore-banner.tsx
+++ b/src/components/ai-chat/session-restore-banner.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { t } from "#src/i18n.ts";
+import { flex } from "#src/primitives/flex.stylex.ts";
+import { buttonReset } from "#src/primitives/reset.stylex.ts";
+import { border, color, font, space } from "#src/tokens.stylex.ts";
+
+interface SessionRestoreBannerProps {
+  onContinue: () => void;
+}
+
+export function SessionRestoreBanner({
+  onContinue,
+}: SessionRestoreBannerProps) {
+  return (
+    <div css={[flex.row, styles.banner]}>
+      <p css={styles.text}>
+        {t({
+          en: "You have a previous conversation",
+          zh: "你有一段之前的对话",
+        })}
+      </p>
+      <button
+        type="button"
+        css={[buttonReset.base, styles.continueButton]}
+        onClick={onContinue}
+      >
+        {t({ en: "Continue", zh: "继续" })}
+      </button>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  banner: {
+    alignItems: "center",
+    gap: space._2,
+    paddingBlock: space._3,
+    paddingInline: space._4,
+    borderWidth: border.size_1,
+    borderStyle: "solid",
+    borderColor: color.controlTrack,
+    borderRadius: border.radius_3,
+    backgroundColor: color.backgroundRaised,
+  },
+  text: {
+    margin: 0,
+    fontSize: font.uiBody,
+    color: color.textMuted,
+  },
+  continueButton: {
+    fontSize: font.uiBodySmall,
+    lineHeight: font.lineHeight_3,
+    paddingBlock: space._1,
+    paddingInline: space._3,
+    borderRadius: border.radius_round,
+    backgroundColor: {
+      default: color.controlActive,
+      ":hover": color.controlActiveHover,
+    },
+    color: color.textOnActive,
+    cursor: "pointer",
+    transition: "background-color 0.15s ease",
+  },
+});

--- a/src/session-store/client.ts
+++ b/src/session-store/client.ts
@@ -1,0 +1,11 @@
+import { Redis } from "@upstash/redis";
+import "server-only";
+
+let redis: Redis | null = null;
+
+export function getRedisClient(): Redis {
+  if (!redis) {
+    redis = Redis.fromEnv();
+  }
+  return redis;
+}

--- a/src/session-store/session-store.test.ts
+++ b/src/session-store/session-store.test.ts
@@ -1,0 +1,78 @@
+import type { UIMessage } from "ai";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mockRedisStore = new Map<string, { value: unknown; ex?: number }>();
+const mockRedis = {
+  get: vi.fn((key: string) => {
+    const entry = mockRedisStore.get(key);
+    return entry ? entry.value : null;
+  }),
+  set: vi.fn((key: string, value: unknown, opts?: { ex?: number }) => {
+    mockRedisStore.set(key, { value, ex: opts?.ex });
+  }),
+};
+
+vi.mock("./client", () => ({
+  getRedisClient: () => mockRedis,
+}));
+
+import {
+  generateSessionId,
+  getSessionMessages,
+  saveSessionMessages,
+} from "./session-store";
+
+function userMessage(text: string): UIMessage {
+  return {
+    id: `msg-${text}`,
+    role: "user",
+    parts: [{ type: "text", text }],
+  };
+}
+
+describe("session-store", () => {
+  it("returns null for a non-existent session", async () => {
+    const result = await getSessionMessages("non-existent-id");
+    expect(result).toBeNull();
+  });
+
+  it("saves and retrieves messages", async () => {
+    const messages = [userMessage("hello")];
+    await saveSessionMessages("test-session", messages);
+    const result = await getSessionMessages("test-session");
+    expect(result).toEqual(messages);
+  });
+
+  it("saves with 24h TTL", async () => {
+    const messages = [userMessage("hello")];
+    await saveSessionMessages("ttl-session", messages);
+    expect(mockRedis.set).toHaveBeenCalledWith(
+      "chat-session:ttl-session",
+      messages,
+      { ex: 86400 },
+    );
+  });
+
+  it("overwrites existing messages", async () => {
+    const initial = [userMessage("first")];
+    await saveSessionMessages("overwrite-session", initial);
+
+    const updated = [userMessage("first"), userMessage("second")];
+    await saveSessionMessages("overwrite-session", updated);
+
+    const result = await getSessionMessages("overwrite-session");
+    expect(result).toEqual(updated);
+  });
+
+  it("generates unique session IDs", () => {
+    const id1 = generateSessionId();
+    const id2 = generateSessionId();
+    expect(id1).not.toBe(id2);
+    // UUID v4 format
+    expect(id1).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+});

--- a/src/session-store/session-store.ts
+++ b/src/session-store/session-store.ts
@@ -1,0 +1,29 @@
+import { randomUUID } from "crypto";
+import type { UIMessage } from "ai";
+import "server-only";
+import { getRedisClient } from "./client";
+
+const KEY_PREFIX = "chat-session:";
+const TTL_SECONDS = 24 * 60 * 60; // 24 hours
+
+export async function getSessionMessages(
+  sessionId: string,
+): Promise<UIMessage[] | null> {
+  const redis = getRedisClient();
+  const data = await redis.get<UIMessage[]>(`${KEY_PREFIX}${sessionId}`);
+  return data;
+}
+
+export async function saveSessionMessages(
+  sessionId: string,
+  messages: UIMessage[],
+): Promise<void> {
+  const redis = getRedisClient();
+  await redis.set(`${KEY_PREFIX}${sessionId}`, messages, {
+    ex: TTL_SECONDS,
+  });
+}
+
+export function generateSessionId(): string {
+  return randomUUID();
+}


### PR DESCRIPTION
## Summary

The AI chat sends the full messages array on every turn, causing payload size to grow linearly with conversation length. This adds server-side Redis storage so the client sends only the latest message + session ID. Redis becomes the single source of truth — the client reconciles via a new GET endpoint on page reload or error recovery.

The POST handler now uses `createUIMessageStream` with a manual pipe pattern so the writer stays open after the LLM stream finishes, allowing post-stream Redis save with error event reporting if the save fails. The pre-stream Redis checkpoint runs in parallel with LLM initialization via `Promise.all`.

## Context

The client stores the session ID in localStorage per locale. Three `useEffect` hooks handle persistence: one persists the session ID when it appears in message metadata, one restores the session on mount (page reload), and one reconciles on error by fetching the server's state. Sessions expire after 24 hours — the client clears localStorage and starts fresh on 404.

Closes #1686