### PR TITLE
fix: add prefers-reduced-motion guards to spatial transitions

### DIFF
--- a/src/components/ai-chat/tool-activity-group.tsx
+++ b/src/components/ai-chat/tool-activity-group.tsx
@@ -5,6 +5,7 @@ import * as stylex from "@stylexjs/stylex";
 import { useState } from "react";
 import { t } from "#src/i18n.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
+import { motionConstants } from "#src/primitives/motion.stylex.ts";
 import { buttonReset } from "#src/primitives/reset.stylex.ts";
 import { color, font, space } from "#src/tokens.stylex.ts";
 import { TERMINAL_STATES, ToolActivityLine } from "./tool-activity-line";
@@ -99,7 +100,10 @@ const styles = stylex.create({
   },
   caret: {
     flexShrink: 0,
-    transition: "transform 0.15s ease",
+    transition: {
+      default: "transform 0.15s ease",
+      [motionConstants.REDUCED_MOTION]: "none",
+    },
   },
   caretOpen: {
     transform: "rotate(90deg)",

--- a/src/components/shared/theme-switch.tsx
+++ b/src/components/shared/theme-switch.tsx
@@ -9,6 +9,7 @@ import { Button } from "#src/components/shared/button.tsx";
 import { useMediaQuery } from "#src/hooks/use-media-query.ts";
 import { useTheme } from "#src/hooks/use-theme.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
+import { motionConstants } from "#src/primitives/motion.stylex.ts";
 import { color, controlSize, font, ratio, space } from "#src/tokens.stylex.ts";
 import type { SwitchState } from "./switch";
 import { Switch } from "./switch";
@@ -172,7 +173,10 @@ const styles = stylex.create({
     position: "absolute",
     top: 0,
     transform: `translateX(${themeSwitchTokens.systemLeft})`,
-    transition: "transform 0.2s ease, opacity 0.2s ease",
+    transition: {
+      default: "transform 0.2s ease, opacity 0.2s ease",
+      [motionConstants.REDUCED_MOTION]: "opacity 0.2s ease",
+    },
   },
   systemIcon: {
     position: "relative",


### PR DESCRIPTION
## Summary

Two components had CSS transitions animating spatial `transform` properties without respecting the `prefers-reduced-motion` media query. Users who prefer reduced motion (due to vestibular disorders or motion sensitivity) would still see the caret rotation animation in the tool activity group and the system button slide animation in the theme switch.

This adds `motionConstants.REDUCED_MOTION` guards to both transitions, following the same pattern already used consistently across the rest of the codebase (e.g., `scroll-to-bottom-button`, `switch`, `card`, `button-shared`). Transform-only transitions fall back to `"none"`, while mixed transitions (transform + opacity) keep the non-spatial part.