### PR TITLE
perf: use direct property lookup in extractRegionData

### DIFF
--- a/src/ai-chat/tools/watch-providers.ts
+++ b/src/ai-chat/tools/watch-providers.ts
@@ -103,10 +103,13 @@ function extractRegionData(
 ): RegionProviders | null {
   if (!results) return null;
 
-  const match = Object.entries(results).find(([code]) => code === countryCode);
-  if (!match) return null;
+  // Direct O(1) property lookup instead of O(n) Object.entries().find().
+  // Widen to `unknown` first so isRecord narrows to Record<string, unknown>,
+  // enabling dynamic key access without type assertions.
+  const resultsRecord: unknown = results;
+  if (!isRecord(resultsRecord)) return null;
 
-  const data: unknown = match[1];
+  const data: unknown = resultsRecord[countryCode];
   if (!isRecord(data)) return null;
 
   return {


### PR DESCRIPTION
## Summary

Replace `Object.entries().find()` linear scan with direct property access by key in `extractRegionData`. The function previously iterated over all country code entries to find a match, which is unnecessary when the country code can be used as a direct property key for O(1) lookup. The change widens the `results` parameter to `unknown` first so the existing `isRecord` type guard can narrow it, enabling dynamic key access without type assertions.