### PR TITLE
refactor: eliminate type assertions in person-credits tool

### DIFF
--- a/src/ai-chat/tools/person-credits.ts
+++ b/src/ai-chat/tools/person-credits.ts
@@ -1,17 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { getPersonCombinedCredits } from "#src/_generated/tmdb-server-functions.ts";
-import type { ResponseType } from "#src/utils/tmdb-client.ts";
-
-// The TMDB OpenAPI spec flattens the combined credits union type, omitting
-// fields that only appear for TV entries. The API returns these at runtime.
-type CombinedCreditEntry = NonNullable<
-  ResponseType<"/3/person/{person_id}/combined_credits", "get">["cast"]
->[number] & {
-  name?: string;
-  first_air_date?: string;
-  department?: string;
-};
 
 export const personCreditsInputSchema = z.object({
   person_id: z.number().describe("The TMDB person ID from search results."),
@@ -22,19 +11,52 @@ const TOOL_DESCRIPTION =
   "Use this when the user asks about someone's career, filmography, or specific roles. " +
   "After receiving results, use present_media to display them visually.";
 
-function getTitle(entry: CombinedCreditEntry): string | undefined {
-  return entry.title ?? entry.name;
+// The TMDB OpenAPI spec flattens the combined credits union type, omitting
+// fields that only appear for TV entries. The API returns these at runtime.
+// Use runtime field access (via Record) instead of type assertions.
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function getReleaseDate(entry: CombinedCreditEntry): string | undefined {
-  return entry.release_date ?? entry.first_air_date;
+function getString(
+  obj: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const val = obj[key];
+  return typeof val === "string" ? val : undefined;
 }
 
-function getMediaType(entry: CombinedCreditEntry): "movie" | "tv" | undefined {
-  if (entry.media_type === "movie" || entry.media_type === "tv") {
-    return entry.media_type;
-  }
+function getNumber(obj: Record<string, unknown>, key: string): number {
+  const val = obj[key];
+  return typeof val === "number" ? val : 0;
+}
+
+function getTitle(entry: Record<string, unknown>): string | undefined {
+  return getString(entry, "title") ?? getString(entry, "name");
+}
+
+function getReleaseDate(entry: Record<string, unknown>): string | undefined {
+  return getString(entry, "release_date") ?? getString(entry, "first_air_date");
+}
+
+function getMediaType(
+  entry: Record<string, unknown>,
+): "movie" | "tv" | undefined {
+  const mt = entry.media_type;
+  if (mt === "movie" || mt === "tv") return mt;
   return undefined;
+}
+
+interface CreditResult {
+  id: number;
+  media_type: "movie" | "tv" | undefined;
+  title: string | undefined;
+  poster_path: string | undefined;
+  vote_average: number;
+  release_date: string | undefined;
+  character: string | undefined;
+  department: string | undefined;
 }
 
 export function createPersonCreditsTool() {
@@ -47,52 +69,47 @@ export function createPersonCreditsTool() {
       });
 
       const seen = new Set<string>();
-      const results: Array<{
-        id: number;
-        media_type: "movie" | "tv" | undefined;
-        title: string | undefined;
-        poster_path: string | undefined;
-        vote_average: number;
-        release_date: string | undefined;
-        character: string | undefined;
-        department: string | undefined;
-      }> = [];
+      const results: CreditResult[] = [];
 
-      for (const entry of (credits.cast ?? []) as CombinedCreditEntry[]) {
-        const mediaType = getMediaType(entry);
-        const key = `${mediaType}:${entry.id}`;
+      for (const raw of credits.cast ?? []) {
+        if (!isRecord(raw)) continue;
+        if (typeof raw.id !== "number") continue;
+        const mediaType = getMediaType(raw);
+        const key = `${mediaType}:${raw.id}`;
         if (seen.has(key)) continue;
         seen.add(key);
         results.push({
-          id: entry.id,
+          id: raw.id,
           media_type: mediaType,
-          title: getTitle(entry),
-          poster_path: entry.poster_path,
-          vote_average: entry.vote_average,
-          release_date: getReleaseDate(entry),
-          character: entry.character,
+          title: getTitle(raw),
+          poster_path: getString(raw, "poster_path"),
+          vote_average: getNumber(raw, "vote_average"),
+          release_date: getReleaseDate(raw),
+          character: getString(raw, "character"),
           department: undefined,
         });
       }
 
-      for (const entry of (credits.crew ?? []) as CombinedCreditEntry[]) {
-        const mediaType = getMediaType(entry);
-        const key = `${mediaType}:${entry.id}`;
+      for (const raw of credits.crew ?? []) {
+        if (!isRecord(raw)) continue;
+        if (typeof raw.id !== "number") continue;
+        const mediaType = getMediaType(raw);
+        const key = `${mediaType}:${raw.id}`;
         if (seen.has(key)) continue;
         seen.add(key);
         results.push({
-          id: entry.id,
+          id: raw.id,
           media_type: mediaType,
-          title: getTitle(entry),
-          poster_path: entry.poster_path,
-          vote_average: entry.vote_average,
-          release_date: getReleaseDate(entry),
+          title: getTitle(raw),
+          poster_path: getString(raw, "poster_path"),
+          vote_average: getNumber(raw, "vote_average"),
+          release_date: getReleaseDate(raw),
           character: undefined,
-          department: entry.department,
+          department: getString(raw, "department"),
         });
       }
 
-      results.sort((a, b) => (b.vote_average ?? 0) - (a.vote_average ?? 0));
+      results.sort((a, b) => b.vote_average - a.vote_average);
 
       return results;
     },


### PR DESCRIPTION
## Summary

The person-credits AI chat tool used an intersection type (`CombinedCreditEntry`) with `as` casts to work around the TMDB OpenAPI spec not fully representing combined credits responses (TV-only fields like `name`, `first_air_date`, and `department` are missing from the generated types). This refactor replaces those type assertions with runtime-safe field-access helpers (`isRecord`, `getString`, `getNumber`) that narrow `unknown` values without any `as` casts, aligning the code with the project's "avoid type assertions" convention while preserving identical runtime behavior.