### PR TITLE
refactor: extract useViewportHeight hook from media list components

### DIFF
--- a/src/components/movie-database/media-list.tsx
+++ b/src/components/movie-database/media-list.tsx
@@ -2,11 +2,12 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { useDeferredValue, useLayoutEffect, useState } from "react";
+import { useDeferredValue, useState } from "react";
 import { VirtuosoGrid } from "react-virtuoso";
 import { Grid } from "#src/components/movie-database/grid.tsx";
 import { useLocale } from "#src/hooks/use-locale.ts";
 import { useMediaFilters } from "#src/hooks/use-media-filters.ts";
+import { useViewportHeight } from "#src/hooks/use-viewport-height.ts";
 import { t } from "#src/i18n.ts";
 import { color, ratio, space } from "#src/tokens.stylex.ts";
 import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
@@ -45,15 +46,8 @@ export function MediaList({ initialPage }: MediaListProps) {
     isFetching,
   } = useSuspenseInfiniteQuery(tmdbQueryOptions);
 
-  // Get viewport height, used for infinite scroll padding
-  const [height, setHeight] = useState(() =>
-    typeof window !== "undefined" ? window.innerHeight : 0,
-  );
-  useLayoutEffect(() => {
-    const onResize = () => setHeight(window.innerHeight);
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
-  }, []);
+  // Viewport height used for infinite scroll pre-fetch padding
+  const height = useViewportHeight();
 
   const [initialCount] = useState(items.length);
 

--- a/src/components/movie-database/similar-media-list.tsx
+++ b/src/components/movie-database/similar-media-list.tsx
@@ -2,9 +2,9 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
-import { useLayoutEffect, useState } from "react";
 import { VirtuosoGrid } from "react-virtuoso";
 import { Grid } from "#src/components/movie-database/grid.tsx";
+import { useViewportHeight } from "#src/hooks/use-viewport-height.ts";
 import { color, ratio, space } from "#src/tokens.stylex.ts";
 import type { SupportedLocale } from "#src/types.ts";
 import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
@@ -40,15 +40,8 @@ export function SimilarMediaList({
     isFetching,
   } = useSuspenseInfiniteQuery(queryOptions);
 
-  // Get viewport height, used for infinite scroll padding
-  const [height, setHeight] = useState(() =>
-    typeof window !== "undefined" ? window.innerHeight : 0,
-  );
-  useLayoutEffect(() => {
-    const onResize = () => setHeight(window.innerHeight);
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
-  }, []);
+  // Viewport height used for infinite scroll pre-fetch padding
+  const height = useViewportHeight();
 
   if (!media.length) {
     return <div css={styles.notFound}>🙉 {notFoundLabel}</div>;

--- a/src/hooks/use-viewport-height.test.ts
+++ b/src/hooks/use-viewport-height.test.ts
@@ -1,0 +1,28 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useViewportHeight } from "./use-viewport-height";
+
+describe("useViewportHeight", () => {
+  it("returns the current window.innerHeight", () => {
+    const { result } = renderHook(() => useViewportHeight());
+    expect(result.current).toBe(window.innerHeight);
+  });
+
+  it("updates when the window is resized", () => {
+    const { result } = renderHook(() => useViewportHeight());
+    const initial = result.current;
+
+    act(() => {
+      // jsdom doesn't actually change innerHeight on resize events,
+      // but we can override it to simulate a resize.
+      Object.defineProperty(window, "innerHeight", {
+        writable: true,
+        configurable: true,
+        value: initial + 200,
+      });
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(result.current).toBe(initial + 200);
+  });
+});

--- a/src/hooks/use-viewport-height.ts
+++ b/src/hooks/use-viewport-height.ts
@@ -1,0 +1,25 @@
+import { useSyncExternalStore } from "react";
+
+function subscribe(onChange: () => void) {
+  window.addEventListener("resize", onChange);
+  return () => window.removeEventListener("resize", onChange);
+}
+
+function getSnapshot() {
+  return window.innerHeight;
+}
+
+function getServerSnapshot() {
+  return 0;
+}
+
+/**
+ * Returns the current viewport height, updating on window resize.
+ *
+ * Uses `useSyncExternalStore` (matching the pattern in `use-media-query.ts`)
+ * so the subscription identity is stable and React can tear-free read the
+ * value during concurrent renders.
+ */
+export function useViewportHeight() {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
## Summary

- Extract duplicated viewport-height tracking logic from `media-list.tsx` and `similar-media-list.tsx` into a new `useViewportHeight` hook
- Uses `useSyncExternalStore` with module-level subscribe/getSnapshot/getServerSnapshot functions, matching the established pattern in `use-media-query.ts`
- Includes tests for initial value and resize tracking

## Test plan

- [x] All 757 existing unit tests pass
- [x] 2 new tests for `useViewportHeight` pass
- [x] Lint clean
- [x] TypeScript compiles
- [x] Production build succeeds