### PR TITLE
refactor: remove redundant useCallback from usePreferences

### DIFF
--- a/src/preference-store/use-preferences.ts
+++ b/src/preference-store/use-preferences.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   clearPreferences,
   deletePreference,
@@ -18,31 +18,28 @@ export function usePreferences() {
     ReadonlyArray<StoredPreference>
   >([]);
 
-  const reload = useCallback(async () => {
+  async function reload() {
     try {
       const all = await getAllPreferences();
       setPreferences(all);
     } catch {
       setPreferences([]);
     }
-  }, []);
+  }
 
   useEffect(() => {
     void reload();
-  }, [reload]);
+  }, []);
 
-  const remove = useCallback(
-    async (id: string) => {
-      await deletePreference(id);
-      await Promise.all([loadPreferencesContext(), reload()]);
-    },
-    [reload],
-  );
+  async function remove(id: string) {
+    await deletePreference(id);
+    await Promise.all([loadPreferencesContext(), reload()]);
+  }
 
-  const clearAll = useCallback(async () => {
+  async function clearAll() {
     await clearPreferences();
     await Promise.all([loadPreferencesContext(), reload()]);
-  }, [reload]);
+  }
 
   return { preferences, reload, remove, clearAll } as const;
 }


### PR DESCRIPTION
## Summary

The project uses React 19 with React Compiler (`reactCompiler: true`), which automatically handles memoization. The `usePreferences` hook had three `useCallback` wrappers — the only instances in the entire codebase — violating the project's explicit "no manual memoization" convention. Removing them aligns this hook with every other hook and component and prevents contributors from incorrectly inferring they need to add `useCallback` in new code.