### PR TITLE
fix: add branded focus-visible ring to horizontal scroll containers

### DIFF
--- a/src/components/ai-chat/person-detail-content.tsx
+++ b/src/components/ai-chat/person-detail-content.tsx
@@ -216,7 +216,7 @@ function FilmographyScroller({
     <div css={filmStyles.scrollWrapper}>
       <div
         ref={scrollRef}
-        css={[scrollX.base, filmStyles.scrollContainer]}
+        css={[scrollX.base, scrollX.focusRing, filmStyles.scrollContainer]}
         role="list"
         aria-label={t({ en: "Filmography", zh: "作品列表" })}
         tabIndex={0}

--- a/src/components/ai-chat/recommended-media-row.tsx
+++ b/src/components/ai-chat/recommended-media-row.tsx
@@ -32,7 +32,7 @@ export function RecommendedMediaRow({
       <div css={styles.scrollWrapper}>
         <div
           ref={scrollRef}
-          css={[scrollX.base, styles.scrollContainer]}
+          css={[scrollX.base, scrollX.focusRing, styles.scrollContainer]}
           role="region"
           aria-label={title}
           tabIndex={0}

--- a/src/components/ai-chat/tool-media-cards.tsx
+++ b/src/components/ai-chat/tool-media-cards.tsx
@@ -26,7 +26,7 @@ export function ToolMediaCards({ items }: ToolMediaCardsProps) {
     <div css={styles.scrollWrapper}>
       <div
         ref={scrollRef}
-        css={[scrollX.base, styles.scrollContainer]}
+        css={[scrollX.base, scrollX.focusRing, styles.scrollContainer]}
         role="list"
         aria-label={t({ en: "Search results", zh: "搜索结果" })}
         tabIndex={0}

--- a/src/components/ai-chat/tool-person-cards.tsx
+++ b/src/components/ai-chat/tool-person-cards.tsx
@@ -26,7 +26,7 @@ export function ToolPersonCards({ items }: ToolPersonCardsProps) {
     <div css={styles.scrollWrapper}>
       <div
         ref={scrollRef}
-        css={[scrollX.base, styles.scrollContainer]}
+        css={[scrollX.base, scrollX.focusRing, styles.scrollContainer]}
         role="list"
         aria-label={t({ en: "People results", zh: "人物结果" })}
         tabIndex={0}

--- a/src/primitives/layout.stylex.ts
+++ b/src/primitives/layout.stylex.ts
@@ -1,4 +1,5 @@
 import * as stylex from "@stylexjs/stylex";
+import { border, color } from "#src/tokens.stylex.ts";
 
 // Position + inset fills
 export const absoluteFill = stylex.create({
@@ -22,6 +23,15 @@ export const scrollX = stylex.create({
   base: {
     overflowX: "auto",
     scrollbarWidth: "none",
+  },
+  /** Visible focus ring for keyboard-navigable scroll containers (tabIndex={0}). */
+  focusRing: {
+    outline: {
+      default: "none",
+      ":focus-visible": `2px solid ${color.controlActive}`,
+    },
+    outlineOffset: { default: null, ":focus-visible": "2px" },
+    borderRadius: border.radius_2,
   },
 });
 


### PR DESCRIPTION
## Summary

- Adds a reusable `scrollX.focusRing` StyleX primitive that renders a branded `:focus-visible` outline (`2px solid controlActive` with `outlineOffset: 2px` and `border.radius_2`) on keyboard-navigable scroll containers
- Applies to all four `tabIndex={0}` horizontal scrollers in the AI chat interface: `ToolMediaCards`, `ToolPersonCards`, `RecommendedMediaRow`, and `FilmographyScroller`
- Follows the existing pattern from the calculator component, which already customises its `:focus-visible` ring with a branded colour

Browsers do render a default focus ring on these elements, but it's an unstyled thin blue/black outline that looks inconsistent with the project's purple-themed UI. This brings the scroll containers in line with the calculator's branded focus ring pattern.

## Test plan

- [ ] Tab through the AI chat with movie/person search results and verify a purple focus ring appears on each horizontal scroll container
- [ ] Verify mouse clicks do NOT trigger the ring (`:focus-visible` only)
- [ ] Verify the calculator's existing focus ring is unaffected