### PR TITLE
chore: remove unused zod-to-json-schema dep and isRecord re-export

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,7 @@
     "serwist": "^9.5.7",
     "sharp": "^0.34.5",
     "twgl.js": "^7.0.0",
-    "zod": "4",
-    "zod-to-json-schema": "^3.25.2"
+    "zod": "4"
   },
   "devDependencies": {
     "@babel/core": "7.29.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,9 +77,6 @@ importers:
       zod:
         specifier: '4'
         version: 4.3.6
-      zod-to-json-schema:
-        specifier: ^3.25.2
-        version: 3.25.2(zod@4.3.6)
     devDependencies:
       '@babel/core':
         specifier: 7.29.0
@@ -5917,11 +5914,6 @@ packages:
   yoctocolors-cjs@2.1.3:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
-
-  zod-to-json-schema@3.25.2:
-    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
-    peerDependencies:
-      zod: ^3.25.28 || ^4
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -12268,10 +12260,6 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.3: {}
-
-  zod-to-json-schema@3.25.2(zod@4.3.6):
-    dependencies:
-      zod: 4.3.6
 
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:

--- a/src/components/ai-chat/map-tool-output.ts
+++ b/src/components/ai-chat/map-tool-output.ts
@@ -7,8 +7,6 @@ import type { MediaListItem, PersonListItem } from "#src/utils/types.ts";
 import type { WatchProviderOutput } from "./tool-watch-providers";
 import { parseWatchProviderOutput } from "./tool-watch-providers";
 
-export { isRecord };
-
 function mapTmdbSearchOutput(output: unknown): ReadonlyArray<MediaListItem> {
   if (!Array.isArray(output)) return [];
 

--- a/src/components/ai-chat/tool-activity-line.tsx
+++ b/src/components/ai-chat/tool-activity-line.tsx
@@ -8,7 +8,7 @@ import { flex } from "#src/primitives/flex.stylex.ts";
 import { truncate } from "#src/primitives/layout.stylex.ts";
 import { motionConstants } from "#src/primitives/motion.stylex.ts";
 import { border, color, font, space } from "#src/tokens.stylex.ts";
-import { isRecord } from "./map-tool-output";
+import { isRecord } from "#src/utils/type-guards.ts";
 
 export const TERMINAL_STATES = new Set([
   "output-available",

--- a/src/components/ai-chat/tool-watch-providers.tsx
+++ b/src/components/ai-chat/tool-watch-providers.tsx
@@ -9,7 +9,7 @@ import { flex } from "#src/primitives/flex.stylex.ts";
 import { border, color, font, space } from "#src/tokens.stylex.ts";
 import { buildSrcSet } from "#src/utils/tmdb-image.ts";
 import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
-import { isRecord } from "./map-tool-output";
+import { isRecord } from "#src/utils/type-guards.ts";
 
 interface ProviderEntry {
   id: number;


### PR DESCRIPTION
## Summary

Remove the `zod-to-json-schema` package which is no longer needed after the Zod 4 migration (Zod 4 has built-in JSON schema support). Also clean up the `isRecord` re-export from `map-tool-output.ts` — consumers now import directly from the canonical `#src/utils/type-guards.ts` module, eliminating an unnecessary indirection.