### PR TITLE
feat: AI-powered review summaries with spiciness control

### DIFF
--- a/src/_generated/tmdb-endpoints.ts
+++ b/src/_generated/tmdb-endpoints.ts
@@ -12,6 +12,7 @@ export type TMDBEndpointPaths =
   | "/3/movie/{movie_id}"
   | "/3/movie/{movie_id}/credits"
   | "/3/movie/{movie_id}/recommendations"
+  | "/3/movie/{movie_id}/reviews"
   | "/3/movie/{movie_id}/videos"
   | "/3/movie/{movie_id}/watch/providers"
   | "/3/person/{person_id}"
@@ -22,6 +23,7 @@ export type TMDBEndpointPaths =
   | "/3/tv/{series_id}"
   | "/3/tv/{series_id}/credits"
   | "/3/tv/{series_id}/recommendations"
+  | "/3/tv/{series_id}/reviews"
   | "/3/tv/{series_id}/videos"
   | "/3/tv/{series_id}/watch/providers";
 
@@ -34,6 +36,7 @@ export const TMDB_ENDPOINTS = [
   "/3/movie/{movie_id}",
   "/3/movie/{movie_id}/credits",
   "/3/movie/{movie_id}/recommendations",
+  "/3/movie/{movie_id}/reviews",
   "/3/movie/{movie_id}/videos",
   "/3/movie/{movie_id}/watch/providers",
   "/3/person/{person_id}",
@@ -44,6 +47,7 @@ export const TMDB_ENDPOINTS = [
   "/3/tv/{series_id}",
   "/3/tv/{series_id}/credits",
   "/3/tv/{series_id}/recommendations",
+  "/3/tv/{series_id}/reviews",
   "/3/tv/{series_id}/videos",
   "/3/tv/{series_id}/watch/providers",
 ] as const;

--- a/src/_generated/tmdb-server-functions.ts
+++ b/src/_generated/tmdb-server-functions.ts
@@ -72,6 +72,16 @@ export async function getMovieRecommendations(
   });
 }
 
