### PR TITLE
feat: replace hardcoded suggested queries with capability-showcasing prompts

### DIFF
--- a/src/app/[locale]/movie-database/ai-mode/page.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/page.tsx
@@ -1,5 +1,4 @@
 import * as stylex from "@stylexjs/stylex";
-import { getTrendingMovies } from "#src/_generated/tmdb-server-functions.ts";
 import { RecommendedMedia } from "#src/components/ai-chat/recommended-media.tsx";
 import { SuggestionChips } from "#src/components/ai-chat/suggestion-chips.tsx";
 import { t } from "#src/i18n.ts";
@@ -16,28 +15,15 @@ export default async function Page({
   const { locale } = await params;
   const validatedLocale: SupportedLocale = validateLocale(locale);
 
-  // Reuses the same fetch that RecommendedMedia makes — deduplicated by Next.js
-  const trendingMovies = await getTrendingMovies({
-    time_window: "week",
-    language: validatedLocale,
-  }).catch(() => null);
-  const trendingTitle = trendingMovies?.results?.find((m) => m.title)?.title;
-
-  const whereCanIStream = t({ en: "Where can I stream", zh: "哪里可以看" });
-
-  const streamingSuggestion = trendingTitle
-    ? `${whereCanIStream} ${trendingTitle}`
-    : t({
-        en: "Where can I stream the top trending movie?",
-        zh: "哪里可以看最热门的电影？",
-      });
-
   const suggestions = [
     t({
       en: "Find me a feel-good movie to watch tonight",
       zh: "帮我找一部今晚看的治愈系电影",
     }),
-    streamingSuggestion,
+    t({
+      en: "Where can I stream the latest trending shows?",
+      zh: "最近的热门剧在哪里可以看？",
+    }),
     t({
       en: "Show me the spicy reviews for the latest releases",
       zh: "给我看看最近上映的片子的辛辣影评",


### PR DESCRIPTION
## Summary

The previous suggested queries on the AI chat page referenced specific titles like "Breaking Bad" and "Inception", which could feel stale or unfamiliar to users who haven't seen them. The new four fixed suggestions — mood-based discovery, streaming availability, spicy reviews, and cast/credits lookup — each showcase a distinct capability of the AI chat without depending on any particular title or name.

## Context

The user explicitly rejected approaches involving random selection from a pool, fetching trending titles from TMDB (slows page load), and referencing specific titles/names. The final design is intentionally static — 4 fixed suggestions chosen to each showcase a distinct AI capability.

Closes #1995