### PR TITLE
fix: correct malformed local() in Inter-fallback font-face src

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -16,9 +16,9 @@
   font-family: "Inter-fallback";
   size-adjust: 107%;
   ascent-override: 90%;
-  src: local(
-    "system-ui, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'"
-  );
+  src:
+    local("Segoe UI"), local("Roboto"), local("Helvetica Neue"),
+    local("Helvetica"), local("Arial");
   unicode-range:
     U+0000, U+0020-007E, U+00A0-00AC, U+00AE-00FF, U+0131, U+0152-0153,
     U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-200B, U+2010-2027, U+202F-2055,


### PR DESCRIPTION
## Summary

The `Inter-fallback` `@font-face` declaration had a malformed `src` property — a comma-separated font stack was passed as a single argument to `local()`, which only accepts one font family name per invocation. No system font has the literal name `"system-ui, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'"`, so the fallback face never matched any installed font. This made the `size-adjust: 107%` and `ascent-override: 90%` metric overrides completely non-functional, causing unnecessary Cumulative Layout Shift during font loading as text fell through to `sans-serif` with default metrics.

Fixes the `src` to use separate `local()` entries for each system font (Segoe UI, Roboto, Helvetica Neue, Helvetica, Arial), covering Windows, Android, macOS, and a universal fallback.