### PR TITLE
refactor: replace @mui/utils with local useControlled hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.64",
     "@ai-sdk/react": "^3.0.144",
-    "@mui/utils": "^7.3.9",
     "@phosphor-icons/react": "^2.1.10",
     "@serwist/next": "^9.5.7",
     "@stylexjs/stylex": "^0.18.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@ai-sdk/react':
         specifier: ^3.0.144
         version: 3.0.144(react@19.3.0-canary-52684925-20251110)(zod@4.3.6)
-      '@mui/utils':
-        specifier: ^7.3.9
-        version: 7.3.9(@types/react@19.2.14)(react@19.3.0-canary-52684925-20251110)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.3.0-canary-52684925-20251110(react@19.3.0-canary-52684925-20251110))(react@19.3.0-canary-52684925-20251110)
@@ -1961,24 +1958,6 @@ packages:
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
     engines: {node: '>=18'}
 
-  '@mui/types@7.4.12':
-    resolution: {integrity: sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@mui/utils@7.3.9':
-    resolution: {integrity: sha512-U6SdZaGbfb65fqTsH3V5oJdFj9uYwyLE2WVuNvmbggTSDBb8QHrFsqY8BN3taK9t3yJ8/BPHD/kNvLNyjwM7Yw==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -2411,9 +2390,6 @@ packages:
 
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
-
-  '@types/prop-types@15.7.15':
-    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -3117,10 +3093,6 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
-
-  clsx@2.1.1:
-    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
-    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -5069,9 +5041,6 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
-
-  react-is@19.2.4:
-    resolution: {integrity: sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==}
 
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
@@ -7733,24 +7702,6 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
-  '@mui/types@7.4.12(@types/react@19.2.14)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  '@mui/utils@7.3.9(@types/react@19.2.14)(react@19.3.0-canary-52684925-20251110)':
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@mui/types': 7.4.12(@types/react@19.2.14)
-      '@types/prop-types': 15.7.15
-      clsx: 2.1.1
-      prop-types: 15.8.1
-      react: 19.3.0-canary-52684925-20251110
-      react-is: 19.2.4
-    optionalDependencies:
-      '@types/react': 19.2.14
-
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.8.1
@@ -8177,8 +8128,6 @@ snapshots:
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
-
-  '@types/prop-types@15.7.15': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -8918,8 +8867,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
-
-  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -11334,8 +11281,6 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
-
-  react-is@19.2.4: {}
 
   react-markdown@10.1.0(@types/react@19.2.14)(react@19.3.0-canary-52684925-20251110):
     dependencies:

--- a/src/components/shared/switch.tsx
+++ b/src/components/shared/switch.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import useControlled from "@mui/utils/useControlled";
 import * as stylex from "@stylexjs/stylex";
 import React, { useLayoutEffect, useRef, useState } from "react";
+import { useControlled } from "#src/hooks/use-controlled.ts";
 import { motionConstants } from "#src/primitives/motion.stylex.ts";
 import { buttonReset } from "#src/primitives/reset.stylex.ts";
 import {
@@ -38,8 +38,7 @@ export function Switch({
   // Optionally controlled state
   const [value, setValue] = useControlled({
     controlled: valueProp,
-    default: "off",
-    name: "Switch",
+    defaultValue: "off",
   });
 
   function setControlledValue(newValue: SwitchState) {

--- a/src/hooks/use-controlled.test.ts
+++ b/src/hooks/use-controlled.test.ts
@@ -1,0 +1,74 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useControlled } from "./use-controlled";
+
+describe("useControlled", () => {
+  it("returns the default value when uncontrolled", () => {
+    const { result } = renderHook(() =>
+      useControlled({ controlled: undefined, defaultValue: "off" }),
+    );
+
+    expect(result.current[0]).toBe("off");
+  });
+
+  it("updates internal state when uncontrolled", () => {
+    const { result } = renderHook(() =>
+      useControlled({ controlled: undefined, defaultValue: "off" }),
+    );
+
+    act(() => {
+      result.current[1]("on");
+    });
+
+    expect(result.current[0]).toBe("on");
+  });
+
+  it("returns the controlled value when controlled", () => {
+    const { result } = renderHook(() =>
+      useControlled({ controlled: "on", defaultValue: "off" }),
+    );
+
+    expect(result.current[0]).toBe("on");
+  });
+
+  it("ignores setValue when controlled", () => {
+    const { result } = renderHook(() =>
+      useControlled({ controlled: "on", defaultValue: "off" }),
+    );
+
+    act(() => {
+      result.current[1]("off");
+    });
+
+    // Value should still be the controlled value
+    expect(result.current[0]).toBe("on");
+  });
+
+  it("reflects updated controlled value on re-render", () => {
+    const { result, rerender } = renderHook(
+      ({ controlled }: { controlled: string | undefined }) =>
+        useControlled({ controlled, defaultValue: "off" }),
+      { initialProps: { controlled: "on" } },
+    );
+
+    expect(result.current[0]).toBe("on");
+
+    rerender({ controlled: "indeterminate" });
+
+    expect(result.current[0]).toBe("indeterminate");
+  });
+
+  it("works with non-string types", () => {
+    const { result } = renderHook(() =>
+      useControlled({ controlled: undefined, defaultValue: 0 }),
+    );
+
+    expect(result.current[0]).toBe(0);
+
+    act(() => {
+      result.current[1](42);
+    });
+
+    expect(result.current[0]).toBe(42);
+  });
+});

--- a/src/hooks/use-controlled.ts
+++ b/src/hooks/use-controlled.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+/**
+ * Hook for optionally controlled state. When `controlled` is provided,
+ * the component is driven by that value; otherwise it maintains its
+ * own internal state starting from `defaultValue`.
+ *
+ * Returns a `[value, setValue]` pair. When controlled, `setValue` is a
+ * no-op (the parent owns the state). When uncontrolled, `setValue`
+ * updates the internal state.
+ */
+export function useControlled<T>({
+  controlled,
+  defaultValue,
+}: {
+  controlled: T | undefined;
+  defaultValue: T;
+}): [T, (next: T) => void] {
+  const isControlledRef = useRef(controlled !== undefined);
+  const [internalValue, setInternalValue] = useState(defaultValue);
+
+  // When controlled, use the provided value (falling back to
+  // defaultValue for the impossible case where controlled becomes
+  // undefined after initialisation).
+  const value = isControlledRef.current
+    ? (controlled ?? defaultValue)
+    : internalValue;
+
+  const setter = isControlledRef.current ? noop : setInternalValue;
+
+  return [value, setter];
+}
+
+function noop() {
+  // intentionally empty — state is owned by the parent
+}


### PR DESCRIPTION
## Summary

The project depended on `@mui/utils` solely for its `useControlled` hook. This replaces it with a minimal ~38-line local implementation (`src/hooks/use-controlled.ts`), removing `@mui/utils` and its transitive dependencies (`@mui/types`, `@types/prop-types`, `clsx`, `react-is`) from the bundle. The new hook has full test coverage (6 tests) and an identical API surface for the Switch component's needs.