### PR TITLE
refactor: use Intl.DurationFormat for locale-aware runtime formatting

### DIFF
--- a/src/app/[locale]/movie-database/[type]/[id]/page.tsx
+++ b/src/app/[locale]/movie-database/[type]/[id]/page.tsx
@@ -79,11 +79,7 @@ export default async function Page({ params }: PageProps) {
             <div css={styles.meta}>
               {[
                 movie.release_date?.split("-")[0],
-                formatRuntime(
-                  movie.runtime,
-                  t({ en: "h", zh: " 小时" }),
-                  t({ en: "m", zh: " 分钟" }),
-                ),
+                formatRuntime(movie.runtime, locale),
                 movie.genres
                   ?.map((genre) => genre.name)
                   .filter(Boolean)

--- a/src/components/ai-chat/media-detail-content.tsx
+++ b/src/components/ai-chat/media-detail-content.tsx
@@ -76,11 +76,7 @@ export function MediaDetailContent({
                   : t({ en: "seasons", zh: "季" })
               }`
             : ""
-          : formatRuntime(
-              detail.runtime,
-              t({ en: "h", zh: " 小时" }),
-              t({ en: "m", zh: " 分钟" }),
-            ),
+          : formatRuntime(detail.runtime, locale),
         detail.genres.join(t({ en: ", ", zh: "、" })),
       ]
         .filter(Boolean)

--- a/src/utils/format-runtime.test.ts
+++ b/src/utils/format-runtime.test.ts
@@ -2,35 +2,43 @@ import { describe, it, expect } from "vitest";
 import { formatRuntime } from "./format-runtime";
 
 describe("formatRuntime", () => {
-  it("formats hours and minutes", () => {
-    expect(formatRuntime(148, "h", "m")).toBe("2h 28m");
+  it("formats hours and minutes in English", () => {
+    expect(formatRuntime(148, "en")).toBe("2h 28m");
   });
 
   it("formats minutes only when less than an hour", () => {
-    expect(formatRuntime(45, "h", "m")).toBe("45m");
+    expect(formatRuntime(45, "en")).toBe("45m");
   });
 
   it("formats exactly one hour without trailing minutes", () => {
-    expect(formatRuntime(60, "h", "m")).toBe("1h");
+    expect(formatRuntime(60, "en")).toBe("1h");
   });
 
   it("returns empty string for zero", () => {
-    expect(formatRuntime(0, "h", "m")).toBe("");
+    expect(formatRuntime(0, "en")).toBe("");
   });
 
   it("returns empty string for NaN", () => {
-    expect(formatRuntime(NaN, "h", "m")).toBe("");
+    expect(formatRuntime(NaN, "en")).toBe("");
   });
 
   it("formats exact multiples of an hour without trailing minutes", () => {
-    expect(formatRuntime(240, "h", "m")).toBe("4h");
+    expect(formatRuntime(240, "en")).toBe("4h");
   });
 
   it("formats single-digit minutes", () => {
-    expect(formatRuntime(65, "h", "m")).toBe("1h 5m");
+    expect(formatRuntime(65, "en")).toBe("1h 5m");
   });
 
-  it("uses the provided locale labels", () => {
-    expect(formatRuntime(148, " 小时", " 分钟")).toBe("2 小时 28 分钟");
+  it("formats in Chinese locale", () => {
+    expect(formatRuntime(148, "zh")).toBe("2小时28分钟");
+  });
+
+  it("formats Chinese locale with hours only", () => {
+    expect(formatRuntime(60, "zh")).toBe("1小时");
+  });
+
+  it("formats Chinese locale with minutes only", () => {
+    expect(formatRuntime(45, "zh")).toBe("45分钟");
   });
 });

--- a/src/utils/format-runtime.ts
+++ b/src/utils/format-runtime.ts
@@ -1,25 +1,26 @@
 /**
- * Formats a movie/TV runtime in minutes into a human-readable string
- * with the given hour and minute labels.
+ * Formats a movie/TV runtime in minutes into a locale-aware, human-readable
+ * string using `Intl.DurationFormat`.
  *
  * Returns an empty string for falsy values (0, NaN, etc.)
  * to avoid showing "0m" for entries without runtime data.
  *
  * Omits the minutes portion when it is zero (e.g. 60 → "1h", not "1h 0m").
  *
- * @example formatRuntime(148, "h", "m") → "2h 28m"
- * @example formatRuntime(60, "h", "m")  → "1h"
- * @example formatRuntime(45, "h", "m")  → "45m"
+ * @example formatRuntime(148, "en") → "2h 28m"
+ * @example formatRuntime(60, "en")  → "1h"
+ * @example formatRuntime(45, "en")  → "45m"
+ * @example formatRuntime(148, "zh") → "2小时28分钟"
  */
-export function formatRuntime(
-  minutes: number,
-  hourLabel: string,
-  minuteLabel: string,
-) {
+export function formatRuntime(minutes: number, locale: string) {
   if (!minutes) return "";
   const hours = Math.floor(minutes / 60);
   const mins = minutes % 60;
-  if (hours > 0 && mins === 0) return `${hours}${hourLabel}`;
-  if (hours > 0) return `${hours}${hourLabel} ${mins}${minuteLabel}`;
-  return `${mins}${minuteLabel}`;
+  const duration: Intl.DurationInput =
+    hours > 0 && mins > 0
+      ? { hours, minutes: mins }
+      : hours > 0
+        ? { hours }
+        : { minutes: mins };
+  return new Intl.DurationFormat(locale, { style: "narrow" }).format(duration);
 }


### PR DESCRIPTION
## Summary

Replaces the manual `formatRuntime(minutes, hourLabel, minuteLabel)` utility with a locale-aware implementation using the standard `Intl.DurationFormat` API: `formatRuntime(minutes, locale)`. The old implementation required callers to manually pass translated labels via `t()` for every call, which produced awkward spacing in Chinese (`"2 小时 28 分钟"` with spurious spaces before CJK characters). `Intl.DurationFormat` with `narrow` style produces the correct locale-native output — `"2h 28m"` in English and `"2小时28分钟"` in Chinese — while simplifying the call sites.

The codebase already uses `Intl.NumberFormat` and `Intl.PluralRules` at the same call sites, and already had `Intl.DurationFormat` type declarations prepared in `src/intl-duration-format.d.ts`, indicating clear intent to adopt this API.