### PR TITLE
fix: add missing dependency array to window blur useEffect

### DIFF
--- a/src/hooks/use-press-animation.ts
+++ b/src/hooks/use-press-animation.ts
@@ -211,7 +211,9 @@ export function usePressAnimation<T extends HTMLElement>({
     };
   }, []);
 
-  // Release press state when window loses focus (e.g., Alt-Tab)
+  // Release press state when window loses focus (e.g., Alt-Tab).
+  // Empty dependency array: handleRelease only reads from refs and calls
+  // stable state setters, so there is no need to re-subscribe on every render.
   useEffect(() => {
     const handleWindowBlur = () => {
       if (isPressedRef.current) {
@@ -220,7 +222,7 @@ export function usePressAnimation<T extends HTMLElement>({
     };
     window.addEventListener("blur", handleWindowBlur);
     return () => window.removeEventListener("blur", handleWindowBlur);
-  });
+  }, []);
 
   return {
     isPressed,


### PR DESCRIPTION
## Summary

The `useEffect` in `usePressAnimation` that subscribes to `window` blur events had no dependency array, causing it to tear down and re-add the event listener on every render. Because `handleRelease` only reads from refs and calls stable state setters, an empty dependency array is sufficient — this avoids unnecessary work without changing behaviour.