### PR TITLE
fix: add aria-hidden to decorative Phosphor icons

### DIFF
--- a/src/app/[locale]/(home)/page.tsx
+++ b/src/app/[locale]/(home)/page.tsx
@@ -47,7 +47,9 @@ export default async function Home(props: PageProps) {
         <h2 css={styles.sectionTitle}>{t({ en: "Projects", zh: "项目" })}</h2>
         <div css={styles.cardList}>
           <ProjectCard
-            icon={<GraduationCapIcon size={64} weight="fill" />}
+            icon={
+              <GraduationCapIcon size={64} weight="fill" aria-hidden="true" />
+            }
             href="https://studentloanstudy.uk/"
             target="_blank"
             css={[styles.card, styles.studentLoan]}
@@ -58,7 +60,7 @@ export default async function Home(props: PageProps) {
             })}
           />
           <ProjectCard
-            icon={<FilmSlateIcon size={64} weight="fill" />}
+            icon={<FilmSlateIcon size={64} weight="fill" aria-hidden="true" />}
             href={getLocalePath("/movie-database", locale)}
             css={[styles.card, styles.movieDatabase]}
             name={t({ en: "Movie Database", zh: "电影数据库" })}
@@ -69,7 +71,7 @@ export default async function Home(props: PageProps) {
             scroll
           />
           <ProjectCard
-            icon={<CalculatorIcon size={64} weight="fill" />}
+            icon={<CalculatorIcon size={64} weight="fill" aria-hidden="true" />}
             href={getLocalePath("/calculator", locale)}
             css={[styles.card, styles.calculator]}
             name={t({ en: "Calculator", zh: "计算器" })}
@@ -80,7 +82,7 @@ export default async function Home(props: PageProps) {
             scroll
           />
           <ProjectCard
-            icon={<PackageIcon size={64} weight="fill" />}
+            icon={<PackageIcon size={64} weight="fill" aria-hidden="true" />}
             href={getLocalePath("/component-library", locale)}
             css={[styles.card, styles.componentLibrary]}
             name={t({ en: "Component Library", zh: "组件库" })}

--- a/src/components/ai-chat/chat-input-bar.tsx
+++ b/src/components/ai-chat/chat-input-bar.tsx
@@ -98,7 +98,7 @@ export function ChatInputBar({
                 styles.attachmentDismiss,
               ]}
             >
-              <XIcon size={12} />
+              <XIcon size={12} aria-hidden="true" />
             </button>
           </span>
         </div>

--- a/src/components/ai-chat/detail-overlay.tsx
+++ b/src/components/ai-chat/detail-overlay.tsx
@@ -66,7 +66,7 @@ export function DetailOverlay({
               onClick={onClose}
               aria-label={t({ en: "Close", zh: "关闭" })}
             >
-              <XIcon size={20} />
+              <XIcon size={20} aria-hidden="true" />
             </button>
             {children}
           </div>

--- a/src/components/ai-chat/media-detail-content.tsx
+++ b/src/components/ai-chat/media-detail-content.tsx
@@ -181,7 +181,7 @@ export function MediaDetailContent({
                   : `Watch trailer for ${displayTitle}`
               }
             >
-              <PlayIcon weight="fill" size={14} />
+              <PlayIcon weight="fill" size={14} aria-hidden="true" />
               {t({ en: "Trailer", zh: "预告" })}
             </a>
           )}

--- a/src/components/movie-database/reset-filter.tsx
+++ b/src/components/movie-database/reset-filter.tsx
@@ -31,7 +31,7 @@ export function ResetFilter({ bright, hideLabel }: ResetFilterProps) {
           e.preventDefault();
           reset();
         }}
-        icon={<FunnelXIcon />}
+        icon={<FunnelXIcon aria-hidden="true" />}
         bright={bright}
       >
         {t({ en: "Reset", zh: "重置" })}

--- a/src/components/movie-database/tmdb-credit.tsx
+++ b/src/components/movie-database/tmdb-credit.tsx
@@ -18,7 +18,7 @@ export function TmdbCredit({ position }: TmdbCreditProps) {
     <MenuButton
       position={position}
       buttonProps={{
-        icon: <InfoIcon />,
+        icon: <InfoIcon aria-hidden="true" />,
         "aria-label": t({ en: "TMDB attribution info", zh: "TMDB 版权信息" }),
       }}
       popupRole={undefined}

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -24,7 +24,7 @@ export function Card({ children, className, style, ...rest }: CardProps) {
       <div css={styles.detailsBackdrop} />
       <div css={styles.detailsIndicator}>
         <span css={styles.detailsText}>{t({ en: "Details", zh: "详情" })}</span>
-        <ArrowRightIcon />
+        <ArrowRightIcon aria-hidden="true" />
       </div>
     </Anchor>
   );

--- a/src/components/shared/theme-switch.tsx
+++ b/src/components/shared/theme-switch.tsx
@@ -86,8 +86,12 @@ export function ThemeSwitch({ labels }: ThemeSwitchProps) {
           title={labels[2]}
         >
           <div css={styles.systemIcon}>
-            <MoonIcon weight="fill" css={styles.systemMoon} />
-            <SunIcon weight="fill" css={styles.systemSun} />
+            <MoonIcon
+              weight="fill"
+              css={styles.systemMoon}
+              aria-hidden="true"
+            />
+            <SunIcon weight="fill" css={styles.systemSun} aria-hidden="true" />
           </div>
         </Button>
       </div>


### PR DESCRIPTION
## Summary

Adds `aria-hidden="true"` to 10 decorative Phosphor icon instances across 8 components where the attribute was missing. The codebase consistently marks decorative icons with `aria-hidden="true"` or `role="presentation"`, but these instances were overlooked. Without the attribute, screen readers may traverse into the SVG DOM and announce meaningless path content alongside the actual button/link labels — this brings the remaining icons into alignment with the established convention.