### PR TITLE
feat: add error boundary components for graceful error handling

### DIFF
--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { useEffect } from "react";
+import { t } from "#src/i18n.ts";
+import { color, font, space } from "#src/tokens.stylex.ts";
+
+/**
+ * Error boundary for pages within the [locale] layout.
+ *
+ * Preserves the root layout (header, theme, I18n provider) so users can
+ * still navigate. Shows a localized message with a retry button.
+ */
+export default function LocaleError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  useEffect(() => {
+    console.error("Page error:", error);
+  }, [error]);
+
+  return (
+    <div css={styles.container} role="alert">
+      <h1 css={styles.heading}>
+        {t({ en: "Something went wrong", zh: "出了点问题" })}
+      </h1>
+      <p css={styles.description}>
+        {t({
+          en: "An unexpected error occurred. Please try again.",
+          zh: "发生了意外错误，请重试。",
+        })}
+      </p>
+      <button css={styles.button} onClick={unstable_retry}>
+        {t({ en: "Try again", zh: "重试" })}
+      </button>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  container: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: "60dvh",
+    textAlign: "center",
+    padding: space._4,
+  },
+  heading: {
+    fontSize: font.vpHeading1,
+    fontWeight: font.weight_7,
+    margin: 0,
+  },
+  description: {
+    fontSize: font.uiBody,
+    color: color.textMuted,
+    margin: `${space._2} 0 0`,
+  },
+  button: {
+    marginTop: space._4,
+    paddingBlock: space._2,
+    paddingInline: space._5,
+    fontSize: font.uiBody,
+    fontWeight: font.weight_5,
+    fontFamily: font.family,
+    borderWidth: 0,
+    borderStyle: "none",
+    borderRadius: "9999px",
+    backgroundColor: color.controlActive,
+    color: color.textOnActive,
+    cursor: "pointer",
+  },
+});

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Global error boundary for the entire application.
+ *
+ * This catches errors that break the root layout itself. It must render
+ * its own <html> and <body> tags since the root layout is not available.
+ * Because no I18n provider exists at this level, text is hardcoded in English.
+ */
+export default function GlobalError({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  useEffect(() => {
+    console.error("Global error:", error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          minHeight: "100dvh",
+          fontFamily:
+            "Inter, system-ui, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+          textAlign: "center",
+          padding: "1rem",
+          margin: 0,
+        }}
+      >
+        <h1 style={{ fontSize: "3rem", margin: 0 }}>Oops</h1>
+        <p style={{ fontSize: "1rem", color: "#505050", margin: "0.75rem 0" }}>
+          Something went wrong. Please try again.
+        </p>
+        <button
+          onClick={unstable_retry}
+          style={{
+            marginTop: "1rem",
+            padding: "0.5rem 1.5rem",
+            fontSize: "0.875rem",
+            fontWeight: 500,
+            border: "none",
+            borderRadius: "9999px",
+            backgroundColor: "#7e10c2",
+            color: "#ffffff",
+            cursor: "pointer",
+          }}
+        >
+          Try again
+        </button>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary

The app currently has no error boundaries, so unhandled runtime errors show the default Next.js error page or a blank screen. This adds two error boundary components for graceful degradation:

- **`src/app/[locale]/error.tsx`** — A locale-scoped error boundary that preserves the root layout (header, theme, i18n provider) so users can still navigate. Shows a localized message (en/zh) with a retry button, styled with the project's design tokens via StyleX.
- **`src/app/global-error.tsx`** — A global fallback that catches errors breaking the root layout itself. Renders its own `<html>`/`<body>` with inline styles (no design token dependencies at this level) and a retry button. Text is hardcoded in English since no i18n provider is available.