### PR TITLE
fix: replace type assertion with runtime typeof guard for personDetail deathday

### DIFF
--- a/src/utils/tmdb-queries.test.ts
+++ b/src/utils/tmdb-queries.test.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 import { server } from "#src/test-msw.ts";
-import { mediaDetail, mediaVideos } from "./tmdb-queries";
+import { mediaDetail, mediaVideos, personDetail } from "./tmdb-queries";
 
 function movieDetailsResponse(
   overrides: Partial<{
@@ -314,5 +314,135 @@ describe("mediaVideos", () => {
     const url = new URL(requestUrl);
     expect(url.searchParams.get("series_id")).toBe("1399");
     expect(result.results).toHaveLength(0);
+  });
+});
+
+function personDetailsResponse(
+  overrides: Partial<{
+    name: string;
+    profile_path: string;
+    biography: string;
+    birthday: string;
+    deathday: unknown;
+    known_for_department: string;
+  }> = {},
+) {
+  return {
+    adult: false,
+    id: 31,
+    name: "Tom Hanks",
+    profile_path: "/xndWFsBlClOJFRdhSt4NBwiPq2o.jpg",
+    biography: "Thomas Jeffrey Hanks is an American actor and filmmaker.",
+    birthday: "1956-07-09",
+    deathday: null,
+    gender: 2,
+    homepage: null,
+    imdb_id: "nm0000158",
+    known_for_department: "Acting",
+    place_of_birth: "Concord, California, USA",
+    popularity: 82.989,
+    also_known_as: [],
+    ...overrides,
+  };
+}
+
+describe("personDetail", () => {
+  it("normalizes person details", async () => {
+    server.use(
+      http.get("*/api/tmdb/get-person-details", () =>
+        HttpResponse.json(personDetailsResponse()),
+      ),
+    );
+
+    const options = personDetail({ id: "31" });
+    const result = await options.queryFn!({} as never);
+
+    expect(result).toEqual({
+      name: "Tom Hanks",
+      profilePath: "/xndWFsBlClOJFRdhSt4NBwiPq2o.jpg",
+      biography: "Thomas Jeffrey Hanks is an American actor and filmmaker.",
+      birthday: "1956-07-09",
+      deathday: null,
+      knownForDepartment: "Acting",
+    });
+  });
+
+  it("returns deathday when it is a string", async () => {
+    server.use(
+      http.get("*/api/tmdb/get-person-details", () =>
+        HttpResponse.json(personDetailsResponse({ deathday: "2014-08-11" })),
+      ),
+    );
+
+    const options = personDetail({ id: "31" });
+    const result = await options.queryFn!({} as never);
+
+    expect(result.deathday).toBe("2014-08-11");
+  });
+
+  it("returns null deathday for non-string values", async () => {
+    server.use(
+      http.get("*/api/tmdb/get-person-details", () =>
+        HttpResponse.json(personDetailsResponse({ deathday: 0 })),
+      ),
+    );
+
+    const options = personDetail({ id: "31" });
+    const result = await options.queryFn!({} as never);
+
+    expect(result.deathday).toBeNull();
+  });
+
+  it("falls back to empty string when name is missing", async () => {
+    server.use(
+      http.get("*/api/tmdb/get-person-details", () =>
+        HttpResponse.json(personDetailsResponse({ name: undefined })),
+      ),
+    );
+
+    const options = personDetail({ id: "31" });
+    const result = await options.queryFn!({} as never);
+
+    expect(result.name).toBe("");
+  });
+
+  it("returns null for missing optional fields", async () => {
+    server.use(
+      http.get("*/api/tmdb/get-person-details", () =>
+        HttpResponse.json(
+          personDetailsResponse({
+            profile_path: undefined,
+            biography: undefined,
+            birthday: undefined,
+            known_for_department: undefined,
+          }),
+        ),
+      ),
+    );
+
+    const options = personDetail({ id: "31" });
+    const result = await options.queryFn!({} as never);
+
+    expect(result.profilePath).toBeNull();
+    expect(result.biography).toBeNull();
+    expect(result.birthday).toBeNull();
+    expect(result.knownForDepartment).toBeNull();
+  });
+
+  it("passes person_id and language as query params", async () => {
+    let requestUrl = "";
+    server.use(
+      http.get("*/api/tmdb/get-person-details", ({ request }) => {
+        requestUrl = request.url;
+        return HttpResponse.json(personDetailsResponse());
+      }),
+    );
+
+    const options = personDetail({ id: "31", language: "zh" });
+    await options.queryFn!({} as never);
+
+    const url = new URL(requestUrl);
+    expect(url.searchParams.get("person_id")).toBe("31");
+    expect(url.searchParams.get("language")).toBe("zh");
   });
 });

--- a/src/utils/tmdb-queries.ts
+++ b/src/utils/tmdb-queries.ts
@@ -293,7 +293,7 @@ export const personDetail = (params: PersonDetailParams) =>
         profilePath: data.profile_path ?? null,
         biography: data.biography ?? null,
         birthday: data.birthday ?? null,
-        deathday: (data.deathday as string | null | undefined) ?? null,
+        deathday: typeof data.deathday === "string" ? data.deathday : null,
         knownForDepartment: data.known_for_department ?? null,
       };
     },


### PR DESCRIPTION
## Summary

The `personDetail` query function used a type assertion (`as string | null | undefined`) to handle the `deathday` field from the TMDB API. This is unsafe because `as` casts bypass runtime checks — if the API returns a non-string truthy value (e.g. `0`, `false`), the assertion would silently pass it through. This replaces it with a `typeof` runtime guard that correctly narrows to `string` or falls back to `null`, and adds comprehensive test coverage for the `personDetail` function.