### PR TITLE
fix: add enterKeyHint to chat textarea for mobile keyboards

### DIFF
--- a/src/components/ai-chat/chat-input-bar.test.tsx
+++ b/src/components/ai-chat/chat-input-bar.test.tsx
@@ -210,4 +210,11 @@ describe("ChatInputBar accessibility", () => {
     const textarea = screen.getByPlaceholderText("Ask about movies...");
     expect(textarea).toHaveAttribute("aria-label", "Ask about movies...");
   });
+
+  it("sets enterKeyHint to send for mobile keyboard UX", () => {
+    renderInputBar();
+
+    const textarea = screen.getByPlaceholderText("Ask about movies...");
+    expect(textarea).toHaveAttribute("enterKeyHint", "send");
+  });
 });

--- a/src/components/ai-chat/chat-input-bar.tsx
+++ b/src/components/ai-chat/chat-input-bar.tsx
@@ -114,6 +114,7 @@ export function ChatInputBar({
         disabled={isLoading}
         css={styles.textarea}
         autoComplete="off"
+        enterKeyHint="send"
       />
       {isLoading ? (
         <button


### PR DESCRIPTION
## Summary

Adds `enterKeyHint="send"` to the chat input textarea. On mobile devices, the Enter key currently shows a generic "Return" label even though pressing it sends the message. This attribute tells the virtual keyboard to display a "Send" button instead, aligning the visual affordance with the actual behavior and making send-on-Enter discoverable for touch users.