### PR TITLE
fix: validate required fields on UIMessage parts

### DIFF
--- a/src/ai-chat/is-ui-message.test.ts
+++ b/src/ai-chat/is-ui-message.test.ts
@@ -134,6 +134,84 @@ describe("isUIMessage", () => {
     ).toBe(false);
   });
 
+  it("rejects a text part missing the text field", () => {
+    expect(
+      isUIMessage({ id: "msg-1", role: "user", parts: [{ type: "text" }] }),
+    ).toBe(false);
+  });
+
+  it("rejects a text part with a non-string text field", () => {
+    expect(
+      isUIMessage({
+        id: "msg-1",
+        role: "user",
+        parts: [{ type: "text", text: 42 }],
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects a reasoning part missing the text field", () => {
+    expect(
+      isUIMessage({
+        id: "msg-1",
+        role: "assistant",
+        parts: [{ type: "reasoning" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects a reasoning part with a non-string text field", () => {
+    expect(
+      isUIMessage({
+        id: "msg-1",
+        role: "assistant",
+        parts: [{ type: "reasoning", text: null }],
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects a file part missing required fields", () => {
+    expect(
+      isUIMessage({
+        id: "msg-1",
+        role: "user",
+        parts: [{ type: "file" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects a file part with missing url", () => {
+    expect(
+      isUIMessage({
+        id: "msg-1",
+        role: "user",
+        parts: [{ type: "file", mediaType: "image/png" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts a valid file part", () => {
+    expect(
+      isUIMessage({
+        id: "msg-1",
+        role: "user",
+        parts: [
+          { type: "file", mediaType: "image/png", url: "data:image/png;..." },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts a step-start part without extra fields", () => {
+    expect(
+      isUIMessage({
+        id: "msg-1",
+        role: "assistant",
+        parts: [{ type: "step-start" }],
+      }),
+    ).toBe(true);
+  });
+
   it("preserves extra fields without rejecting", () => {
     expect(
       isUIMessage({

--- a/src/ai-chat/is-ui-message.ts
+++ b/src/ai-chat/is-ui-message.ts
@@ -2,18 +2,36 @@ import type { UIMessage } from "ai";
 
 const validRoles = new Set(["system", "user", "assistant"]);
 
+function isValidPart(part: unknown): boolean {
+  if (typeof part !== "object" || part === null) return false;
+  if (!("type" in part) || typeof part.type !== "string") return false;
+
+  // Validate required fields for part types that carry content.
+  // A missing `text` field on a text/reasoning part would send `undefined`
+  // to the LLM, so we reject malformed parts at the validation boundary.
+  switch (part.type) {
+    case "text":
+    case "reasoning":
+      return "text" in part && typeof part.text === "string";
+    case "file":
+      return (
+        "mediaType" in part &&
+        typeof part.mediaType === "string" &&
+        "url" in part &&
+        typeof part.url === "string"
+      );
+    default:
+      // step-start, source-url, source-document, tool-invocation, data, etc.
+      // — no further validation needed for the type guard.
+      return true;
+  }
+}
+
 export function isUIMessage(val: unknown): val is UIMessage {
   if (typeof val !== "object" || val === null) return false;
   if (!("id" in val) || typeof val.id !== "string") return false;
   if (!("role" in val) || typeof val.role !== "string") return false;
   if (!validRoles.has(val.role)) return false;
   if (!("parts" in val) || !Array.isArray(val.parts)) return false;
-  // Every part must be an object with a string `type` field
-  return val.parts.every(
-    (part: unknown) =>
-      typeof part === "object" &&
-      part !== null &&
-      "type" in part &&
-      typeof part.type === "string",
-  );
+  return val.parts.every(isValidPart);
 }


### PR DESCRIPTION
## Summary

The `isUIMessage` type guard previously only verified that each message part was an object with a string `type` field, allowing structurally invalid parts (e.g. a text part missing its `text` property) to pass validation. This could result in `undefined` values being sent to the LLM downstream. The guard now validates part-specific required fields — `text` must be a string for text/reasoning parts, and `mediaType`/`url` must be strings for file parts — catching malformed messages at the validation boundary.