### PR TITLE
feat: add streaming platform availability cards in AI chat

### DIFF
--- a/src/_generated/tmdb-endpoints.ts
+++ b/src/_generated/tmdb-endpoints.ts
@@ -14,6 +14,7 @@ export type TMDBEndpointPaths =
   | "/3/movie/{movie_id}"
   | "/3/movie/{movie_id}/recommendations"
   | "/3/movie/{movie_id}/videos"
+  | "/3/movie/{movie_id}/watch/providers"
   | "/3/search/movie"
   | "/3/search/multi"
   | "/3/search/person"
@@ -22,7 +23,8 @@ export type TMDBEndpointPaths =
   | "/3/trending/tv/{time_window}"
   | "/3/tv/{series_id}"
   | "/3/tv/{series_id}/recommendations"
-  | "/3/tv/{series_id}/videos";
+  | "/3/tv/{series_id}/videos"
+  | "/3/tv/{series_id}/watch/providers";
 
 export const TMDB_ENDPOINTS = [
   "/3/configuration",
@@ -35,6 +37,7 @@ export const TMDB_ENDPOINTS = [
   "/3/movie/{movie_id}",
   "/3/movie/{movie_id}/recommendations",
   "/3/movie/{movie_id}/videos",
+  "/3/movie/{movie_id}/watch/providers",
   "/3/search/movie",
   "/3/search/multi",
   "/3/search/person",
@@ -44,4 +47,5 @@ export const TMDB_ENDPOINTS = [
   "/3/tv/{series_id}",
   "/3/tv/{series_id}/recommendations",
   "/3/tv/{series_id}/videos",
+  "/3/tv/{series_id}/watch/providers",
 ] as const;

--- a/src/_generated/tmdb-server-functions.ts
+++ b/src/_generated/tmdb-server-functions.ts
@@ -84,6 +84,18 @@ export async function getMovieVideos(
   return tmdbGet("/3/movie/{movie_id}/videos", queryParams, { movie_id });
 }
 
+export async function getMovieWatchProviders(
+  params: { movie_id: string } & QueryParams<
+    "/3/movie/{movie_id}/watch/providers",
+    "get"
+  >,
+) {
+  const { movie_id, ...queryParams } = params;
+  return tmdbGet("/3/movie/{movie_id}/watch/providers", queryParams, {
+    movie_id,
+  });
+}
+
 export async function getTrendingMovies(
   params: { time_window: string } & QueryParams<
     "/3/trending/movie/{time_window}",
@@ -139,6 +151,18 @@ export async function getTvShowVideos(
 ) {
   const { series_id, ...queryParams } = params;
   return tmdbGet("/3/tv/{series_id}/videos", queryParams, { series_id });
+}
+
+export async function getTvShowWatchProviders(
+  params: { series_id: string } & QueryParams<
+    "/3/tv/{series_id}/watch/providers",
+    "get"
+  >,
+) {
+  const { series_id, ...queryParams } = params;
+  return tmdbGet("/3/tv/{series_id}/watch/providers", queryParams, {
+    series_id,
+  });
 }
 
 export async function searchMovies(

--- a/src/ai-chat/chat.ts
+++ b/src/ai-chat/chat.ts
@@ -9,6 +9,7 @@ import { getChatSystemInstructions } from "./system-instructions";
 import { createPresentMediaTool } from "./tools/present-media";
 import { createSemanticSearchTool } from "./tools/semantic-search";
 import { createTmdbSearchTool } from "./tools/tmdb-search";
+import { createWatchProvidersTool } from "./tools/watch-providers";
 
 export type { ChatInput } from "./schema";
 
@@ -16,8 +17,13 @@ interface ChatOptions extends ChatInput {
   model?: LanguageModel;
 }
 
-export async function chat({ messages, locale, model }: ChatOptions) {
-  const system = getChatSystemInstructions(locale);
+export async function chat({
+  messages,
+  locale,
+  countryCode,
+  model,
+}: ChatOptions) {
+  const system = getChatSystemInstructions(locale, countryCode);
   const modelMessages = await convertToModelMessages(messages);
 
   return streamText({
@@ -28,6 +34,7 @@ export async function chat({ messages, locale, model }: ChatOptions) {
       semantic_search: createSemanticSearchTool(locale),
       tmdb_search: createTmdbSearchTool(locale),
       present_media: createPresentMediaTool(),
+      watch_providers: createWatchProvidersTool(),
     },
     providerOptions: contextManagementProviderOptions,
     stopWhen: stepCountIs(5),

--- a/src/ai-chat/schema.ts
+++ b/src/ai-chat/schema.ts
@@ -5,6 +5,7 @@ import { isUIMessage } from "./is-ui-message";
 export const chatInputSchema = z.object({
   messages: z.array(z.custom<UIMessage>(isUIMessage)).min(1),
   locale: z.enum(["en", "zh"]).default("en"),
+  countryCode: z.string().length(2).optional(),
 });
 
 export type ChatInput = z.infer<typeof chatInputSchema>;

--- a/src/ai-chat/system-instructions.md
+++ b/src/ai-chat/system-instructions.md
@@ -1,5 +1,6 @@
 - Date: {currentDate}
 - User Locale: {locale}
+- User Country: {countryCode}
 
 ---
 
@@ -27,6 +28,9 @@ Engage in natural conversation about movies and TV shows. You can:
 - Use available tools to ground your recommendations in real data whenever the user asks for suggestions based on genre, mood, themes, or similarity to other titles. Prefer tool-grounded results over answering purely from memory
 - When recommending titles, present them visually using available tools
 - **Tool efficiency**: Do not use `tmdb_search` to verify or look up titles returned by `semantic_search` — semantic search results already include all the metadata you need (title, year, rating, poster). Use `tmdb_search` only when the user asks about a specific title or person by name. After searching, call `present_media` promptly rather than running additional searches
+- **Watch providers**: When users ask where to watch something, use `tmdb_search` to find the TMDB ID first, then call `watch_providers`. The tool has two modes:
+  - **Region mode** (default): Pass `region` to get all providers for a specific country. The tool displays a visual card showing platforms grouped by type. Use the user's country code (from "User Country" above) as the region. If the country is "unknown", default to US. If the user mentions a specific country, use that country's code instead. Add a brief text summary but don't exhaustively list every provider — the card shows them all.
+  - **Provider search mode**: Pass `provider_name` (e.g. "Netflix") to search across ALL countries at once. This returns which countries carry that provider and how (stream/rent/buy). Use this for questions like "Is X on Netflix?", "Where can I stream X on Disney+?", "Which countries have X on Hulu?". Summarize the results in text — mention the user's own country first if it appears in the results.
 
 ## Boundaries
 

--- a/src/ai-chat/system-instructions.ts
+++ b/src/ai-chat/system-instructions.ts
@@ -18,10 +18,14 @@ function getTemplate(): string {
   return template;
 }
 
-export function getChatSystemInstructions(locale: SupportedLocale): string {
+export function getChatSystemInstructions(
+  locale: SupportedLocale,
+  countryCode?: string,
+): string {
   const currentDate = new Date().toISOString().split("T")[0];
 
   return getTemplate()
     .replaceAll("{currentDate}", currentDate)
-    .replaceAll("{locale}", locale);
+    .replaceAll("{locale}", locale)
+    .replaceAll("{countryCode}", countryCode ?? "unknown");
 }

--- a/src/ai-chat/tools/watch-providers.test.ts
+++ b/src/ai-chat/tools/watch-providers.test.ts
@@ -1,0 +1,534 @@
+import { http, HttpResponse } from "msw";
+import { beforeAll, describe, expect, it } from "vitest";
+import { server } from "#src/test-msw.ts";
+import {
+  createWatchProvidersTool,
+  watchProvidersInputSchema,
+} from "./watch-providers";
+
+beforeAll(() => {
+  process.env.TMDB_API_TOKEN = "test-token";
+});
+
+const TMDB_BASE = "https://api.themoviedb.org";
+
+function provider(overrides: {
+  provider_id: number;
+  provider_name: string;
+  display_priority: number;
+  logo_path?: string;
+}) {
+  return {
+    logo_path: overrides.logo_path ?? `/logo-${overrides.provider_id}.jpg`,
+    provider_id: overrides.provider_id,
+    provider_name: overrides.provider_name,
+    display_priority: overrides.display_priority,
+  };
+}
+
+function watchProvidersResponse(id: number, results: Record<string, unknown>) {
+  return { id, results };
+}
+
+const executeContext = {
+  toolCallId: "test",
+  messages: [] as never[],
+  abortSignal: AbortSignal.timeout(5000),
+};
+
+interface RegionResult {
+  id: number;
+  mediaType: string;
+  region: string;
+  providers: {
+    link: string | null;
+    flatrate: Array<{ id: number; name: string; logoPath: string }>;
+    rent: Array<{ id: number; name: string; logoPath: string }>;
+    buy: Array<{ id: number; name: string; logoPath: string }>;
+    ads: Array<{ id: number; name: string; logoPath: string }>;
+    free: Array<{ id: number; name: string; logoPath: string }>;
+  } | null;
+}
+
+interface ProviderSearchResultType {
+  id: number;
+  mediaType: string;
+  providerName: string;
+  regions: Array<{ country: string; types: string[] }>;
+}
+
+/**
+ * Helper that calls execute and returns the result as a plain object.
+ * The tool's generic return type confuses ESLint's type resolver,
+ * so we round-trip through JSON to get a clean object.
+ */
+async function executeTool(input: {
+  id: number;
+  media_type: "movie" | "tv";
+  region?: string;
+  provider_name?: string;
+}) {
+  const tool = createWatchProvidersTool();
+  const result = await tool.execute!(input, executeContext);
+  return JSON.parse(JSON.stringify(result)) as
+    | RegionResult
+    | ProviderSearchResultType;
+}
+
+function asRegionResult(result: RegionResult | ProviderSearchResultType) {
+  return result as RegionResult;
+}
+
+function asSearchResult(result: RegionResult | ProviderSearchResultType) {
+  return result as ProviderSearchResultType;
+}
+
+describe("watchProvidersInputSchema", () => {
+  it("accepts valid input with all fields", () => {
+    const result = watchProvidersInputSchema.parse({
+      id: 550,
+      media_type: "movie",
+      region: "US",
+    });
+    expect(result).toEqual({ id: 550, media_type: "movie", region: "US" });
+  });
+
+  it("accepts input without optional region", () => {
+    const result = watchProvidersInputSchema.parse({
+      id: 1399,
+      media_type: "tv",
+    });
+    expect(result).toEqual({ id: 1399, media_type: "tv" });
+  });
+
+  it("rejects invalid media_type", () => {
+    expect(() =>
+      watchProvidersInputSchema.parse({
+        id: 550,
+        media_type: "person",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects non-numeric id", () => {
+    expect(() =>
+      watchProvidersInputSchema.parse({
+        id: "abc",
+        media_type: "movie",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects region with wrong length", () => {
+    expect(() =>
+      watchProvidersInputSchema.parse({
+        id: 550,
+        media_type: "movie",
+        region: "USA",
+      }),
+    ).toThrow();
+  });
+
+  it("accepts provider_name", () => {
+    const result = watchProvidersInputSchema.parse({
+      id: 550,
+      media_type: "movie",
+      provider_name: "Netflix",
+    });
+    expect(result).toEqual({
+      id: 550,
+      media_type: "movie",
+      provider_name: "Netflix",
+    });
+  });
+});
+
+describe("createWatchProvidersTool", () => {
+  it("returns a tool with description and inputSchema", () => {
+    const tool = createWatchProvidersTool();
+    expect(tool.description).toBeDefined();
+    expect(tool.description).toContain("watch provider");
+    expect(tool.inputSchema).toBeDefined();
+  });
+
+  it("returns a tool with an execute function", () => {
+    const tool = createWatchProvidersTool();
+    expect(tool.execute).toBeDefined();
+    expect(typeof tool.execute).toBe("function");
+  });
+});
+
+describe("watch providers execute", () => {
+  it("returns providers for a movie region", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/watch/providers`, () =>
+        HttpResponse.json(
+          watchProvidersResponse(550, {
+            US: {
+              link: "https://www.themoviedb.org/movie/550/watch?locale=US",
+              flatrate: [
+                provider({
+                  provider_id: 8,
+                  provider_name: "Netflix",
+                  display_priority: 1,
+                }),
+              ],
+              rent: [
+                provider({
+                  provider_id: 2,
+                  provider_name: "Apple TV",
+                  display_priority: 2,
+                }),
+              ],
+              buy: [
+                provider({
+                  provider_id: 3,
+                  provider_name: "Google Play",
+                  display_priority: 3,
+                }),
+              ],
+            },
+          }),
+        ),
+      ),
+    );
+
+    const result = await executeTool({
+      id: 550,
+      media_type: "movie",
+      region: "US",
+    });
+
+    expect(result).toEqual({
+      id: 550,
+      mediaType: "movie",
+      region: "US",
+      providers: {
+        link: "https://www.themoviedb.org/movie/550/watch?locale=US",
+        flatrate: [{ id: 8, name: "Netflix", logoPath: "/logo-8.jpg" }],
+        rent: [{ id: 2, name: "Apple TV", logoPath: "/logo-2.jpg" }],
+        buy: [{ id: 3, name: "Google Play", logoPath: "/logo-3.jpg" }],
+        ads: [],
+        free: [],
+      },
+    });
+  });
+
+  it("returns providers for a TV show", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/tv/1399/watch/providers`, () =>
+        HttpResponse.json(
+          watchProvidersResponse(1399, {
+            US: {
+              link: "https://www.themoviedb.org/tv/1399/watch?locale=US",
+              flatrate: [
+                provider({
+                  provider_id: 384,
+                  provider_name: "HBO Max",
+                  display_priority: 1,
+                }),
+              ],
+            },
+          }),
+        ),
+      ),
+    );
+
+    const result = await executeTool({
+      id: 1399,
+      media_type: "tv",
+      region: "US",
+    });
+
+    expect(result).toEqual({
+      id: 1399,
+      mediaType: "tv",
+      region: "US",
+      providers: {
+        link: "https://www.themoviedb.org/tv/1399/watch?locale=US",
+        flatrate: [{ id: 384, name: "HBO Max", logoPath: "/logo-384.jpg" }],
+        rent: [],
+        buy: [],
+        ads: [],
+        free: [],
+      },
+    });
+  });
+
+  it("returns providers: null when region has no data", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/watch/providers`, () =>
+        HttpResponse.json(
+          watchProvidersResponse(550, {
+            US: {
+              link: "https://www.themoviedb.org/movie/550/watch?locale=US",
+              flatrate: [
+                provider({
+                  provider_id: 8,
+                  provider_name: "Netflix",
+                  display_priority: 1,
+                }),
+              ],
+            },
+          }),
+        ),
+      ),
+    );
+
+    const result = await executeTool({
+      id: 550,
+      media_type: "movie",
+      region: "JP",
+    });
+
+    expect(result).toEqual({
+      id: 550,
+      mediaType: "movie",
+      region: "JP",
+      providers: null,
+    });
+  });
+
+  it("returns providers: null when response has no results", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/999999/watch/providers`, () =>
+        HttpResponse.json({ id: 999999 }),
+      ),
+    );
+
+    const result = await executeTool({
+      id: 999999,
+      media_type: "movie",
+      region: "US",
+    });
+
+    expect(result).toEqual({
+      id: 999999,
+      mediaType: "movie",
+      region: "US",
+      providers: null,
+    });
+  });
+
+  it("defaults region to US when not specified", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/watch/providers`, () =>
+        HttpResponse.json(
+          watchProvidersResponse(550, {
+            US: {
+              link: "https://www.themoviedb.org/movie/550/watch?locale=US",
+              flatrate: [
+                provider({
+                  provider_id: 8,
+                  provider_name: "Netflix",
+                  display_priority: 1,
+                }),
+              ],
+            },
+          }),
+        ),
+      ),
+    );
+
+    const raw = await executeTool({ id: 550, media_type: "movie" });
+    const result = asRegionResult(raw);
+
+    expect(result.region).toBe("US");
+    expect(result.providers).not.toBeNull();
+    expect(result.providers?.flatrate).toHaveLength(1);
+  });
+
+  it("sorts providers by display_priority", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/watch/providers`, () =>
+        HttpResponse.json(
+          watchProvidersResponse(550, {
+            US: {
+              link: "https://www.themoviedb.org/movie/550/watch?locale=US",
+              flatrate: [
+                provider({
+                  provider_id: 119,
+                  provider_name: "Amazon Prime",
+                  display_priority: 10,
+                }),
+                provider({
+                  provider_id: 8,
+                  provider_name: "Netflix",
+                  display_priority: 1,
+                }),
+                provider({
+                  provider_id: 337,
+                  provider_name: "Disney+",
+                  display_priority: 5,
+                }),
+              ],
+            },
+          }),
+        ),
+      ),
+    );
+
+    const result = asRegionResult(
+      await executeTool({ id: 550, media_type: "movie", region: "US" }),
+    );
+
+    expect(result.providers).not.toBeNull();
+    const names = result.providers!.flatrate.map((p) => p.name);
+    expect(names).toEqual(["Netflix", "Disney+", "Amazon Prime"]);
+  });
+
+  it("strips unnecessary fields from providers", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/watch/providers`, () =>
+        HttpResponse.json(
+          watchProvidersResponse(550, {
+            US: {
+              link: "https://www.themoviedb.org/movie/550/watch?locale=US",
+              flatrate: [
+                {
+                  provider_id: 8,
+                  provider_name: "Netflix",
+                  logo_path: "/netflix.jpg",
+                  display_priority: 1,
+                  extra_field: "should be stripped",
+                },
+              ],
+            },
+          }),
+        ),
+      ),
+    );
+
+    const result = asRegionResult(
+      await executeTool({ id: 550, media_type: "movie", region: "US" }),
+    );
+
+    expect(result.providers).not.toBeNull();
+    const firstProvider = result.providers!.flatrate[0];
+    expect(firstProvider).toBeDefined();
+    expect(Object.keys(firstProvider)).toEqual(["id", "name", "logoPath"]);
+  });
+});
+
+describe("watch providers provider search", () => {
+  it("finds provider across multiple regions", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/watch/providers`, () =>
+        HttpResponse.json(
+          watchProvidersResponse(550, {
+            US: {
+              link: "https://example.com/US",
+              flatrate: [
+                provider({
+                  provider_id: 8,
+                  provider_name: "Netflix",
+                  display_priority: 1,
+                }),
+              ],
+            },
+            GB: {
+              link: "https://example.com/GB",
+              rent: [
+                provider({
+                  provider_id: 8,
+                  provider_name: "Netflix",
+                  display_priority: 1,
+                }),
+              ],
+            },
+            DE: {
+              link: "https://example.com/DE",
+              flatrate: [
+                provider({
+                  provider_id: 337,
+                  provider_name: "Disney Plus",
+                  display_priority: 1,
+                }),
+              ],
+            },
+          }),
+        ),
+      ),
+    );
+
+    const result = asSearchResult(
+      await executeTool({
+        id: 550,
+        media_type: "movie",
+        provider_name: "Netflix",
+      }),
+    );
+
+    expect(result.providerName).toBe("Netflix");
+    expect(result.regions).toHaveLength(2);
+    expect(result.regions).toEqual(
+      expect.arrayContaining([
+        { country: "GB", types: ["rent"] },
+        { country: "US", types: ["flatrate"] },
+      ]),
+    );
+  });
+
+  it("returns empty regions when provider not found", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/watch/providers`, () =>
+        HttpResponse.json(
+          watchProvidersResponse(550, {
+            US: {
+              link: "https://example.com/US",
+              flatrate: [
+                provider({
+                  provider_id: 337,
+                  provider_name: "Disney Plus",
+                  display_priority: 1,
+                }),
+              ],
+            },
+          }),
+        ),
+      ),
+    );
+
+    const result = asSearchResult(
+      await executeTool({
+        id: 550,
+        media_type: "movie",
+        provider_name: "Netflix",
+      }),
+    );
+
+    expect(result.regions).toEqual([]);
+  });
+
+  it("matches provider name case-insensitively", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/watch/providers`, () =>
+        HttpResponse.json(
+          watchProvidersResponse(550, {
+            US: {
+              link: "https://example.com/US",
+              flatrate: [
+                provider({
+                  provider_id: 8,
+                  provider_name: "Netflix",
+                  display_priority: 1,
+                }),
+              ],
+            },
+          }),
+        ),
+      ),
+    );
+
+    const result = asSearchResult(
+      await executeTool({
+        id: 550,
+        media_type: "movie",
+        provider_name: "netflix",
+      }),
+    );
+
+    expect(result.regions).toHaveLength(1);
+    expect(result.regions[0].country).toBe("US");
+  });
+});

