### PR TITLE
fix: auto-scroll to bottom during AI chat streaming

### DIFF
--- a/src/components/ai-chat/chat-message-list.tsx
+++ b/src/components/ai-chat/chat-message-list.tsx
@@ -88,6 +88,25 @@ export function ChatMessageList({
     }
   }, [messages.length, lastMessageRole, isAtBottom]);
 
+  useEffect(() => {
+    if (status !== "streaming") return;
+
+    let rafId: number;
+    let lastScrollHeight = document.documentElement.scrollHeight;
+
+    const tick = () => {
+      const currentScrollHeight = document.documentElement.scrollHeight;
+      if (isAtBottom && currentScrollHeight !== lastScrollHeight) {
+        window.scrollTo({ top: currentScrollHeight });
+        lastScrollHeight = currentScrollHeight;
+      }
+      rafId = requestAnimationFrame(tick);
+    };
+
+    rafId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafId);
+  }, [status, isAtBottom]);
+
   const showTypingIndicator = status === "submitted";
   const showError = status === "error" && error != null;
   const latestInputTokens = getLatestInputTokens(messages);


### PR DESCRIPTION
## Summary

Fixes auto-scroll not working during AI chat streaming. The existing scroll-to-bottom effect only triggered when `messages.length` changed, but during streaming the array length stays constant — tokens update the last message in-place. This meant users had to manually scroll down to see new content as it streamed in.

Adds a `requestAnimationFrame` loop that runs while the chat status is `"streaming"` to detect `scrollHeight` changes and keep the viewport pinned to the bottom. The loop respects the user's scroll position — if they've scrolled up to read earlier messages, auto-scroll is suppressed.

Closes #1812