### PR TITLE
fix: add prefers-reduced-motion support to switch thumb transition

### DIFF
--- a/src/components/shared/switch.tsx
+++ b/src/components/shared/switch.tsx
@@ -3,6 +3,7 @@
 import useControlled from "@mui/utils/useControlled";
 import * as stylex from "@stylexjs/stylex";
 import React, { useLayoutEffect, useRef, useState } from "react";
+import { motionConstants } from "#src/primitives/motion.stylex.ts";
 import { buttonReset } from "#src/primitives/reset.stylex.ts";
 import {
   border,
@@ -220,7 +221,10 @@ const styles = stylex.create({
   },
   animate: {
     "::before": {
-      transition: `transform ${switchTokens.thumbTransitionDuration} ease, box-shadow 0.4s ease`,
+      transition: {
+        default: `transform ${switchTokens.thumbTransitionDuration} ease, box-shadow 0.4s ease`,
+        [motionConstants.REDUCED_MOTION]: "box-shadow 0.4s ease",
+      },
     },
   },
   dragging: (position) => ({


### PR DESCRIPTION
## Summary

The Switch component's thumb sliding animation (the `transform` transition) now respects the `prefers-reduced-motion` media query. When reduced motion is preferred, the thumb position change is instant while the subtle `box-shadow` transition is preserved. This follows the same pattern used in the recent card transitions fix (b023c46).