### PR TITLE
feat: add save_preference tool for cross-session preference memory

### DIFF
--- a/src/ai-chat/chat.ts
+++ b/src/ai-chat/chat.ts
@@ -13,6 +13,7 @@ import { createPresentPersonTool } from "./tools/present-person";
 import { createPresentProviderRegionsTool } from "./tools/present-provider-regions";
 import { createPresentWatchProvidersTool } from "./tools/present-watch-providers";
 import { createReviewSummaryTool } from "./tools/review-summary";
+import { createSavePreferenceTool } from "./tools/save-preference";
 import { createSemanticSearchTool } from "./tools/semantic-search";
 import { createTmdbSearchTool } from "./tools/tmdb-search";
 import { createWatchProvidersTool } from "./tools/watch-providers";
@@ -46,6 +47,7 @@ export async function chat({
       person_credits: createPersonCreditsTool(),
       present_person: createPresentPersonTool(),
       review_summary: createReviewSummaryTool(locale),
+      save_preference: createSavePreferenceTool(),
       web_search: anthropic.tools.webSearch_20250305(
         countryCode && countryCode !== "unknown"
           ? {

--- a/src/ai-chat/eval/save-preference.eval.ts
+++ b/src/ai-chat/eval/save-preference.eval.ts
@@ -1,0 +1,23 @@
+import { describe, it } from "vitest";
+import { runSingleTurnEval } from "./run-eval";
+import type { EvalCase } from "./types";
+
+const cases: EvalCase[] = [
+  {
+    name: "Saves preferences when user expresses likes and dislikes",
+    input:
+      "I absolutely love sci-fi movies and Christopher Nolan, but I really can't stand horror films.",
+    criteria: [
+      "Calls the save_preference tool with preferences that capture the user's likes (sci-fi genre, Christopher Nolan as director) and dislike (horror genre)",
+      "Responds naturally to the user's stated preferences, e.g. by acknowledging them or offering recommendations",
+    ],
+    includeToolCalls: true,
+    requireToolCall: "save_preference",
+  },
+];
+
+describe("Save Preference", () => {
+  it.each(cases)("$name", async (evalCase) => {
+    await runSingleTurnEval(evalCase);
+  });
+});

--- a/src/ai-chat/system-instructions.md
+++ b/src/ai-chat/system-instructions.md
@@ -36,6 +36,16 @@ Engage in natural conversation about movies and TV shows. You can:
 - **Review summaries**: When users ask about reviews, critical reception, or what people think of a movie or TV show, use `review_summary`. Pass the TMDB ID, media type, and title. The `spiciness` parameter controls the tone (1 = neutral/factual, 5 = bold/opinionated) — default to 3 unless the user asks for a specific tone. When the user requests a different spiciness level, call the tool again with the new value. After the tool returns, do **not** repeat or paraphrase the summary — the tool's visual card already displays it. Keep your follow-up text minimal (e.g. a brief observation or question)
 - **Web search**: Use `web_search` as a **fallback** when TMDB tools and your own knowledge cannot confidently answer. Ideal for: recent news/announcements, award ceremony results, box office numbers, behind-the-scenes stories, sequel/reboot updates, real-time industry events. Do NOT use for standard title lookups, recommendations, cast info, or watch providers — use the dedicated tools for those. When presenting results, cite sources by name (e.g. "According to Variety…") but do not include URLs
 
+## User Preferences
+
+The user's first message in a session may contain a `[User Preferences]` block listing their stored likes and dislikes. Use these to personalise recommendations:
+
+- Reference relevant preferences naturally (e.g. "Since you enjoy sci-fi…") rather than listing them back
+- Weight recommendations toward liked categories and away from disliked ones
+- When the user expresses new preferences during conversation (e.g. "I love Christopher Nolan", "I can't stand horror"), call `save_preference` to persist them. Extract the category, value, and sentiment
+- Do not re-save preferences the user has already stored — only save new ones
+- If no preferences block is present, the user has no stored preferences yet — still call `save_preference` when you detect new preference signals
+
 ## Boundaries
 
 - Only discuss topics related to movies, TV shows, and the entertainment industry

--- a/src/ai-chat/tools/save-preference.test.ts
+++ b/src/ai-chat/tools/save-preference.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  createSavePreferenceTool,
+  savePreferenceInputSchema,
+} from "./save-preference";
+
+describe("savePreferenceInputSchema", () => {
+  it("accepts valid input", () => {
+    const result = savePreferenceInputSchema.parse({
+      preferences: [
+        { category: "genre", value: "sci-fi", sentiment: "like" },
+        { category: "director", value: "Christopher Nolan", sentiment: "like" },
+      ],
+    });
+    expect(result.preferences).toHaveLength(2);
+  });
+
+  it("accepts empty preferences array", () => {
+    const result = savePreferenceInputSchema.parse({ preferences: [] });
+    expect(result.preferences).toEqual([]);
+  });
+
+  it("accepts all valid categories", () => {
+    const categories = [
+      "genre",
+      "actor",
+      "director",
+      "content_rating",
+      "language",
+      "keyword",
+    ] as const;
+    for (const category of categories) {
+      const result = savePreferenceInputSchema.parse({
+        preferences: [{ category, value: "test", sentiment: "like" }],
+      });
+      expect(result.preferences[0].category).toBe(category);
+    }
+  });
+
+  it("rejects missing preferences field", () => {
+    expect(() => savePreferenceInputSchema.parse({})).toThrow();
+  });
+
+  it("rejects invalid category", () => {
+    expect(() =>
+      savePreferenceInputSchema.parse({
+        preferences: [{ category: "mood", value: "happy", sentiment: "like" }],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects invalid sentiment", () => {
+    expect(() =>
+      savePreferenceInputSchema.parse({
+        preferences: [
+          { category: "genre", value: "horror", sentiment: "neutral" },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects non-string value", () => {
+    expect(() =>
+      savePreferenceInputSchema.parse({
+        preferences: [{ category: "genre", value: 42, sentiment: "like" }],
+      }),
+    ).toThrow();
+  });
+});
+
+describe("createSavePreferenceTool", () => {
+  it("returns a tool with description and inputSchema", () => {
+    const tool = createSavePreferenceTool();
+    expect(tool.description).toBeDefined();
+    expect(tool.inputSchema).toBeDefined();
+  });
+
+  it("execute is a pass-through", async () => {
+    const tool = createSavePreferenceTool();
+    const input = {
+      preferences: [
+        {
+          category: "genre" as const,
+          value: "sci-fi",
+          sentiment: "like" as const,
+        },
+        {
+          category: "actor" as const,
+          value: "Keanu Reeves",
+          sentiment: "like" as const,
+        },
+      ],
+    };
+    const result = await tool.execute!(input, {
+      toolCallId: "test",
+      messages: [],
+      abortSignal: AbortSignal.timeout(5000),
+    });
+    expect(result).toEqual(input);
+  });
+});

--- a/src/ai-chat/tools/save-preference.ts
+++ b/src/ai-chat/tools/save-preference.ts
@@ -1,0 +1,45 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+export const savePreferenceInputSchema = z.object({
+  preferences: z
+    .array(
+      z.object({
+        category: z
+          .enum([
+            "genre",
+            "actor",
+            "director",
+            "content_rating",
+            "language",
+            "keyword",
+          ])
+          .describe("The type of preference being saved."),
+        value: z
+          .string()
+          .describe(
+            "The preference value, e.g. a genre name, actor name, or keyword.",
+          ),
+        sentiment: z
+          .enum(["like", "dislike"])
+          .describe("Whether the user likes or dislikes this."),
+      }),
+    )
+    .describe("List of user preferences detected from the conversation."),
+});
+
+export type SavePreferenceInput = z.infer<typeof savePreferenceInputSchema>;
+
+const TOOL_DESCRIPTION =
+  "Save user preferences detected during conversation. " +
+  "Call this when the user expresses likes or dislikes about genres, actors, " +
+  "directors, content ratings, languages, or themes/keywords. " +
+  "Preferences are stored client-side for future personalisation.";
+
+export function createSavePreferenceTool() {
+  return tool({
+    description: TOOL_DESCRIPTION,
+    inputSchema: savePreferenceInputSchema,
+    execute: (input) => Promise.resolve(input),
+  });
+}

--- a/src/ai-chat/use-ai-chat.ts
+++ b/src/ai-chat/use-ai-chat.ts
@@ -6,6 +6,10 @@ import { DefaultChatTransport } from "ai";
 import { useEffect, useState } from "react";
 import { z } from "zod";
 import { isUIMessage } from "#src/ai-chat/is-ui-message.ts";
+import {
+  getCachedPreferencesContext,
+  loadPreferencesContext,
+} from "#src/preference-store/preference-store.ts";
 import type { SupportedLocale } from "#src/types.ts";
 
 export interface ChatMessageMetadata {
@@ -94,6 +98,24 @@ function getOrCreateChat(locale: SupportedLocale): Chat<ChatUIMessage> {
         return { body: { sessionId, locale, trigger } };
       }
       const lastMessage = messages[messages.length - 1];
+
+      // Inject stored preferences into the first message of a new session
+      if (!sessionId && lastMessage) {
+        const prefsCtx = getCachedPreferencesContext();
+        if (prefsCtx) {
+          const enrichedMessage = {
+            ...lastMessage,
+            parts: [
+              { type: "text" as const, text: prefsCtx },
+              ...lastMessage.parts,
+            ],
+          };
+          return {
+            body: { sessionId, message: enrichedMessage, locale, trigger },
+          };
+        }
+      }
+
       return { body: { sessionId, message: lastMessage, locale, trigger } };
     },
   });
@@ -140,6 +162,12 @@ export function useAIChat({ locale }: { locale: SupportedLocale }) {
   const [previousSessionId, setPreviousSessionId] = useState<string | null>(
     null,
   );
+
+  // Warm the preferences cache from IndexedDB on mount so it's available
+  // for the transport to inject into the first message of a new session.
+  useEffect(() => {
+    loadPreferencesContext().catch(() => {});
+  }, []);
 
   // Deferred to useEffect so the initial render matches the server (null),
   // avoiding a hydration mismatch — localStorage is not available during SSR.

--- a/src/components/ai-chat/chat-message-list.tsx
+++ b/src/components/ai-chat/chat-message-list.tsx
@@ -9,6 +9,7 @@ import {
 } from "#src/ai-chat/context-management-shared.ts";
 import type { ChatMessageMetadata } from "#src/ai-chat/use-ai-chat.ts";
 import { t } from "#src/i18n.ts";
+import { usePreferencePersistence } from "#src/preference-store/use-preference-persistence.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { color, font, space } from "#src/tokens.stylex.ts";
 import { ChatMessage } from "./chat-message";
@@ -51,6 +52,8 @@ export function ChatMessageList({
   scrollToBottomLabel,
   errorLabel,
 }: ChatMessageListProps) {
+  usePreferencePersistence(messages);
+
   const [isAtBottom, setIsAtBottom] = useState(true);
 
   const scrollToBottom = () => {

--- a/src/components/ai-chat/tool-activity-line.tsx
+++ b/src/components/ai-chat/tool-activity-line.tsx
@@ -100,6 +100,9 @@ export function ToolActivityLine({
     case "web_search":
       label = t({ en: "Web Search", zh: "网络搜索" });
       break;
+    case "save_preference":
+      label = t({ en: "Saving Preferences", zh: "保存偏好" });
+      break;
     default:
       label = toolName;
   }
@@ -153,6 +156,12 @@ export function ToolActivityLine({
         input.title.length > MAX_SUMMARY_LENGTH
           ? `${input.title.slice(0, MAX_SUMMARY_LENGTH)}…`
           : input.title;
+    }
+  } else if (toolName === "save_preference") {
+    if (isRecord(input) && Array.isArray(input.preferences)) {
+      const count = input.preferences.length;
+      summary =
+        count.toString() + " " + (count === 1 ? itemSingular : itemPlural);
     }
   }
 

--- a/src/preference-store/preference-store.test.ts
+++ b/src/preference-store/preference-store.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { StoredPreference } from "./preference-store";
+import { formatPreferencesContext, makeId } from "./preference-store";
+
+function pref(
+  overrides: Partial<StoredPreference> &
+    Pick<StoredPreference, "category" | "value" | "sentiment">,
+): StoredPreference {
+  return {
+    id: makeId(overrides.category, overrides.value),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("makeId", () => {
+  it("creates composite key from category and lowercase value", () => {
+    expect(makeId("genre", "Sci-Fi")).toBe("genre:sci-fi");
+  });
+
+  it("handles already-lowercase values", () => {
+    expect(makeId("actor", "keanu reeves")).toBe("actor:keanu reeves");
+  });
+
+  it("produces the same key for different casings", () => {
+    expect(makeId("director", "Christopher Nolan")).toBe(
+      makeId("director", "christopher nolan"),
+    );
+  });
+});
+
+describe("formatPreferencesContext", () => {
+  it("returns null for empty array", () => {
+    expect(formatPreferencesContext([])).toBeNull();
+  });
+
+  it("formats likes only", () => {
+    const ctx = formatPreferencesContext([
+      pref({ category: "genre", value: "sci-fi", sentiment: "like" }),
+      pref({
+        category: "director",
+        value: "Denis Villeneuve",
+        sentiment: "like",
+      }),
+    ]);
+    expect(ctx).toBe(
+      "[User Preferences]\nLikes: sci-fi (genre), Denis Villeneuve (director)",
+    );
+  });
+
+  it("formats dislikes only", () => {
+    const ctx = formatPreferencesContext([
+      pref({ category: "genre", value: "horror", sentiment: "dislike" }),
+    ]);
+    expect(ctx).toBe("[User Preferences]\nDislikes: horror (genre)");
+  });
+
+  it("formats both likes and dislikes", () => {
+    const ctx = formatPreferencesContext([
+      pref({ category: "genre", value: "sci-fi", sentiment: "like" }),
+      pref({ category: "genre", value: "horror", sentiment: "dislike" }),
+    ]);
+    expect(ctx).toContain("[User Preferences]");
+    expect(ctx).toContain("Likes: sci-fi (genre)");
+    expect(ctx).toContain("Dislikes: horror (genre)");
+  });
+
+  it("includes all category types", () => {
+    const prefs = [
+      pref({ category: "genre", value: "action", sentiment: "like" }),
+      pref({ category: "actor", value: "Keanu Reeves", sentiment: "like" }),
+      pref({ category: "director", value: "Nolan", sentiment: "like" }),
+      pref({ category: "content_rating", value: "PG-13", sentiment: "like" }),
+      pref({ category: "language", value: "Korean", sentiment: "like" }),
+      pref({ category: "keyword", value: "time travel", sentiment: "like" }),
+    ];
+    const ctx = formatPreferencesContext(prefs);
+    expect(ctx).toContain("action (genre)");
+    expect(ctx).toContain("Keanu Reeves (actor)");
+    expect(ctx).toContain("Nolan (director)");
+    expect(ctx).toContain("PG-13 (content_rating)");
+    expect(ctx).toContain("Korean (language)");
+    expect(ctx).toContain("time travel (keyword)");
+  });
+});

--- a/src/preference-store/preference-store.ts
+++ b/src/preference-store/preference-store.ts
@@ -1,0 +1,149 @@
+const DB_NAME = "ai-chat-preferences";
+const DB_VERSION = 1;
+const STORE_NAME = "preferences";
+
+export interface StoredPreference {
+  /** Composite key: `${category}:${value}` */
+  id: string;
+  category:
+    | "genre"
+    | "actor"
+    | "director"
+    | "content_rating"
+    | "language"
+    | "keyword";
+  value: string;
+  sentiment: "like" | "dislike";
+  updatedAt: number;
+}
+
+export function makeId(
+  category: StoredPreference["category"],
+  value: string,
+): string {
+  return `${category}:${value.toLowerCase()}`;
+}
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: "id" });
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () =>
+      reject(request.error ?? new Error("Failed to open IndexedDB"));
+  });
+}
+
+export async function getAllPreferences(): Promise<StoredPreference[]> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readonly");
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.getAll();
+    request.onsuccess = () => resolve(request.result as StoredPreference[]);
+    request.onerror = () =>
+      reject(request.error ?? new Error("Failed to read preferences"));
+  });
+}
+
+export async function mergePreferences(
+  preferences: ReadonlyArray<{
+    category: StoredPreference["category"];
+    value: string;
+    sentiment: StoredPreference["sentiment"];
+  }>,
+): Promise<void> {
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME, "readwrite");
+  const store = tx.objectStore(STORE_NAME);
+  const now = Date.now();
+
+  for (const pref of preferences) {
+    const record: StoredPreference = {
+      id: makeId(pref.category, pref.value),
+      category: pref.category,
+      value: pref.value,
+      sentiment: pref.sentiment,
+      updatedAt: now,
+    };
+    store.put(record);
+  }
+
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () =>
+      reject(tx.error ?? new Error("Failed to merge preferences"));
+  });
+}
+
+export async function clearPreferences(): Promise<void> {
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME, "readwrite");
+  const store = tx.objectStore(STORE_NAME);
+  store.clear();
+
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () =>
+      reject(tx.error ?? new Error("Failed to clear preferences"));
+  });
+}
+
+let cachedContext: string | null = null;
+let cacheLoaded = false;
+
+export function formatPreferencesContext(
+  prefs: ReadonlyArray<StoredPreference>,
+): string | null {
+  if (prefs.length === 0) return null;
+
+  const likes = prefs.filter((p) => p.sentiment === "like");
+  const dislikes = prefs.filter((p) => p.sentiment === "dislike");
+
+  const lines: string[] = ["[User Preferences]"];
+
+  if (likes.length > 0) {
+    lines.push(
+      "Likes: " + likes.map((p) => `${p.value} (${p.category})`).join(", "),
+    );
+  }
+
+  if (dislikes.length > 0) {
+    lines.push(
+      "Dislikes: " +
+        dislikes.map((p) => `${p.value} (${p.category})`).join(", "),
+    );
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Load preferences from IndexedDB and update the in-memory cache.
+ * Returns the formatted context string, or null if no preferences are stored.
+ */
+export async function loadPreferencesContext(): Promise<string | null> {
+  try {
+    const prefs = await getAllPreferences();
+    cachedContext = formatPreferencesContext(prefs);
+  } catch {
+    cachedContext = null;
+  }
+  cacheLoaded = true;
+  return cachedContext;
+}
+
+/**
+ * Synchronous accessor for the cached preferences context.
+ * Returns null if the cache hasn't been loaded yet or no preferences exist.
+ */
+export function getCachedPreferencesContext(): string | null {
+  return cacheLoaded ? cachedContext : null;
+}

--- a/src/preference-store/use-preference-persistence.ts
+++ b/src/preference-store/use-preference-persistence.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { getToolName, isToolUIPart, type UIMessage } from "ai";
+import { useEffect, useRef } from "react";
+import { savePreferenceInputSchema } from "#src/ai-chat/tools/save-preference.ts";
+import { loadPreferencesContext, mergePreferences } from "./preference-store";
+
+/**
+ * Observes chat messages for `save_preference` tool calls and persists
+ * detected preferences to IndexedDB. Each tool call ID is processed at most
+ * once.
+ */
+export function usePreferencePersistence(
+  messages: ReadonlyArray<UIMessage>,
+): void {
+  const processedRef = useRef(new Set<string>());
+
+  useEffect(() => {
+    const processed = processedRef.current;
+
+    for (const message of messages) {
+      if (message.role !== "assistant") continue;
+
+      for (const part of message.parts) {
+        if (!isToolUIPart(part)) continue;
+        if (getToolName(part) !== "save_preference") continue;
+        if (part.state !== "output-available") continue;
+        if (processed.has(part.toolCallId)) continue;
+
+        processed.add(part.toolCallId);
+
+        const parsed = savePreferenceInputSchema.safeParse(part.input);
+        if (!parsed.success) continue;
+
+        mergePreferences(parsed.data.preferences)
+          .then(() => loadPreferencesContext())
+          .catch(() => {
+            // IndexedDB write failed — preference is lost but non-critical
+          });
+      }
+    }
+  }, [messages]);
+}


### PR DESCRIPTION
## Summary

Introduces a `save_preference` tool so the AI chat assistant can remember user preferences (e.g. "I love sci-fi", "I hate horror") across sessions. The tool follows the existing `present_media` pass-through pattern — the server handler returns the input unchanged, and a new `usePreferencePersistence` hook intercepts tool call results, persists them to IndexedDB via a new preference store module, and refreshes an in-memory cache. On subsequent sessions, stored preferences are injected as a `[User Preferences]` block prepended to the user's first message so the model can personalise recommendations from the outset.

Supporting changes include a tool activity line label, system prompt instructions for when and how to invoke the tool, and an eval case.

## Context

The `save_preference` tool follows the same pass-through pattern as `present_media` — server returns input as-is, client handles persistence. Preferences are stored client-side only (IndexedDB) with no server-side user tracking. They are injected as user-provided context (not in the system prompt) to avoid prompt injection risk from stored values. The preference context is sent once per session in the first message to avoid busting the prompt cache.

Closes #1925