### PR TITLE
fix: allow localhost dev servers on any port

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,3 @@
 export const BASE_URL = "https://qingqi.dev";
 export const LOCALE_COOKIE_NAME = "NEXT_LOCALE";
-export const ALLOWED_REFERER = [
-  BASE_URL,
-  "http://localhost:3000",
-  ".vercel.app",
-];
+export const ALLOWED_REFERER = [BASE_URL, ".vercel.app"];

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -25,6 +25,14 @@ describe("proxy referer validation for API routes", () => {
     expect(response.status).toBe(200);
   });
 
+  it("allows requests with localhost on any port", () => {
+    const response = proxy(
+      apiRequest("/api/ai-chat", "http://localhost:5173/search"),
+    );
+
+    expect(response.status).toBe(200);
+  });
+
   it("rejects requests with no referer", async () => {
     const response = proxy(apiRequest("/api/ai-chat"));
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -11,11 +11,12 @@ function validateReferer(request: NextRequest): NextResponse | null {
 
   try {
     const refererUrl = new URL(referer);
-    if (
-      !ALLOWED_REFERER.some((allowedReferer) =>
-        refererUrl.origin.endsWith(allowedReferer),
-      )
-    ) {
+    const isLocalhost =
+      refererUrl.hostname === "localhost" && refererUrl.protocol === "http:";
+    const isAllowedReferer = ALLOWED_REFERER.some((allowedReferer) =>
+      refererUrl.origin.endsWith(allowedReferer),
+    );
+    if (!isLocalhost && !isAllowedReferer) {
       throw new Error("Unauthorized");
     }
   } catch {


### PR DESCRIPTION
## Summary

The proxy middleware's allowed-referer list included a hardcoded `http://localhost:3000` entry, which only permitted local dev servers running on that exact port. This blocked development workflows using other ports (e.g., Vite's default 5173). The fix removes the hardcoded entry and adds an explicit hostname-based check that accepts any `http://localhost` origin regardless of port.

## Context

The changes touch three files: `src/constants.ts` (removed hardcoded localhost:3000 from ALLOWED_REFERER), `src/proxy.ts` (added hostname-based localhost check separate from the endsWith matching), and `src/proxy.test.ts` (added test for port 5173).