### PR TITLE
fix: add overscroll-behavior containment to horizontal scroll containers

### DIFF
--- a/src/components/ai-chat/markdown-content.tsx
+++ b/src/components/ai-chat/markdown-content.tsx
@@ -61,6 +61,7 @@ const styles = stylex.create({
     padding: space._2,
     marginBlock: 0,
     overflowX: "auto",
+    overscrollBehaviorX: "contain",
   },
   codeBlock: {
     fontFamily: "monospace",
@@ -76,6 +77,7 @@ const styles = stylex.create({
   },
   tableWrapper: {
     overflowX: "auto",
+    overscrollBehaviorX: "contain",
     marginBlock: 0,
   },
   table: {

--- a/src/primitives/layout.stylex.ts
+++ b/src/primitives/layout.stylex.ts
@@ -22,6 +22,7 @@ export const fixedFill = stylex.create({
 export const scrollX = stylex.create({
   base: {
     overflowX: "auto",
+    overscrollBehaviorX: "contain",
     scrollbarWidth: "none",
   },
   /** Visible focus ring for keyboard-navigable scroll containers (tabIndex={0}). */


### PR DESCRIPTION
## Summary

Prevents browser back navigation when swiping left on horizontal scroll containers in AI chat. Without `overscrollBehaviorX: "contain"`, overscroll on these containers propagates to the browser, which interprets a left swipe as a back navigation gesture. The fix applies to the shared `scrollX` primitive (used by media cards, person cards, and recommended media rows) and to inline horizontal scroll styles in markdown content (code blocks and table wrappers).

Closes #1810