### PR TITLE
feat: show provider name in tool activity line summary

### DIFF
--- a/src/components/ai-chat/tool-activity-line.test.tsx
+++ b/src/components/ai-chat/tool-activity-line.test.tsx
@@ -179,6 +179,37 @@ describe("ToolActivityLine", () => {
       expect(screen.getByText("GB")).toBeInTheDocument();
     });
 
+    it("shows provider name for watch_providers in provider search mode", () => {
+      render(
+        <ToolActivityLine
+          toolName="watch_providers"
+          state="output-available"
+          input={{
+            id: 550,
+            media_type: "movie",
+            provider_name: "Netflix",
+          }}
+        />,
+      );
+      expect(screen.getByText("Netflix")).toBeInTheDocument();
+    });
+
+    it("prefers provider_name over region for watch_providers summary", () => {
+      render(
+        <ToolActivityLine
+          toolName="watch_providers"
+          state="output-available"
+          input={{
+            id: 550,
+            media_type: "movie",
+            provider_name: "Disney Plus",
+            region: "US",
+          }}
+        />,
+      );
+      expect(screen.getByText("Disney Plus")).toBeInTheDocument();
+    });
+
     it("shows title for review_summary", () => {
       render(
         <ToolActivityLine

--- a/src/components/ai-chat/tool-activity-line.tsx
+++ b/src/components/ai-chat/tool-activity-line.tsx
@@ -108,8 +108,12 @@ export function ToolActivityLine({
   if (toolName === "tmdb_search" || toolName === "semantic_search") {
     summary = getQuerySummary(input);
   } else if (toolName === "watch_providers") {
-    if (isRecord(input) && typeof input.region === "string") {
-      summary = input.region;
+    if (isRecord(input)) {
+      if (typeof input.provider_name === "string") {
+        summary = input.provider_name;
+      } else if (typeof input.region === "string") {
+        summary = input.region;
+      }
     }
   } else if (toolName === "present_media") {
     const count = getMediaCount(input);


### PR DESCRIPTION
## Summary

The watch_providers tool now supports a provider search mode (added in #1896), where the input includes a `provider_name` field instead of a `region`. The tool activity line previously only displayed the region as its summary, so provider-based searches showed no summary text. This change makes the activity line display the provider name when present, falling back to region when it is not.