### PR TITLE
fix: remove non-null assertion on mediaType in FilmographyScroller

### DIFF
--- a/src/components/ai-chat/person-detail-content.tsx
+++ b/src/components/ai-chat/person-detail-content.tsx
@@ -224,30 +224,33 @@ function FilmographyScroller({
         aria-label={t({ en: "Filmography", zh: "作品列表" })}
         tabIndex={0}
       >
-        {items.map((item) => (
-          <div
-            key={`${item.mediaType}-${item.id}`}
-            css={filmStyles.cardWrapper}
-            role="listitem"
-          >
-            <CompactMediaCard
-              media={item}
-              onClick={
-                item.mediaType
-                  ? () => {
-                      setFocusedPerson(null);
-                      setFocusedMedia({
-                        id: item.id,
-                        mediaType: item.mediaType!,
-                        title: item.title,
-                        posterPath: item.posterPath,
-                      });
-                    }
-                  : undefined
-              }
-            />
-          </div>
-        ))}
+        {items.map((item) => {
+          const { mediaType } = item;
+          return (
+            <div
+              key={`${mediaType}-${item.id}`}
+              css={filmStyles.cardWrapper}
+              role="listitem"
+            >
+              <CompactMediaCard
+                media={item}
+                onClick={
+                  mediaType
+                    ? () => {
+                        setFocusedPerson(null);
+                        setFocusedMedia({
+                          id: item.id,
+                          mediaType,
+                          title: item.title,
+                          posterPath: item.posterPath,
+                        });
+                      }
+                    : undefined
+                }
+              />
+            </div>
+          );
+        })}
       </div>
       <div
         css={[filmStyles.fadeEdge, filmStyles.fadeLeft]}


### PR DESCRIPTION
## Summary

The `FilmographyScroller` component used a non-null assertion (`item.mediaType!`) to pass `mediaType` into `setFocusedMedia`, bypassing TypeScript's null safety despite `mediaType` being optional on the item type. This replaces the assertion with a destructuring-before-conditional pattern — extracting `mediaType` from `item` upfront so the truthy check naturally narrows the type, making the non-null assertion unnecessary. This is consistent with how sibling components in the codebase handle the same pattern.