### PR TITLE
fix: position scroll-to-bottom button above chat input bar

### DIFF
--- a/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
@@ -1,18 +1,22 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { useAIChat } from "#src/ai-chat/use-ai-chat.ts";
 import {
   ChatActionsContext,
   type AttachedMedia,
 } from "#src/components/ai-chat/chat-actions-context.tsx";
 import { ChatInputBar } from "#src/components/ai-chat/chat-input-bar.tsx";
-import { ChatMessageList } from "#src/components/ai-chat/chat-message-list.tsx";
+import {
+  ChatMessageList,
+  SCROLL_THRESHOLD,
+} from "#src/components/ai-chat/chat-message-list.tsx";
 import { MediaDetailProvider } from "#src/components/ai-chat/media-detail-context.tsx";
 import { MediaDetailOverlay } from "#src/components/ai-chat/media-detail-overlay.tsx";
 import { PersonDetailOverlay } from "#src/components/ai-chat/person-detail-overlay.tsx";
 import { PreferenceManager } from "#src/components/ai-chat/preference-panel.tsx";
+import { ScrollToBottomButton } from "#src/components/ai-chat/scroll-to-bottom-button.tsx";
 import { SessionRestoreBanner } from "#src/components/ai-chat/session-restore-banner.tsx";
 import { border, color, layer, space } from "#src/tokens.stylex.ts";
 import type { SupportedLocale } from "#src/types.ts";
