### PR TITLE
fix: prevent leaking internal error messages in AI chat stream

### DIFF
--- a/src/app/api/ai-chat/route.ts
+++ b/src/app/api/ai-chat/route.ts
@@ -87,9 +87,10 @@ export async function POST(request: NextRequest) {
             writer.write(value);
           }
         } catch (error) {
+          console.error("AI Chat inner stream error:", error);
           writer.write({
             type: "error",
-            errorText: error instanceof Error ? error.message : "Stream error",
+            errorText: "Stream error",
           });
           return;
         }
@@ -108,7 +109,7 @@ export async function POST(request: NextRequest) {
       },
       onError: (error) => {
         console.error("AI Chat stream error:", error);
-        return error instanceof Error ? error.message : "Internal server error";
+        return "Internal server error";
       },
     });
 


### PR DESCRIPTION
## Summary

Replace `error.message` with generic error strings in the AI chat stream error handlers to prevent leaking internal error details (stack traces, library internals) to the client. The full error is still logged server-side via `console.error` for debugging purposes.