### PR TITLE
fix: guard cached image complete check with naturalWidth

### DIFF
--- a/src/components/ai-chat/compact-person-card.tsx
+++ b/src/components/ai-chat/compact-person-card.tsx
@@ -56,7 +56,7 @@ function ProfilePhoto({
         onLoad={() => setLoaded(true)}
         onError={() => setErrored(true)}
         ref={(el) => {
-          if (el?.complete) setLoaded(true);
+          if (el?.complete && el.naturalWidth > 0) setLoaded(true);
         }}
       />
     </>

--- a/src/components/movie-database/poster-image.tsx
+++ b/src/components/movie-database/poster-image.tsx
@@ -58,7 +58,7 @@ export function PosterImage({ posterPath, alt }: PosterImageProps) {
         onLoad={() => setImgLoaded(true)}
         onError={() => setImgErrored(true)}
         ref={(el) => {
-          if (el && el.complete) {
+          if (el && el.complete && el.naturalWidth > 0) {
             setImgLoaded(true);
           }
         }}


### PR DESCRIPTION
## Summary

Prevents a visual flash when browser-cached broken images momentarily appear as loaded before the error fallback shows. The ref callbacks in PosterImage and ProfilePhoto check `el.complete` to detect cached images and skip the loading skeleton, but per the HTML spec, `complete` is `true` even for images that failed to load. Adding a `naturalWidth > 0` guard ensures only successfully loaded cached images skip the skeleton.