### PR TITLE
fix: resolve TypeScript errors in ai-chat test files

### DIFF
--- a/src/ai-chat/tools/review-summary.test.ts
+++ b/src/ai-chat/tools/review-summary.test.ts
@@ -78,7 +78,8 @@ async function executeTool(input: {
   spiciness?: number;
 }) {
   const tool = createReviewSummaryTool("en");
-  const result = await tool.execute!(input, executeContext);
+  const parsed = reviewSummaryInputSchema.parse(input);
+  const result = await tool.execute!(parsed, executeContext);
   return JSON.parse(JSON.stringify(result)) as ReviewSummaryResult;
 }
 

--- a/src/app/api/ai-chat/route.test.ts
+++ b/src/app/api/ai-chat/route.test.ts
@@ -1,3 +1,4 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
 import type { UIMessage } from "ai";
 import { simulateReadableStream, stepCountIs, streamText } from "ai";
 import { MockLanguageModelV3 } from "ai/test";
@@ -10,9 +11,12 @@ import { createPresentPersonTool } from "#src/ai-chat/tools/present-person.ts";
 import { createPresentProviderRegionsTool } from "#src/ai-chat/tools/present-provider-regions.ts";
 import { createPresentWatchProvidersTool } from "#src/ai-chat/tools/present-watch-providers.ts";
 import { createReviewSummaryTool } from "#src/ai-chat/tools/review-summary.ts";
+import { createSavePreferenceTool } from "#src/ai-chat/tools/save-preference.ts";
 import { createSemanticSearchTool } from "#src/ai-chat/tools/semantic-search.ts";
 import { createTmdbSearchTool } from "#src/ai-chat/tools/tmdb-search.ts";
 import { createWatchProvidersTool } from "#src/ai-chat/tools/watch-providers.ts";
+
+const anthropic = createAnthropic({ apiKey: "test-key" });
 
 vi.mock("#src/ai-chat/chat.ts", () => ({
   chat: vi.fn(),
@@ -78,6 +82,8 @@ function mockStreamResult() {
       person_credits: createPersonCreditsTool(),
       present_person: createPresentPersonTool(),
       review_summary: createReviewSummaryTool("en"),
+      save_preference: createSavePreferenceTool(),
+      web_search: anthropic.tools.webSearch_20250305({ maxUses: 3 }),
     },
     stopWhen: stepCountIs(5),
   });


### PR DESCRIPTION
## Summary
- Add missing `save_preference` and `web_search` tools to the `mockStreamResult()` helper in `route.test.ts`, matching the tools registered in the production `chat()` function
- Parse test input through `reviewSummaryInputSchema` in `review-summary.test.ts` so Zod's `.default(3)` on `spiciness` is applied, aligning the type with what `execute()` expects

## Context
Recent PRs (#1887 review summaries, #1924 web search, #1928 save preference) added tools to `chat()` but did not update the test mock, causing 7 TypeScript errors that break `pnpm build:tsc`.

## Test plan
- [x] `pnpm build:tsc` passes with zero errors (was 7 errors before)
- [x] `pnpm test` — all 841 tests pass
- [x] `pnpm build` — full build succeeds
- [x] `pnpm lint:changed` — clean
- [x] `pnpm format:changed` — clean