### PR TITLE
fix: require sessionId in schema for regenerate-message trigger

### DIFF
--- a/src/ai-chat/session-schema.ts
+++ b/src/ai-chat/session-schema.ts
@@ -2,19 +2,18 @@ import type { UIMessage } from "ai";
 import { z } from "zod";
 import { isUIMessage } from "./is-ui-message";
 
-const sharedFields = {
-  sessionId: z.string().uuid().optional(),
-  locale: z.enum(["en", "zh"]).default("en"),
-};
+const localeField = { locale: z.enum(["en", "zh"]).default("en") };
 
 export const sessionChatInputSchema = z.discriminatedUnion("trigger", [
   z.object({
-    ...sharedFields,
+    sessionId: z.string().uuid().optional(),
+    ...localeField,
     trigger: z.literal("submit-message"),
     message: z.custom<UIMessage>(isUIMessage),
   }),
   z.object({
-    ...sharedFields,
+    sessionId: z.string().uuid(),
+    ...localeField,
     trigger: z.literal("regenerate-message"),
   }),
 ]);

--- a/src/app/api/ai-chat/route.test.ts
+++ b/src/app/api/ai-chat/route.test.ts
@@ -217,6 +217,20 @@ describe("POST /api/ai-chat", () => {
     });
   });
 
+  it("returns 400 for regenerate-message without sessionId", async () => {
+    const response = await POST(
+      chatRequest({
+        trigger: "regenerate-message",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Invalid request body",
+    });
+  });
+
   it("returns 400 for invalid locale", async () => {
     const response = await POST(
       chatRequest({

--- a/src/app/api/ai-chat/route.ts
+++ b/src/app/api/ai-chat/route.ts
@@ -31,12 +31,6 @@ export async function POST(request: NextRequest) {
         messages = [input.message];
       }
     } else {
-      if (!input.sessionId) {
-        return Response.json(
-          { success: false, error: "Invalid request body" },
-          { status: 400 },
-        );
-      }
       const stored = await getSessionMessages(input.sessionId);
       if (!stored) {
         return Response.json({ error: "session-not-found" }, { status: 404 });


### PR DESCRIPTION
## Summary

The `regenerate-message` trigger always requires an existing session (you cannot regenerate without prior messages), but `sessionId` was marked optional in the Zod schema and validated separately at runtime in the route handler. This moves the validation into the schema itself by making `sessionId` required for the `regenerate-message` variant of the discriminated union, removing the redundant runtime check in the route handler. A test is added to confirm that requests missing `sessionId` on regenerate are rejected at the schema level with a 400 response.