### PR TITLE
chore: add ai-sdk dependabot group and improve merge-dependabot skill

### DIFF
--- a/.claude/skills/merge-dependabot/SKILL.md
+++ b/.claude/skills/merge-dependabot/SKILL.md
@@ -8,103 +8,46 @@ user-invocable: true
 
 Autonomously process open Dependabot PRs one at a time. For each: verify the actual version being upgraded, review the official changelog for breaking changes, run quality checks, and — for production dependencies — sanity-test in the browser with playwright. Merge if safe, skip if uncertain, and report everything at the end.
 
-## Pre-flight
-
-Before processing any PRs, verify master's CI is healthy:
-
-```bash
-gh run list --branch master --limit 3 --json conclusion,name,headBranch
-```
-
-If recent CI runs are failing on master, stop and report. Merging into a broken master just adds noise.
-
 ## Phase 1: Discover
+
+First verify master's CI is healthy (`gh run list --branch master --limit 3 --json conclusion,name,headBranch`). If recent runs are failing, stop and report.
+
+Then list open Dependabot PRs:
 
 ```bash
 gh pr list --author "app/dependabot" --state open --json number,title,mergeable,headRefName,labels
 ```
 
-Print a numbered summary of all open Dependabot PRs, then begin processing them sequentially.
+Print a numbered summary, then process them **strictly one at a time, in sequence**. Never set auto-merge. Never use `@dependabot rebase`. Only move to the next PR after the current one is fully merged or skipped.
 
 ## Phase 2: Process Each PR
 
-Work through PRs **strictly one at a time, in sequence**. Never set auto-merge. Never use `@dependabot rebase`. Every rebase, push, CI wait, and merge must happen in order — only move to the next PR after the current one is fully merged (or skipped). This prevents timing races where concurrent merges and rebases conflict with each other.
-
 ### Step 1 — Checkout and rebase
-
-Always start by checking out the branch and rebasing on master — even if GitHub says the PR is mergeable, a local rebase ensures a clean linear history:
 
 ```bash
 git fetch origin <headRefName>
 git checkout <headRefName>
 git rebase origin/master
-```
-
-If the rebase succeeds cleanly, force-push with lease (this is safe — these are bot-owned branches):
-
-```bash
 git push --force-with-lease origin <headRefName>
 ```
 
-If the rebase has conflicts:
+Force-push is safe — these are bot-owned branches. If the force-push fails with "stale info", Dependabot auto-rebased the branch. Delete the local branch, re-fetch, and restart this PR.
 
-- If the conflicts are only in the lockfile (`pnpm-lock.yaml`), resolve by accepting the incoming version and regenerating: delete the lockfile, run `pnpm install`, then `git add pnpm-lock.yaml` and `git rebase --continue`
-- If there are non-lockfile conflicts that aren't straightforward to resolve, skip the PR and note the conflict details in the summary
+If the rebase has lockfile conflicts: delete `pnpm-lock.yaml`, run `pnpm install`, stage and continue. For non-lockfile conflicts that aren't straightforward, skip the PR.
 
-### Step 2 — Determine actual versions from the PR diff
+### Step 2 — Understand the change
 
-Dependabot does not update PR titles or descriptions after initial creation — the versions shown can be stale. Always check the real diff:
+PR titles can be stale. Always check `gh pr diff <number>` for the real `from`/`to` versions and whether the package is in `dependencies` (prod) or `devDependencies` (dev).
 
-```bash
-gh pr diff <number>
-```
+Review the official changelog (find the repo via `pnpm info <package> repository.url`, then check GitHub Releases or CHANGELOG.md). Identify breaking changes, deprecations, and migration steps. If no changelog exists for a major bump, skip the PR.
 
