### PR TITLE
fix: add prefers-reduced-motion support to skeleton pulse animation

### DIFF
--- a/src/components/shared/skeleton.tsx
+++ b/src/components/shared/skeleton.tsx
@@ -1,5 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 import type { CSSProperties, Ref } from "react";
+import { motionConstants } from "#src/primitives/motion.stylex.ts";
 import { border, color } from "#src/tokens.stylex.ts";
 import { skeletonTokens } from "./skeleton.stylex";
 
@@ -46,7 +47,10 @@ const pulse = stylex.keyframes({
 
 const styles = stylex.create({
   skeleton: {
-    animationName: pulse,
+    animationName: {
+      default: pulse,
+      [motionConstants.REDUCED_MOTION]: "none",
+    },
     animationDuration: "2s",
     animationTimingFunction: "cubic-bezier(.4,0,.6,1)",
     animationFillMode: "both",


### PR DESCRIPTION
## Summary

The skeleton component's pulse animation plays unconditionally, which can cause discomfort for users who have enabled the "prefers-reduced-motion" OS setting. This applies the same `{ default: animation, [REDUCED_MOTION]: "none" }` pattern already used by other animations in the codebase (e.g., `slideUp`, `slideDown` in `motion.stylex.ts`) to disable the skeleton pulse when reduced motion is preferred.