### PR TITLE
feat: return crew data from media_credits AI chat tool

### DIFF
--- a/src/ai-chat/tools/media-credits.ts
+++ b/src/ai-chat/tools/media-credits.ts
@@ -15,7 +15,8 @@ const TOOL_DESCRIPTION =
   "Use this when the user asks who stars in, acts in, or directed a specific title. " +
   "After receiving results, use present_person to display the cast visually.";
 
-const MAX_RESULTS = 20;
+const MAX_CAST = 20;
+const MAX_CREW = 20;
 
 export function createMediaCreditsTool() {
   return tool({
@@ -28,7 +29,7 @@ export function createMediaCreditsTool() {
           ? await getTvShowCredits({ series_id: idString })
           : await getMovieCredits({ movie_id: idString });
 
-      const cast = (credits.cast ?? []).slice(0, MAX_RESULTS).map((entry) => ({
+      const cast = (credits.cast ?? []).slice(0, MAX_CAST).map((entry) => ({
         id: entry.id,
         name: entry.name,
         profile_path: entry.profile_path,
@@ -37,7 +38,16 @@ export function createMediaCreditsTool() {
         order: entry.order,
       }));
 
-      return cast;
+      const crew = (credits.crew ?? []).slice(0, MAX_CREW).map((entry) => ({
+        id: entry.id,
+        name: entry.name,
+        profile_path: entry.profile_path,
+        known_for_department: entry.known_for_department,
+        department: entry.department,
+        job: entry.job,
+      }));
+
+      return { cast, crew };
     },
   });
 }

--- a/src/components/ai-chat/map-tool-output.test.ts
+++ b/src/components/ai-chat/map-tool-output.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { MediaListItem } from "#src/utils/types.ts";
 import {
+  buildPersonResultsMap,
   buildSearchResultsMap,
   mapToolOutputToMediaItems,
   resolveMediaItems,
@@ -310,5 +311,96 @@ describe("resolveMediaItems", () => {
         searchResults,
       ),
     ).toEqual([]);
+  });
+});
+
+describe("buildPersonResultsMap for media_credits", () => {
+  it("extracts persons from { cast, crew } object format", () => {
+    const output = {
+      cast: [
+        {
+          id: 1,
+          name: "Brad Pitt",
+          profile_path: "/brad.jpg",
+          known_for_department: "Acting",
+          character: "Tyler Durden",
+          order: 0,
+        },
+      ],
+      crew: [
+        {
+          id: 2,
+          name: "David Fincher",
+          profile_path: "/fincher.jpg",
+          known_for_department: "Directing",
+          department: "Directing",
+          job: "Director",
+        },
+      ],
+    };
+
+    const map = buildPersonResultsMap("media_credits", output);
+
+    expect(map.size).toBe(2);
+    expect(map.get(1)?.name).toBe("Brad Pitt");
+    expect(map.get(2)?.name).toBe("David Fincher");
+  });
+
+  it("deduplicates persons who appear in both cast and crew", () => {
+    const output = {
+      cast: [
+        {
+          id: 1,
+          name: "Clint Eastwood",
+          profile_path: "/clint.jpg",
+          known_for_department: "Acting",
+          character: "Walt Kowalski",
+          order: 0,
+        },
+      ],
+      crew: [
+        {
+          id: 1,
+          name: "Clint Eastwood",
+          profile_path: "/clint.jpg",
+          known_for_department: "Directing",
+          department: "Directing",
+          job: "Director",
+        },
+      ],
+    };
+
+    const map = buildPersonResultsMap("media_credits", output);
+
+    expect(map.size).toBe(1);
+    expect(map.get(1)?.name).toBe("Clint Eastwood");
+  });
+
+  it("handles legacy flat array format for backwards compatibility", () => {
+    const output = [
+      {
+        id: 1,
+        name: "Brad Pitt",
+        profile_path: "/brad.jpg",
+        known_for_department: "Acting",
+      },
+    ];
+
+    const map = buildPersonResultsMap("media_credits", output);
+
+    expect(map.size).toBe(1);
+    expect(map.get(1)?.name).toBe("Brad Pitt");
+  });
+
+  it("returns empty map for non-object/non-array input", () => {
+    expect(buildPersonResultsMap("media_credits", null).size).toBe(0);
+    expect(buildPersonResultsMap("media_credits", "string").size).toBe(0);
+    expect(buildPersonResultsMap("media_credits", 42).size).toBe(0);
+  });
+
+  it("handles empty cast and crew arrays", () => {
+    const output = { cast: [], crew: [] };
+    const map = buildPersonResultsMap("media_credits", output);
+    expect(map.size).toBe(0);
   });
 });

--- a/src/components/ai-chat/map-tool-output.ts
+++ b/src/components/ai-chat/map-tool-output.ts
@@ -168,13 +168,11 @@ function mapTmdbSearchPersonOutput(
   return items;
 }
 
-function mapMediaCreditsPersonOutput(
-  output: unknown,
-): ReadonlyArray<PersonListItem> {
-  if (!Array.isArray(output)) return [];
+function extractPersonEntries(arr: unknown): PersonListItem[] {
+  if (!Array.isArray(arr)) return [];
 
   const items: PersonListItem[] = [];
-  for (const entry of output) {
+  for (const entry of arr) {
     if (!isRecord(entry)) continue;
     if (typeof entry.id !== "number") continue;
 
@@ -190,6 +188,28 @@ function mapMediaCreditsPersonOutput(
     });
   }
   return items;
+}
+
+function mapMediaCreditsPersonOutput(
+  output: unknown,
+): ReadonlyArray<PersonListItem> {
+  // New format: { cast: [...], crew: [...] }
+  if (isRecord(output)) {
+    const castItems = extractPersonEntries(output.cast);
+    const crewItems = extractPersonEntries(output.crew);
+    const seen = new Set<number>();
+    const items: PersonListItem[] = [];
+
+    for (const item of [...castItems, ...crewItems]) {
+      if (seen.has(item.id)) continue;
+      seen.add(item.id);
+      items.push(item);
+    }
+    return items;
+  }
+
+  // Legacy format: flat array (backwards-compatible with cached data)
+  return extractPersonEntries(output);
 }
 
 export function buildPersonResultsMap(


### PR DESCRIPTION
## Summary

The `media_credits` tool previously only returned cast members, so when users asked "who directed this movie?" or "who wrote this show?" the AI had no data to answer with. This change adds crew data (directors, writers, producers, etc.) to the tool's output, returning `{ cast, crew }` instead of a flat cast array.

The output mapping layer handles the new structure with deduplication (for people like Clint Eastwood who appear in both cast and crew), and maintains backwards compatibility with the legacy flat array format for any cached responses.