### PR TITLE
refactor: remove no-op React.cache wrapper from tmdbGet

### DIFF
--- a/src/utils/tmdb-client.ts
+++ b/src/utils/tmdb-client.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import "server-only";
-import { cache, cacheSignal } from "react";
+import { cacheSignal } from "react";
 import type { paths } from "#src/_generated/tmdbV3.d.ts";
 import { buildTmdbUrl } from "./build-tmdb-url";
 
@@ -87,30 +87,28 @@ export async function tmdbGet<TPath extends keyof paths>(
   params?: QueryParams<TPath, "get">,
   pathParams?: PathParams<TPath>,
 ) {
-  return cache(async () => {
-    // Replace path parameters with sanitized values
-    let resolvedPath = `${path}`;
-    if (pathParams) {
-      for (const [key, value] of Object.entries(pathParams)) {
-        const sanitizedValue = sanitizePathParam(value);
-        resolvedPath = resolvedPath.replace(`{${key}}`, sanitizedValue);
-      }
+  // Replace path parameters with sanitized values
+  let resolvedPath = `${path}`;
+  if (pathParams) {
+    for (const [key, value] of Object.entries(pathParams)) {
+      const sanitizedValue = sanitizePathParam(value);
+      resolvedPath = resolvedPath.replace(`{${key}}`, sanitizedValue);
     }
+  }
 
-    const url = buildTmdbUrl({
-      baseUrl: `${BASE_URL}${resolvedPath}`,
-      params,
-    });
+  const url = buildTmdbUrl({
+    baseUrl: `${BASE_URL}${resolvedPath}`,
+    params,
+  });
 
-    // Additional security check: ensure the URL is still pointing to TMDB
-    const urlObj = new URL(url);
-    if (urlObj.hostname !== "api.themoviedb.org") {
-      throw new Error("Invalid URL: must be a TMDB API endpoint");
-    }
+  // Additional security check: ensure the URL is still pointing to TMDB
+  const urlObj = new URL(url);
+  if (urlObj.hostname !== "api.themoviedb.org") {
+    throw new Error("Invalid URL: must be a TMDB API endpoint");
+  }
 
-    const errorMessage = `Failed to fetch ${path}`;
-    return tmdbFetch<ResponseType<TPath, "get">>(url, errorMessage);
-  })();
+  const errorMessage = `Failed to fetch ${path}`;
+  return tmdbFetch<ResponseType<TPath, "get">>(url, errorMessage);
 }
 
 // Usage examples:


### PR DESCRIPTION
## Summary

`React.cache` was being called inside `tmdbGet`, wrapping a new anonymous function on every invocation. Per React docs, each call to `cache()` creates a separate memoized function that does not share cache with others — so this wrapper could never deduplicate anything and was a pure no-op. Removing it eliminates misleading code that suggests React-level request deduplication is active when it isn't. The actual caching is correctly handled by `fetch` with `cache: "force-cache"` and `next: { revalidate: 86400 }`, which remains untouched.