### PR TITLE
fix: reset image loading state when poster path changes

### DIFF
--- a/src/components/ai-chat/compact-person-card.tsx
+++ b/src/components/ai-chat/compact-person-card.tsx
@@ -2,7 +2,7 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { t } from "#src/i18n.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { buttonReset } from "#src/primitives/reset.stylex.ts";
@@ -31,6 +31,15 @@ function ProfilePhoto({
   const { data: config } = useSuspenseQuery(tmdbQueries.configuration);
   const [loaded, setLoaded] = useState(false);
   const [errored, setErrored] = useState(false);
+
+  // Reset image loading state when the profile path changes so a new image
+  // gets a fresh load attempt instead of being stuck in a stale error/loaded state.
+  const prevProfilePathRef = useRef(profilePath);
+  if (prevProfilePathRef.current !== profilePath) {
+    prevProfilePathRef.current = profilePath;
+    setLoaded(false);
+    setErrored(false);
+  }
 
   if (!config.images?.base_url || !config.images?.profile_sizes || errored) {
     return <div css={[flex.center, styles.photoFallback]}>{alt.charAt(0)}</div>;

--- a/src/components/movie-database/poster-image.tsx
+++ b/src/components/movie-database/poster-image.tsx
@@ -2,7 +2,7 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Skeleton } from "#src/components/shared/skeleton.tsx";
 import { t } from "#src/i18n.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
@@ -26,6 +26,15 @@ export function PosterImage({ posterPath, alt }: PosterImageProps) {
 
   const [imgLoaded, setImgLoaded] = useState(false);
   const [imgErrored, setImgErrored] = useState(false);
+
+  // Reset image loading state when the poster path changes so a new image
+  // gets a fresh load attempt instead of being stuck in a stale error/loaded state.
+  const prevPosterPathRef = useRef(posterPath);
+  if (prevPosterPathRef.current !== posterPath) {
+    prevPosterPathRef.current = posterPath;
+    setImgLoaded(false);
+    setImgErrored(false);
+  }
 
   if (!config.images?.base_url || !config.images?.poster_sizes || imgErrored) {
     return (


### PR DESCRIPTION
## Summary

Poster and profile image components in the AI chat tracked `imgLoaded` and `imgErrored` as React state but never reset these values when the image path prop changed. If React reconciliation reused a component instance with a different path, stale error or loaded states from the previous image persisted — causing the new image to appear permanently broken or to skip its loading skeleton. This fixes the issue by tracking the previous path in a ref and resetting both states during render when the path diverges, following the React "adjusting state during rendering" pattern.

Closes #1811