### PR TITLE
refactor: replace type assertion with runtime type guard in preference store

### DIFF
--- a/src/preference-store/preference-store.test.ts
+++ b/src/preference-store/preference-store.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { StoredPreference } from "./preference-store";
-import { formatPreferencesContext, makeId } from "./preference-store";
+import {
+  formatPreferencesContext,
+  isStoredPreference,
+  makeId,
+} from "./preference-store";
 
 function pref(
   overrides: Partial<StoredPreference> &
@@ -26,6 +30,132 @@ describe("makeId", () => {
     expect(makeId("director", "Christopher Nolan")).toBe(
       makeId("director", "christopher nolan"),
     );
+  });
+});
+
+describe("isStoredPreference", () => {
+  it("accepts a valid preference object", () => {
+    expect(
+      isStoredPreference({
+        id: "genre:sci-fi",
+        category: "genre",
+        value: "sci-fi",
+        sentiment: "like",
+        updatedAt: Date.now(),
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts all valid categories", () => {
+    const categories = [
+      "genre",
+      "actor",
+      "director",
+      "content_rating",
+      "language",
+      "keyword",
+    ];
+    for (const category of categories) {
+      expect(
+        isStoredPreference({
+          id: `${category}:test`,
+          category,
+          value: "test",
+          sentiment: "like",
+          updatedAt: 0,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("accepts both sentiment values", () => {
+    for (const sentiment of ["like", "dislike"]) {
+      expect(
+        isStoredPreference({
+          id: "genre:test",
+          category: "genre",
+          value: "test",
+          sentiment,
+          updatedAt: 0,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects null", () => {
+    expect(isStoredPreference(null)).toBe(false);
+  });
+
+  it("rejects undefined", () => {
+    expect(isStoredPreference(undefined)).toBe(false);
+  });
+
+  it("rejects non-objects", () => {
+    expect(isStoredPreference("string")).toBe(false);
+    expect(isStoredPreference(42)).toBe(false);
+    expect(isStoredPreference(true)).toBe(false);
+  });
+
+  it("rejects arrays", () => {
+    expect(isStoredPreference([])).toBe(false);
+  });
+
+  it("rejects objects with missing fields", () => {
+    expect(isStoredPreference({ id: "genre:test" })).toBe(false);
+    expect(
+      isStoredPreference({
+        id: "genre:test",
+        category: "genre",
+        value: "test",
+        sentiment: "like",
+        // missing updatedAt
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects objects with invalid category", () => {
+    expect(
+      isStoredPreference({
+        id: "invalid:test",
+        category: "invalid",
+        value: "test",
+        sentiment: "like",
+        updatedAt: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects objects with invalid sentiment", () => {
+    expect(
+      isStoredPreference({
+        id: "genre:test",
+        category: "genre",
+        value: "test",
+        sentiment: "neutral",
+        updatedAt: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects objects with wrong field types", () => {
+    expect(
+      isStoredPreference({
+        id: 123,
+        category: "genre",
+        value: "test",
+        sentiment: "like",
+        updatedAt: 0,
+      }),
+    ).toBe(false);
+    expect(
+      isStoredPreference({
+        id: "genre:test",
+        category: "genre",
+        value: "test",
+        sentiment: "like",
+        updatedAt: "not-a-number",
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/preference-store/preference-store.ts
+++ b/src/preference-store/preference-store.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "#src/utils/type-guards.ts";
+
 const DB_NAME = "ai-chat-preferences";
 const DB_VERSION = 1;
 const STORE_NAME = "preferences";
@@ -24,6 +26,36 @@ export function makeId(
   return `${category}:${value.toLowerCase()}`;
 }
 
+const validCategories: ReadonlySet<string> = new Set([
+  "genre",
+  "actor",
+  "director",
+  "content_rating",
+  "language",
+  "keyword",
+]);
+const validSentiments: ReadonlySet<string> = new Set(["like", "dislike"]);
+
+/**
+ * Runtime type guard for StoredPreference.
+ *
+ * IndexedDB returns untyped data — values could be corrupted or left over
+ * from a previous schema version. This guard filters out malformed entries
+ * so callers never see invalid shapes.
+ */
+export function isStoredPreference(value: unknown): value is StoredPreference {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.id === "string" &&
+    typeof value.category === "string" &&
+    validCategories.has(value.category) &&
+    typeof value.value === "string" &&
+    typeof value.sentiment === "string" &&
+    validSentiments.has(value.sentiment) &&
+    typeof value.updatedAt === "number"
+  );
+}
+
 function openDB(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(DB_NAME, DB_VERSION);
@@ -47,7 +79,10 @@ export async function getAllPreferences(): Promise<StoredPreference[]> {
     const tx = db.transaction(STORE_NAME, "readonly");
     const store = tx.objectStore(STORE_NAME);
     const request = store.getAll();
-    request.onsuccess = () => resolve(request.result as StoredPreference[]);
+    request.onsuccess = () => {
+      const raw: unknown[] = request.result;
+      resolve(raw.filter(isStoredPreference));
+    };
     request.onerror = () =>
       reject(request.error ?? new Error("Failed to read preferences"));
     tx.oncomplete = () => db.close();


### PR DESCRIPTION
## Summary

Replaces the unsafe `as StoredPreference[]` type assertion in `getAllPreferences()` with a runtime type guard that validates each entry read from IndexedDB. The project conventions explicitly prohibit type assertions, and this was the only remaining `as Type` assertion in the preference store. The new `isStoredPreference` guard validates all five required fields (including enum membership for `category` and `sentiment`), silently filtering out any malformed entries so callers never see invalid shapes. This provides defense-in-depth at the IndexedDB trust boundary — if data is ever corrupted or left over from a future schema migration, the application gracefully omits those entries rather than propagating malformed objects.