-From the `package.json` changes, extract:
-
-- The real `from` and `to` versions
-- Whether the package lives in `dependencies` (production) or `devDependencies` (development)
-
-For grouped PRs (multiple packages updated together), repeat for each package.
-
-### Step 3 — Review the official changelog
-
-Fetch the actual changelog — never rely on the PR description.
-
-1. Find the source repo:
-
-   ```bash
-   npm view <package-name> repository.url
-   ```
-
-2. Fetch the changelog (try in order):
-   - **GitHub Releases**: Use `WebFetch` to read the releases page and find entries between the `from` and `to` versions
-   - **CHANGELOG.md**: Fetch the raw file from the repo's default branch
-
-3. From the changelog, identify:
-   - **Breaking changes** between `from` and `to`
-   - **Deprecations** that might affect the codebase
-   - **Migration steps** required by the upgrade
-   - Whether this is a **patch**, **minor**, or **major** bump
-
-If a changelog cannot be found and this is a major version bump, treat it as risky and skip.
-
-### Step 4 — Install dependencies
-
-The branch is already checked out from Step 1. Install dependencies to pick up the version changes:
+### Step 3 — Verify it works
 
 ```bash
-pnpm install
+CI=true pnpm install
 ```
 
-### Step 5 — Address breaking changes
-
-If the changelog identified breaking changes or required migrations:
-
-1. Search the codebase for affected APIs, patterns, or configuration
-2. If the migration is straightforward and well-documented, apply it
-3. If the migration is complex, ambiguous, or could have subtle side effects — skip the PR and explain what needs to be done in the summary
-
-### Step 6 — Run quality checks
+If the changelog identified breaking changes, search the codebase for affected code and apply straightforward migrations. Skip the PR if migration is complex or uncertain.
 
 ```bash
 pnpm lint:changed
@@ -113,96 +56,38 @@ pnpm test
 pnpm build
 ```
 
-If a check fails:
+If a check fails due to the upgrade, attempt a fix. If the fix isn't clear, skip the PR.
 
-- Read the error carefully. If it's clearly caused by the upgrade, attempt a fix based on the changelog or migration guide.
-- Re-run the failing check after fixing.
-- If the fix is non-trivial or uncertain, skip the PR and include the error in the summary.
+### Step 4 — Sanity test production dependencies
 
-### Step 7 — Sanity test production dependencies
+**Skip for dev dependencies** — passing checks already confirm compatibility.
 
-**For dev dependencies, skip this step.** Instead, briefly note any special considerations worth calling out — for example:
+**For production dependencies**, use `playwright-cli` to verify affected pages still work:
 
-- A testing framework update: "tests passing confirms compatibility"
-- A build tool update: "successful build confirms compatibility"
-- A local dev tool update (e.g., dev server, HMR): "consider spinning up `pnpm dev` to verify local development still works"
+1. Search the codebase for imports of the package to identify affected pages
+2. Start `pnpm dev` in the background
+3. Visit affected pages, interact with relevant UI, check for console errors, take screenshots
+4. Stop the dev server
 
-**For production dependencies**, the goal is to verify that user-facing behavior hasn't regressed — especially behavior that unit tests don't cover or that could differ between test and browser environments.
+Skip the PR if anything looks broken.
 
-1. **Find usage in the codebase**: Search for imports of the package:
+### Step 5 — Push, wait for CI, merge
 
