### PR TITLE
chore: use SSR entry point for remaining phosphor icon imports

### DIFF
--- a/src/components/movie-database/trailer-button.tsx
+++ b/src/components/movie-database/trailer-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PlayIcon } from "@phosphor-icons/react/Play";
+import { PlayIcon } from "@phosphor-icons/react/dist/ssr/Play";
 import * as stylex from "@stylexjs/stylex";
 import type { PropsWithChildren } from "react";
 import { useState } from "react";

--- a/src/components/shared/locale-selector.tsx
+++ b/src/components/shared/locale-selector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { TranslateIcon } from "@phosphor-icons/react/Translate";
+import { TranslateIcon } from "@phosphor-icons/react/dist/ssr/Translate";
 import * as stylex from "@stylexjs/stylex";
 import { usePathname, useSearchParams } from "next/navigation";
 import { LOCALE_COOKIE_NAME } from "#src/constants.ts";

--- a/src/components/shared/overlay.tsx
+++ b/src/components/shared/overlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { XIcon } from "@phosphor-icons/react/X";
+import { XIcon } from "@phosphor-icons/react/dist/ssr/X";
 import * as stylex from "@stylexjs/stylex";
 import {
   useDeferredValue,

--- a/src/components/shared/theme-switch.tsx
+++ b/src/components/shared/theme-switch.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { MoonIcon } from "@phosphor-icons/react/Moon";
-import { SunIcon } from "@phosphor-icons/react/Sun";
+import { MoonIcon } from "@phosphor-icons/react/dist/ssr/Moon";
+import { SunIcon } from "@phosphor-icons/react/dist/ssr/Sun";
 import * as stylex from "@stylexjs/stylex";
 import { useLayoutEffect, useRef, useState } from "react";
 import { getDocumentClassName } from "#src/app/global-styles.ts";


### PR DESCRIPTION
## Summary

- Standardised 6 `@phosphor-icons/react` imports across 4 files (`overlay.tsx`, `theme-switch.tsx`, `locale-selector.tsx`, `trailer-button.tsx`) from the CSR entry point (`@phosphor-icons/react/X`) to the SSR entry point (`@phosphor-icons/react/dist/ssr/X`)
- The CSR variant uses `IconBase` which calls `useContext(IconContext)` on every render, but this project has no `IconContext` provider — the lookup always returns the default. The SSR variant uses `SSRBase` with inline defaults, eliminating the unnecessary context call and removing `context.es.js` from those client bundles
- All other icon imports in the codebase (25+) already use the `dist/ssr/` path — this change makes the remaining 6 consistent

## Test plan

- [x] `pnpm lint:changed` passes
- [x] `pnpm format:changed` passes
- [x] `pnpm test` passes (820/820)
- [x] `pnpm build` succeeds
- [x] Verified CSR and SSR variants produce identical SVG output when no `IconContext.Provider` exists (same defaults: `currentColor`, `1em`, `regular`, `false`)
- [x] Verified no remaining CSR-style imports (`grep` finds zero matches for `from "@phosphor-icons/react/` without `dist/`)