### PR TITLE
fix: add X-Frame-Options header and Secure cookie attribute

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -28,6 +28,10 @@ module.exports = async () => {
           value: "nosniff",
         },
         {
+          key: "X-Frame-Options",
+          value: "DENY",
+        },
+        {
           key: "Content-Security-Policy",
           value: "frame-ancestors 'none'",
         },

--- a/src/components/shared/locale-selector.tsx
+++ b/src/components/shared/locale-selector.tsx
@@ -74,7 +74,8 @@ export function LocaleSelector({
 function setLocaleCookie(locale: SupportedLocale) {
   // set cookie for next-i18n-router
   const maxAge = 31536000; // 1 year in seconds
-  document.cookie = `${LOCALE_COOKIE_NAME}=${locale};max-age=${maxAge};path=/;SameSite=Lax`;
+  const secure = window.location.protocol === "https:" ? ";Secure" : "";
+  document.cookie = `${LOCALE_COOKIE_NAME}=${locale};max-age=${maxAge};path=/;SameSite=Lax${secure}`;
 }
 
 const styles = stylex.create({


### PR DESCRIPTION
## Summary

Adds two defense-in-depth security hardening measures. First, includes the `X-Frame-Options: DENY` response header alongside the existing `Content-Security-Policy: frame-ancestors 'none'` — this provides clickjacking protection for older browsers that don't support CSP `frame-ancestors`. Second, adds the `Secure` attribute to the locale preference cookie so it won't be transmitted over insecure HTTP connections. The `Secure` flag is conditionally applied only when the page is served over HTTPS, so local development is unaffected.