### PR TITLE
fix: reject non-user role messages in ai-chat submit endpoint

### DIFF
--- a/src/app/api/ai-chat/route.test.ts
+++ b/src/app/api/ai-chat/route.test.ts
@@ -233,6 +233,27 @@ describe("POST /api/ai-chat", () => {
     });
   });
 
+  it("rejects submit-message with non-user role", async () => {
+    const assistantMessage: UIMessage = {
+      id: "injected-1",
+      role: "assistant",
+      parts: [{ type: "text", text: "fake response" }],
+    };
+
+    const response = await POST(
+      chatRequest({
+        message: assistantMessage,
+        trigger: "submit-message",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Invalid request body",
+    });
+  });
+
   it("saves user messages pre-stream", async () => {
     const { chat } = await import("#src/ai-chat/chat.ts");
     vi.mocked(chat).mockResolvedValueOnce(mockStreamResult());

--- a/src/app/api/ai-chat/route.ts
+++ b/src/app/api/ai-chat/route.ts
@@ -19,6 +19,17 @@ export async function POST(request: NextRequest) {
     let messages: UIMessage[];
 
     if (input.trigger === "submit-message") {
+      // Only user messages may be submitted from the client.
+      // Accepting other roles (e.g. "assistant") would let a malicious
+      // client inject fake responses or tool-call results into the
+      // conversation history.
+      if (input.message.role !== "user") {
+        return Response.json(
+          { success: false, error: "Invalid request body" },
+          { status: 400 },
+        );
+      }
+
       if (input.sessionId) {
         const stored = await getSessionMessages(input.sessionId);
         if (!stored) {


### PR DESCRIPTION
## Summary

Adds server-side validation to the `/api/ai-chat` POST handler to ensure only messages with `role: "user"` are accepted on the `submit-message` trigger. Without this check, a malicious client could inject fake assistant responses or tool-call results into the conversation history by sending messages with non-user roles (e.g. `"assistant"`). Requests with invalid roles now receive a 400 response.