### PR TITLE
refactor: replace ChatInput Zod schema with plain TypeScript interface

### DIFF
--- a/src/ai-chat/chat.ts
+++ b/src/ai-chat/chat.ts
@@ -14,8 +14,6 @@ import { createSemanticSearchTool } from "./tools/semantic-search";
 import { createTmdbSearchTool } from "./tools/tmdb-search";
 import { createWatchProvidersTool } from "./tools/watch-providers";
 
-export type { ChatInput } from "./schema";
-
 interface ChatOptions extends ChatInput {
   model?: LanguageModel;
 }

--- a/src/ai-chat/schema.ts
+++ b/src/ai-chat/schema.ts
@@ -1,11 +1,8 @@
 import type { UIMessage } from "ai";
-import { z } from "zod";
-import { isUIMessage } from "./is-ui-message";
+import type { SupportedLocale } from "#src/types.ts";
 
-export const chatInputSchema = z.object({
-  messages: z.array(z.custom<UIMessage>(isUIMessage)).min(1),
-  locale: z.enum(["en", "zh"]).default("en"),
-  countryCode: z.string().length(2).optional(),
-});
-
-export type ChatInput = z.infer<typeof chatInputSchema>;
+export interface ChatInput {
+  messages: UIMessage[];
+  locale: SupportedLocale;
+  countryCode?: string;
+}


### PR DESCRIPTION
## Summary

The `chatInputSchema` Zod schema in `src/ai-chat/schema.ts` was only being consumed as a type (`ChatInput`) by the internal chat module. Actual runtime validation of chat input now happens at the API route boundary via `sessionChatInputSchema` in `session-schema.ts`, making the Zod schema here redundant. This replaces it with a plain TypeScript interface, removing the unnecessary Zod and `isUIMessage` runtime imports from the module. Also removes the re-export of `ChatInput` from `chat.ts` since consumers can import it directly from `schema.ts`.