### PR TITLE
fix: default Button type to "button" to prevent accidental form submission

### DIFF
--- a/src/components/shared/button.test.tsx
+++ b/src/components/shared/button.test.tsx
@@ -120,3 +120,26 @@ describe("Button Interaction", () => {
     expect(labelElement).toHaveAttribute("id", "my-label");
   });
 });
+
+describe("Button type attribute", () => {
+  it('defaults to type="button" to prevent accidental form submission', () => {
+    render(<Button>Click</Button>);
+
+    const button = screen.getByRole("button");
+    expect(button).toHaveAttribute("type", "button");
+  });
+
+  it("allows overriding the type to submit", () => {
+    render(<Button type="submit">Submit</Button>);
+
+    const button = screen.getByRole("button");
+    expect(button).toHaveAttribute("type", "submit");
+  });
+
+  it("allows overriding the type to reset", () => {
+    render(<Button type="reset">Reset</Button>);
+
+    const button = screen.getByRole("button");
+    expect(button).toHaveAttribute("type", "reset");
+  });
+});

--- a/src/components/shared/button.tsx
+++ b/src/components/shared/button.tsx
@@ -23,6 +23,7 @@ export function Button({
   isActive,
   labelId,
   style,
+  type = "button",
   ...restProps
 }: ButtonProps) {
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -38,6 +39,7 @@ export function Button({
     <button
       {...restProps}
       ref={buttonRef}
+      type={type}
       className={className}
       disabled={disabled}
       style={{ ...style, ...pressedStyle }}


### PR DESCRIPTION
## Summary

HTML `<button>` elements default to `type="submit"`, which means any `<button>` placed inside a `<form>` will trigger form submission on click. The `Button` component did not set an explicit `type`, inheriting this unsafe default. While no current `Button` usage sits inside a form, this is a latent bug — every other native `<button>` in the codebase already sets `type` explicitly, and this reusable wrapper should provide the same safety by default. The fix defaults `type` to `"button"` in the component props, keeping it overridable for consumers that need `type="submit"` or `type="reset"`.