### PR TITLE
fix: add prefers-reduced-motion support to AnimateToTarget

### DIFF
--- a/src/components/shared/animate-to-target.tsx
+++ b/src/components/shared/animate-to-target.tsx
@@ -57,6 +57,25 @@ export function AnimateToTarget({
       return;
 
     prevStateRef.current = animateToTarget;
+
+    // Skip transform/scale animation when the user prefers reduced motion.
+    // Only a simple cross-fade is played instead.
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+
+    if (prefersReducedMotion) {
+      const fadeAnimation = containerEl.animate(
+        animateToTarget
+          ? [{ opacity: 1 }, { opacity: 0 }]
+          : [{ opacity: 0 }, { opacity: 1 }],
+        { duration: 150, fill: "none", easing: "ease-in-out" },
+      );
+      return () => {
+        fadeAnimation.cancel();
+      };
+    }
+
     const target = document.getElementById(targetId);
     if (!target) return;
 


### PR DESCRIPTION
## Summary

The `AnimateToTarget` component performs transform and scale animations that can cause discomfort for motion-sensitive users. This adds a `prefers-reduced-motion` media query check so that when the user prefers reduced motion, only a simple 150ms cross-fade is played instead of the full transform/scale animation. This extends the reduced-motion accessibility work started in #1875 (which covered card transitions) to the `AnimateToTarget` component.