### PR TITLE
fix: respect prefers-reduced-motion in JavaScript scrollTo calls

### DIFF
--- a/src/components/ai-chat/chat-message-list.tsx
+++ b/src/components/ai-chat/chat-message-list.tsx
@@ -11,6 +11,7 @@ import type { ChatMessageMetadata } from "#src/ai-chat/use-ai-chat.ts";
 import { t } from "#src/i18n.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { color, font, space } from "#src/tokens.stylex.ts";
+import { getScrollBehavior } from "#src/utils/get-scroll-behavior.ts";
 import { ChatMessage } from "./chat-message";
 import { ScrollToBottomButton } from "./scroll-to-bottom-button";
 import { TypingIndicator } from "./typing-indicator";
@@ -56,7 +57,7 @@ export function ChatMessageList({
   const scrollToBottom = () => {
     window.scrollTo({
       top: document.documentElement.scrollHeight,
-      behavior: "smooth",
+      behavior: getScrollBehavior(),
     });
     setIsAtBottom(true);
   };

--- a/src/components/movie-database/media-filters-provider.tsx
+++ b/src/components/movie-database/media-filters-provider.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect, useState, type PropsWithChildren } from "react";
+import { getScrollBehavior } from "#src/utils/get-scroll-behavior.ts";
 import type {
   GenreFilterType,
   MediaType,
@@ -171,7 +172,7 @@ export function MediaFiltersProvider({
     }
 
     window.history.replaceState({}, "", url);
-    window.scrollTo({ behavior: "smooth", top: 0 });
+    window.scrollTo({ behavior: getScrollBehavior(), top: 0 });
   }, [mediaFilters]);
 
   return (

--- a/src/utils/get-scroll-behavior.test.ts
+++ b/src/utils/get-scroll-behavior.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getScrollBehavior } from "./get-scroll-behavior";
+
+describe("getScrollBehavior", () => {
+  let matchMediaSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    matchMediaSpy = vi.fn();
+    window.matchMedia = matchMediaSpy;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 'smooth' when user has no motion preference", () => {
+    matchMediaSpy.mockReturnValue({ matches: false });
+
+    expect(getScrollBehavior()).toBe("smooth");
+    expect(matchMediaSpy).toHaveBeenCalledWith(
+      "(prefers-reduced-motion: reduce)",
+    );
+  });
+
+  it("returns 'instant' when user prefers reduced motion", () => {
+    matchMediaSpy.mockReturnValue({ matches: true });
+
+    expect(getScrollBehavior()).toBe("instant");
+    expect(matchMediaSpy).toHaveBeenCalledWith(
+      "(prefers-reduced-motion: reduce)",
+    );
+  });
+});

--- a/src/utils/get-scroll-behavior.ts
+++ b/src/utils/get-scroll-behavior.ts
@@ -1,0 +1,15 @@
+/**
+ * Returns `"instant"` when the user prefers reduced motion, `"smooth"` otherwise.
+ *
+ * CSS `scroll-behavior` automatically respects `prefers-reduced-motion` when set
+ * to `auto`, but the JavaScript `scrollTo({ behavior })` API does **not** honour
+ * the media query — `"smooth"` always animates regardless of the user's system
+ * preference. This helper bridges that gap so every programmatic scroll call
+ * can respect the preference without duplicating the `matchMedia` check.
+ */
+export function getScrollBehavior(): ScrollBehavior {
+  if (typeof window === "undefined") return "instant";
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ? "instant"
+    : "smooth";
+}


### PR DESCRIPTION
## Summary

The CSS `scroll-behavior: auto` property automatically respects `prefers-reduced-motion`, but the JavaScript `scrollTo({ behavior: "smooth" })` API does not — it always animates regardless of the user's system preference. This adds a `getScrollBehavior()` utility that checks the `prefers-reduced-motion: reduce` media query and returns `"instant"` or `"smooth"` accordingly, and wires it into the two `scrollTo` call sites (AI chat message list and media filters provider).