-   ```
-   Grep for: from ['"]<package-name>
-   ```
-
-2. **Map to pages and user flows**: Based on where the dependency is imported, determine which routes, components, and features could be affected.
-
-3. **Create and print an action plan**: Before testing, output the plan — what pages to visit, what interactions to try, what to look for. Focus on:
-   - Pages/components that directly consume the dependency
-   - User flows that exercise its functionality
-   - Visual rendering if the dependency affects UI
-   - Real browser behavior that test mocks can't replicate
-
-4. **Start the dev server** in the background:
-
-   ```bash
-   pnpm dev &
-   ```
-
-   Wait for `localhost:3000` to respond before proceeding.
-
-5. **Execute the test plan using the `playwright-cli` skill**:
-   - Open each page from the action plan
-   - Take snapshots to verify pages render correctly
-   - Interact with relevant UI elements (clicks, form fills, navigation)
-   - Check for console errors or unexpected behavior
-   - Take screenshots as evidence of successful testing
-
-6. **Stop the dev server** when done (kill the background process).
-
-If anything looks broken or suspicious, skip the PR and describe what was observed.
-
-### Step 8 — Push, wait for CI, then merge
-
-**Never use auto-merge.** Each PR must be fully merged before moving to the next one.
-
-If you made any changes (migration fixes, lockfile regeneration, etc.), commit and push them:
-
-```bash
-git push origin <headRefName>
-```
-
-If you rebased in Step 1, force-push is needed (already covered there).
-
-**Wait for CI to pass** on the PR branch before merging. Poll the PR's check status:
+Commit and push any changes made during the process. Wait for CI:
 
 ```bash
 gh pr checks <number> --watch
 ```
 
-If CI fails on something you didn't touch (e.g., a flaky test unrelated to the upgrade), note it and retry once. If CI fails due to the upgrade itself and the fix isn't clear, skip the PR.
-
-**Merge** when all of the following are true:
-
-- Changelog review showed no unaddressed breaking changes
-- All local quality checks passed
-- CI is green on the PR branch
-- For prod deps: browser sanity testing showed no issues
-- Reasonable confidence the upgrade is safe
+Then merge:
 
 ```bash
 gh pr merge <number> --squash
 ```
 
-**Skip** when any of these apply:
+If merge is blocked by branch protection due to a check that is also failing on master (e.g., flaky test), use `--admin`. If CI fails due to the upgrade and the fix isn't clear, skip the PR.
 
-- Breaking changes need non-trivial or uncertain migration
-- Quality checks or CI fail and the fix isn't clear
-- Browser sanity testing revealed problems
-- Major version bump with no changelog available
-- Anything feels uncertain — err on the side of caution
-
-After processing each PR (merged or skipped), return to master and re-fetch before starting the next PR:
+After each PR (merged or skipped), return to master:
 
 ```bash
 git checkout origin/master
@@ -211,8 +96,6 @@ git fetch origin master
 
 ## Phase 3: Summary
 
-After all PRs are processed, print a clear report:
-
 ```
 ## Dependabot PR Summary
 
@@ -220,8 +103,14 @@ After all PRs are processed, print a clear report:
 - #N — package from → to (dev/prod)
 
 ### Skipped
-- #N — package — reason (e.g., "major bump, needs manual migration", "rebase requested")
+- #N — package — reason
 
 ### Action Required
-- [PRs that need human attention, with clear explanation of what to do]
+- [PRs needing human attention, with explanation]
 ```
+
+## Phase 4: Self-Improvement
+
+After every batch, reflect: **did anything require manual intervention or wasted work that could be prevented next time?** If yes, edit the workflow steps in this file or infrastructure files (`.github/dependabot.yml`, etc.) directly.
+
+Add a `### Process Improvements` section to the summary report listing any changes made.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,10 @@ updates:
           - "@vitest*"
           - "@vitejs/plugin-react"
           - "vite-plugin-babel"
+      ai-sdk:
+        patterns:
+          - "ai"
+          - "@ai-sdk*"
       postcss:
         patterns:
           - "postcss-*"


### PR DESCRIPTION
## Summary

During a Dependabot batch, `@ai-sdk/anthropic` and `ai` had a type incompatibility and had to be upgraded together. To prevent this from surfacing as separate conflicting PRs in the future, a Dependabot group has been added for AI SDK packages. Separately, the `merge-dependabot` skill was substantially trimmed — from ~240 lines to ~96 lines — to remove over-specified scaffolding the agent doesn't need.

## Context

Workflow steps were merged (versions+changelog → "understand the change", install+migrations+checks → "verify it works"), prescriptive sub-steps were replaced with concise instructions, and a Phase 4 self-improvement section was added so the skill evolves after each batch. A separate lessons/references system was considered and rejected as unnecessary complexity.