### PR TITLE
fix: propagate search results across chat messages for poster display

### DIFF
--- a/src/components/ai-chat/chat-message-list.tsx
+++ b/src/components/ai-chat/chat-message-list.tsx
@@ -12,8 +12,10 @@ import { t } from "#src/i18n.ts";
 import { usePreferencePersistence } from "#src/preference-store/use-preference-persistence.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { color, font, space } from "#src/tokens.stylex.ts";
-import { ChatMessage } from "./chat-message";
+import type { MediaListItem, PersonListItem } from "#src/utils/types.ts";
+import { ChatMessage, deriveMessageData } from "./chat-message";
 import { ScrollToBottomButton } from "./scroll-to-bottom-button";
+import type { WatchProviderOutput } from "./tool-watch-providers";
 import { TypingIndicator } from "./typing-indicator";
 
 const SCROLL_THRESHOLD = 50;
@@ -40,6 +42,52 @@ function getLatestInputTokens(
     }
   }
   return 0;
+}
+
+interface CumulativeMaps {
+  searchResultsMap: ReadonlyMap<string, MediaListItem>;
+  personResultsMap: ReadonlyMap<number, PersonListItem>;
+  watchProvidersMap: ReadonlyMap<string, WatchProviderOutput>;
+}
+
+/**
+ * For each message, builds a cumulative map of search results, person results,
+ * and watch providers from all *prior* messages. This allows later messages
+ * (e.g. a second `present_media` call) to look up items discovered by earlier
+ * tool calls without re-searching.
+ */
+function buildCumulativeMaps(
+  messages: ReadonlyArray<UIMessage>,
+): ReadonlyArray<CumulativeMaps> {
+  const result: CumulativeMaps[] = [];
+  const cumulativeSearch = new Map<string, MediaListItem>();
+  const cumulativePerson = new Map<number, PersonListItem>();
+  const cumulativeWp = new Map<string, WatchProviderOutput>();
+
+  for (const message of messages) {
+    // Each message gets a snapshot of the cumulative maps from *prior* messages
+    result.push({
+      searchResultsMap: new Map(cumulativeSearch),
+      personResultsMap: new Map(cumulativePerson),
+      watchProvidersMap: new Map(cumulativeWp),
+    });
+
+    // After taking the snapshot, add this message's results to the cumulative maps
+    const { searchResultsMap, personResultsMap, watchProvidersMap } =
+      deriveMessageData(message.parts);
+
+    for (const [key, value] of searchResultsMap) {
+      cumulativeSearch.set(key, value);
+    }
+    for (const [key, value] of personResultsMap) {
+      cumulativePerson.set(key, value);
+    }
+    for (const [key, value] of watchProvidersMap) {
+      cumulativeWp.set(key, value);
+    }
+  }
+
+  return result;
 }
 
 export function ChatMessageList({
@@ -93,6 +141,11 @@ export function ChatMessageList({
   const latestInputTokens = getLatestInputTokens(messages);
   const showUsageWarning = latestInputTokens >= USAGE_WARNING_THRESHOLD;
 
+  // Build cumulative search/person/watch-provider maps so that later messages
+  // can look up media items discovered by earlier tool calls (e.g. a second
+  // present_media call can find items from a prior tmdb_search).
+  const cumulativeMaps = buildCumulativeMaps(messages);
+
   return (
     <div css={[flex.col, styles.container]}>
       {messages.length === 0 ? (
@@ -114,6 +167,11 @@ export function ChatMessageList({
               }
               isLastAssistantMessage={
                 message.role === "assistant" && index === lastAssistantIndex
+              }
+              cumulativeSearchResults={cumulativeMaps[index]?.searchResultsMap}
+              cumulativePersonResults={cumulativeMaps[index]?.personResultsMap}
+              cumulativeWatchProviders={
+                cumulativeMaps[index]?.watchProvidersMap
               }
             />
           ))}

--- a/src/components/ai-chat/chat-message.test.tsx
+++ b/src/components/ai-chat/chat-message.test.tsx
@@ -260,6 +260,47 @@ describe("ChatMessage", () => {
     expect(screen.getByText("1 tool call")).toBeInTheDocument();
   });
 
+  it("renders present_media cards using cumulative search results from prior messages", () => {
+    const priorSearchResults = new Map([
+      [
+        "movie:1",
+        {
+          id: 1,
+          title: "Inception",
+          posterPath: "/inception.jpg",
+          rating: 8.4,
+          mediaType: "movie" as const,
+        },
+      ],
+    ]);
+
+    render(
+      <MediaDetailProvider>
+        <ChatMessage
+          message={createMessage({
+            role: "assistant",
+            parts: [
+              {
+                type: "dynamic-tool",
+                toolName: "present_media",
+                toolCallId: "present-call-2",
+                state: "output-available",
+                input: { media: [{ id: 1, media_type: "movie" }] },
+                output: { media: [{ id: 1, media_type: "movie" }] },
+              },
+              { type: "text", text: "Here it is again!" },
+            ],
+          })}
+          cumulativeSearchResults={priorSearchResults}
+        />
+      </MediaDetailProvider>,
+    );
+
+    // The poster image should render using data from the cumulative map
+    expect(screen.getByAltText("Inception")).toBeInTheDocument();
+    expect(screen.getByText("Here it is again!")).toBeInTheDocument();
+  });
+
   it("shows tool activity group for tool parts", () => {
     render(
       <ChatMessage

--- a/src/components/ai-chat/chat-message.tsx
+++ b/src/components/ai-chat/chat-message.tsx
@@ -26,24 +26,45 @@ interface ChatMessageProps {
   message: UIMessage;
   isStreaming?: boolean;
   isLastAssistantMessage?: boolean;
+  cumulativeSearchResults?: ReadonlyMap<string, MediaListItem>;
+  cumulativePersonResults?: ReadonlyMap<number, PersonListItem>;
+  cumulativeWatchProviders?: ReadonlyMap<string, WatchProviderOutput>;
 }
 
 export function ChatMessage({
   message,
   isStreaming = false,
   isLastAssistantMessage = false,
+  cumulativeSearchResults,
+  cumulativePersonResults,
+  cumulativeWatchProviders,
 }: ChatMessageProps) {
   const isUser = message.role === "user";
 
   const {
-    searchResultsMap,
-    personResultsMap,
-    watchProvidersMap,
+    searchResultsMap: localSearchResults,
+    personResultsMap: localPersonResults,
+    watchProvidersMap: localWatchProviders,
     toolParts,
     hasVisibleContent,
     firstToolIndex,
     partKeys,
   } = deriveMessageData(message.parts);
+
+  // Merge cumulative maps from prior messages with this message's own maps.
+  // Local (per-message) entries take precedence over cumulative ones.
+  const searchResultsMap = mergeMaps(
+    cumulativeSearchResults,
+    localSearchResults,
+  );
+  const personResultsMap = mergeMaps(
+    cumulativePersonResults,
+    localPersonResults,
+  );
+  const watchProvidersMap = mergeMaps(
+    cumulativeWatchProviders,
+    localWatchProviders,
+  );
 
   if (!hasVisibleContent) return null;
 
@@ -132,7 +153,7 @@ function isCompactionPart(part: TextUIPart): boolean {
   return part.providerMetadata?.anthropic?.type === "compaction";
 }
 
-function deriveMessageData(parts: UIMessage["parts"]) {
+export function deriveMessageData(parts: UIMessage["parts"]) {
   const searchResultsMap = new Map<string, MediaListItem>();
   const personResultsMap = new Map<number, PersonListItem>();
   const watchProvidersMap = new Map<string, WatchProviderOutput>();
@@ -220,6 +241,23 @@ function deriveMessageData(parts: UIMessage["parts"]) {
     firstToolIndex,
     partKeys,
   };
+}
+
+/**
+ * Merges a cumulative map from prior messages with a local map from the current
+ * message. Local entries take precedence over cumulative ones.
+ */
+function mergeMaps<K, V>(
+  cumulative: ReadonlyMap<K, V> | undefined,
+  local: ReadonlyMap<K, V>,
+): ReadonlyMap<K, V> {
+  if (!cumulative || cumulative.size === 0) return local;
+  if (local.size === 0) return cumulative;
+  const merged = new Map(cumulative);
+  for (const [key, value] of local) {
+    merged.set(key, value);
+  }
+  return merged;
 }
 
 const styles = stylex.create({


### PR DESCRIPTION
## Summary

Fixes poster images breaking on second render in AI chat. When the AI presented a movie a second time (e.g. "present again"), the `present_media` tool call had no preceding `tmdb_search` in that message, so its per-message search results map was empty and posters fell back to "No Poster".

The root cause was that each `ChatMessage` built its search results map exclusively from its own tool parts, with no visibility into results from earlier messages. The fix builds cumulative maps at the `ChatMessageList` level and passes them down, so later messages can resolve media items discovered by prior tool calls.

## Context

Supersedes #1997, which attempted to fix this as a stale component state issue using refs during render (violating Rules of React). The actual bug was not in the `PosterImage` component at all — it was in how search results were scoped per-message rather than accumulated across the conversation.

Closes #1811