--- a/src/ai-chat/tools/watch-providers.ts
+++ b/src/ai-chat/tools/watch-providers.ts
@@ -1,0 +1,207 @@
+import { tool } from "ai";
+import { z } from "zod";
+import {
+  getMovieWatchProviders,
+  getTvShowWatchProviders,
+} from "#src/_generated/tmdb-server-functions.ts";
+import type { ResponseType } from "#src/utils/tmdb-client.ts";
+
+export const watchProvidersInputSchema = z.object({
+  id: z.number().describe("The TMDB ID of the movie or TV show."),
+  media_type: z.enum(["movie", "tv"]).describe('Either "movie" or "tv".'),
+  region: z
+    .string()
+    .length(2)
+    .optional()
+    .describe(
+      "ISO 3166-1 country code (2 letters, e.g. US, GB, DE). " +
+        "Infer from user locale or mentioned country. Defaults to US. " +
+        "Ignored when provider_name is set.",
+    ),
+  provider_name: z
+    .string()
+    .optional()
+    .describe(
+      'When set, searches ALL regions for this provider (e.g. "Netflix", "Disney Plus") ' +
+        "and returns which countries carry it. Use for questions like " +
+        '"Is X on Netflix?", "Which countries have X on Disney+?".',
+    ),
+});
+
+const TOOL_DESCRIPTION =
+  "Get watch provider (streaming/rent/buy) availability for a movie or TV show. " +
+  "Use this when the user asks where to watch something, whether it's on a specific platform, " +
+  "or about streaming availability. Infer the region from the user's locale. " +
+  "Set provider_name to search across all regions for a specific platform.";
+
+type MovieWatchResponse = ResponseType<
+  "/3/movie/{movie_id}/watch/providers",
+  "get"
+>;
+type TvWatchResponse = ResponseType<"/3/tv/{series_id}/watch/providers", "get">;
+
+interface ProviderEntry {
+  id: number;
+  name: string;
+  logoPath: string;
+}
+
+interface RegionProviders {
+  link: string | null;
+  flatrate: ProviderEntry[];
+  rent: ProviderEntry[];
+  buy: ProviderEntry[];
+  ads: ProviderEntry[];
+  free: ProviderEntry[];
+}
+
+interface WatchProvidersResult {
+  id: number;
+  mediaType: "movie" | "tv";
+  region: string;
+  providers: RegionProviders | null;
+}
+
+type AvailabilityType = "flatrate" | "rent" | "buy" | "ads" | "free";
+
+interface ProviderSearchResult {
+  id: number;
+  mediaType: "movie" | "tv";
+  providerName: string;
+  regions: Array<{
+    country: string;
+    types: AvailabilityType[];
+  }>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function mapProviders(items: unknown): ProviderEntry[] {
+  if (!Array.isArray(items)) return [];
+  const entries: Array<{ entry: ProviderEntry; priority: number }> = [];
+  for (const raw of items) {
+    if (!isRecord(raw)) continue;
+    if (typeof raw.provider_id !== "number") continue;
+    if (typeof raw.display_priority !== "number") continue;
+    entries.push({
+      entry: {
+        id: raw.provider_id,
+        name: typeof raw.provider_name === "string" ? raw.provider_name : "",
+        logoPath: typeof raw.logo_path === "string" ? raw.logo_path : "",
+      },
+      priority: raw.display_priority,
+    });
+  }
+  return entries.sort((a, b) => a.priority - b.priority).map((e) => e.entry);
+}
+
+function extractRegionData(
+  results: MovieWatchResponse["results"] | TvWatchResponse["results"],
+  countryCode: string,
+): RegionProviders | null {
+  if (!results) return null;
+
+  const match = Object.entries(results).find(([code]) => code === countryCode);
+  if (!match) return null;
+
+  const data = match[1];
+  if (!data) return null;
+
+  // data is a union of 200+ country types with varying optional fields.
+  // Use Record access to avoid union narrowing issues.
+  const record = data as Record<string, unknown>;
+  return {
+    link: typeof record.link === "string" ? record.link : null,
+    flatrate: mapProviders(record.flatrate),
+    rent: mapProviders(record.rent),
+    buy: mapProviders(record.buy),
+    ads: mapProviders(record.ads),
+    free: mapProviders(record.free),
+  };
+}
+
+const AVAILABILITY_TYPES: AvailabilityType[] = [
+  "flatrate",
+  "rent",
+  "buy",
+  "ads",
+  "free",
+];
+
+function hasProviderName(items: unknown, name: string): boolean {
+  if (!Array.isArray(items)) return false;
+  const lower = name.toLowerCase();
+  return items.some(
+    (item) =>
+      isRecord(item) &&
+      typeof item.provider_name === "string" &&
+      item.provider_name.toLowerCase().includes(lower),
+  );
+}
+
+function searchProviderAcrossRegions(
+  results: MovieWatchResponse["results"] | TvWatchResponse["results"],
+  providerName: string,
+): ProviderSearchResult["regions"] {
+  if (!results) return [];
+
+  const regions: ProviderSearchResult["regions"] = [];
+
+  for (const [code, data] of Object.entries(results)) {
+    if (!data) continue;
+    const record = data as Record<string, unknown>;
+    const types: AvailabilityType[] = [];
+
+    for (const availType of AVAILABILITY_TYPES) {
+      if (hasProviderName(record[availType], providerName)) {
+        types.push(availType);
+      }
+    }
+
+    if (types.length > 0) {
+      regions.push({ country: code, types });
+    }
+  }
+
+  return regions.sort((a, b) => a.country.localeCompare(b.country));
+}
+
+async function fetchWatchProviders(id: number, mediaType: "movie" | "tv") {
+  return mediaType === "movie"
+    ? getMovieWatchProviders({ movie_id: String(id) })
+    : getTvShowWatchProviders({ series_id: String(id) });
+}
+
+export function createWatchProvidersTool() {
+  return tool({
+    description: TOOL_DESCRIPTION,
+    inputSchema: watchProvidersInputSchema,
+    execute: async ({
+      id,
+      media_type,
+      region,
+      provider_name,
+    }): Promise<WatchProvidersResult | ProviderSearchResult> => {
+      const response = await fetchWatchProviders(id, media_type);
+
+      if (provider_name) {
+        return {
+          id,
+          mediaType: media_type,
+          providerName: provider_name,
+          regions: searchProviderAcrossRegions(response.results, provider_name),
+        };
+      }
+
+      const countryCode = region?.toUpperCase() ?? "US";
+      return {
+        id,
+        mediaType: media_type,
+        region: countryCode,
+        providers: extractRegionData(response.results, countryCode),
+      };
+    },
+  });
+}

--- a/src/app/api/ai-chat/route.test.ts
+++ b/src/app/api/ai-chat/route.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createPresentMediaTool } from "#src/ai-chat/tools/present-media.ts";
 import { createSemanticSearchTool } from "#src/ai-chat/tools/semantic-search.ts";
 import { createTmdbSearchTool } from "#src/ai-chat/tools/tmdb-search.ts";
