### PR TITLE
refactor: extract shared isRecord type guard to utils module

### DIFF
--- a/src/ai-chat/tools/person-credits.ts
+++ b/src/ai-chat/tools/person-credits.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { getPersonCombinedCredits } from "#src/_generated/tmdb-server-functions.ts";
+import { isRecord } from "#src/utils/type-guards.ts";
 
 export const personCreditsInputSchema = z.object({
   person_id: z.number().describe("The TMDB person ID from search results."),
@@ -14,10 +15,6 @@ const TOOL_DESCRIPTION =
 // The TMDB OpenAPI spec flattens the combined credits union type, omitting
 // fields that only appear for TV entries. The API returns these at runtime.
 // Use runtime field access (via Record) instead of type assertions.
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function getString(
   obj: Record<string, unknown>,

--- a/src/ai-chat/tools/watch-providers.ts
+++ b/src/ai-chat/tools/watch-providers.ts
@@ -5,6 +5,7 @@ import {
   getTvShowWatchProviders,
 } from "#src/_generated/tmdb-server-functions.ts";
 import type { ResponseType } from "#src/utils/tmdb-client.ts";
+import { isRecord } from "#src/utils/type-guards.ts";
 
 export const watchProvidersInputSchema = z.object({
   id: z.number().describe("The TMDB ID of the movie or TV show."),
@@ -72,10 +73,6 @@ interface ProviderSearchResult {
     country: string;
     types: AvailabilityType[];
   }>;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function mapProviders(items: unknown): ProviderEntry[] {

--- a/src/components/ai-chat/map-tool-output.ts
+++ b/src/components/ai-chat/map-tool-output.ts
@@ -1,10 +1,9 @@
 import { presentMediaInputSchema } from "#src/ai-chat/tools/present-media.ts";
 import { presentPersonInputSchema } from "#src/ai-chat/tools/present-person.ts";
+import { isRecord } from "#src/utils/type-guards.ts";
 import type { MediaListItem, PersonListItem } from "#src/utils/types.ts";
 
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
+export { isRecord };
 
 function mapTmdbSearchOutput(output: unknown): ReadonlyArray<MediaListItem> {
   if (!Array.isArray(output)) return [];

--- a/src/utils/type-guards.ts
+++ b/src/utils/type-guards.ts
@@ -1,0 +1,4 @@
+/** Narrow an unknown value to a plain object (excludes arrays and null). */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Summary

Three files (`person-credits.ts`, `watch-providers.ts`, `map-tool-output.ts`) each had their own identical copy of the `isRecord` type guard function. This extracts it into a shared `src/utils/type-guards.ts` module so there is a single source of truth, reducing duplication and making future maintenance easier.

The `map-tool-output.ts` module re-exports `isRecord` to preserve its existing public API for downstream consumers.