### PR TITLE
fix: split deprecated "any maskable" icon purpose into separate entries

### DIFF
--- a/tooling/pwa-icons/hash-icons.mjs
+++ b/tooling/pwa-icons/hash-icons.mjs
@@ -79,13 +79,15 @@ function generateHashedIcons() {
       type: "image/png",
     });
 
-    // For 512x512, also add maskable version
+    // For 512x512, also add a maskable entry.
+    // These must be separate entries — the combined "any maskable" value
+    // is deprecated since Chrome 120 and triggers a console warning.
     if (size === "512x512") {
       icons.push({
         src: hashedFileName,
         sizes: size,
         type: "image/png",
-        purpose: "any maskable",
+        purpose: "maskable",
       });
     }
   }


### PR DESCRIPTION
## Summary

Chrome deprecates the combined `"any maskable"` value in the manifest icon `purpose` field, logging a console warning about incorrect padding on some platforms. The PWA icon codegen script declared the 512x512 icon with `"purpose": "any maskable"` in a single entry. Since the icon is already declared once without a `purpose` (which defaults to `"any"`), the second entry only needs `"purpose": "maskable"` — splitting the combined value into separate entries as recommended.