### PR TITLE
refactor: extract useDialogFocus hook from overlay components

### DIFF
--- a/src/components/ai-chat/media-detail-overlay.tsx
+++ b/src/components/ai-chat/media-detail-overlay.tsx
@@ -2,11 +2,12 @@
 
 import { XIcon } from "@phosphor-icons/react/dist/ssr/X";
 import * as stylex from "@stylexjs/stylex";
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import { createPortal } from "react-dom";
 import { RemoveScroll } from "react-remove-scroll";
 import { breakpoints } from "#src/breakpoints.stylex.ts";
 import { usePortalTarget } from "#src/contexts/portal-context.tsx";
+import { useDialogFocus } from "#src/hooks/use-dialog-focus.ts";
 import { t } from "#src/i18n.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { fixedFill } from "#src/primitives/layout.stylex.ts";
@@ -15,9 +16,6 @@ import { buttonReset } from "#src/primitives/reset.stylex.ts";
 import { border, color, layer, space } from "#src/tokens.stylex.ts";
 import { MediaDetailContent } from "./media-detail-content";
 import { useMediaDetail, type FocusedMedia } from "./media-detail-context";
-
-const FOCUSABLE_SELECTOR =
-  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 function getDialogLabel(media: FocusedMedia): string {
   if (media.title) return media.title;
@@ -30,51 +28,16 @@ export function MediaDetailOverlay() {
   const { focusedMedia, setFocusedMedia } = useMediaDetail();
   const portalTarget = usePortalTarget();
   const closeButtonRef = useRef<HTMLButtonElement>(null);
-  const triggerRef = useRef<HTMLElement | null>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!focusedMedia) return;
+  const handleClose = () => setFocusedMedia(null);
 
-    triggerRef.current =
-      document.activeElement instanceof HTMLElement
-        ? document.activeElement
-        : null;
-    // Allow the portal to render before focusing
-    requestAnimationFrame(() => {
-      closeButtonRef.current?.focus();
-    });
-
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        setFocusedMedia(null);
-        return;
-      }
-
-      // Trap focus within the dialog
-      if (event.key === "Tab" && dialogRef.current) {
-        const focusableElements =
-          dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
-        if (focusableElements.length === 0) return;
-
-        const first = focusableElements[0];
-        const last = focusableElements[focusableElements.length - 1];
-
-        if (event.shiftKey && document.activeElement === first) {
-          event.preventDefault();
-          last.focus();
-        } else if (!event.shiftKey && document.activeElement === last) {
-          event.preventDefault();
-          first.focus();
-        }
-      }
-    }
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-      triggerRef.current?.focus();
-    };
-  }, [focusedMedia, setFocusedMedia]);
+  useDialogFocus({
+    isOpen: focusedMedia != null,
+    dialogRef,
+    onClose: handleClose,
+    initialFocusRef: closeButtonRef,
+  });
 
   if (!focusedMedia || !portalTarget) {
     return null;

--- a/src/components/ai-chat/person-detail-overlay.tsx
+++ b/src/components/ai-chat/person-detail-overlay.tsx
@@ -2,11 +2,12 @@
 
 import { XIcon } from "@phosphor-icons/react/dist/ssr/X";
 import * as stylex from "@stylexjs/stylex";
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import { createPortal } from "react-dom";
 import { RemoveScroll } from "react-remove-scroll";
 import { breakpoints } from "#src/breakpoints.stylex.ts";
 import { usePortalTarget } from "#src/contexts/portal-context.tsx";
+import { useDialogFocus } from "#src/hooks/use-dialog-focus.ts";
 import { t } from "#src/i18n.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { fixedFill } from "#src/primitives/layout.stylex.ts";
@@ -16,9 +17,6 @@ import { border, color, layer, space } from "#src/tokens.stylex.ts";
 import { useMediaDetail, type FocusedPerson } from "./media-detail-context";
 import { PersonDetailContent } from "./person-detail-content";
 
-const FOCUSABLE_SELECTOR =
-  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
-
 function getDialogLabel(person: FocusedPerson): string {
   return person.name ?? t({ en: "Person details", zh: "人物详情" });
 }
@@ -27,49 +25,16 @@ export function PersonDetailOverlay() {
   const { focusedPerson, setFocusedPerson } = useMediaDetail();
   const portalTarget = usePortalTarget();
   const closeButtonRef = useRef<HTMLButtonElement>(null);
-  const triggerRef = useRef<HTMLElement | null>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!focusedPerson) return;
+  const handleClose = () => setFocusedPerson(null);
 
-    triggerRef.current =
-      document.activeElement instanceof HTMLElement
-        ? document.activeElement
-        : null;
-    requestAnimationFrame(() => {
-      closeButtonRef.current?.focus();
-    });
-
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        setFocusedPerson(null);
-        return;
-      }
-
-      if (event.key === "Tab" && dialogRef.current) {
-        const focusableElements =
-          dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
-        if (focusableElements.length === 0) return;
-
-        const first = focusableElements[0];
-        const last = focusableElements[focusableElements.length - 1];
-
-        if (event.shiftKey && document.activeElement === first) {
-          event.preventDefault();
-          last.focus();
-        } else if (!event.shiftKey && document.activeElement === last) {
-          event.preventDefault();
-          first.focus();
-        }
-      }
-    }
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-      triggerRef.current?.focus();
-    };
-  }, [focusedPerson, setFocusedPerson]);
+  useDialogFocus({
+    isOpen: focusedPerson != null,
+    dialogRef,
+    onClose: handleClose,
+    initialFocusRef: closeButtonRef,
+  });
 
   if (!focusedPerson || !portalTarget) {
     return null;

--- a/src/components/shared/overlay.tsx
+++ b/src/components/shared/overlay.tsx
@@ -3,7 +3,6 @@
 import { XIcon } from "@phosphor-icons/react/X";
 import * as stylex from "@stylexjs/stylex";
 import {
-  useEffect,
   useDeferredValue,
   useRef,
   ViewTransition,
@@ -13,12 +12,10 @@ import { createPortal } from "react-dom";
 import { RemoveScroll } from "react-remove-scroll";
 import { breakpoints } from "#src/breakpoints.stylex.ts";
 import { usePortalTarget } from "#src/contexts/portal-context.tsx";
+import { useDialogFocus } from "#src/hooks/use-dialog-focus.ts";
 import { t } from "#src/i18n.ts";
 import { border, color, layer, space } from "#src/tokens.stylex.ts";
 import { Button } from "./button";
-
-const FOCUSABLE_SELECTOR =
-  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), iframe, [tabindex]:not([tabindex="-1"])';
 
 interface OverlayProps {
   isOpen: boolean;
@@ -35,56 +32,12 @@ export function Overlay({
   const portalTarget = usePortalTarget();
   const deferredIsOpen = useDeferredValue(isOpen);
   const dialogRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLElement | null>(null);
 
-  useEffect(() => {
-    if (!deferredIsOpen) return;
-
-    // Remember the element that had focus before the overlay opened
-    triggerRef.current =
-      document.activeElement instanceof HTMLElement
-        ? document.activeElement
-        : null;
-
-    // Move focus into the dialog once the portal renders
-    requestAnimationFrame(() => {
-      const firstFocusable =
-        dialogRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
-      firstFocusable?.focus();
-    });
-
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        onClose();
-        return;
-      }
-
-      // Trap focus within the dialog
-      if (event.key === "Tab" && dialogRef.current) {
-        const focusableElements =
-          dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
-        if (focusableElements.length === 0) return;
-
-        const first = focusableElements[0];
-        const last = focusableElements[focusableElements.length - 1];
-
-        if (event.shiftKey && document.activeElement === first) {
-          event.preventDefault();
-          last.focus();
-        } else if (!event.shiftKey && document.activeElement === last) {
-          event.preventDefault();
-          first.focus();
-        }
-      }
-    }
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-      // Restore focus to the element that opened the overlay
-      triggerRef.current?.focus();
-    };
-  }, [deferredIsOpen, onClose]);
+  useDialogFocus({
+    isOpen: deferredIsOpen,
+    dialogRef,
+    onClose,
+  });
 
   if (!deferredIsOpen || !portalTarget) {
     return null;

--- a/src/hooks/use-dialog-focus.test.ts
+++ b/src/hooks/use-dialog-focus.test.ts
@@ -1,0 +1,172 @@
+import { fireEvent } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useDialogFocus } from "./use-dialog-focus";
+
+function createFocusableDialog() {
+  const dialog = document.createElement("div");
+  const button1 = document.createElement("button");
+  button1.textContent = "First";
+  const button2 = document.createElement("button");
+  button2.textContent = "Second";
+  const button3 = document.createElement("button");
+  button3.textContent = "Third";
+  dialog.append(button1, button2, button3);
+  document.body.append(dialog);
+  return { dialog, button1, button2, button3 };
+}
+
+describe("useDialogFocus", () => {
+  let cleanup: (() => void) | undefined;
+
+  beforeEach(() => {
+    // Stub requestAnimationFrame to execute callbacks synchronously
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      cb(0);
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("moves focus to the first focusable element when opened", () => {
+    const { dialog, button1 } = createFocusableDialog();
+    const dialogRef = { current: dialog };
+    const onClose = vi.fn();
+
+    renderHook(() => useDialogFocus({ isOpen: true, dialogRef, onClose }));
+
+    expect(button1).toHaveFocus();
+  });
+
+  it("moves focus to initialFocusRef when provided", () => {
+    const { dialog, button2 } = createFocusableDialog();
+    const dialogRef = { current: dialog };
+    const initialFocusRef = { current: button2 };
+    const onClose = vi.fn();
+
+    renderHook(() =>
+      useDialogFocus({
+        isOpen: true,
+        dialogRef,
+        onClose,
+        initialFocusRef,
+      }),
+    );
+
+    expect(button2).toHaveFocus();
+  });
+
+  it("does not move focus when closed", () => {
+    const { dialog, button1 } = createFocusableDialog();
+    const dialogRef = { current: dialog };
+    const onClose = vi.fn();
+
+    renderHook(() => useDialogFocus({ isOpen: false, dialogRef, onClose }));
+
+    expect(button1).not.toHaveFocus();
+  });
+
+  it("calls onClose when Escape is pressed", () => {
+    const { dialog } = createFocusableDialog();
+    const dialogRef = { current: dialog };
+    const onClose = vi.fn();
+
+    renderHook(() => useDialogFocus({ isOpen: true, dialogRef, onClose }));
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onClose on Escape when closed", () => {
+    const { dialog } = createFocusableDialog();
+    const dialogRef = { current: dialog };
+    const onClose = vi.fn();
+
+    renderHook(() => useDialogFocus({ isOpen: false, dialogRef, onClose }));
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("wraps focus from last to first element on Tab", () => {
+    const { dialog, button1, button3 } = createFocusableDialog();
+    const dialogRef = { current: dialog };
+    const onClose = vi.fn();
+
+    renderHook(() => useDialogFocus({ isOpen: true, dialogRef, onClose }));
+
+    button3.focus();
+    expect(button3).toHaveFocus();
+
+    fireEvent.keyDown(document, { key: "Tab" });
+
+    expect(button1).toHaveFocus();
+  });
+
+  it("wraps focus from first to last element on Shift+Tab", () => {
+    const { dialog, button1, button3 } = createFocusableDialog();
+    const dialogRef = { current: dialog };
+    const onClose = vi.fn();
+
+    renderHook(() => useDialogFocus({ isOpen: true, dialogRef, onClose }));
+
+    button1.focus();
+    expect(button1).toHaveFocus();
+
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+
+    expect(button3).toHaveFocus();
+  });
+
+  it("does not trap focus for Tab on middle elements", () => {
+    const { dialog, button2 } = createFocusableDialog();
+    const dialogRef = { current: dialog };
+    const onClose = vi.fn();
+
+    renderHook(() => useDialogFocus({ isOpen: true, dialogRef, onClose }));
+
+    button2.focus();
+    expect(button2).toHaveFocus();
+
+    // Tab on a middle element should not be prevented
+    const event = new KeyboardEvent("keydown", {
+      key: "Tab",
+      bubbles: true,
+      cancelable: true,
+    });
+    const prevented = !document.dispatchEvent(event);
+    expect(prevented).toBe(false);
+  });
+
+  it("saves and restores trigger focus on cleanup", () => {
+    const trigger = document.createElement("button");
+    trigger.textContent = "Trigger";
+    document.body.append(trigger);
+    trigger.focus();
+    expect(trigger).toHaveFocus();
+
+    const { dialog } = createFocusableDialog();
+    const dialogRef = { current: dialog };
+    const onClose = vi.fn();
+
+    const { unmount } = renderHook(() =>
+      useDialogFocus({ isOpen: true, dialogRef, onClose }),
+    );
+
+    // Focus moved into dialog
+    expect(trigger).not.toHaveFocus();
+
+    unmount();
+
+    // Focus restored to trigger
+    expect(trigger).toHaveFocus();
+  });
+});

--- a/src/hooks/use-dialog-focus.ts
+++ b/src/hooks/use-dialog-focus.ts
@@ -1,0 +1,85 @@
+import { useEffect, useRef, type RefObject } from "react";
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), iframe, [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Manages focus lifecycle for modal dialogs:
+ * - Saves the element that triggered the dialog
+ * - Moves focus into the dialog once it renders
+ * - Traps Tab/Shift+Tab within the dialog
+ * - Closes on Escape
+ * - Restores focus to the trigger element on cleanup
+ *
+ * @param isOpen - Whether the dialog is currently open.
+ * @param dialogRef - Ref to the dialog container element (used for focus trapping).
+ * @param onClose - Called when the user presses Escape.
+ * @param initialFocusRef - Optional ref to the element that should receive focus when
+ *   the dialog opens. Falls back to the first focusable element inside the dialog.
+ */
+export function useDialogFocus({
+  isOpen,
+  dialogRef,
+  onClose,
+  initialFocusRef,
+}: {
+  isOpen: boolean;
+  dialogRef: RefObject<HTMLElement | null>;
+  onClose: () => void;
+  initialFocusRef?: RefObject<HTMLElement | null>;
+}) {
+  const triggerRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    // Remember the element that had focus before the dialog opened
+    triggerRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+
+    // Move focus into the dialog once the portal renders
+    requestAnimationFrame(() => {
+      if (initialFocusRef?.current) {
+        initialFocusRef.current.focus();
+      } else {
+        const firstFocusable =
+          dialogRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+        firstFocusable?.focus();
+      }
+    });
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+        return;
+      }
+
+      // Trap focus within the dialog
+      if (event.key === "Tab" && dialogRef.current) {
+        const focusableElements =
+          dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+        if (focusableElements.length === 0) return;
+
+        const first = focusableElements[0];
+        const last = focusableElements[focusableElements.length - 1];
+
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      // Restore focus to the element that opened the dialog
+      triggerRef.current?.focus();
+    };
+  }, [isOpen, onClose, dialogRef, initialFocusRef]);
+}


### PR DESCRIPTION
## Summary

Three overlay components (`MediaDetailOverlay`, `PersonDetailOverlay`, `Overlay`) each had their own copy of identical focus management logic — saving the trigger element, moving focus into the dialog, trapping Tab/Shift+Tab, closing on Escape, and restoring focus on cleanup. This extracts all of that into a single `useDialogFocus` hook, eliminating the duplication and making focus behavior easier to maintain and update in one place.

The hook supports both explicit initial focus (via `initialFocusRef`) and automatic first-focusable-element detection, covering the slight variation between the three consumers.