### PR TITLE
fix: change calculator Backspace from all-clear to delete-last-character

### DIFF
--- a/src/components/calculator/calculator.test.tsx
+++ b/src/components/calculator/calculator.test.tsx
@@ -93,3 +93,89 @@ describe("Calculator error recovery", () => {
     expect(getDisplay()).toHaveTextContent("5");
   });
 });
+
+describe("Calculator Backspace", () => {
+  it("deletes the last digit of a multi-digit number", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    await pressButtons(user, ["1", "2", "3"]);
+    expect(getDisplay()).toHaveTextContent("123");
+
+    await user.keyboard("{Backspace}");
+    expect(getDisplay()).toHaveTextContent("12");
+  });
+
+  it("resets to 0 when deleting the only digit", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    await pressButtons(user, ["5"]);
+    expect(getDisplay()).toHaveTextContent("5");
+
+    await user.keyboard("{Backspace}");
+    expect(getDisplay()).toHaveTextContent("0");
+  });
+
+  it("resets to 0 when backspacing the initial 0", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    expect(getDisplay()).toHaveTextContent("0");
+    await user.keyboard("{Backspace}");
+    expect(getDisplay()).toHaveTextContent("0");
+  });
+
+  it("removes the operator and restores the previous number", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    await pressButtons(user, ["4", "2", "Add"]);
+    expect(getDisplay()).toHaveTextContent("42 +");
+
+    await user.keyboard("{Backspace}");
+    expect(getDisplay()).toHaveTextContent("42");
+  });
+
+  it("deletes digits after a decimal point", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    await pressButtons(user, ["3", "Decimal point", "5"]);
+    expect(getDisplay()).toHaveTextContent("3.5");
+
+    await user.keyboard("{Backspace}");
+    // Raw is now "3." — display shows "3" since Number("3.") === 3
+    expect(getDisplay()).toHaveTextContent("3");
+
+    // Typing another digit continues after the decimal
+    await pressButtons(user, ["7"]);
+    expect(getDisplay()).toHaveTextContent("3.7");
+  });
+
+  it("recovers from error state", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    await pressButtons(user, ["5", "Divide", "0", "Equals"]);
+    expect(getDisplay()).toHaveTextContent("Error");
+
+    await user.keyboard("{Backspace}");
+    expect(getDisplay()).toHaveTextContent("0");
+  });
+
+  it("works correctly in the middle of a calculation", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    // Type 12 + 34, then backspace to get 12 + 3, then complete
+    await pressButtons(user, ["1", "2", "Add", "3", "4"]);
+    expect(getDisplay()).toHaveTextContent("12 + 34");
+
+    await user.keyboard("{Backspace}");
+    expect(getDisplay()).toHaveTextContent("12 + 3");
+
+    await pressButtons(user, ["Equals"]);
+    expect(getDisplay()).toHaveTextContent("15");
+  });
+});

--- a/src/components/calculator/calculator.tsx
+++ b/src/components/calculator/calculator.tsx
@@ -31,8 +31,50 @@ export function Calculator() {
   const [tokens, setTokens] = useState<Token[]>([]);
   const [currentToken, setCurrentToken] = useState<Token>(createInitialToken);
 
+  const isError =
+    currentToken.type === "number" && Number.isNaN(currentToken.value);
+
+  const handleBackspace = () => {
+    if (isError) {
+      setTokens([]);
+      setCurrentToken(createInitialToken());
+      return;
+    }
+
+    if (currentToken.type === "number") {
+      const newRaw = currentToken.raw.slice(0, -1);
+      if (newRaw === "" || newRaw === "-") {
+        // Deleted the only digit (or the digit after a minus sign) — reset to 0
+        setCurrentToken(createInitialToken());
+      } else {
+        setCurrentToken({
+          ...currentToken,
+          value: Number(newRaw),
+          raw: newRaw,
+        });
+      }
+      return;
+    }
+
+    // Current token is a binary operator — remove it and restore the previous number
+    if (tokens.length > 0) {
+      const lastToken = tokens[tokens.length - 1];
+      setTokens(tokens.slice(0, -1));
+      setCurrentToken(lastToken);
+    } else {
+      setCurrentToken(createInitialToken());
+    }
+  };
+
   const handleKeyDown = (event: React.KeyboardEvent) => {
     const key = event.key;
+
+    if (key === "Backspace") {
+      event.preventDefault();
+      handleBackspace();
+      return;
+    }
+
     const keyMap: Record<string, string> = {
       "0": "0",
       "1": "1",
@@ -51,7 +93,6 @@ export function Calculator() {
       Enter: "=",
       "=": "=",
       Escape: "ac",
-      Backspace: "ac",
       ".": ".",
       "%": "%",
     };
@@ -61,9 +102,6 @@ export function Calculator() {
       handleClick(keyMap[key]);
     }
   };
-
-  const isError =
-    currentToken.type === "number" && Number.isNaN(currentToken.value);
 
   const handleClick = (label: string) => {
     if (label === BUTTON_CLEAR) {


### PR DESCRIPTION
## Summary

The calculator's Backspace key was mapped to "all clear" (same as Escape), wiping the entire calculation instead of deleting just the last character. This is unexpected — every standard calculator (iOS, Android, macOS, Google) treats Backspace as delete-last-digit, not reset. A user who types "12345" and wants to correct it to "1234" had to start over from scratch.

Backspace now deletes the last character of the current number, or removes the operator and restores the previous number. Escape remains mapped to AC for full reset. Seven new tests cover multi-digit deletion, single-digit reset, initial-state backspace, operator removal, decimal continuation, error recovery, and mid-calculation correction.