### PR TITLE
feat: add dot grid background to AI mode page

### DIFF
--- a/src/app/[locale]/movie-database/ai-mode/layout.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/layout.tsx
@@ -1,5 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 import type { Metadata } from "next";
+import { DotGridBackground } from "#src/components/ai-chat/dot-grid-background.tsx";
 import { RetryableErrorBoundary } from "#src/components/shared/retryable-error-boundary.tsx";
 import { BASE_URL } from "#src/constants.ts";
 import { t } from "#src/i18n.ts";
@@ -54,6 +55,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         zh: "出错了。",
       })}
     >
+      <DotGridBackground />
       <main css={styles.container}>{children}</main>
     </RetryableErrorBoundary>
   );

--- a/src/components/ai-chat/dot-grid-background.tsx
+++ b/src/components/ai-chat/dot-grid-background.tsx
@@ -1,0 +1,19 @@
+import * as stylex from "@stylexjs/stylex";
+import { color, layer } from "#src/tokens.stylex.ts";
+
+export function DotGridBackground() {
+  return <div css={styles.background} role="presentation" />;
+}
+
+const styles = stylex.create({
+  background: {
+    position: "fixed",
+    inset: 0,
+    zIndex: layer.background,
+    pointerEvents: "none",
+    backgroundImage: `radial-gradient(circle, ${color.textMuted} 1px, transparent 1px), radial-gradient(ellipse at 80% 20%, ${color.controlActive} 0%, transparent 70%)`,
+    backgroundSize: "24px 24px, 100% 100%",
+    backgroundRepeat: "repeat, no-repeat",
+    opacity: 0.12,
+  },
+});


### PR DESCRIPTION
## Summary

Gives the AI Mode page (`/movie-database/ai-mode`) a distinct visual identity by adding a fixed `DotGridBackground` server component. Without this, the page shares the same blank background as the rest of the app and lacks the branded feel appropriate for an AI-focused experience. The component renders a repeating dot grid using `color.textMuted` with a radial brand-purple gradient wash (`color.controlActive`) at low opacity, sitting behind all content via the `layer.background` z-index.

## Context

This is the simpler alternative to a WebGL animated gradient considered for issue #1673. It follows the same pattern as the existing `BackgroundLines` component used on the home page, using design tokens throughout for consistency with the visual language.

Closes #1673