### PR TITLE
fix: return 400 instead of 500 for malformed JSON in AI chat routes

### DIFF
--- a/src/app/api/ai-chat/route.test.ts
+++ b/src/app/api/ai-chat/route.test.ts
@@ -386,6 +386,22 @@ describe("POST /api/ai-chat", () => {
     });
   });
 
+  it("returns 400 for malformed JSON body", async () => {
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/ai-chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not valid json{{{",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "Invalid request body",
+    });
+  });
+
   it("includes sessionId in stream metadata", async () => {
     const { chat } = await import("#src/ai-chat/chat.ts");
     vi.mocked(chat).mockResolvedValueOnce(mockStreamResult());

--- a/src/app/api/ai-chat/route.ts
+++ b/src/app/api/ai-chat/route.ts
@@ -114,7 +114,7 @@ export async function POST(request: NextRequest) {
 
     return createUIMessageStreamResponse({ stream });
   } catch (error) {
-    if (error instanceof z.ZodError) {
+    if (error instanceof z.ZodError || error instanceof SyntaxError) {
       return Response.json(
         { success: false, error: "Invalid request body" },
         { status: 400 },

--- a/src/app/api/ai-chat/session/route.test.ts
+++ b/src/app/api/ai-chat/session/route.test.ts
@@ -72,6 +72,19 @@ describe("POST /api/ai-chat/session", () => {
     expect(response.status).toBe(400);
   });
 
+  it("returns 400 for malformed JSON body", async () => {
+    const response = await POST(
+      new NextRequest("http://localhost:3000/api/ai-chat/session", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not valid json{{{",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid request body" });
+  });
+
   it("returns 500 when Redis read fails", async () => {
     const { getSessionMessages } =
       await import("#src/session-store/session-store.ts");

--- a/src/app/api/ai-chat/session/route.ts
+++ b/src/app/api/ai-chat/session/route.ts
@@ -23,6 +23,9 @@ export async function POST(request: NextRequest) {
 
     return Response.json({ messages, sessionId: parsed.data.sessionId });
   } catch (error) {
+    if (error instanceof SyntaxError) {
+      return Response.json({ error: "Invalid request body" }, { status: 400 });
+    }
     console.error("AI Chat session POST error:", error);
     return Response.json({ error: "Internal server error" }, { status: 500 });
   }


### PR DESCRIPTION
## Summary

When a client sends a request with malformed JSON to the AI chat endpoints (`/api/ai-chat` and `/api/ai-chat/session`), the `request.json()` call throws a `SyntaxError` that was previously uncaught, resulting in a 500 Internal Server Error. This fix catches `SyntaxError` alongside `ZodError` and returns a proper 400 Bad Request response, preventing noisy 500 errors in logs and giving clients a meaningful error message.