### PR TITLE
perf: add decoding="async" to native img elements

### DIFF
--- a/src/components/ai-chat/compact-person-card.tsx
+++ b/src/components/ai-chat/compact-person-card.tsx
@@ -53,6 +53,7 @@ function ProfilePhoto({
         srcSet={srcSet}
         sizes="80px"
         loading="lazy"
+        decoding="async"
         onLoad={() => setLoaded(true)}
         onError={() => setErrored(true)}
         ref={(el) => {

--- a/src/components/ai-chat/media-detail-content.tsx
+++ b/src/components/ai-chat/media-detail-content.tsx
@@ -239,6 +239,7 @@ function PosterImage({
       src={src}
       srcSet={srcSet}
       sizes="90px"
+      decoding="async"
     />
   );
 }
@@ -265,6 +266,7 @@ function BackdropImage({
         src={src}
         srcSet={srcSet}
         sizes="600px"
+        decoding="async"
       />
       <div role="presentation" css={styles.backdropGradient} />
     </div>

--- a/src/components/ai-chat/person-detail-content.tsx
+++ b/src/components/ai-chat/person-detail-content.tsx
@@ -125,7 +125,14 @@ function ProfileImage({
   const { src, srcSet } = buildSrcSet(baseUrl, sizes, path);
   return (
     // eslint-disable-next-line @next/next/no-img-element
-    <img css={styles.photo} alt={alt} src={src} srcSet={srcSet} sizes="90px" />
+    <img
+      css={styles.photo}
+      alt={alt}
+      src={src}
+      srcSet={srcSet}
+      sizes="90px"
+      decoding="async"
+    />
   );
 }
 

--- a/src/components/ai-chat/tool-watch-providers.tsx
+++ b/src/components/ai-chat/tool-watch-providers.tsx
@@ -218,6 +218,7 @@ function ProviderLogo({
       width={size}
       height={size}
       loading="lazy"
+      decoding="async"
     />
   );
 }

--- a/src/components/movie-database/backdrop-image.tsx
+++ b/src/components/movie-database/backdrop-image.tsx
@@ -40,6 +40,7 @@ export async function BackdropImage({ backdropPath, alt }: BackdropImageProps) {
         srcSet={srcSet}
         sizes="100vw"
         fetchPriority="high"
+        decoding="async"
       />
 
       <div role="presentation" css={[absoluteFill.all, styles.mask1]} />

--- a/src/components/movie-database/poster-image.tsx
+++ b/src/components/movie-database/poster-image.tsx
@@ -55,6 +55,7 @@ export function PosterImage({ posterPath, alt }: PosterImageProps) {
         srcSet={srcSet}
         sizes="auto,(max-width: 326px) 100vw,(max-width: 485px) 50vw,(max-width: 644px) 33.3vw,(max-width: 767px) 25vw,(max-width: 969px) 33.3vw,(max-width: 1079px) 25vw,(max-width: 1259px) 33.3vw,(max-width: 1571px) 25vw,362px"
         loading="lazy"
+        decoding="async"
         onLoad={() => setImgLoaded(true)}
         onError={() => setImgErrored(true)}
         ref={(el) => {


### PR DESCRIPTION
## Summary

- Add `decoding="async"` attribute to all 7 native `<img>` elements across 6 component files
- Matches the default behavior of Next.js's `<Image>` component, which these components intentionally bypass since TMDB images are already CDN-optimized
- Hints the browser to decode images off the main thread, avoiding potential decode-blocking during rendering

## Affected files

- `src/components/movie-database/backdrop-image.tsx` (hero backdrop)
- `src/components/movie-database/poster-image.tsx` (poster grid)
- `src/components/ai-chat/compact-person-card.tsx` (person profile photos)
- `src/components/ai-chat/media-detail-content.tsx` (poster + backdrop in detail overlay)
- `src/components/ai-chat/person-detail-content.tsx` (person photo in detail overlay)
- `src/components/ai-chat/tool-watch-providers.tsx` (provider logos)

## Test plan

- [x] `pnpm lint:changed` passes
- [x] `pnpm format:changed` passes
- [x] `pnpm test` passes (841 tests)
- [x] `pnpm build` passes
- [x] Verified all native `<img>` elements in the codebase are covered