### PR TITLE
fix: style hr element in AI chat markdown renderer

### DIFF
--- a/src/components/ai-chat/markdown-content.test.tsx
+++ b/src/components/ai-chat/markdown-content.test.tsx
@@ -88,6 +88,15 @@ describe("MarkdownContent", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders horizontal rules", () => {
+    const { container } = render(
+      <MarkdownContent content={"Above\n\n---\n\nBelow"} />,
+    );
+    expect(container.querySelector("hr")).toBeInTheDocument();
+    expect(screen.getByText("Above")).toBeInTheDocument();
+    expect(screen.getByText("Below")).toBeInTheDocument();
+  });
+
   it("renders multiple paragraphs", () => {
     render(<MarkdownContent content={"First paragraph\n\nSecond paragraph"} />);
     expect(screen.getByText("First paragraph")).toBeInTheDocument();

--- a/src/components/ai-chat/markdown-content.tsx
+++ b/src/components/ai-chat/markdown-content.tsx
@@ -46,6 +46,14 @@ const styles = stylex.create({
   li: {
     marginBlock: space._00,
   },
+  hr: {
+    width: "100%",
+    borderStyle: "none",
+    borderBlockStartWidth: border.size_1,
+    borderBlockStartStyle: "solid",
+    borderBlockStartColor: color.controlTrack,
+    marginBlock: 0,
+  },
   blockquote: {
     borderInlineStartWidth: border.size_2,
     borderInlineStartStyle: "solid",
@@ -116,6 +124,7 @@ const components: Components = {
   ul: ({ node, ...props }) => <ul css={styles.ul} {...props} />,
   ol: ({ node, ...props }) => <ol css={styles.ol} {...props} />,
   li: ({ node, ...props }) => <li css={styles.li} {...props} />,
+  hr: ({ node, ...props }) => <hr css={styles.hr} {...props} />,
   blockquote: ({ node, ...props }) => (
     <blockquote css={styles.blockquote} {...props} />
   ),


### PR DESCRIPTION
## Summary

The `<hr>` element in AI chat markdown messages rendered as a tiny dot instead of a horizontal line. This happened because `modern-normalize` sets `box-sizing: border-box` globally, which caused the default border-based `<hr>` rendering to collapse inside the flex column layout used by the markdown content wrapper. The fix adds a custom `hr` component with explicit StyleX styles (resetting borders and applying a single `border-block-start` line) to the markdown renderer.

Closes #1809