### PR TITLE
fix: handle IndexedDB errors in preference remove and clearAll

### DIFF
--- a/src/components/ai-chat/preference-panel.tsx
+++ b/src/components/ai-chat/preference-panel.tsx
@@ -132,8 +132,11 @@ function PreferencePanel({
   }
 
   const handleClearAll = async () => {
-    await onClearAll();
-    setConfirmingClear(false);
+    try {
+      await onClearAll();
+    } finally {
+      setConfirmingClear(false);
+    }
   };
 
   return createPortal(

--- a/src/preference-store/use-preferences.ts
+++ b/src/preference-store/use-preferences.ts
@@ -32,13 +32,25 @@ export function usePreferences() {
   }, []);
 
   async function remove(id: string) {
-    await deletePreference(id);
-    await Promise.all([loadPreferencesContext(), reload()]);
+    try {
+      await deletePreference(id);
+      await Promise.all([loadPreferencesContext(), reload()]);
+    } catch {
+      // IndexedDB may be unavailable (private browsing, quota exceeded).
+      // Reload to keep the UI consistent with what is actually stored.
+      await reload();
+    }
   }
 
   async function clearAll() {
-    await clearPreferences();
-    await Promise.all([loadPreferencesContext(), reload()]);
+    try {
+      await clearPreferences();
+      await Promise.all([loadPreferencesContext(), reload()]);
+    } catch {
+      // IndexedDB may be unavailable (private browsing, quota exceeded).
+      // Reload to keep the UI consistent with what is actually stored.
+      await reload();
+    }
   }
 
   return { preferences, reload, remove, clearAll } as const;


### PR DESCRIPTION
## Summary
- Add try/catch to `remove` and `clearAll` in `usePreferences` to handle IndexedDB failures (private browsing, quota exceeded) — calls `reload()` on error to keep UI in sync, matching the pattern already used by `reload()` itself and `mergePreferences` in `use-preference-persistence.ts`
- Wrap `handleClearAll` in `preference-panel.tsx` with try/finally so `setConfirmingClear(false)` always runs, preventing the confirmation dialog from getting stuck

## Test plan
- [x] `pnpm lint:changed` passes
- [x] `pnpm format:changed` passes
- [x] `pnpm test` passes (888 tests)
- [x] `pnpm build` succeeds