### PR TITLE
fix: stop flow gradient animation for prefers-reduced-motion

### DIFF
--- a/src/components/shared/flow-gradient/flow-gradient.tsx
+++ b/src/components/shared/flow-gradient/flow-gradient.tsx
@@ -18,10 +18,6 @@ export function FlowGradient() {
   );
   const isDark = theme === "system" ? preferDark : theme === "dark";
 
-  if (prefersReducedMotion) {
-    return <div css={[styles.canvas, styles.staticGradient]} />;
-  }
-
   return (
     <canvas
       ref={(el) => {
@@ -39,6 +35,7 @@ export function FlowGradient() {
                     colorAltTop: [1, 0.3, 0.3],
                     colorAltBottom: [1, 0.3, 0.3],
                   },
+              { reducedMotion: prefersReducedMotion },
             );
           }
         }
@@ -58,9 +55,5 @@ const styles = stylex.create({
       [motionConstants.REDUCED_MOTION]: null,
     },
     zIndex: layer.base,
-  },
-  staticGradient: {
-    backgroundImage: `radial-gradient(ellipse at 30% 20%, ${color.controlActive}, transparent 60%), radial-gradient(ellipse at 70% 80%, ${color.controlActive}, transparent 60%)`,
-    opacity: 0.15,
   },
 });

--- a/src/components/shared/flow-gradient/loop.ts
+++ b/src/components/shared/flow-gradient/loop.ts
@@ -201,6 +201,7 @@ export function start(
     colorAltBottom = [1, 0, 0],
     colorBackground = [0.953, 0.929, 0.929],
   }: Options,
+  { reducedMotion = false } = {},
 ) {
   const abortController = new AbortController();
 
@@ -216,7 +217,14 @@ export function start(
   observer.observe(canvas);
 
   // Ripple effect mouse tracking
-  const pointerState = setupPointerEvents(abortController.signal);
+  const pointerState = reducedMotion
+    ? ({
+        mousePosition: [0, 0],
+        rippleStrength: 1,
+        rippleStrengthTarget: 1,
+        ripplePhase: 0,
+      } satisfies PointerState)
+    : setupPointerEvents(abortController.signal);
 
   let bufferInfo: BufferInfo | undefined;
   let lastTimestamp = 0;
@@ -234,23 +242,25 @@ export function start(
       resized = false;
     }
 
-    const rippleSpeed = 5; // 1 / 0.2s = 5
-    pointerState.rippleStrength +=
-      (pointerState.rippleStrengthTarget - pointerState.rippleStrength) *
-      rippleSpeed *
-      deltaTime;
-    pointerState.rippleStrength =
-      Math.floor(pointerState.rippleStrength * 1000) / 1000;
+    if (!reducedMotion) {
+      const rippleSpeed = 5; // 1 / 0.2s = 5
+      pointerState.rippleStrength +=
+        (pointerState.rippleStrengthTarget - pointerState.rippleStrength) *
+        rippleSpeed *
+        deltaTime;
+      pointerState.rippleStrength =
+        Math.floor(pointerState.rippleStrength * 1000) / 1000;
 
-    pointerState.ripplePhase +=
-      rippleSpeed * deltaTime * pointerState.rippleStrength * 1.5;
-    pointerState.ripplePhase =
-      Math.floor(pointerState.ripplePhase * 1000) / 1000;
+      pointerState.ripplePhase +=
+        rippleSpeed * deltaTime * pointerState.rippleStrength * 1.5;
+      pointerState.ripplePhase =
+        Math.floor(pointerState.ripplePhase * 1000) / 1000;
+    }
 
     const uniforms = {
       u_resolution: [gl.canvas.width, gl.canvas.height],
       u_dpi: computeDPI(gl.canvas.width),
-      u_time: timestamp,
+      u_time: reducedMotion ? 0 : timestamp,
       u_colorTop: colorTop,
       u_colorBottom: colorBottom,
       u_colorAltTop: colorAltTop,
@@ -265,14 +275,17 @@ export function start(
     drawBufferInfo(gl, bufferInfo);
   };
 
-  const cancelAnimation = createAnimationLoop({
-    render,
-    signal: abortController.signal,
-    fps: 60,
-  });
+  let cancelAnimation: (() => void) | undefined;
+  if (!reducedMotion) {
+    cancelAnimation = createAnimationLoop({
+      render,
+      signal: abortController.signal,
+      fps: 60,
+    });
+  }
 
   return () => {
-    cancelAnimation();
+    cancelAnimation?.();
     observer.disconnect();
     abortController.abort();
   };


### PR DESCRIPTION
## Summary

- When `prefers-reduced-motion: reduce` is active, skip the animation loop and pointer events — the WebGL shader renders a single static frame at t=0 instead
- No new CSS gradient or element swap needed; the same canvas and shader produce the visual, just frozen
- `willChange: transform` is still conditionally removed via the existing `REDUCED_MOTION` media query constant

## Test plan

- [ ] Enable "Reduce motion" in OS accessibility settings
- [ ] Verify the homepage gradient renders as a static image (no animation, no pointer interaction)
- [ ] Disable "Reduce motion" and verify the gradient animates normally
- [ ] Resize the browser with reduced motion on — gradient should still resize correctly