### PR TITLE
fix: omit trailing zero minutes in formatRuntime output

### DIFF
--- a/src/utils/format-runtime.test.ts
+++ b/src/utils/format-runtime.test.ts
@@ -10,8 +10,8 @@ describe("formatRuntime", () => {
     expect(formatRuntime(45, "h", "m")).toBe("45m");
   });
 
-  it("formats exactly one hour", () => {
-    expect(formatRuntime(60, "h", "m")).toBe("1h 0m");
+  it("formats exactly one hour without trailing minutes", () => {
+    expect(formatRuntime(60, "h", "m")).toBe("1h");
   });
 
   it("returns empty string for zero", () => {
@@ -22,8 +22,8 @@ describe("formatRuntime", () => {
     expect(formatRuntime(NaN, "h", "m")).toBe("");
   });
 
-  it("formats large values", () => {
-    expect(formatRuntime(240, "h", "m")).toBe("4h 0m");
+  it("formats exact multiples of an hour without trailing minutes", () => {
+    expect(formatRuntime(240, "h", "m")).toBe("4h");
   });
 
   it("formats single-digit minutes", () => {

--- a/src/utils/format-runtime.ts
+++ b/src/utils/format-runtime.ts
@@ -5,7 +5,10 @@
  * Returns an empty string for falsy values (0, NaN, etc.)
  * to avoid showing "0m" for entries without runtime data.
  *
+ * Omits the minutes portion when it is zero (e.g. 60 → "1h", not "1h 0m").
+ *
  * @example formatRuntime(148, "h", "m") → "2h 28m"
+ * @example formatRuntime(60, "h", "m")  → "1h"
  * @example formatRuntime(45, "h", "m")  → "45m"
  */
 export function formatRuntime(
@@ -16,5 +19,7 @@ export function formatRuntime(
   if (!minutes) return "";
   const hours = Math.floor(minutes / 60);
   const mins = minutes % 60;
-  return `${hours > 0 ? `${hours}${hourLabel} ` : ""}${mins}${minuteLabel}`;
+  if (hours > 0 && mins === 0) return `${hours}${hourLabel}`;
+  if (hours > 0) return `${hours}${hourLabel} ${mins}${minuteLabel}`;
+  return `${mins}${minuteLabel}`;
 }


### PR DESCRIPTION
## Summary

`formatRuntime(60, "h", "m")` previously returned `"1h 0m"`, which looks awkward when there are no remaining minutes. The function now omits the minutes portion when it is exactly zero, producing cleaner output like `"1h"` and `"4h"` for exact hour values.