+import { createWatchProvidersTool } from "#src/ai-chat/tools/watch-providers.ts";
 
 vi.mock("#src/ai-chat/chat.ts", () => ({
   chat: vi.fn(),
@@ -64,6 +65,7 @@ function mockStreamResult() {
       semantic_search: createSemanticSearchTool("en"),
       tmdb_search: createTmdbSearchTool("en"),
       present_media: createPresentMediaTool(),
+      watch_providers: createWatchProvidersTool(),
     },
     stopWhen: stepCountIs(5),
   });

--- a/src/app/api/ai-chat/route.ts
+++ b/src/app/api/ai-chat/route.ts
@@ -50,7 +50,11 @@ export async function POST(request: NextRequest) {
     // Pre-stream checkpoint: save user messages while LLM initializes
     const [, result] = await Promise.all([
       saveSessionMessages(sessionId, messages),
-      chat({ messages, locale: input.locale }),
+      chat({
+        messages,
+        locale: input.locale,
+        countryCode: request.headers.get("x-vercel-ip-country") ?? undefined,
+      }),
     ]);
 
     let finishedMessages: UIMessage[] | undefined;

--- a/src/components/ai-chat/chat-message.test.tsx
+++ b/src/components/ai-chat/chat-message.test.tsx
@@ -171,6 +171,69 @@ describe("ChatMessage", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders watch_providers visual card with provider data", () => {
+    render(
+      <MediaDetailProvider>
+        <ChatMessage
+          message={createMessage({
+            role: "assistant",
+            parts: [
+              { type: "text", text: "Here's where you can watch it:" },
+              {
+                type: "dynamic-tool",
+                toolName: "tmdb_search",
+                toolCallId: "search-call",
+                state: "output-available",
+                input: { query: "Fight Club" },
+                output: [
+                  {
+                    id: 550,
+                    media_type: "movie",
+                    title: "Fight Club",
+                    poster_path: "/fightclub.jpg",
+                    vote_average: 8.4,
+                  },
+                ],
+              },
+              {
+                type: "dynamic-tool",
+                toolName: "watch_providers",
+                toolCallId: "wp-call",
+                state: "output-available",
+                input: { id: 550, media_type: "movie", region: "US" },
+                output: {
+                  id: 550,
+                  mediaType: "movie",
+                  region: "US",
+                  providers: {
+                    link: "https://www.themoviedb.org/movie/550/watch?locale=US",
+                    flatrate: [
+                      {
+                        id: 8,
+                        name: "Netflix",
+                        logoPath: "/netflix.jpg",
+                      },
+                    ],
+                    rent: [],
+                    buy: [],
+                    ads: [],
+                    free: [],
+                  },
+                },
+              },
+            ],
+          })}
+        />
+      </MediaDetailProvider>,
+    );
+
+    expect(
+      screen.getByText("Here's where you can watch it:"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Where to Watch")).toBeInTheDocument();
+    expect(screen.getByAltText("Netflix")).toBeInTheDocument();
+  });
+
   it("does not render cards for search tool parts but shows activity", () => {
     render(
       <ChatMessage

--- a/src/components/ai-chat/chat-message.tsx
+++ b/src/components/ai-chat/chat-message.tsx
@@ -77,11 +77,13 @@ export function ChatMessage({
         if (isToolUIPart(part)) {
           const toolName = getToolName(part);
           const isFirstTool = index === firstToolIndex;
-          const hasPresentMedia = toolName === "present_media";
+          const hasVisualOutput =
+            toolName === "present_media" || toolName === "watch_providers";
 
-          if (!isFirstTool && !hasPresentMedia) return null;
+          if (!isFirstTool && !hasVisualOutput) return null;
 
           const toolInput = "input" in part ? part.input : undefined;
+          const toolOutput = "output" in part ? part.output : undefined;
           return (
             <div key={key}>
               {isFirstTool && (
@@ -90,11 +92,12 @@ export function ChatMessage({
                   isStreaming={isStreaming}
                 />
               )}
-              {hasPresentMedia && (
+              {hasVisualOutput && (
                 <ToolVisualOutput
                   toolName={toolName}
                   state={part.state}
                   input={toolInput}
+                  output={toolOutput}
                   searchResultsMap={searchResultsMap}
                 />
               )}

--- a/src/components/ai-chat/tool-activity-line.test.tsx
+++ b/src/components/ai-chat/tool-activity-line.test.tsx
@@ -37,6 +37,17 @@ describe("ToolActivityLine", () => {
       expect(screen.getByText("Presenting Results")).toBeInTheDocument();
     });
 
+    it("maps watch_providers to Watch Providers", () => {
+      render(
+        <ToolActivityLine
+          toolName="watch_providers"
+          state="output-available"
+          input={{ id: 550, media_type: "movie", region: "US" }}
+        />,
+      );
+      expect(screen.getByText("Watch Providers")).toBeInTheDocument();
+    });
+
     it("shows raw name for unknown tools", () => {
       render(
         <ToolActivityLine
@@ -139,6 +150,17 @@ describe("ToolActivityLine", () => {
         />,
       );
       expect(screen.getByText("1 item")).toBeInTheDocument();
+    });
+
+    it("shows region for watch_providers", () => {
+      render(
+        <ToolActivityLine
+          toolName="watch_providers"
+          state="output-available"
+          input={{ id: 550, media_type: "movie", region: "GB" }}
+        />,
+      );
+      expect(screen.getByText("GB")).toBeInTheDocument();
     });
 
     it("omits summary for unknown tools", () => {

--- a/src/components/ai-chat/tool-activity-line.tsx
+++ b/src/components/ai-chat/tool-activity-line.tsx
@@ -64,6 +64,9 @@ export function ToolActivityLine({
     case "present_media":
       label = t({ en: "Presenting Results", zh: "展示结果" });
       break;
+    case "watch_providers":
+      label = t({ en: "Watch Providers", zh: "观看渠道" });
+      break;
     default:
       label = toolName;
   }
@@ -74,6 +77,10 @@ export function ToolActivityLine({
   let summary: string | null = null;
   if (toolName === "tmdb_search" || toolName === "semantic_search") {
     summary = getQuerySummary(input);
+  } else if (toolName === "watch_providers") {
+    if (isRecord(input) && typeof input.region === "string") {
+      summary = input.region;
+    }
   } else if (toolName === "present_media") {
     const count = getMediaCount(input);
     if (count !== null) {

--- a/src/components/ai-chat/tool-visual-output.test.tsx
+++ b/src/components/ai-chat/tool-visual-output.test.tsx
@@ -114,6 +114,61 @@ describe("ToolVisualOutput", () => {
     });
   });
 
+  describe("watch_providers", () => {
+    it("renders skeleton for input-streaming", () => {
+      const { container } = render(
+        <ToolVisualOutput
+          toolName="watch_providers"
+          state="input-streaming"
+          input={{ id: 550, media_type: "movie", region: "US" }}
+          searchResultsMap={emptyMap}
+        />,
+      );
+
+      expect(container.innerHTML).not.toBe("");
+    });
+
+    it("renders card for output-available", () => {
+      render(
+        <ToolVisualOutput
+          toolName="watch_providers"
+          state="output-available"
+          input={{ id: 550, media_type: "movie", region: "US" }}
+          output={{
+            id: 550,
+            mediaType: "movie",
+            region: "US",
+            providers: {
+              link: "https://example.com",
+              flatrate: [{ id: 8, name: "Netflix", logoPath: "/netflix.jpg" }],
+              rent: [],
+              buy: [],
+              ads: [],
+              free: [],
+            },
+          }}
+          searchResultsMap={emptyMap}
+        />,
+      );
+
+      expect(screen.getByText("Where to Watch")).toBeInTheDocument();
+      expect(screen.getByAltText("Netflix")).toBeInTheDocument();
+    });
+
+    it("shows error for output-error", () => {
+      render(
+        <ToolVisualOutput
+          toolName="watch_providers"
+          state="output-error"
+          input={{ id: 550, media_type: "movie", region: "US" }}
+          searchResultsMap={emptyMap}
+        />,
+      );
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+  });
+
   describe("non-present_media tools", () => {
     it("returns null for tmdb_search", () => {
       const { container } = render(

--- a/src/components/ai-chat/tool-visual-output.tsx
+++ b/src/components/ai-chat/tool-visual-output.tsx
@@ -7,11 +7,17 @@ import type { MediaListItem } from "#src/utils/types.ts";
 import { resolveMediaItems } from "./map-tool-output";
 import { ToolMediaCards } from "./tool-media-cards";
 import { ToolMediaCardsSkeleton } from "./tool-media-cards-skeleton";
+import {
+  parseWatchProviderOutput,
+  ToolWatchProviders,
+} from "./tool-watch-providers";
+import { ToolWatchProvidersSkeleton } from "./tool-watch-providers-skeleton";
 
 interface ToolVisualOutputProps {
   toolName: string;
   state: string;
   input: unknown;
+  output?: unknown;
   searchResultsMap: ReadonlyMap<string, MediaListItem>;
 }
 
@@ -19,28 +25,54 @@ export function ToolVisualOutput({
   toolName,
   state,
   input,
+  output,
   searchResultsMap,
 }: ToolVisualOutputProps) {
-  if (toolName !== "present_media") {
+  if (toolName === "present_media") {
+    if (state === "output-error") {
+      return (
+        <p css={styles.error} role="alert">
+          {t({ en: "Failed to load results", zh: "加载结果失败" })}
+        </p>
+      );
+    }
+
+    if (state === "input-streaming") {
+      return <ToolMediaCardsSkeleton />;
+    }
+
+    if (state === "input-available" || state === "output-available") {
+      const items = resolveMediaItems(input, searchResultsMap);
+      if (items.length === 0) return null;
+      return <ToolMediaCards items={items} />;
+    }
+
     return null;
   }
 
-  if (state === "output-error") {
-    return (
-      <p css={styles.error} role="alert">
-        {t({ en: "Failed to load results", zh: "加载结果失败" })}
-      </p>
-    );
-  }
+  if (toolName === "watch_providers") {
+    if (state === "output-error") {
+      return (
+        <p css={styles.error} role="alert">
+          {t({
+            en: "Failed to load watch providers",
+            zh: "加载观看渠道失败",
+          })}
+        </p>
+      );
+    }
 
-  if (state === "input-streaming") {
-    return <ToolMediaCardsSkeleton />;
-  }
+    if (state === "input-streaming" || state === "input-available") {
+      return <ToolWatchProvidersSkeleton />;
+    }
 
-  if (state === "input-available" || state === "output-available") {
-    const items = resolveMediaItems(input, searchResultsMap);
-    if (items.length === 0) return null;
-    return <ToolMediaCards items={items} />;
+    if (state === "output-available") {
+      const data = parseWatchProviderOutput(output);
+      if (!data) return null;
+      return <ToolWatchProviders data={data} />;
+    }
+
+    return null;
   }
 
   return null;

--- a/src/components/ai-chat/tool-watch-providers-skeleton.tsx
+++ b/src/components/ai-chat/tool-watch-providers-skeleton.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { border, color, space } from "#src/tokens.stylex.ts";
+import { Skeleton } from "../shared/skeleton";
+
+const ROW_COUNTS = [3, 2];
+const STAGGER_DELAY = 80;
+
+export function ToolWatchProvidersSkeleton() {
+  let delayIndex = 0;
+  return (
+    <div css={styles.card}>
+      <div css={styles.headerRow}>
+        <Skeleton
+          width={100}
+          height={14}
+          delay={delayIndex++ * STAGGER_DELAY}
+        />
+        <Skeleton width={24} height={18} delay={delayIndex++ * STAGGER_DELAY} />
+      </div>
+      {ROW_COUNTS.map((count, rowIndex) => (
+        <div key={rowIndex} css={styles.section}>
+          <Skeleton
+            width={50}
+            height={12}
+            delay={delayIndex++ * STAGGER_DELAY}
+          />
+          <div css={styles.logoRow}>
+            {Array.from({ length: count }, (_, i) => (
+              <Skeleton
+                key={i}
+                width={36}
+                height={36}
+                delay={delayIndex++ * STAGGER_DELAY}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  card: {
+    backgroundColor: color.backgroundHover,
+    borderRadius: border.radius_2,
+    padding: space._3,
+    marginTop: space._2,
+  },
+  headerRow: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: space._2,
+  },
+  section: {
+    marginBottom: space._2,
+  },
+  logoRow: {
+    display: "flex",
+    gap: space._1,
+    marginTop: space._1,
+  },
+});

--- a/src/components/ai-chat/tool-watch-providers.test.tsx
+++ b/src/components/ai-chat/tool-watch-providers.test.tsx
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "#src/test-utils.tsx";
+import {
+  parseWatchProviderOutput,
+  ToolWatchProviders,
+} from "./tool-watch-providers";
+
+function makeProviderData(
+  overrides: Partial<Parameters<typeof ToolWatchProviders>[0]["data"]> = {},
+) {
+  return {
+    id: 550,
+    mediaType: "movie" as const,
+    region: "US",
+    providers: {
+      link: "https://www.themoviedb.org/movie/550/watch?locale=US",
+      flatrate: [
+        { id: 8, name: "Netflix", logoPath: "/netflix.jpg" },
+        { id: 337, name: "Disney+", logoPath: "/disney.jpg" },
+      ],
+      rent: [{ id: 2, name: "Apple TV", logoPath: "/apple.jpg" }],
+      buy: [{ id: 3, name: "Google Play", logoPath: "/google.jpg" }],
+      ads: [],
+      free: [],
+    },
+    ...overrides,
+  };
+}
+
+describe("ToolWatchProviders", () => {
+  it("renders provider logos grouped by category", () => {
+    render(<ToolWatchProviders data={makeProviderData()} />);
+
+    expect(screen.getByText("Stream")).toBeInTheDocument();
+    expect(screen.getByText("Rent")).toBeInTheDocument();
+    expect(screen.getByText("Buy")).toBeInTheDocument();
+
+    expect(screen.getByAltText("Netflix")).toBeInTheDocument();
+    expect(screen.getByAltText("Disney+")).toBeInTheDocument();
+    expect(screen.getByAltText("Apple TV")).toBeInTheDocument();
+    expect(screen.getByAltText("Google Play")).toBeInTheDocument();
+  });
+
+  it("omits empty categories", () => {
+    const data = makeProviderData({
+      providers: {
+        link: null,
+        flatrate: [{ id: 8, name: "Netflix", logoPath: "/netflix.jpg" }],
+        rent: [],
+        buy: [],
+        ads: [],
+        free: [],
+      },
+    });
+    render(<ToolWatchProviders data={data} />);
+
+    expect(screen.getByText("Stream")).toBeInTheDocument();
+    expect(screen.queryByText("Rent")).not.toBeInTheDocument();
+    expect(screen.queryByText("Buy")).not.toBeInTheDocument();
+    expect(screen.queryByText("Ads")).not.toBeInTheDocument();
+    expect(screen.queryByText("Free")).not.toBeInTheDocument();
+  });
+
+  it("shows 'Not available' when providers is null", () => {
+    const data = makeProviderData({ providers: null });
+    render(<ToolWatchProviders data={data} />);
+
+    expect(screen.getByText("Not available in US")).toBeInTheDocument();
+  });
+
+  it("shows JustWatch attribution text", () => {
+    render(<ToolWatchProviders data={makeProviderData()} />);
+
+    expect(screen.getByText("Data provided by JustWatch")).toBeInTheDocument();
+  });
+
+  it("shows region in header", () => {
+    render(<ToolWatchProviders data={makeProviderData({ region: "GB" })} />);
+
+    expect(screen.getByText("GB")).toBeInTheDocument();
+    expect(screen.getByText("Where to Watch")).toBeInTheDocument();
+  });
+
+  it("renders JustWatch as a link when link is available", () => {
+    render(<ToolWatchProviders data={makeProviderData()} />);
+
+    const link = screen.getByText("Data provided by JustWatch");
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveAttribute(
+      "href",
+      "https://www.themoviedb.org/movie/550/watch?locale=US",
+    );
+  });
+
+  it("renders JustWatch as plain text when link is null", () => {
+    const data = makeProviderData({ providers: null });
+    render(<ToolWatchProviders data={data} />);
+
+    const text = screen.getByText("Data provided by JustWatch");
+    expect(text.tagName).toBe("SPAN");
+  });
+});
+
+describe("parseWatchProviderOutput", () => {
+  it("parses valid output", () => {
+    const output = {
+      id: 550,
+      mediaType: "movie",
+      region: "US",
+      providers: {
+        link: "https://example.com",
+        flatrate: [{ id: 8, name: "Netflix", logoPath: "/netflix.jpg" }],
+        rent: [],
+        buy: [],
+        ads: [],
+        free: [],
+      },
+    };
+    const result = parseWatchProviderOutput(output);
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe(550);
+    expect(result?.providers?.flatrate).toHaveLength(1);
+  });
+
+  it("returns null for invalid output", () => {
+    expect(parseWatchProviderOutput(null)).toBeNull();
+    expect(parseWatchProviderOutput(undefined)).toBeNull();
+    expect(parseWatchProviderOutput("string")).toBeNull();
+    expect(parseWatchProviderOutput({ id: "not-a-number" })).toBeNull();
+  });
+
+  it("handles providers: null", () => {
+    const output = {
+      id: 550,
+      mediaType: "movie",
+      region: "US",
+      providers: null,
+    };
+    const result = parseWatchProviderOutput(output);
+    expect(result).not.toBeNull();
+    expect(result?.providers).toBeNull();
+  });
+
+  it("rejects invalid media_type", () => {
+    const output = {
+      id: 550,
+      mediaType: "person",
+      region: "US",
+      providers: null,
+    };
+    expect(parseWatchProviderOutput(output)).toBeNull();
+  });
+});

--- a/src/components/ai-chat/tool-watch-providers.tsx
+++ b/src/components/ai-chat/tool-watch-providers.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { t } from "#src/i18n.ts";
+import { flex } from "#src/primitives/flex.stylex.ts";
+import { border, color, font, space } from "#src/tokens.stylex.ts";
+import { buildSrcSet } from "#src/utils/tmdb-image.ts";
+import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
+import { isRecord } from "./map-tool-output";
+
+interface ProviderEntry {
+  id: number;
+  name: string;
+  logoPath: string;
+}
+
+interface WatchProviderData {
+  id: number;
+  mediaType: "movie" | "tv";
+  region: string;
+  providers: {
+    link: string | null;
+    flatrate: ProviderEntry[];
+    rent: ProviderEntry[];
+    buy: ProviderEntry[];
+    ads: ProviderEntry[];
+    free: ProviderEntry[];
+  } | null;
+}
+
+type ProviderCategory = "flatrate" | "free" | "ads" | "rent" | "buy";
+
+const CATEGORY_KEYS: ReadonlyArray<ProviderCategory> = [
+  "flatrate",
+  "free",
+  "ads",
+  "rent",
+  "buy",
+];
+
+function parseProviderEntry(entry: unknown): ProviderEntry | null {
+  if (!isRecord(entry)) return null;
+  if (typeof entry.id !== "number") return null;
+  if (typeof entry.name !== "string") return null;
+  if (typeof entry.logoPath !== "string") return null;
+  return { id: entry.id, name: entry.name, logoPath: entry.logoPath };
+}
+
+function parseProviderList(list: unknown): ProviderEntry[] {
+  if (!Array.isArray(list)) return [];
+  const entries: ProviderEntry[] = [];
+  for (const item of list) {
+    const parsed = parseProviderEntry(item);
+    if (parsed) entries.push(parsed);
+  }
+  return entries;
+}
+
+export function parseWatchProviderOutput(
+  output: unknown,
+): WatchProviderData | null {
+  if (!isRecord(output)) return null;
+  if (typeof output.id !== "number") return null;
+  if (output.mediaType !== "movie" && output.mediaType !== "tv") return null;
+  if (typeof output.region !== "string") return null;
+
+  if (output.providers === null || output.providers === undefined) {
+    return {
+      id: output.id,
+      mediaType: output.mediaType,
+      region: output.region,
+      providers: null,
+    };
+  }
+
+  if (!isRecord(output.providers)) return null;
+
+  return {
+    id: output.id,
+    mediaType: output.mediaType,
+    region: output.region,
+    providers: {
+      link:
+        typeof output.providers.link === "string"
+          ? output.providers.link
+          : null,
+      flatrate: parseProviderList(output.providers.flatrate),
+      rent: parseProviderList(output.providers.rent),
+      buy: parseProviderList(output.providers.buy),
+      ads: parseProviderList(output.providers.ads),
+      free: parseProviderList(output.providers.free),
+    },
+  };
+}
+
+const LOGO_SIZE = 36;
+
+function ProviderLogo({ provider }: { provider: ProviderEntry }) {
+  const { data: config } = useSuspenseQuery(tmdbQueries.configuration);
+
+  const baseUrl =
+    config.images?.secure_base_url ?? config.images?.base_url ?? "";
+  const logoSizes = config.images?.logo_sizes ?? [];
+
+  if (!baseUrl || !provider.logoPath) return null;
+
+  const { src, srcSet } = buildSrcSet(baseUrl, logoSizes, provider.logoPath);
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      css={styles.logo}
+      src={src}
+      srcSet={srcSet}
+      sizes={`${LOGO_SIZE}px`}
+      alt={provider.name}
+      title={provider.name}
+      width={LOGO_SIZE}
+      height={LOGO_SIZE}
+      loading="lazy"
+    />
+  );
+}
+
+function ProviderSection({
+  label,
+  providers,
+}: {
+  label: string;
+  providers: ReadonlyArray<ProviderEntry>;
+}) {
+  if (providers.length === 0) return null;
+  return (
+    <div css={styles.section}>
+      <div css={styles.sectionLabel}>{label}</div>
+      <div css={[flex.wrap, styles.logoRow]}>
+        {providers.map((p) => (
+          <ProviderLogo key={p.id} provider={p} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function getCategoryLabel(key: ProviderCategory): string {
+  switch (key) {
+    case "flatrate":
+      return t({ en: "Stream", zh: "订阅" });
+    case "free":
+      return t({ en: "Free", zh: "免费" });
+    case "ads":
+      return t({ en: "Ads", zh: "含广告" });
+    case "rent":
+      return t({ en: "Rent", zh: "租借" });
+    case "buy":
+      return t({ en: "Buy", zh: "购买" });
+  }
+}
+
+interface ToolWatchProvidersProps {
+  data: WatchProviderData;
+}
+
+export function ToolWatchProviders({ data }: ToolWatchProvidersProps) {
+  const { region, providers } = data;
+
+  return (
+    <div css={styles.card}>
+      <div css={[flex.between, styles.header]}>
+        <span css={styles.title}>
+          {t({ en: "Where to Watch", zh: "在哪里看" })}
+        </span>
+        <span css={styles.regionBadge}>{region}</span>
+      </div>
+
+      {providers === null ? (
+        <p css={styles.emptyText}>
+          {t({ en: "Not available in ", zh: "在" })}
+          {region}
+          {t({ en: "", zh: "不可用" })}
+        </p>
+      ) : (
+        <>
+          {CATEGORY_KEYS.map((key) => (
+            <CategorySection
+              key={key}
+              categoryKey={key}
+              providers={providers[key]}
+            />
+          ))}
+        </>
+      )}
+
+      <div css={styles.attribution}>
+        {providers?.link ? (
+          <a
+            href={providers.link}
+            target="_blank"
+            rel="noopener noreferrer"
+            css={styles.attributionLink}
+          >
+            {t({
+              en: "Data provided by JustWatch",
+              zh: "数据由 JustWatch 提供",
+            })}
+          </a>
+        ) : (
+          <span>
+            {t({
+              en: "Data provided by JustWatch",
+              zh: "数据由 JustWatch 提供",
+            })}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CategorySection({
+  categoryKey,
+  providers,
+}: {
+  categoryKey: ProviderCategory;
+  providers: ReadonlyArray<ProviderEntry>;
+}) {
+  const label = getCategoryLabel(categoryKey);
+  return <ProviderSection label={label} providers={providers} />;
+}
+
+const styles = stylex.create({
+  card: {
+    backgroundColor: color.backgroundHover,
+    borderRadius: border.radius_2,
+    padding: space._3,
+    marginTop: space._2,
+  },
+  header: {
+    marginBottom: space._2,
+  },
+  title: {
+    fontSize: font.uiBodySmall,
+    fontWeight: font.weight_6,
+  },
+  regionBadge: {
+    fontSize: font.uiBodySmall,
+    fontWeight: font.weight_5,
+    color: color.textMuted,
+    backgroundColor: color.backgroundRaised,
+    borderRadius: border.radius_1,
+    paddingInline: space._1,
+    paddingBlock: space._00,
+  },
+  section: {
+    marginBottom: space._2,
+  },
+  sectionLabel: {
+    fontSize: font.uiBodySmall,
+    color: color.textMuted,
+    marginBottom: space._1,
+  },
+  logoRow: {
+    gap: space._1,
+  },
+  logo: {
+    width: `${LOGO_SIZE}px`,
+    height: `${LOGO_SIZE}px`,
+    borderRadius: border.radius_1,
+    objectFit: "cover",
+  },
+  emptyText: {
+    margin: 0,
+    fontSize: font.uiBodySmall,
+    color: color.textMuted,
+    fontStyle: "italic",
+    paddingBlock: space._1,
+  },
+  attribution: {
+    fontSize: font.uiBodySmall,
+    color: color.textMuted,
+    marginTop: space._1,
+    paddingTop: space._1,
+    borderTopWidth: border.size_1,
+    borderTopStyle: "solid",
+    borderTopColor: color.border,
+  },
+  attributionLink: {
+    color: color.textMuted,
+    textDecoration: {
+      default: "none",
+      ":hover": "underline",
+    },
+  },
+});

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -26,6 +26,7 @@ const createTestQueryClient = () => {
       base_url: "http://image.tmdb.org/t/p/",
       secure_base_url: "https://image.tmdb.org/t/p/",
       poster_sizes: ["w92", "w154", "w185", "w342", "w500", "w780", "original"],
+      logo_sizes: ["w45", "w92", "w154", "w185", "w300", "w500", "original"],
     },
   });
 

--- a/src/utils/tmdb-client.ts
+++ b/src/utils/tmdb-client.ts
@@ -21,15 +21,26 @@ export type PathParams<T extends string> =
     ? { [K in Param]: string } & PathParams<Rest>
     : Record<string, string>;
 
-/** Extract query parameters for a given path and method */
+/** Value types that TMDB query parameters can carry */
+type SearchParamValue = string | number | boolean | undefined | null;
+
+/**
+ * Extract query parameters for a given path and method.
+ *
+ * When the OpenAPI spec declares no query parameters the fallback is
+ * `Record<string, SearchParamValue>` instead of `Record<string, never>`.
+ * `Record<string, never>` creates an impossible type when intersected with
+ * path-parameter objects (e.g. `{ movie_id: string } & Record<string, never>`),
+ * whereas `Record<string, SearchParamValue>` stays compatible.
+ */
 export type QueryParams<
   TPath extends keyof paths,
   TMethod extends keyof paths[TPath],
 > = paths[TPath][TMethod] extends { parameters: { query?: infer Q } }
   ? Q extends Record<string, unknown>
     ? Q
-    : Record<string, never>
-  : Record<string, never>;
+    : Record<string, SearchParamValue>
+  : Record<string, SearchParamValue>;
 
 /** Extract response type for a given path and method */
 export type ResponseType<

--- a/tooling/tmdb-codegen/endpoints-config.js
+++ b/tooling/tmdb-codegen/endpoints-config.js
@@ -53,6 +53,16 @@ export const endpoints = [
     functionName: "getMovieRecommendations",
   },
 
+  // Watch Providers
+  {
+    path: "/3/movie/{movie_id}/watch/providers",
+    functionName: "getMovieWatchProviders",
+  },
+  {
+    path: "/3/tv/{series_id}/watch/providers",
+    functionName: "getTvShowWatchProviders",
+  },
+
   // TV Details & Media
   { path: "/3/tv/{series_id}", functionName: "getTvShowDetails" },
   { path: "/3/tv/{series_id}/videos", functionName: "getTvShowVideos" },


### PR DESCRIPTION
## Summary

Add a `watch_providers` AI tool and inline visual card so users can ask "where can I watch X?" and see streaming/rent/buy platform availability directly in chat. The tool connects to the TMDB watch providers API (powered by JustWatch) and supports two modes: region-based lookup (showing all platforms in a country, using `x-vercel-ip-country` for automatic detection) and provider search (finding which countries carry a specific platform like Netflix). The visual card renders provider logos grouped by availability type with a loading skeleton and JustWatch attribution.

Also fixes a `QueryParams` type issue where `Record<string, never>` created impossible intersection types when combined with path parameters for endpoints that have no query params.

Closes #1672