### PR TITLE
fix: render poster image when posterPath exists but title is missing

### DIFF
--- a/src/components/movie-database/media-poster.tsx
+++ b/src/components/movie-database/media-poster.tsx
@@ -13,14 +13,23 @@ interface MediaPosterProps {
   compact?: boolean;
 }
 
+function getPosterAlt(media: MediaListItem): string {
+  if (media.title) return media.title;
+  if (media.mediaType === "movie")
+    return t({ en: "Movie poster", zh: "电影海报" });
+  if (media.mediaType === "tv")
+    return t({ en: "TV show poster", zh: "电视剧海报" });
+  return t({ en: "Media poster", zh: "媒体海报" });
+}
+
 export function MediaPoster({ media, compact }: MediaPosterProps) {
   const locale = useLocale();
   const formatter = new Intl.NumberFormat(locale, { maximumFractionDigits: 1 });
 
   return (
     <>
-      {media.posterPath && media.title ? (
-        <PosterImage posterPath={media.posterPath} alt={media.title} />
+      {media.posterPath ? (
+        <PosterImage posterPath={media.posterPath} alt={getPosterAlt(media)} />
       ) : (
         <div
           css={[


### PR DESCRIPTION
## Summary

Previously, `MediaPoster` only rendered the `<PosterImage>` when both `posterPath` and `title` were present. If a media item had a poster image but no title (which can happen with TMDB data), the component fell through to the "No Poster" placeholder despite a valid image being available.

This change decouples the two conditions: the poster image now renders whenever `posterPath` exists, and a new `getPosterAlt` helper provides appropriate alt text by falling back to a generic media-type label (e.g. "Movie poster", "TV show poster") when the title is unavailable.