@@ -54,6 +58,27 @@ export function AIChatView({
   const [attachedMedia, setAttachedMedia] = useState<AttachedMedia | null>(
     null,
   );
+  const [isAtBottom, setIsAtBottom] = useState(true);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const { scrollHeight } = document.documentElement;
+      const atBottom =
+        scrollHeight - window.scrollY - window.innerHeight < SCROLL_THRESHOLD;
+      setIsAtBottom(atBottom);
+    };
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  const scrollToBottom = () => {
+    window.scrollTo({
+      top: document.documentElement.scrollHeight,
+      behavior: "smooth",
+    });
+    setIsAtBottom(true);
+  };
+
   const handleSend = (text: string) => {
     const message = attachedMedia
       ? `[About: ${attachedMedia.title} (${attachedMedia.mediaType})] ${text}`
@@ -78,13 +103,18 @@ export function AIChatView({
           messages={messages}
           status={status}
           error={error}
+          isAtBottom={isAtBottom}
           emptyState={emptyState}
           messagesLabel={messagesLabel}
           typingIndicatorLabel={typingIndicatorLabel}
-          scrollToBottomLabel={scrollToBottomLabel}
           errorLabel={errorLabel}
         />
         <div css={styles.inputArea}>
+          <ScrollToBottomButton
+            visible={!isAtBottom && messages.length > 0}
+            label={scrollToBottomLabel}
+            onClick={scrollToBottom}
+          />
           <PreferenceManager />
           <ChatInputBar
             placeholder={placeholder}

--- a/src/components/ai-chat/chat-message-list.test.tsx
+++ b/src/components/ai-chat/chat-message-list.test.tsx
@@ -14,9 +14,9 @@ const defaultProps = {
   emptyState: <div>Welcome to AI Mode</div>,
   messagesLabel: "Chat messages",
   typingIndicatorLabel: "AI is thinking…",
-  scrollToBottomLabel: "Scroll to bottom",
   errorLabel: "Something went wrong. Please try again.",
   error: undefined,
+  isAtBottom: true,
 };
 
 describe("ChatMessageList", () => {
@@ -94,21 +94,6 @@ describe("ChatMessageList", () => {
       <ChatMessageList messages={messages} status="ready" {...defaultProps} />,
     );
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
-  });
-
-  it("renders scroll-to-bottom button hidden when there are no messages", () => {
-    const { container } = render(
-      <ChatMessageList messages={[]} status="ready" {...defaultProps} />,
-    );
-    // The button exists in the DOM but is hidden from the accessibility tree
-    expect(
-      screen.queryByRole("button", { name: "Scroll to bottom" }),
-    ).not.toBeInTheDocument();
-    const button = container.querySelector(
-      'button[aria-label="Scroll to bottom"]',
-    );
-    expect(button).toBeInTheDocument();
-    expect(button).toHaveAttribute("aria-hidden", "true");
   });
 
   it("uses log role with accessible label on messages container", () => {

--- a/src/components/ai-chat/chat-message-list.tsx
+++ b/src/components/ai-chat/chat-message-list.tsx
@@ -2,7 +2,7 @@
 
 import * as stylex from "@stylexjs/stylex";
 import type { ChatStatus, UIMessage } from "ai";
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useEffect } from "react";
 import {
   COMPACTION_TRIGGER_TOKENS,
   USAGE_WARNING_RATIO,
@@ -14,21 +14,20 @@ import { flex } from "#src/primitives/flex.stylex.ts";
 import { color, font, space } from "#src/tokens.stylex.ts";
 import type { MediaListItem, PersonListItem } from "#src/utils/types.ts";
 import { ChatMessage, deriveMessageData } from "./chat-message";
-import { ScrollToBottomButton } from "./scroll-to-bottom-button";
 import type { WatchProviderOutput } from "./tool-watch-providers";
 import { TypingIndicator } from "./typing-indicator";
 
-const SCROLL_THRESHOLD = 50;
+export const SCROLL_THRESHOLD = 50;
 const USAGE_WARNING_THRESHOLD = COMPACTION_TRIGGER_TOKENS * USAGE_WARNING_RATIO;
 
 interface ChatMessageListProps {
   messages: ReadonlyArray<UIMessage<ChatMessageMetadata>>;
   status: ChatStatus;
   error: Error | undefined;
+  isAtBottom: boolean;
   emptyState: ReactNode;
   messagesLabel: string;
   typingIndicatorLabel: string;
-  scrollToBottomLabel: string;
   errorLabel: string;
 }
 
@@ -94,34 +93,13 @@ export function ChatMessageList({
   messages,
   status,
   error,
+  isAtBottom,
   emptyState,
   messagesLabel,
   typingIndicatorLabel,
-  scrollToBottomLabel,
   errorLabel,
 }: ChatMessageListProps) {
   usePreferencePersistence(messages);
-
-  const [isAtBottom, setIsAtBottom] = useState(true);
-
-  const scrollToBottom = () => {
-    window.scrollTo({
-      top: document.documentElement.scrollHeight,
-      behavior: "smooth",
-    });
-    setIsAtBottom(true);
-  };
-
-  useEffect(() => {
-    const handleScroll = () => {
-      const { scrollHeight } = document.documentElement;
-      const atBottom =
-        scrollHeight - window.scrollY - window.innerHeight < SCROLL_THRESHOLD;
-      setIsAtBottom(atBottom);
-    };
-    window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
 
   const lastMessageRole =
     messages.length > 0 ? messages[messages.length - 1]?.role : undefined;
@@ -212,11 +190,6 @@ export function ChatMessageList({
           })}
         </p>
       )}
-      <ScrollToBottomButton
-        visible={!isAtBottom && messages.length > 0}
-        label={scrollToBottomLabel}
-        onClick={scrollToBottom}
-      />
     </div>
   );
 }

--- a/src/components/ai-chat/scroll-to-bottom-button.tsx
+++ b/src/components/ai-chat/scroll-to-bottom-button.tsx
@@ -37,8 +37,8 @@ export function ScrollToBottomButton({
 
 const styles = stylex.create({
   button: {
-    position: "fixed",
-    bottom: `calc(${space._10} + env(safe-area-inset-bottom))`,
+    position: "absolute",
+    bottom: `calc(100% + ${space._2})`,
     left: "50%",
     transform: "translateX(-50%)",
     display: "inline-flex",


### PR DESCRIPTION
## Summary

The scroll-to-bottom button in the AI chat was partially covered by the chat input box because it used `position: fixed` with a hardcoded bottom offset that didn't account for the variable-height input area. This moves the button into the sticky input area container and uses `position: absolute` with `bottom: 100%` so it always sits directly above the input bar, regardless of input area height (multi-line text, attachments, etc.).

## Context

The scroll detection state (`isAtBottom`) and `scrollToBottom` callback were lifted from `ChatMessageList` to `AIChatView` so the button could be rendered inside the sticky input area container. `ChatMessageList` now receives `isAtBottom` as a prop for its auto-scroll-on-new-message behavior.

Closes #1813