### PR TITLE
fix: use UTC date methods in calculateAge to prevent timezone off-by-one

### DIFF
--- a/src/components/ai-chat/person-detail-content.tsx
+++ b/src/components/ai-chat/person-detail-content.tsx
@@ -9,6 +9,7 @@ import { useScrollFades } from "#src/hooks/use-scroll-fades.ts";
 import { t } from "#src/i18n.ts";
 import { scrollX } from "#src/primitives/layout.stylex.ts";
 import { border, color, font, layer, space } from "#src/tokens.stylex.ts";
+import { calculateAge } from "#src/utils/calculate-age.ts";
 import { buildSrcSet } from "#src/utils/tmdb-image.ts";
 import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
 import type { MediaListItem } from "#src/utils/types.ts";
@@ -17,17 +18,6 @@ import { CompactMediaCard } from "./compact-media-card";
 import { useMediaDetail, type FocusedPerson } from "./media-detail-context";
 
 const MAX_CREDITS = 20;
-
-function calculateAge(birthday: string, deathday: string | null): number {
-  const birth = new Date(birthday);
-  const end = deathday ? new Date(deathday) : new Date();
-  let age = end.getFullYear() - birth.getFullYear();
-  const monthDiff = end.getMonth() - birth.getMonth();
-  if (monthDiff < 0 || (monthDiff === 0 && end.getDate() < birth.getDate())) {
-    age--;
-  }
-  return age;
-}
 
 export function PersonDetailContent({
   id,

--- a/src/utils/calculate-age.test.ts
+++ b/src/utils/calculate-age.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { calculateAge } from "./calculate-age";
+
+describe("calculateAge", () => {
+  it("calculates age for a living person", () => {
+    // Use a fixed deathday to avoid test flakiness from current date
+    expect(calculateAge("1990-06-15", "2026-03-30")).toBe(35);
+  });
+
+  it("calculates age when birthday has not yet occurred in the end year", () => {
+    expect(calculateAge("1990-12-25", "2026-03-30")).toBe(35);
+  });
+
+  it("calculates age when birthday has already occurred in the end year", () => {
+    expect(calculateAge("1990-01-01", "2026-03-30")).toBe(36);
+  });
+
+  it("returns 0 for a person born and died on the same day", () => {
+    expect(calculateAge("2000-05-10", "2000-05-10")).toBe(0);
+  });
+
+  it("calculates age for a deceased person", () => {
+    expect(calculateAge("1955-10-28", "2011-10-05")).toBe(55);
+  });
+
+  it("calculates age correctly on exact birthday", () => {
+    expect(calculateAge("1990-03-30", "2026-03-30")).toBe(36);
+  });
+
+  it("calculates age correctly the day before birthday", () => {
+    expect(calculateAge("1990-03-31", "2026-03-30")).toBe(35);
+  });
+
+  it("handles leap year birthdays", () => {
+    // Born on Feb 29, checking age on Feb 28
+    expect(calculateAge("2000-02-29", "2025-02-28")).toBe(24);
+    // Born on Feb 29, checking age on Mar 1
+    expect(calculateAge("2000-02-29", "2025-03-01")).toBe(25);
+  });
+
+  it("handles year boundaries correctly", () => {
+    // Born Dec 31, checking Jan 1 of next year
+    expect(calculateAge("1990-12-31", "1991-01-01")).toBe(0);
+  });
+
+  it("uses UTC to avoid timezone-related off-by-one errors", () => {
+    // "1990-01-01" parsed as Date is midnight UTC.
+    // In UTC-5 timezone, local time would be Dec 31 23:00, causing
+    // getFullYear() to return 1989 instead of 1990. UTC methods avoid this.
+    expect(calculateAge("1990-01-01", "2026-01-01")).toBe(36);
+  });
+});

--- a/src/utils/calculate-age.ts
+++ b/src/utils/calculate-age.ts
@@ -1,0 +1,29 @@
+/**
+ * Calculates a person's age from their birthday and an optional death date.
+ *
+ * Uses UTC methods to avoid timezone-related off-by-one errors.
+ * TMDB date strings like "1990-01-15" are parsed as UTC midnight by the
+ * Date constructor. Using local-time getters (getFullYear, getMonth,
+ * getDate) would shift the date backward in negative-UTC-offset timezones,
+ * potentially returning the wrong age on boundary dates.
+ *
+ * @param birthday - ISO date string (YYYY-MM-DD)
+ * @param deathday - ISO date string or null (uses current UTC date)
+ * @returns Age in whole years
+ */
+export function calculateAge(
+  birthday: string,
+  deathday: string | null,
+): number {
+  const birth = new Date(birthday);
+  const end = deathday ? new Date(deathday) : new Date();
+  let age = end.getUTCFullYear() - birth.getUTCFullYear();
+  const monthDiff = end.getUTCMonth() - birth.getUTCMonth();
+  if (
+    monthDiff < 0 ||
+    (monthDiff === 0 && end.getUTCDate() < birth.getUTCDate())
+  ) {
+    age--;
+  }
+  return age;
+}


### PR DESCRIPTION
## Summary

The `calculateAge` function in the person detail component used local-time `Date` methods (`getFullYear`, `getMonth`, `getDate`). TMDB date strings like `"1990-01-15"` are parsed as UTC midnight, so in negative-UTC-offset timezones the local-time getters shift the date backward by a day, potentially returning the wrong age on boundary dates. This switches to UTC methods (`getUTCFullYear`, `getUTCMonth`, `getUTCDate`) to eliminate the off-by-one.

The function is also extracted into `src/utils/calculate-age.ts` with unit tests covering edge cases (leap years, year boundaries, exact birthdays, deceased persons, and the UTC correctness scenario).