### PR TITLE
perf: remove lazy loading from media detail overlay images

### DIFF
--- a/src/components/ai-chat/media-detail-content.tsx
+++ b/src/components/ai-chat/media-detail-content.tsx
@@ -239,7 +239,6 @@ function PosterImage({
       src={src}
       srcSet={srcSet}
       sizes="90px"
-      loading="lazy"
     />
   );
 }
@@ -266,7 +265,6 @@ function BackdropImage({
         src={src}
         srcSet={srcSet}
         sizes="600px"
-        loading="lazy"
       />
       <div role="presentation" css={styles.backdropGradient} />
     </div>


### PR DESCRIPTION
## Summary

The poster and backdrop images in the AI chat media detail overlay are immediately visible when the overlay opens, making `loading="lazy"` counterproductive — it delays fetching of above-the-fold content. Removing the attribute lets the browser fetch these images eagerly, improving perceived load time when viewing media details.