### PR TITLE
feat: add preference manager UI to AI mode input area

### DIFF
--- a/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
@@ -12,6 +12,7 @@ import { ChatMessageList } from "#src/components/ai-chat/chat-message-list.tsx";
 import { MediaDetailProvider } from "#src/components/ai-chat/media-detail-context.tsx";
 import { MediaDetailOverlay } from "#src/components/ai-chat/media-detail-overlay.tsx";
 import { PersonDetailOverlay } from "#src/components/ai-chat/person-detail-overlay.tsx";
+import { PreferenceManager } from "#src/components/ai-chat/preference-panel.tsx";
 import { SessionRestoreBanner } from "#src/components/ai-chat/session-restore-banner.tsx";
 import { border, color, layer, space } from "#src/tokens.stylex.ts";
 import type { SupportedLocale } from "#src/types.ts";
@@ -53,7 +54,6 @@ export function AIChatView({
   const [attachedMedia, setAttachedMedia] = useState<AttachedMedia | null>(
     null,
   );
-
   const handleSend = (text: string) => {
     const message = attachedMedia
       ? `[About: ${attachedMedia.title} (${attachedMedia.mediaType})] ${text}`
@@ -85,6 +85,7 @@ export function AIChatView({
           errorLabel={errorLabel}
         />
         <div css={styles.inputArea}>
+          <PreferenceManager />
           <ChatInputBar
             placeholder={placeholder}
             sendLabel={sendLabel}

--- a/src/components/ai-chat/preference-panel.tsx
+++ b/src/components/ai-chat/preference-panel.tsx
@@ -1,0 +1,549 @@
+"use client";
+
+import { InfoIcon } from "@phosphor-icons/react/dist/ssr/Info";
+import { SlidersHorizontalIcon } from "@phosphor-icons/react/dist/ssr/SlidersHorizontal";
+import { ThumbsDownIcon } from "@phosphor-icons/react/dist/ssr/ThumbsDown";
+import { ThumbsUpIcon } from "@phosphor-icons/react/dist/ssr/ThumbsUp";
+import { TrashIcon } from "@phosphor-icons/react/dist/ssr/Trash";
+import { XIcon } from "@phosphor-icons/react/dist/ssr/X";
+import * as stylex from "@stylexjs/stylex";
+import { useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { RemoveScroll } from "react-remove-scroll";
+import { breakpoints } from "#src/breakpoints.stylex.ts";
+import { usePortalTarget } from "#src/contexts/portal-context.tsx";
+import { useDialogFocus } from "#src/hooks/use-dialog-focus.ts";
+import { t } from "#src/i18n.ts";
+import type { StoredPreference } from "#src/preference-store/preference-store.ts";
+import { usePreferences } from "#src/preference-store/use-preferences.ts";
+import { flex } from "#src/primitives/flex.stylex.ts";
+import { fixedFill } from "#src/primitives/layout.stylex.ts";
+import { motionConstants } from "#src/primitives/motion.stylex.ts";
+import { buttonReset } from "#src/primitives/reset.stylex.ts";
+import { border, color, font, layer, space } from "#src/tokens.stylex.ts";
+
+const CATEGORY_ORDER: ReadonlyArray<StoredPreference["category"]> = [
+  "genre",
+  "director",
+  "actor",
+  "keyword",
+  "language",
+  "content_rating",
+];
+
+/**
+ * Renders the preferences trigger button and manages the panel overlay.
+ * Uses a single `usePreferences()` instance so the button indicator
+ * and the panel content always stay in sync.
+ */
+export function PreferenceManager() {
+  const [isOpen, setIsOpen] = useState(false);
+  const { preferences, remove, clearAll } = usePreferences();
+
+  return (
+    <>
+      <button
+        type="button"
+        css={[buttonReset.base, flex.inlineCenter, triggerStyles.button]}
+        onClick={() => setIsOpen(true)}
+        aria-label={t({ en: "Preferences", zh: "偏好设置" })}
+      >
+        <SlidersHorizontalIcon size={16} role="presentation" />
+        {preferences.length > 0 && (
+          <span css={triggerStyles.dot} aria-hidden="true" />
+        )}
+      </button>
+      <PreferencePanel
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        preferences={preferences}
+        onRemove={(id) => void remove(id)}
+        onClearAll={clearAll}
+      />
+    </>
+  );
+}
+
+const triggerStyles = stylex.create({
+  button: {
+    position: "relative",
+    width: "1.75rem",
+    height: "1.75rem",
+    borderRadius: border.radius_round,
+    color: color.textMuted,
+    backgroundColor: {
+      default: "transparent",
+      ":hover": color.backgroundHover,
+    },
+    cursor: "pointer",
+    transition: "background-color 0.15s ease, color 0.15s ease",
+    marginBottom: space._1,
+  },
+  dot: {
+    position: "absolute",
+    top: "3px",
+    right: "3px",
+    width: "6px",
+    height: "6px",
+    borderRadius: border.radius_round,
+    backgroundColor: color.controlActive,
+  },
+});
+
+interface PreferencePanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  preferences: ReadonlyArray<StoredPreference>;
+  onRemove: (id: string) => void;
+  onClearAll: () => Promise<void>;
+}
+
+function PreferencePanel({
+  isOpen,
+  onClose,
+  preferences,
+  onRemove,
+  onClearAll,
+}: PreferencePanelProps) {
+  const portalTarget = usePortalTarget();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const [confirmingClear, setConfirmingClear] = useState(false);
+
+  useDialogFocus({
+    isOpen,
+    dialogRef,
+    onClose,
+    initialFocusRef: closeButtonRef,
+  });
+
+  if (!isOpen || !portalTarget) {
+    return null;
+  }
+
+  const grouped = new Map<StoredPreference["category"], StoredPreference[]>();
+  for (const pref of preferences) {
+    const list = grouped.get(pref.category);
+    if (list) {
+      list.push(pref);
+    } else {
+      grouped.set(pref.category, [pref]);
+    }
+  }
+
+  const handleClearAll = async () => {
+    await onClearAll();
+    setConfirmingClear(false);
+  };
+
+  return createPortal(
+    <>
+      <div
+        css={[fixedFill.all, styles.backdrop]}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <RemoveScroll allowPinchZoom forwardProps>
+        <div css={[fixedFill.all, styles.panelContainer]}>
+          <div
+            ref={dialogRef}
+            css={styles.panel}
+            role="dialog"
+            aria-modal="true"
+            aria-label={t({ en: "Your preferences", zh: "你的偏好" })}
+          >
+            <div css={[flex.between, styles.header]}>
+              <h2 css={styles.title}>
+                {t({ en: "Your Preferences", zh: "你的偏好" })}
+              </h2>
+              <button
+                ref={closeButtonRef}
+                type="button"
+                css={[buttonReset.base, flex.inlineCenter, styles.closeButton]}
+                onClick={onClose}
+                aria-label={t({ en: "Close", zh: "关闭" })}
+              >
+                <XIcon size={18} />
+              </button>
+            </div>
+
+            <div css={[flex.row, styles.infoBanner]}>
+              <InfoIcon size={16} css={styles.infoIcon} role="presentation" />
+              <p css={styles.infoText}>
+                {t({
+                  en: "Preferences are stored locally on your device. They help the AI personalise recommendations. Nothing is sent to a server.",
+                  zh: "偏好仅存储在你的设备上，用于帮助 AI 个性化推荐，不会发送至服务器。",
+                })}
+              </p>
+            </div>
+
+            <div css={styles.body}>
+              {preferences.length === 0 ? (
+                <div css={[flex.center, styles.emptyState]}>
+                  <p css={styles.emptyText}>
+                    {t({
+                      en: "No preferences yet. Chat with the AI and it will learn what you like.",
+                      zh: "还没有偏好记录。和 AI 聊天，它会了解你的喜好。",
+                    })}
+                  </p>
+                </div>
+              ) : (
+                CATEGORY_ORDER.filter((cat) => grouped.has(cat)).map(
+                  (category) => (
+                    <CategorySection
+                      key={category}
+                      category={category}
+                      preferences={grouped.get(category) ?? []}
+                      onRemove={onRemove}
+                    />
+                  ),
+                )
+              )}
+            </div>
+
+            {preferences.length > 0 && (
+              <div css={styles.footer}>
+                {confirmingClear ? (
+                  <div css={[flex.row, styles.confirmRow]}>
+                    <p css={styles.confirmText}>
+                      {t({
+                        en: "Clear all preferences?",
+                        zh: "清除所有偏好？",
+                      })}
+                    </p>
+                    <button
+                      type="button"
+                      css={[buttonReset.base, styles.confirmButton]}
+                      onClick={() => void handleClearAll()}
+                    >
+                      {t({ en: "Yes, clear", zh: "确认清除" })}
+                    </button>
+                    <button
+                      type="button"
+                      css={[buttonReset.base, styles.cancelButton]}
+                      onClick={() => setConfirmingClear(false)}
+                    >
+                      {t({ en: "Cancel", zh: "取消" })}
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    css={[buttonReset.base, flex.row, styles.clearButton]}
+                    onClick={() => setConfirmingClear(true)}
+                  >
+                    <TrashIcon size={14} role="presentation" />
+                    {t({
+                      en: "Clear all preferences",
+                      zh: "清除所有偏好",
+                    })}
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </RemoveScroll>
+    </>,
+    portalTarget,
+  );
+}
+
+function CategorySection({
+  category,
+  preferences: prefs,
+  onRemove,
+}: {
+  category: StoredPreference["category"];
+  preferences: ReadonlyArray<StoredPreference>;
+  onRemove: (id: string) => void;
+}) {
+  const label = {
+    genre: t({ en: "Genres", zh: "类型" }),
+    actor: t({ en: "Actors", zh: "演员" }),
+    director: t({ en: "Directors", zh: "导演" }),
+    content_rating: t({ en: "Content rating", zh: "内容分级" }),
+    language: t({ en: "Languages", zh: "语言" }),
+    keyword: t({ en: "Keywords", zh: "关键词" }),
+  }[category];
+
+  return (
+    <div css={styles.categorySection}>
+      <h3 css={styles.categoryLabel}>{label}</h3>
+      <div css={[flex.wrap, styles.chipContainer]}>
+        {prefs.map((pref) => (
+          <PreferenceChip
+            key={pref.id}
+            preference={pref}
+            onRemove={() => onRemove(pref.id)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PreferenceChip({
+  preference,
+  onRemove,
+}: {
+  preference: StoredPreference;
+  onRemove: () => void;
+}) {
+  const isLike = preference.sentiment === "like";
+  return (
+    <span css={[styles.chip, isLike ? styles.chipLike : styles.chipDislike]}>
+      <span css={[flex.inlineCenter, styles.sentimentIcon]}>
+        {isLike ? (
+          <ThumbsUpIcon size={12} weight="fill" role="presentation" />
+        ) : (
+          <ThumbsDownIcon size={12} weight="fill" role="presentation" />
+        )}
+      </span>
+      <span css={styles.chipLabel}>{preference.value}</span>
+      <button
+        type="button"
+        css={[buttonReset.base, flex.inlineCenter, styles.chipRemove]}
+        onClick={onRemove}
+        aria-label={t({ en: "Remove", zh: "移除" })}
+      >
+        <XIcon size={10} />
+      </button>
+    </span>
+  );
+}
+
+const fadeIn = stylex.keyframes({
+  from: { opacity: 0 },
+});
+
+const slideUp = stylex.keyframes({
+  from: { transform: "translateY(100%)" },
+});
+
+const panelEasing = "cubic-bezier(0.32, 0.72, 0, 1)";
+
+const styles = stylex.create({
+  backdrop: {
+    backgroundColor: "rgba(0, 0, 0, 0.6)",
+    zIndex: layer.overlay,
+    pointerEvents: "all",
+    animationName: fadeIn,
+    animationDuration: "200ms",
+    animationTimingFunction: panelEasing,
+    animationFillMode: "backwards",
+  },
+  panelContainer: {
+    zIndex: layer.tooltip,
+    pointerEvents: "none",
+    display: "flex",
+    alignItems: "flex-end",
+    justifyContent: "center",
+    padding: space._2,
+    paddingTop: space._8,
+    [breakpoints.md]: {
+      alignItems: "center",
+      padding: space._5,
+    },
+  },
+  panel: {
+    position: "relative",
+    display: "flex",
+    flexDirection: "column",
+    width: { default: "100%", [breakpoints.md]: "min(480px, 90vw)" },
+    maxHeight: { default: "80vh", [breakpoints.md]: "70vh" },
+    backgroundColor: color.backgroundRaised,
+    borderRadius: border.radius_4,
+    overflow: "hidden",
+    pointerEvents: "all",
+    animationName: {
+      default: slideUp,
+      [motionConstants.REDUCED_MOTION]: "none",
+    },
+    animationDuration: "300ms",
+    animationTimingFunction: panelEasing,
+    animationFillMode: "backwards",
+  },
+  header: {
+    paddingTop: space._4,
+    paddingBottom: space._3,
+    paddingLeft: space._5,
+    paddingRight: space._4,
+  },
+  title: {
+    margin: 0,
+    fontSize: font.uiHeading2,
+    fontWeight: font.weight_6,
+    color: color.textMain,
+    letterSpacing: "-0.01em",
+  },
+  closeButton: {
+    width: "2rem",
+    height: "2rem",
+    borderRadius: border.radius_round,
+    color: color.textMuted,
+    backgroundColor: {
+      default: "transparent",
+      ":hover": color.backgroundHover,
+    },
+    transition: "background-color 0.15s ease",
+    cursor: "pointer",
+  },
+  infoBanner: {
+    gap: space._2,
+    marginInline: space._4,
+    marginBottom: space._3,
+    paddingBlock: space._2,
+    paddingInline: space._3,
+    borderRadius: border.radius_2,
+    backgroundColor: color.backgroundMain,
+    alignItems: "flex-start",
+  },
+  infoIcon: {
+    flexShrink: 0,
+    color: color.textMuted,
+    marginTop: "0.15rem",
+  },
+  infoText: {
+    margin: 0,
+    fontSize: font.uiBodySmall,
+    lineHeight: font.lineHeight_4,
+    color: color.textMuted,
+  },
+  body: {
+    flex: 1,
+    overflowY: "auto",
+    paddingInline: space._4,
+    paddingBottom: space._3,
+  },
+  emptyState: {
+    paddingBlock: space._9,
+  },
+  emptyText: {
+    margin: 0,
+    fontSize: font.uiBody,
+    color: color.textMuted,
+    textAlign: "center",
+    lineHeight: font.lineHeight_4,
+    maxWidth: "24ch",
+  },
+  categorySection: {
+    marginBottom: space._4,
+  },
+  categoryLabel: {
+    margin: 0,
+    marginBottom: space._2,
+    fontSize: font.uiBodySmall,
+    fontWeight: font.weight_5,
+    color: color.textMuted,
+    textTransform: "uppercase",
+    letterSpacing: "0.06em",
+  },
+  chipContainer: {
+    gap: space._1,
+  },
+  chip: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: space._1,
+    paddingBlock: space._0,
+    paddingLeft: space._2,
+    paddingRight: space._1,
+    borderRadius: border.radius_round,
+    borderWidth: border.size_1,
+    borderStyle: "solid",
+    fontSize: font.uiBodySmall,
+    lineHeight: font.lineHeight_3,
+    transition: "background-color 0.15s ease, border-color 0.15s ease",
+  },
+  chipLike: {
+    borderColor: `color-mix(in srgb, ${color.controlActive} 30%, transparent)`,
+    backgroundColor: {
+      default: `color-mix(in srgb, ${color.controlActive} 8%, transparent)`,
+      ":hover": `color-mix(in srgb, ${color.controlActive} 14%, transparent)`,
+    },
+    color: color.textMain,
+  },
+  chipDislike: {
+    borderColor: "color-mix(in srgb, #e05050 25%, transparent)",
+    backgroundColor: {
+      default: "color-mix(in srgb, #e05050 6%, transparent)",
+      ":hover": "color-mix(in srgb, #e05050 12%, transparent)",
+    },
+    color: color.textMain,
+  },
+  sentimentIcon: {
+    flexShrink: 0,
+  },
+  chipLabel: {
+    whiteSpace: "nowrap",
+  },
+  chipRemove: {
+    flexShrink: 0,
+    width: "1.1rem",
+    height: "1.1rem",
+    borderRadius: border.radius_round,
+    color: color.textMuted,
+    backgroundColor: {
+      default: "transparent",
+      ":hover": color.controlTrack,
+    },
+    opacity: 0.5,
+    transition: "opacity 0.15s ease, background-color 0.15s ease",
+    cursor: "pointer",
+  },
+  footer: {
+    paddingBlock: space._3,
+    paddingInline: space._5,
+    borderTopWidth: border.size_1,
+    borderTopStyle: "solid",
+    borderTopColor: color.controlTrack,
+  },
+  clearButton: {
+    gap: space._1,
+    fontSize: font.uiBodySmall,
+    color: {
+      default: color.textMuted,
+      ":hover": color.textMain,
+    },
+    cursor: "pointer",
+    transition: "color 0.15s ease",
+  },
+  confirmRow: {
+    gap: space._2,
+    alignItems: "center",
+  },
+  confirmText: {
+    margin: 0,
+    fontSize: font.uiBodySmall,
+    color: color.textMain,
+  },
+  confirmButton: {
+    fontSize: font.uiBodySmall,
+    lineHeight: font.lineHeight_3,
+    paddingBlock: space._0,
+    paddingInline: space._3,
+    borderRadius: border.radius_round,
+    backgroundColor: {
+      default: color.controlActive,
+      ":hover": color.controlActiveHover,
+    },
+    color: color.textOnActive,
+    cursor: "pointer",
+    transition: "background-color 0.15s ease",
+  },
+  cancelButton: {
+    fontSize: font.uiBodySmall,
+    lineHeight: font.lineHeight_3,
+    paddingBlock: space._0,
+    paddingInline: space._3,
+    borderRadius: border.radius_round,
+    backgroundColor: {
+      default: "transparent",
+      ":hover": color.backgroundHover,
+    },
+    color: color.textMuted,
+    cursor: "pointer",
+    transition: "background-color 0.15s ease",
+  },
+});

--- a/src/preference-store/preference-store.ts
+++ b/src/preference-store/preference-store.ts
@@ -90,6 +90,24 @@ export async function mergePreferences(
   });
 }
 
+export async function deletePreference(id: string): Promise<void> {
+  const db = await openDB();
+  const tx = db.transaction(STORE_NAME, "readwrite");
+  const store = tx.objectStore(STORE_NAME);
+  store.delete(id);
+
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => {
+      db.close();
+      resolve();
+    };
+    tx.onerror = () => {
+      db.close();
+      reject(tx.error ?? new Error("Failed to delete preference"));
+    };
+  });
+}
+
 export async function clearPreferences(): Promise<void> {
   const db = await openDB();
   const tx = db.transaction(STORE_NAME, "readwrite");

--- a/src/preference-store/use-preferences.ts
+++ b/src/preference-store/use-preferences.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  clearPreferences,
+  deletePreference,
+  getAllPreferences,
+  loadPreferencesContext,
+  type StoredPreference,
+} from "./preference-store";
+
+/**
+ * Loads all stored preferences from IndexedDB and provides mutators
+ * for deleting individual items or clearing everything.
+ */
+export function usePreferences() {
+  const [preferences, setPreferences] = useState<
+    ReadonlyArray<StoredPreference>
+  >([]);
+
+  const reload = useCallback(async () => {
+    try {
+      const all = await getAllPreferences();
+      setPreferences(all);
+    } catch {
+      setPreferences([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const remove = useCallback(
+    async (id: string) => {
+      await deletePreference(id);
+      await Promise.all([loadPreferencesContext(), reload()]);
+    },
+    [reload],
+  );
+
+  const clearAll = useCallback(async () => {
+    await clearPreferences();
+    await Promise.all([loadPreferencesContext(), reload()]);
+  }, [reload]);
+
+  return { preferences, reload, remove, clearAll } as const;
+}


### PR DESCRIPTION
## Summary

Adds a preference management UI to give users transparency and control over their stored AI chat preferences (closes #1680). A `deletePreference` function is added to the IndexedDB store, and a `usePreferences` hook encapsulates reactive state with mutators for individual removal and bulk clear. A new `PreferenceManager` component renders a trigger button (with a dot indicator when preferences exist) that opens a slide-up panel overlay displaying preferences grouped by category as sentiment-tinted chips, with per-chip removal, an inline "clear all" confirmation flow, a client-only storage disclosure banner, full i18n (English and Chinese), and accessible dialog semantics with focus trap and reduced-motion support.

## Context

The implementation went through a /simplify review which caught and fixed a stale state bug (merged separate PreferenceButton and PreferencePanel into a single PreferenceManager component with one usePreferences hook), removed dead `version` state, parallelized sequential IDB reads with Promise.all, removed unnecessary wrapper divs and narrating comments. Dislike chips were given a warm red tint after visual review showed the original muted styling was too subtle.

Closes #1680