+export async function getMovieReviews(
+  params: { movie_id: string } & QueryParams<
+    "/3/movie/{movie_id}/reviews",
+    "get"
+  >,
+) {
+  const { movie_id, ...queryParams } = params;
+  return tmdbGet("/3/movie/{movie_id}/reviews", queryParams, { movie_id });
+}
+
 export async function getMovieVideos(
   params: { movie_id: string } & QueryParams<
     "/3/movie/{movie_id}/videos",
@@ -168,6 +178,16 @@ export async function getTvShowRecommendations(
   return tmdbGet("/3/tv/{series_id}/recommendations", queryParams, {
     series_id,
   });
+}
+
+export async function getTvShowReviews(
+  params: { series_id: string } & QueryParams<
+    "/3/tv/{series_id}/reviews",
+    "get"
+  >,
+) {
+  const { series_id, ...queryParams } = params;
+  return tmdbGet("/3/tv/{series_id}/reviews", queryParams, { series_id });
 }
 
 export async function getTvShowVideos(

--- a/src/_generated/tmdbV3.d.ts
+++ b/src/_generated/tmdbV3.d.ts
@@ -7355,58 +7355,71 @@ export interface operations {
         content: {
           "application/json": {
             /**
-             * @default true
+             * @default false
              * @example false
              */
             adult: boolean;
-            /** @example /hZkgoQYus5vegHoetLkCJzb17zJ.jpg */
+            /** @example /2w4xG178RpB4MDAIfTkqAuSJzec.jpg */
             backdrop_path?: string;
-            belongs_to_collection?: unknown;
+            belongs_to_collection?: {
+              /**
+               * @default 0
+               * @example 10
+               */
+              id: number;
+              /** @example Star Wars Collection */
+              name?: string;
+              /** @example /pWVLFh4OuejTpUaDQbB1C4zoS2p.jpg */
+              poster_path?: string;
+              /** @example /iY2ujEY2m68OTTlPFTiHub9joHS.jpg */
+              backdrop_path?: string;
+            };
             /**
              * @default 0
-             * @example 63000000
+             * @example 11000000
              */
             budget: number;
             genres?: {
               /**
                * @default 0
-               * @example 18
+               * @example 12
                */
               id: number;
-              /** @example Drama */
+              /** @example Adventure */
               name?: string;
             }[];
-            /** @example http://www.foxmovies.com/movies/fight-club */
+            /** @example http://www.starwars.com/films/star-wars-episode-iv-a-new-hope */
             homepage?: string;
             /**
              * @default 0
-             * @example 550
+             * @example 11
              */
             id: number;
-            /** @example tt0137523 */
+            /** @example tt0076759 */
             imdb_id?: string;
+            origin_country?: string[];
             /** @example en */
             original_language?: string;
-            /** @example Fight Club */
+            /** @example Star Wars */
             original_title?: string;
-            /** @example A ticking-time-bomb insomniac and a slippery soap salesman channel primal male aggression into a shocking new form of therapy. Their concept catches on, with underground "fight clubs" forming in every town, until an eccentric gets in the way and ignites an out-of-control spiral toward oblivion. */
+            /** @example Princess Leia is captured and held hostage by the evil Imperial forces in their effort to take over the galactic Empire. Venturesome Luke Skywalker and dashing captain Han Solo team together with the loveable robot duo R2-D2 and C-3PO to rescue the beautiful princess and restore peace and justice in the Empire. */
             overview?: string;
             /**
              * @default 0
-             * @example 61.416
+             * @example 20.6912
              */
             popularity: number;
-            /** @example /pB8BM7pdSp6B6Ih7QZ4DrQ3PmJK.jpg */
+            /** @example /6FfCtAuVAW8XJjZ7eWeLibRLWTw.jpg */
             poster_path?: string;
             production_companies?: {
               /**
                * @default 0
-               * @example 508
+               * @example 1
                */
               id: number;
-              /** @example /7cxRWzi4LsVm4Utfpr1hfARNurT.png */
+              /** @example /tlVSws0RvvtPBwViUyOFAO0vcQS.png */
               logo_path?: string;
-              /** @example Regency Enterprises */
+              /** @example Lucasfilm Ltd. */
               name?: string;
               /** @example US */
               origin_country?: string;
@@ -7417,16 +7430,16 @@ export interface operations {
               /** @example United States of America */
               name?: string;
             }[];
-            /** @example 1999-10-15 */
+            /** @example 1977-05-25 */
             release_date?: string;
             /**
              * @default 0
-             * @example 100853753
+             * @example 775398007
              */
             revenue: number;
             /**
              * @default 0
-             * @example 139
+             * @example 121
              */
             runtime: number;
             spoken_languages?: {
@@ -7439,23 +7452,23 @@ export interface operations {
             }[];
             /** @example Released */
             status?: string;
-            /** @example Mischief. Mayhem. Soap. */
+            /** @example A long time ago in a galaxy far, far away... */
             tagline?: string;
-            /** @example Fight Club */
+            /** @example Star Wars */
             title?: string;
             /**
-             * @default true
+             * @default false
              * @example false
              */
             video: boolean;
             /**
              * @default 0
-             * @example 8.433
+             * @example 8.2
              */
             vote_average: number;
             /**
              * @default 0
-             * @example 26280
+             * @example 22061
              */
             vote_count: number;
           };

--- a/src/ai-chat/chat.ts
+++ b/src/ai-chat/chat.ts
@@ -12,6 +12,7 @@ import { createPresentMediaTool } from "./tools/present-media";
 import { createPresentPersonTool } from "./tools/present-person";
 import { createPresentProviderRegionsTool } from "./tools/present-provider-regions";
 import { createPresentWatchProvidersTool } from "./tools/present-watch-providers";
+import { createReviewSummaryTool } from "./tools/review-summary";
 import { createSemanticSearchTool } from "./tools/semantic-search";
 import { createTmdbSearchTool } from "./tools/tmdb-search";
 import { createWatchProvidersTool } from "./tools/watch-providers";
@@ -43,6 +44,7 @@ export async function chat({
       media_credits: createMediaCreditsTool(),
       person_credits: createPersonCreditsTool(),
       present_person: createPresentPersonTool(),
+      review_summary: createReviewSummaryTool(locale),
     },
     providerOptions: contextManagementProviderOptions,
     stopWhen: stepCountIs(5),

--- a/src/ai-chat/system-instructions.md
+++ b/src/ai-chat/system-instructions.md
@@ -33,6 +33,7 @@ Engage in natural conversation about movies and TV shows. You can:
   - **Provider search mode**: Pass `provider_name` (e.g. "Netflix") to `watch_providers` to search across ALL countries at once. Use for questions like "Is X on Netflix?", "Which countries have X on Disney+?". Then call `present_provider_regions` with `{ id, media_type, provider_name }` to display the visual card. Mention the user's own country first if it appears in the results.
 - **Person tools**: When `tmdb_search` returns person results, use `present_person` to display them as profile cards. Use `person_credits` when the user asks about a person's filmography or work history, then use `present_media` to display the resulting films visually
 - **Cast tools**: Use `media_credits` when the user asks who stars in, acts in, or directed a specific movie or TV show. After receiving cast results, use `present_person` to display them as profile cards
+- **Review summaries**: When users ask about reviews, critical reception, or what people think of a movie or TV show, use `review_summary`. Pass the TMDB ID, media type, and title. The `spiciness` parameter controls the tone (1 = neutral/factual, 5 = bold/opinionated) — default to 3 unless the user asks for a specific tone. When the user requests a different spiciness level, call the tool again with the new value. After the tool returns, do **not** repeat or paraphrase the summary — the tool's visual card already displays it. Keep your follow-up text minimal (e.g. a brief observation or question)
 
 ## Boundaries
 

--- a/src/ai-chat/tools/review-summary.test.ts
+++ b/src/ai-chat/tools/review-summary.test.ts
@@ -1,0 +1,333 @@
+import { http, HttpResponse } from "msw";
+import { beforeAll, describe, expect, it } from "vitest";
+import { server } from "#src/test-msw.ts";
+import {
+  createReviewSummaryTool,
+  reviewSummaryInputSchema,
+} from "./review-summary";
+
+beforeAll(() => {
+  process.env.TMDB_API_TOKEN = "test-token";
+  process.env.ANTHROPIC_API_KEY = "test-key";
+});
+
+const TMDB_BASE = "https://api.themoviedb.org";
+const ANTHROPIC_BASE = "https://api.anthropic.com";
+
+function reviewsResponse(
+  id: number,
+  reviews: Array<{
+    author: string;
+    content: string;
+    rating?: number;
+  }>,
+) {
+  return {
+    id,
+    page: 1,
+    total_pages: 1,
+    total_results: reviews.length,
+    results: reviews.map((r, i) => ({
+      author: r.author,
+      author_details: {
+        name: r.author,
+        username: r.author.toLowerCase(),
+        avatar_path: null,
+        rating: r.rating ?? null,
+      },
+      content: r.content,
+      created_at: "2024-01-01T00:00:00.000Z",
+      id: `review-${i}`,
+      updated_at: "2024-01-01T00:00:00.000Z",
+    })),
+  };
+}
+
+function anthropicMessageResponse(text: string) {
+  return {
+    id: "msg_test",
+    type: "message",
+    role: "assistant",
+    content: [{ type: "text", text }],
+    model: "claude-sonnet-4-6",
+    stop_reason: "end_turn",
+    usage: { input_tokens: 100, output_tokens: 50 },
+  };
+}
+
+const executeContext = {
+  toolCallId: "test",
+  messages: [],
+  abortSignal: AbortSignal.timeout(10000),
+};
+
+interface ReviewSummaryResult {
+  id: number;
+  mediaType: string;
+  title: string;
+  spiciness: number;
+  summary: string;
+  reviewCount: number;
+  averageRating: number | null;
+}
+
+async function executeTool(input: {
+  id: number;
+  media_type: "movie" | "tv";
+  title: string;
+  spiciness?: number;
+}) {
+  const tool = createReviewSummaryTool("en");
+  const result = await tool.execute!(input, executeContext);
+  return JSON.parse(JSON.stringify(result)) as ReviewSummaryResult;
+}
+
+describe("reviewSummaryInputSchema", () => {
+  it("accepts valid input with all fields", () => {
+    const result = reviewSummaryInputSchema.parse({
+      id: 550,
+      media_type: "movie",
+      title: "Fight Club",
+      spiciness: 4,
+    });
+    expect(result).toEqual({
+      id: 550,
+      media_type: "movie",
+      title: "Fight Club",
+      spiciness: 4,
+    });
+  });
+
+  it("accepts input without optional spiciness (defaults to 3)", () => {
+    const result = reviewSummaryInputSchema.parse({
+      id: 1399,
+      media_type: "tv",
+      title: "Game of Thrones",
+    });
+    expect(result).toEqual({
+      id: 1399,
+      media_type: "tv",
+      title: "Game of Thrones",
+      spiciness: 3,
+    });
+  });
+
+  it("rejects invalid media_type", () => {
+    expect(() =>
+      reviewSummaryInputSchema.parse({
+        id: 550,
+        media_type: "person",
+        title: "Fight Club",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects spiciness below 1", () => {
+    expect(() =>
+      reviewSummaryInputSchema.parse({
+        id: 550,
+        media_type: "movie",
+        title: "Fight Club",
+        spiciness: 0,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects spiciness above 5", () => {
+    expect(() =>
+      reviewSummaryInputSchema.parse({
+        id: 550,
+        media_type: "movie",
+        title: "Fight Club",
+        spiciness: 6,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects non-integer spiciness", () => {
+    expect(() =>
+      reviewSummaryInputSchema.parse({
+        id: 550,
+        media_type: "movie",
+        title: "Fight Club",
+        spiciness: 2.5,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects missing title", () => {
+    expect(() =>
+      reviewSummaryInputSchema.parse({
+        id: 550,
+        media_type: "movie",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("createReviewSummaryTool", () => {
+  it("returns a tool with description and inputSchema", () => {
+    const tool = createReviewSummaryTool("en");
+    expect(tool.description).toBeDefined();
+    expect(tool.description).toContain("review");
+    expect(tool.inputSchema).toBeDefined();
+  });
+
+  it("returns a tool with an execute function", () => {
+    const tool = createReviewSummaryTool("en");
+    expect(tool.execute).toBeDefined();
+    expect(typeof tool.execute).toBe("function");
+  });
+});
+
+describe("review summary execute", () => {
+  it("returns summary for a movie with reviews", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/reviews`, () =>
+        HttpResponse.json(
+          reviewsResponse(550, [
+            {
+              author: "Reviewer1",
+              content: "A masterpiece of modern cinema.",
+              rating: 9,
+            },
+            {
+              author: "Reviewer2",
+              content: "Thought-provoking and beautifully directed.",
+              rating: 8,
+            },
+          ]),
+        ),
+      ),
+      http.post(`${ANTHROPIC_BASE}/v1/messages`, () =>
+        HttpResponse.json(
+          anthropicMessageResponse(
+            "An overwhelmingly positive reception, praised for its direction and thought-provoking narrative.",
+          ),
+        ),
+      ),
+    );
+
+    const result = await executeTool({
+      id: 550,
+      media_type: "movie",
+      title: "Fight Club",
+      spiciness: 3,
+    });
+
+    expect(result.id).toBe(550);
+    expect(result.mediaType).toBe("movie");
+    expect(result.title).toBe("Fight Club");
+    expect(result.spiciness).toBe(3);
+    expect(result.summary).toContain("positive");
+    expect(result.reviewCount).toBe(2);
+    expect(result.averageRating).toBe(8.5);
+  });
+
+  it("returns summary for a TV show", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/tv/1399/reviews`, () =>
+        HttpResponse.json(
+          reviewsResponse(1399, [
+            {
+              author: "Reviewer1",
+              content: "Best TV series ever made.",
+              rating: 10,
+            },
+          ]),
+        ),
+      ),
+      http.post(`${ANTHROPIC_BASE}/v1/messages`, () =>
+        HttpResponse.json(
+          anthropicMessageResponse("Widely regarded as one of the best."),
+        ),
+      ),
+    );
+
+    const result = await executeTool({
+      id: 1399,
+      media_type: "tv",
+      title: "Game of Thrones",
+    });
+
+    expect(result.id).toBe(1399);
+    expect(result.mediaType).toBe("tv");
+    expect(result.reviewCount).toBe(1);
+    expect(result.averageRating).toBe(10);
+  });
+
+  it("handles no reviews gracefully", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/999999/reviews`, () =>
+        HttpResponse.json({
+          id: 999999,
+          page: 1,
+          total_pages: 0,
+          total_results: 0,
+          results: [],
+        }),
+      ),
+    );
+
+    const result = await executeTool({
+      id: 999999,
+      media_type: "movie",
+      title: "Unknown Movie",
+    });
+
+    expect(result.reviewCount).toBe(0);
+    expect(result.averageRating).toBeNull();
+    expect(result.summary).toContain("Unknown Movie");
+  });
+
+  it("returns null averageRating when reviews have no ratings", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/reviews`, () =>
+        HttpResponse.json(
+          reviewsResponse(550, [
+            { author: "Reviewer1", content: "Great movie!" },
+            { author: "Reviewer2", content: "Loved it." },
+          ]),
+        ),
+      ),
+      http.post(`${ANTHROPIC_BASE}/v1/messages`, () =>
+        HttpResponse.json(
+          anthropicMessageResponse("Generally positive reception."),
+        ),
+      ),
+    );
+
+    const result = await executeTool({
+      id: 550,
+      media_type: "movie",
+      title: "Fight Club",
+    });
+
+    expect(result.averageRating).toBeNull();
+    expect(result.reviewCount).toBe(2);
+  });
+
+  it("passes spiciness through to the result", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/reviews`, () =>
+        HttpResponse.json(
+          reviewsResponse(550, [
+            { author: "R1", content: "Awesome!", rating: 9 },
+          ]),
+        ),
+      ),
+      http.post(`${ANTHROPIC_BASE}/v1/messages`, () =>
+        HttpResponse.json(anthropicMessageResponse("A wild ride of a movie!")),
+      ),
+    );
+
+    const result = await executeTool({
+      id: 550,
+      media_type: "movie",
+      title: "Fight Club",
+      spiciness: 5,
+    });
+
+    expect(result.spiciness).toBe(5);
+  });
+});

--- a/src/ai-chat/tools/review-summary.ts
+++ b/src/ai-chat/tools/review-summary.ts
@@ -1,0 +1,199 @@
+import { generateText, tool } from "ai";
+import { z } from "zod";
+import {
+  getMovieReviews,
+  getTvShowReviews,
+} from "#src/_generated/tmdb-server-functions.ts";
+import type { SupportedLocale } from "#src/types.ts";
+import { isRecord } from "#src/utils/type-guards.ts";
+import { getAnthropicModel } from "../client";
+
+export const reviewSummaryInputSchema = z.object({
+  id: z.number().describe("The TMDB ID of the movie or TV show."),
+  media_type: z.enum(["movie", "tv"]).describe('Either "movie" or "tv".'),
+  title: z
+    .string()
+    .describe("The title of the movie or TV show, for display purposes."),
+  spiciness: z
+    .number()
+    .int()
+    .min(1)
+    .max(5)
+    .default(3)
+    .describe(
+      "Tone level for the summary. " +
+        "1 = neutral and factual, 3 = balanced with personality, " +
+        "5 = bold, opinionated, and entertaining. Defaults to 3.",
+    ),
+});
+
+const TOOL_DESCRIPTION =
+  "Fetch user reviews for a movie or TV show and generate an AI summary " +
+  "with adjustable tone. Use when users ask about reviews, critical reception, " +
+  "or what people think of a title. The spiciness parameter controls the tone " +
+  "(1 = neutral, 5 = bold/opinionated).";
+
+const MAX_REVIEWS = 20;
+const MAX_REVIEW_LENGTH = 500;
+
+interface ReviewEntry {
+  author: string;
+  content: string;
+  rating: number | null;
+}
+
+function extractReviews(results: unknown): ReviewEntry[] {
+  if (!Array.isArray(results)) return [];
+  const reviews: ReviewEntry[] = [];
+  for (const raw of results) {
+    if (!isRecord(raw)) continue;
+    const content = typeof raw.content === "string" ? raw.content : "";
+    if (content.length === 0) continue;
+
+    let rating: number | null = null;
+    if (isRecord(raw.author_details)) {
+      const r = raw.author_details.rating;
+      if (typeof r === "number" && r > 0) {
+        rating = r;
+      }
+    }
+
+    reviews.push({
+      author: typeof raw.author === "string" ? raw.author : "Anonymous",
+      content:
+        content.length > MAX_REVIEW_LENGTH
+          ? content.slice(0, MAX_REVIEW_LENGTH) + "…"
+          : content,
+      rating,
+    });
+
+    if (reviews.length >= MAX_REVIEWS) break;
+  }
+  return reviews;
+}
+
+function computeAverageRating(reviews: ReadonlyArray<ReviewEntry>) {
+  const rated = reviews.filter((r) => r.rating !== null);
+  if (rated.length === 0) return null;
+  const sum = rated.reduce((acc, r) => acc + (r.rating ?? 0), 0);
+  return Math.round((sum / rated.length) * 10) / 10;
+}
+
+function getSpicinessInstruction(spiciness: number): string {
+  if (spiciness <= 1) {
+    return "Write a balanced, neutral summary that focuses on factual consensus. Be objective and measured like a professional film critic.";
+  }
+  if (spiciness <= 2) {
+    return "Write a mostly neutral summary with occasional personality. Stay close to the facts but allow some dry wit.";
+  }
+  if (spiciness <= 3) {
+    return "Write an engaging summary that captures the range of opinions with personality. Be conversational and let your voice show through.";
+  }
+  if (spiciness <= 4) {
+    return "Write a lively, opinionated summary with strong takes. Be snarky and entertaining — playfully roast the film's weaknesses while acknowledging what works.";
+  }
+  return (
+    "Write in the style of an Honest Trailers narrator: sarcastically affectionate, hyperbolic, mock-dramatic. " +
+    "Roast the movie lovingly. Use dramatic pauses (dashes, ellipses), rhetorical questions, and over-the-top descriptions. " +
+    "Acknowledge what fans love while mercilessly pointing out the ridiculous parts."
+  );
+}
+
+function buildSummarizationPrompt(
+  title: string,
+  reviews: ReadonlyArray<ReviewEntry>,
+  spiciness: number,
+  locale: SupportedLocale,
+): string {
+  const reviewBlock = reviews
+    .map((r) => {
+      const ratingStr = r.rating !== null ? ` [${r.rating}/10]` : "";
+      return `- ${r.author}${ratingStr}: ${r.content}`;
+    })
+    .join("\n");
+
+  const languageInstruction =
+    locale === "zh" ? "Respond entirely in Chinese." : "Respond in English.";
+
+  return [
+    `Summarize user reviews for "${title}".`,
+    "",
+    getSpicinessInstruction(spiciness),
+    languageInstruction,
+    "",
+    "Keep the summary concise (2-4 sentences). Do not use markdown formatting.",
+    "Do not mention specific reviewer names. Focus on the overall sentiment and key themes.",
+    "",
+    "Reviews:",
+    reviewBlock,
+  ].join("\n");
+}
+
+interface ReviewSummaryResult {
+  id: number;
+  mediaType: "movie" | "tv";
+  title: string;
+  spiciness: number;
+  summary: string;
+  reviewCount: number;
+  averageRating: number | null;
+}
+
+export function createReviewSummaryTool(locale: SupportedLocale) {
+  return tool({
+    description: TOOL_DESCRIPTION,
+    inputSchema: reviewSummaryInputSchema,
+    execute: async (
+      { id, media_type, title, spiciness },
+      { abortSignal },
+    ): Promise<ReviewSummaryResult> => {
+      const idString = id.toString();
+      const response =
+        media_type === "tv"
+          ? await getTvShowReviews({ series_id: idString })
+          : await getMovieReviews({ movie_id: idString });
+
+      const reviews = extractReviews(response.results);
+
+      if (reviews.length === 0) {
+        const noReviewMessage =
+          locale === "zh"
+            ? `目前还没有关于"${title}"的用户评论。`
+            : `No user reviews are available for "${title}" yet.`;
+        return {
+          id,
+          mediaType: media_type,
+          title,
+          spiciness,
+          summary: noReviewMessage,
+          reviewCount: 0,
+          averageRating: null,
+        };
+      }
+
+      const averageRating = computeAverageRating(reviews);
+      const prompt = buildSummarizationPrompt(
+        title,
+        reviews,
+        spiciness,
+        locale,
+      );
+
+      const { text } = await generateText({
+        model: getAnthropicModel(),
+        prompt,
+        abortSignal,
+      });
+
+      return {
+        id,
+        mediaType: media_type,
+        title,
+        spiciness,
+        summary: text,
+        reviewCount: reviews.length,
+        averageRating,
+      };
+    },
+  });
+}

--- a/src/app/api/ai-chat/route.test.ts
+++ b/src/app/api/ai-chat/route.test.ts
@@ -7,6 +7,7 @@ import { createMediaCreditsTool } from "#src/ai-chat/tools/media-credits.ts";
 import { createPersonCreditsTool } from "#src/ai-chat/tools/person-credits.ts";
 import { createPresentMediaTool } from "#src/ai-chat/tools/present-media.ts";
 import { createPresentPersonTool } from "#src/ai-chat/tools/present-person.ts";
+import { createReviewSummaryTool } from "#src/ai-chat/tools/review-summary.ts";
 import { createSemanticSearchTool } from "#src/ai-chat/tools/semantic-search.ts";
 import { createTmdbSearchTool } from "#src/ai-chat/tools/tmdb-search.ts";
 import { createWatchProvidersTool } from "#src/ai-chat/tools/watch-providers.ts";
@@ -72,6 +73,7 @@ function mockStreamResult() {
       media_credits: createMediaCreditsTool(),
       person_credits: createPersonCreditsTool(),
       present_person: createPresentPersonTool(),
+      review_summary: createReviewSummaryTool("en"),
     },
     stopWhen: stepCountIs(5),
   });

--- a/src/components/ai-chat/chat-message-list.tsx
+++ b/src/components/ai-chat/chat-message-list.tsx
@@ -74,6 +74,9 @@ export function ChatMessageList({
 
   const lastMessageRole =
     messages.length > 0 ? messages[messages.length - 1]?.role : undefined;
+  const lastAssistantIndex = messages.findLastIndex(
+    (m) => m.role === "assistant",
+  );
 
   useEffect(() => {
     if (messages.length === 0) return;
@@ -105,6 +108,9 @@ export function ChatMessageList({
                 status === "streaming" &&
                 message.role === "assistant" &&
                 index === messages.length - 1
+              }
+              isLastAssistantMessage={
+                message.role === "assistant" && index === lastAssistantIndex
               }
             />
           ))}

--- a/src/components/ai-chat/chat-message.tsx
+++ b/src/components/ai-chat/chat-message.tsx
@@ -25,11 +25,13 @@ import type { WatchProviderOutput } from "./tool-watch-providers";
 interface ChatMessageProps {
   message: UIMessage;
   isStreaming?: boolean;
+  isLastAssistantMessage?: boolean;
 }
 
 export function ChatMessage({
   message,
   isStreaming = false,
+  isLastAssistantMessage = false,
 }: ChatMessageProps) {
   const isUser = message.role === "user";
 
@@ -88,7 +90,8 @@ export function ChatMessage({
             toolName === "present_media" ||
             toolName === "present_watch_providers" ||
             toolName === "present_provider_regions" ||
-            toolName === "present_person";
+            toolName === "present_person" ||
+            toolName === "review_summary";
 
           if (!isFirstTool && !hasVisualOutput) return null;
 
@@ -111,6 +114,7 @@ export function ChatMessage({
                   searchResultsMap={searchResultsMap}
                   personResultsMap={personResultsMap}
                   watchProvidersMap={watchProvidersMap}
+                  isLastAssistantMessage={isLastAssistantMessage}
                 />
               )}
             </div>

--- a/src/components/ai-chat/tool-activity-line.test.tsx
+++ b/src/components/ai-chat/tool-activity-line.test.tsx
@@ -48,6 +48,22 @@ describe("ToolActivityLine", () => {
       expect(screen.getByText("Watch Providers")).toBeInTheDocument();
     });
 
+    it("maps review_summary to Review Summary", () => {
+      render(
+        <ToolActivityLine
+          toolName="review_summary"
+          state="output-available"
+          input={{
+            id: 550,
+            media_type: "movie",
+            title: "Fight Club",
+            spiciness: 3,
+          }}
+        />,
+      );
+      expect(screen.getByText("Review Summary")).toBeInTheDocument();
+    });
+
     it("shows raw name for unknown tools", () => {
       render(
         <ToolActivityLine
@@ -161,6 +177,22 @@ describe("ToolActivityLine", () => {
         />,
       );
       expect(screen.getByText("GB")).toBeInTheDocument();
+    });
+
+    it("shows title for review_summary", () => {
+      render(
+        <ToolActivityLine
+          toolName="review_summary"
+          state="output-available"
+          input={{
+            id: 550,
+            media_type: "movie",
+            title: "Fight Club",
+            spiciness: 3,
+          }}
+        />,
+      );
+      expect(screen.getByText("Fight Club")).toBeInTheDocument();
     });
 
     it("omits summary for unknown tools", () => {

--- a/src/components/ai-chat/tool-activity-line.tsx
+++ b/src/components/ai-chat/tool-activity-line.tsx
@@ -94,6 +94,9 @@ export function ToolActivityLine({
     case "present_provider_regions":
       label = t({ en: "Presenting Regions", zh: "展示地区" });
       break;
+    case "review_summary":
+      label = t({ en: "Review Summary", zh: "评论摘要" });
+      break;
     default:
       label = toolName;
   }
@@ -132,6 +135,13 @@ export function ToolActivityLine({
   } else if (toolName === "present_provider_regions") {
     if (isRecord(input) && typeof input.provider_name === "string") {
       summary = input.provider_name;
+    }
+  } else if (toolName === "review_summary") {
+    if (isRecord(input) && typeof input.title === "string") {
+      summary =
+        input.title.length > MAX_SUMMARY_LENGTH
+          ? `${input.title.slice(0, MAX_SUMMARY_LENGTH)}…`
+          : input.title;
     }
   }
 

--- a/src/components/ai-chat/tool-review-summary-skeleton.tsx
+++ b/src/components/ai-chat/tool-review-summary-skeleton.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { border, color, space } from "#src/tokens.stylex.ts";
+import { Skeleton } from "../shared/skeleton";
+
+const STAGGER_DELAY = 80;
+
+export function ToolReviewSummarySkeleton() {
+  return (
+    <div css={styles.card}>
+      <div css={styles.headerRow}>
+        <Skeleton width={110} height={14} delay={0 * STAGGER_DELAY} />
+        <Skeleton width={70} height={18} delay={1 * STAGGER_DELAY} />
+      </div>
+      <div css={styles.summaryLines}>
+        <Skeleton fill height={14} delay={2 * STAGGER_DELAY} />
+        <Skeleton fill height={14} delay={3 * STAGGER_DELAY} />
+        <Skeleton width={200} height={14} delay={4 * STAGGER_DELAY} />
+      </div>
+      <div css={styles.buttonsArea}>
+        {Array.from({ length: 5 }, (_, i) => (
+          <Skeleton
+            key={i}
+            width={40}
+            height={36}
+            delay={(5 + i) * STAGGER_DELAY}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  card: {
+    backgroundColor: color.backgroundHover,
+    borderRadius: border.radius_2,
+    padding: space._3,
+    marginTop: space._2,
+  },
+  headerRow: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: space._2,
+  },
+  summaryLines: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space._1,
+  },
+  buttonsArea: {
+    display: "flex",
+    justifyContent: "center",
+    gap: space._1,
+    marginTop: space._3,
+    paddingTop: space._2,
+    borderTopWidth: border.size_1,
+    borderTopStyle: "solid",
+    borderTopColor: color.border,
+  },
+});

--- a/src/components/ai-chat/tool-review-summary.test.tsx
+++ b/src/components/ai-chat/tool-review-summary.test.tsx
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "#src/test-utils.tsx";
+import { ChatActionsContext } from "./chat-actions-context";
+import {
+  parseReviewSummaryOutput,
+  ToolReviewSummary,
+} from "./tool-review-summary";
+
+function makeReviewData(
+  overrides: Partial<Parameters<typeof ToolReviewSummary>[0]["data"]> = {},
+) {
+  return {
+    id: 550,
+    mediaType: "movie" as const,
+    title: "Fight Club",
+    spiciness: 3,
+    summary: "A thrilling and thought-provoking film that divided critics.",
+    reviewCount: 15,
+    averageRating: 8.2,
+    ...overrides,
+  };
+}
+
+const mockActions = {
+  sendMessage: () => {},
+  attachedMedia: null,
+  setAttachedMedia: () => {},
+};
+
+function renderWithActions(ui: React.ReactNode) {
+  return render(
+    <ChatActionsContext value={mockActions}>{ui}</ChatActionsContext>,
+  );
+}
+
+describe("ToolReviewSummary", () => {
+  it("renders summary text", () => {
+    renderWithActions(
+      <ToolReviewSummary data={makeReviewData()} isInteractive />,
+    );
+
+    expect(
+      screen.getByText(
+        "A thrilling and thought-provoking film that divided critics.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders review count", () => {
+    renderWithActions(
+      <ToolReviewSummary data={makeReviewData()} isInteractive />,
+    );
+
+    expect(screen.getByText(/15/)).toBeInTheDocument();
+    expect(screen.getByText(/reviews/)).toBeInTheDocument();
+  });
+
+  it("renders singular review count", () => {
+    renderWithActions(
+      <ToolReviewSummary
+        data={makeReviewData({ reviewCount: 1 })}
+        isInteractive
+      />,
+    );
+
+    expect(screen.getByText("1 review")).toBeInTheDocument();
+  });
+
+  it("renders average rating when available", () => {
+    renderWithActions(
+      <ToolReviewSummary data={makeReviewData()} isInteractive />,
+    );
+
+    expect(screen.getByText(/8\.2/)).toBeInTheDocument();
+  });
+
+  it("omits average rating when null", () => {
+    renderWithActions(
+      <ToolReviewSummary
+        data={makeReviewData({ averageRating: null })}
+        isInteractive
+      />,
+    );
+
+    expect(screen.queryByText("★")).not.toBeInTheDocument();
+  });
+
+  it("renders spiciness buttons when interactive", () => {
+    renderWithActions(
+      <ToolReviewSummary data={makeReviewData()} isInteractive />,
+    );
+
+    expect(screen.getByRole("button", { name: "Mild" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Balanced" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Fire" })).toBeInTheDocument();
+  });
+
+  it("hides spiciness buttons when not interactive", () => {
+    renderWithActions(
+      <ToolReviewSummary data={makeReviewData()} isInteractive={false} />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Mild" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders header text", () => {
+    renderWithActions(
+      <ToolReviewSummary data={makeReviewData()} isInteractive />,
+    );
+
+    expect(screen.getByText("Review Summary")).toBeInTheDocument();
+  });
+});
+
+describe("parseReviewSummaryOutput", () => {
+  it("parses valid output", () => {
+    const output = {
+      id: 550,
+      mediaType: "movie",
+      title: "Fight Club",
+      spiciness: 3,
+      summary: "Great movie.",
+      reviewCount: 10,
+      averageRating: 8.5,
+    };
+    const result = parseReviewSummaryOutput(output);
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe(550);
+    expect(result?.summary).toBe("Great movie.");
+    expect(result?.averageRating).toBe(8.5);
+  });
+
+  it("handles null averageRating", () => {
+    const output = {
+      id: 550,
+      mediaType: "movie",
+      title: "Fight Club",
+      spiciness: 3,
+      summary: "Great movie.",
+      reviewCount: 0,
+      averageRating: null,
+    };
+    const result = parseReviewSummaryOutput(output);
+    expect(result).not.toBeNull();
+    expect(result?.averageRating).toBeNull();
+  });
+
+  it("returns null for invalid output", () => {
+    expect(parseReviewSummaryOutput(null)).toBeNull();
+    expect(parseReviewSummaryOutput(undefined)).toBeNull();
+    expect(parseReviewSummaryOutput("string")).toBeNull();
+    expect(parseReviewSummaryOutput({ id: "not-a-number" })).toBeNull();
+  });
+
+  it("rejects invalid mediaType", () => {
+    const output = {
+      id: 550,
+      mediaType: "person",
+      title: "Fight Club",
+      spiciness: 3,
+      summary: "Great movie.",
+      reviewCount: 10,
+      averageRating: 8.5,
+    };
+    expect(parseReviewSummaryOutput(output)).toBeNull();
+  });
+
+  it("rejects missing summary", () => {
+    const output = {
+      id: 550,
+      mediaType: "movie",
+      title: "Fight Club",
+      spiciness: 3,
+      reviewCount: 10,
+      averageRating: 8.5,
+    };
+    expect(parseReviewSummaryOutput(output)).toBeNull();
+  });
+
+  it("rejects missing title", () => {
+    const output = {
+      id: 550,
+      mediaType: "movie",
+      spiciness: 3,
+      summary: "Great movie.",
+      reviewCount: 10,
+      averageRating: 8.5,
+    };
+    expect(parseReviewSummaryOutput(output)).toBeNull();
+  });
+});

--- a/src/components/ai-chat/tool-review-summary.tsx
+++ b/src/components/ai-chat/tool-review-summary.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { ArrowUpIcon } from "@phosphor-icons/react/dist/ssr/ArrowUp";
+import { CoffeeIcon } from "@phosphor-icons/react/dist/ssr/Coffee";
+import { LightningIcon } from "@phosphor-icons/react/dist/ssr/Lightning";
+import { PepperIcon } from "@phosphor-icons/react/dist/ssr/Pepper";
+import { ScalesIcon } from "@phosphor-icons/react/dist/ssr/Scales";
+import { SmileyWinkIcon } from "@phosphor-icons/react/dist/ssr/SmileyWink";
+import * as stylex from "@stylexjs/stylex";
+import type { ComponentType } from "react";
+import { useState } from "react";
+import { useLocale } from "#src/hooks/use-locale.ts";
+import { t } from "#src/i18n.ts";
+import { flex } from "#src/primitives/flex.stylex.ts";
+import { buttonReset } from "#src/primitives/reset.stylex.ts";
+import { border, color, font, space } from "#src/tokens.stylex.ts";
+import { isRecord } from "#src/utils/type-guards.ts";
+import { useChatActions } from "./chat-actions-context";
+
+interface ReviewSummaryData {
+  id: number;
+  mediaType: "movie" | "tv";
+  title: string;
+  spiciness: number;
+  summary: string;
+  reviewCount: number;
+  averageRating: number | null;
+}
+
+export function parseReviewSummaryOutput(
+  output: unknown,
+): ReviewSummaryData | null {
+  if (!isRecord(output)) return null;
+  if (typeof output.id !== "number") return null;
+  if (output.mediaType !== "movie" && output.mediaType !== "tv") return null;
+  if (typeof output.title !== "string") return null;
+  if (typeof output.spiciness !== "number") return null;
+  if (typeof output.summary !== "string") return null;
+  if (typeof output.reviewCount !== "number") return null;
+
+  const averageRating =
+    typeof output.averageRating === "number" ? output.averageRating : null;
+
+  return {
+    id: output.id,
+    mediaType: output.mediaType,
+    title: output.title,
+    spiciness: output.spiciness,
+    summary: output.summary,
+    reviewCount: output.reviewCount,
+    averageRating,
+  };
+}
+
+interface IconProps {
+  size: number;
+  weight: "regular" | "fill" | "bold";
+  "aria-hidden": boolean;
+}
+
+const ICON_SIZE = 18;
+
+const LEVEL_ICONS: ReadonlyArray<{
+  level: number;
+  Icon: ComponentType<IconProps>;
+}> = [
+  { level: 1, Icon: ScalesIcon },
+  { level: 2, Icon: CoffeeIcon },
+  { level: 3, Icon: SmileyWinkIcon },
+  { level: 4, Icon: LightningIcon },
+  { level: 5, Icon: PepperIcon },
+];
+
+interface ToolReviewSummaryProps {
+  data: ReviewSummaryData;
+  isInteractive: boolean;
+}
+
+export function ToolReviewSummary({
+  data,
+  isInteractive,
+}: ToolReviewSummaryProps) {
+  const { sendMessage } = useChatActions();
+  const locale = useLocale();
+  const [selectedLevel, setSelectedLevel] = useState<number | null>(null);
+
+  const spicinessLabels: Record<number, string> = {
+    1: t({ en: "Mild", zh: "温和" }),
+    2: t({ en: "Chill", zh: "平淡" }),
+    3: t({ en: "Balanced", zh: "适中" }),
+    4: t({ en: "Spicy", zh: "辛辣" }),
+    5: t({ en: "Fire", zh: "火辣" }),
+  };
+
+  function handleTap(level: number) {
+    if (!isInteractive || level === data.spiciness) return;
+    if (selectedLevel === level) {
+      setSelectedLevel(null);
+      const message =
+        locale === "zh"
+          ? `用辣度 ${level} 重新总结"${data.title}"的评论`
+          : `Summarize reviews for "${data.title}" with spiciness level ${level}`;
+      sendMessage(message);
+    } else {
+      setSelectedLevel(level);
+    }
+  }
+
+  return (
+    <div css={styles.card}>
+      <div css={[flex.between, styles.header]}>
+        <span css={styles.title}>
+          {t({ en: "Review Summary", zh: "评论摘要" })}
+        </span>
+        <div css={[flex.row, styles.badges]}>
+          {data.averageRating !== null && (
+            <span css={styles.ratingBadge}>
+              {"★ "}
+              {data.averageRating}
+            </span>
+          )}
+          <span css={styles.countBadge}>
+            {data.reviewCount === 1
+              ? t({ en: "1 review", zh: "1 条评论" })
+              : `${data.reviewCount} ${t({ en: "reviews", zh: "条评论" })}`}
+          </span>
+        </div>
+      </div>
+
+      <p css={styles.summary}>{data.summary}</p>
+
+      {isInteractive && (
+        <div css={styles.controlSection}>
+          <div css={[flex.row, styles.levelButtons]}>
+            {LEVEL_ICONS.map(({ level, Icon }) => {
+              const isCurrent = level === data.spiciness;
+              const isSelected = level === selectedLevel;
+              return (
+                <button
+                  key={level}
+                  type="button"
+                  css={[
+                    buttonReset.base,
+                    styles.levelButton,
+                    isCurrent && styles.levelButtonCurrent,
+                    isSelected && styles.levelButtonSelected,
+                  ]}
+                  onClick={() => handleTap(level)}
+                  aria-label={spicinessLabels[level]}
+                  aria-pressed={isCurrent}
+                >
+                  {isSelected ? (
+                    <ArrowUpIcon
+                      size={ICON_SIZE}
+                      weight="bold"
+                      aria-hidden={true}
+                    />
+                  ) : (
+                    <Icon
+                      size={ICON_SIZE}
+                      weight={isCurrent ? "fill" : "regular"}
+                      aria-hidden={true}
+                    />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+          {selectedLevel !== null && (
+            <p css={styles.selectedLabel}>{spicinessLabels[selectedLevel]}</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  card: {
+    backgroundColor: color.backgroundHover,
+    borderRadius: border.radius_2,
+    padding: space._3,
+    marginTop: space._2,
+  },
+  header: {
+    marginBottom: space._2,
+  },
+  title: {
+    fontSize: font.uiBodySmall,
+    fontWeight: font.weight_6,
+  },
+  badges: {
+    gap: space._1,
+  },
+  ratingBadge: {
+    fontSize: font.uiBodySmall,
+    fontWeight: font.weight_5,
+    color: color.textMuted,
+  },
+  countBadge: {
+    fontSize: font.uiBodySmall,
+    fontWeight: font.weight_5,
+    color: color.textMuted,
+    backgroundColor: color.backgroundRaised,
+    borderRadius: border.radius_1,
+    paddingInline: space._1,
+    paddingBlock: space._00,
+  },
+  summary: {
+    margin: 0,
+    fontSize: font.uiBody,
+    lineHeight: font.lineHeight_4,
+    whiteSpace: "pre-wrap",
+  },
+  controlSection: {
+    marginTop: space._3,
+    paddingTop: space._2,
+    borderTopWidth: border.size_1,
+    borderTopStyle: "solid",
+    borderTopColor: color.border,
+  },
+  levelButtons: {
+    gap: space._1,
+    justifyContent: "center",
+    flexWrap: "wrap",
+  },
+  levelButton: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: space._00,
+    paddingBlock: space._1,
+    paddingInline: space._2,
+    borderRadius: border.radius_2,
+    borderWidth: border.size_1,
+    borderStyle: "solid",
+    borderColor: "transparent",
+    color: color.textMuted,
+    fontSize: font.uiBodySmall,
+    transition:
+      "background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease",
+  },
+  levelButtonCurrent: {
+    backgroundColor: color.controlActive,
+    color: color.textOnActive,
+    borderColor: color.controlActive,
+  },
+  levelButtonSelected: {
+    borderColor: color.controlActive,
+    color: color.controlActive,
+    backgroundColor: color.backgroundMain,
+  },
+  selectedLabel: {
+    margin: 0,
+    marginTop: space._1,
+    fontSize: font.uiBodySmall,
+    color: color.textMuted,
+    textAlign: "center",
+  },
+});

--- a/src/components/ai-chat/tool-visual-output.test.tsx
+++ b/src/components/ai-chat/tool-visual-output.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { render, screen } from "#src/test-utils.tsx";
 import type { MediaListItem, PersonListItem } from "#src/utils/types.ts";
+import { ChatActionsContext } from "./chat-actions-context";
 import { MediaDetailProvider } from "./media-detail-context";
 import { ToolVisualOutput } from "./tool-visual-output";
 import type { WatchProviderOutput } from "./tool-watch-providers";
@@ -420,6 +421,129 @@ describe("ToolVisualOutput", () => {
             watchProvidersMap={emptyWpMap}
           />
         </MediaDetailProvider>,
+      );
+
+      expect(container.innerHTML).toBe("");
+    });
+  });
+
+  describe("review_summary", () => {
+    const mockActions = {
+      sendMessage: () => {},
+      attachedMedia: null,
+      setAttachedMedia: () => {},
+    };
+
+    it("renders skeleton for input-streaming", () => {
+      const { container } = render(
+        <ChatActionsContext value={mockActions}>
+          <ToolVisualOutput
+            toolName="review_summary"
+            state="input-streaming"
+            input={undefined}
+            searchResultsMap={emptyMap}
+            personResultsMap={emptyPersonMap}
+            watchProvidersMap={emptyWpMap}
+          />
+        </ChatActionsContext>,
+      );
+
+      expect(container.innerHTML).not.toBe("");
+    });
+
+    it("renders skeleton for input-available", () => {
+      const { container } = render(
+        <ChatActionsContext value={mockActions}>
+          <ToolVisualOutput
+            toolName="review_summary"
+            state="input-available"
+            input={{
+              id: 550,
+              media_type: "movie",
+              title: "Fight Club",
+              spiciness: 3,
+            }}
+            searchResultsMap={emptyMap}
+            personResultsMap={emptyPersonMap}
+            watchProvidersMap={emptyWpMap}
+          />
+        </ChatActionsContext>,
+      );
+
+      expect(container.innerHTML).not.toBe("");
+    });
+
+    it("renders card for output-available", () => {
+      render(
+        <ChatActionsContext value={mockActions}>
+          <ToolVisualOutput
+            toolName="review_summary"
+            state="output-available"
+            input={{
+              id: 550,
+              media_type: "movie",
+              title: "Fight Club",
+              spiciness: 3,
+            }}
+            output={{
+              id: 550,
+              mediaType: "movie",
+              title: "Fight Club",
+              spiciness: 3,
+              summary: "A mind-bending thriller.",
+              reviewCount: 10,
+              averageRating: 8.5,
+            }}
+            searchResultsMap={emptyMap}
+            personResultsMap={emptyPersonMap}
+            watchProvidersMap={emptyWpMap}
+            isLastAssistantMessage
+          />
+        </ChatActionsContext>,
+      );
+
+      expect(screen.getByText("Review Summary")).toBeInTheDocument();
+      expect(screen.getByText("A mind-bending thriller.")).toBeInTheDocument();
+    });
+
+    it("shows error for output-error", () => {
+      render(
+        <ToolVisualOutput
+          toolName="review_summary"
+          state="output-error"
+          input={{
+            id: 550,
+            media_type: "movie",
+            title: "Fight Club",
+            spiciness: 3,
+          }}
+          searchResultsMap={emptyMap}
+          personResultsMap={emptyPersonMap}
+          watchProvidersMap={emptyWpMap}
+        />,
+      );
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    it("returns null for invalid output", () => {
+      const { container } = render(
+        <ChatActionsContext value={mockActions}>
+          <ToolVisualOutput
+            toolName="review_summary"
+            state="output-available"
+            input={{
+              id: 550,
+              media_type: "movie",
+              title: "Fight Club",
+              spiciness: 3,
+            }}
+            output={{ invalid: true }}
+            searchResultsMap={emptyMap}
+            personResultsMap={emptyPersonMap}
+            watchProvidersMap={emptyWpMap}
+          />
+        </ChatActionsContext>,
       );
 
       expect(container.innerHTML).toBe("");

--- a/src/components/ai-chat/tool-visual-output.tsx
+++ b/src/components/ai-chat/tool-visual-output.tsx
@@ -13,6 +13,11 @@ import {
 import { ToolMediaCards } from "./tool-media-cards";
 import { ToolMediaCardsSkeleton } from "./tool-media-cards-skeleton";
 import { ToolPersonCards } from "./tool-person-cards";
+import {
+  parseReviewSummaryOutput,
+  ToolReviewSummary,
+} from "./tool-review-summary";
+import { ToolReviewSummarySkeleton } from "./tool-review-summary-skeleton";
 import type { WatchProviderOutput } from "./tool-watch-providers";
 import { ToolWatchProviders } from "./tool-watch-providers";
 import { ToolWatchProvidersSkeleton } from "./tool-watch-providers-skeleton";
@@ -25,15 +30,18 @@ interface ToolVisualOutputProps {
   searchResultsMap: ReadonlyMap<string, MediaListItem>;
   personResultsMap: ReadonlyMap<number, PersonListItem>;
   watchProvidersMap: ReadonlyMap<string, WatchProviderOutput>;
+  isLastAssistantMessage?: boolean;
 }
 
 export function ToolVisualOutput({
   toolName,
   state,
   input,
+  output,
   searchResultsMap,
   personResultsMap,
   watchProvidersMap,
+  isLastAssistantMessage = false,
 }: ToolVisualOutputProps) {
   if (toolName === "present_media") {
     if (state === "output-error") {
@@ -105,6 +113,33 @@ export function ToolVisualOutput({
           : resolveProviderRegions(input, watchProvidersMap);
       if (!data) return null;
       return <ToolWatchProviders data={data} />;
+    }
+
+    return null;
+  }
+
+  if (toolName === "review_summary") {
+    if (state === "output-error") {
+      return (
+        <p css={styles.error} role="alert">
+          {t({
+            en: "Failed to load review summary",
+            zh: "加载评论摘要失败",
+          })}
+        </p>
+      );
+    }
+
+    if (state === "input-streaming" || state === "input-available") {
+      return <ToolReviewSummarySkeleton />;
+    }
+
+    if (state === "output-available") {
+      const data = parseReviewSummaryOutput(output);
+      if (!data) return null;
+      return (
+        <ToolReviewSummary data={data} isInteractive={isLastAssistantMessage} />
+      );
     }
 
     return null;

--- a/tooling/tmdb-codegen/endpoints-config.js
+++ b/tooling/tmdb-codegen/endpoints-config.js
@@ -39,6 +39,7 @@ export const endpoints = [
 
   // Movie Details & Media
   { path: "/3/movie/{movie_id}", functionName: "getMovieDetails" },
+  { path: "/3/movie/{movie_id}/reviews", functionName: "getMovieReviews" },
   { path: "/3/movie/{movie_id}/videos", functionName: "getMovieVideos" },
   {
     path: "/3/movie/{movie_id}/recommendations",
@@ -57,6 +58,7 @@ export const endpoints = [
 
   // TV Details & Media
   { path: "/3/tv/{series_id}", functionName: "getTvShowDetails" },
+  { path: "/3/tv/{series_id}/reviews", functionName: "getTvShowReviews" },
   { path: "/3/tv/{series_id}/videos", functionName: "getTvShowVideos" },
   {
     path: "/3/tv/{series_id}/recommendations",


### PR DESCRIPTION
## Summary

- New `review_summary` AI chat tool that fetches TMDB user reviews and generates a tone-adjustable summary via a secondary LLM call
- Visual card displays the summary with a spiciness slider (1 = neutral, 5 = bold/opinionated) — adjusting the slider regenerates the summary at the new tone
- Added TMDB review endpoints (`getMovieReviews`, `getTvShowReviews`) to the codegen config

Closes #1833

## Test plan

- [x] Ask the AI chat about reviews for a popular movie (e.g. "What do people think of Inception?")
- [x] Verify the review summary card renders with summary text, rating badge, and review count
- [x] Drag the spiciness slider and verify the summary regenerates with a different tone
- [x] Test with a TV show (e.g. "How are the reviews for Breaking Bad?")
- [x] Test in Chinese locale
- [x] `pnpm test` passes (735 tests)
- [x] `pnpm build` passes