### PR TITLE
feat: add smooth text reveal animation to AI chat streaming

### DIFF
--- a/src/components/ai-chat/chat-message.tsx
+++ b/src/components/ai-chat/chat-message.tsx
@@ -9,6 +9,7 @@ import {
   type TextUIPart,
   type UIMessage,
 } from "ai";
+import { useState } from "react";
 import { border, color, font, space } from "#src/tokens.stylex.ts";
 import type { MediaListItem, PersonListItem } from "#src/utils/types.ts";
 import { CompactionNotice } from "./compaction-notice";
@@ -17,7 +18,7 @@ import {
   buildSearchResultsMap,
   buildWatchProvidersMap,
 } from "./map-tool-output";
-import { MarkdownContent } from "./markdown-content";
+import { SmoothedMarkdownContent } from "./smoothed-markdown-content";
 import { ToolActivityGroup } from "./tool-activity-group";
 import { ToolVisualOutput } from "./tool-visual-output";
 import type { WatchProviderOutput } from "./tool-watch-providers";
@@ -34,6 +35,7 @@ export function ChatMessage({
   isLastAssistantMessage = false,
 }: ChatMessageProps) {
   const isUser = message.role === "user";
+  const [releasedTextParts, setReleasedTextParts] = useState(1);
 
   const {
     searchResultsMap,
@@ -43,9 +45,13 @@ export function ChatMessage({
     hasVisibleContent,
     firstToolIndex,
     partKeys,
+    textPartCount,
+    textPartTrailingBuffers,
   } = deriveMessageData(message.parts);
 
   if (!hasVisibleContent) return null;
+
+  let textPartIndex = 0;
 
   return (
     <div
@@ -54,6 +60,7 @@ export function ChatMessage({
       {message.parts.map((part, index) => {
         const key = partKeys[index];
         if (isTextUIPart(part)) {
+          const currentTextIndex = textPartIndex++;
           if (isUser) {
             return (
               <p key={key} css={[styles.partBase, styles.text]}>
@@ -61,6 +68,11 @@ export function ChatMessage({
               </p>
             );
           }
+
+          // During streaming, queue text parts so each waits for the
+          // previous one's animation to finish before appearing.
+          if (isStreaming && currentTextIndex >= releasedTextParts) return null;
+
           if (isCompactionPart(part)) {
             return (
               <div key={key} css={styles.partBase}>
@@ -68,9 +80,28 @@ export function ChatMessage({
               </div>
             );
           }
+
+          const isActiveTextPart =
+            isStreaming && currentTextIndex === releasedTextParts - 1;
+          // Won't receive more content — safe to fire onCaughtUp
+          const isSealed = !isStreaming || currentTextIndex < textPartCount - 1;
           return (
             <div key={key} css={styles.partBase}>
-              <MarkdownContent content={part.text} />
+              <SmoothedMarkdownContent
+                content={part.text}
+                onCaughtUp={
+                  isActiveTextPart
+                    ? () => setReleasedTextParts((prev) => prev + 1)
+                    : undefined
+                }
+                sealed={isSealed}
+                startRevealed={!isStreaming}
+                trailingBufferHint={
+                  isStreaming
+                    ? textPartTrailingBuffers[currentTextIndex]
+                    : undefined
+                }
+              />
             </div>
           );
         }
@@ -144,6 +175,8 @@ function deriveMessageData(parts: UIMessage["parts"]) {
   }> = [];
   let hasVisibleContent = false;
   let firstToolIndex = -1;
+  let textPartCount = 0;
+  const textPartLengths: number[] = [];
   const partKeys: string[] = [];
   const typeCounts = new Map<string, number>();
 
@@ -205,10 +238,23 @@ function deriveMessageData(parts: UIMessage["parts"]) {
           watchProvidersMap.set(key, value);
         }
       }
-    } else if (!hasVisibleContent) {
-      if (isTextUIPart(part) && part.text.length > 0) hasVisibleContent = true;
-      else if (isReasoningUIPart(part)) hasVisibleContent = true;
+    } else {
+      if (isTextUIPart(part)) {
+        textPartCount++;
+        textPartLengths.push(part.text.length);
+        if (!hasVisibleContent && part.text.length > 0)
+          hasVisibleContent = true;
+      } else if (!hasVisibleContent && isReasoningUIPart(part)) {
+        hasVisibleContent = true;
+      }
     }
+  }
+
+  const textPartTrailingBuffers: number[] = [];
+  let trailingSum = 0;
+  for (let i = textPartLengths.length - 1; i >= 0; i--) {
+    textPartTrailingBuffers[i] = trailingSum;
+    trailingSum += textPartLengths[i];
   }
 
   return {
@@ -219,6 +265,8 @@ function deriveMessageData(parts: UIMessage["parts"]) {
     hasVisibleContent,
     firstToolIndex,
     partKeys,
+    textPartCount,
+    textPartTrailingBuffers,
   };
 }
 

--- a/src/components/ai-chat/smoothed-markdown-content.tsx
+++ b/src/components/ai-chat/smoothed-markdown-content.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { MarkdownContent } from "./markdown-content";
+import { useSmoothedText } from "./use-smoothed-text";
+
+interface SmoothedMarkdownContentProps {
+  content: string;
+  onCaughtUp?: () => void;
+  sealed?: boolean;
+  startRevealed?: boolean;
+  trailingBufferHint?: number;
+}
+
+export function SmoothedMarkdownContent({
+  content,
+  onCaughtUp,
+  sealed,
+  startRevealed,
+  trailingBufferHint,
+}: SmoothedMarkdownContentProps) {
+  const displayedText = useSmoothedText(content, {
+    onCaughtUp,
+    sealed,
+    startRevealed,
+    trailingBufferHint,
+  });
+  return <MarkdownContent content={displayedText} />;
+}

--- a/src/components/ai-chat/use-smoothed-text.test.ts
+++ b/src/components/ai-chat/use-smoothed-text.test.ts
@@ -1,0 +1,500 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  closeOpenMarkers,
+  createMarkerTracker,
+  useSmoothedText,
+} from "./use-smoothed-text";
+
+describe("closeOpenMarkers", () => {
+  it("returns text unchanged when no markers present", () => {
+    expect(closeOpenMarkers("Hello world")).toBe("Hello world");
+  });
+
+  it("returns text unchanged when all markers are closed", () => {
+    expect(closeOpenMarkers("**bold** and *italic*")).toBe(
+      "**bold** and *italic*",
+    );
+  });
+
+  it("closes unclosed bold", () => {
+    expect(closeOpenMarkers("Hello **world")).toBe("Hello **world**");
+  });
+
+  it("closes unclosed italic", () => {
+    expect(closeOpenMarkers("Hello *world")).toBe("Hello *world*");
+  });
+
+  it("closes unclosed bold+italic", () => {
+    expect(closeOpenMarkers("Hello ***world")).toBe("Hello ***world***");
+  });
+
+  it("closes unclosed inline code", () => {
+    expect(closeOpenMarkers("Hello `code")).toBe("Hello `code`");
+  });
+
+  it("closes unclosed strikethrough", () => {
+    expect(closeOpenMarkers("Hello ~~strike")).toBe("Hello ~~strike~~");
+  });
+
+  it("closes unclosed code fence", () => {
+    expect(closeOpenMarkers("```js\nconst x = 1")).toBe(
+      "```js\nconst x = 1\n```",
+    );
+  });
+
+  it("does not close markers inside code fences", () => {
+    expect(closeOpenMarkers("```\n**not bold\n```")).toBe(
+      "```\n**not bold\n```",
+    );
+  });
+
+  it("does not close markers inside inline code", () => {
+    expect(closeOpenMarkers("`**not bold`")).toBe("`**not bold`");
+  });
+
+  it("handles multiple unclosed markers", () => {
+    const result = closeOpenMarkers("**bold and *italic");
+    expect(result).toBe("**bold and *italic***");
+  });
+
+  it("treats * at line start followed by space as list marker", () => {
+    expect(closeOpenMarkers("* list item")).toBe("* list item");
+    expect(closeOpenMarkers("line\n* list item")).toBe("line\n* list item");
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(closeOpenMarkers("")).toBe("");
+  });
+
+  it("strips opening markers with no content during progressive reveal", () => {
+    // Progressive reveal of **bold** should never flash raw asterisks
+    expect(closeOpenMarkers("*")).toBe("");
+    expect(closeOpenMarkers("**")).toBe("");
+    expect(closeOpenMarkers("**b")).toBe("**b**");
+    expect(closeOpenMarkers("**bo")).toBe("**bo**");
+    expect(closeOpenMarkers("**bold")).toBe("**bold**");
+    expect(closeOpenMarkers("**bold*")).toBe("**bold**");
+    expect(closeOpenMarkers("**bold**")).toBe("**bold**");
+  });
+
+  it("strips partial closing bold marker instead of adding extra asterisks", () => {
+    expect(closeOpenMarkers("Some **text*")).toBe("Some **text**");
+  });
+
+  it("strips opening bold+italic markers with no content", () => {
+    expect(closeOpenMarkers("***")).toBe("");
+    expect(closeOpenMarkers("Hello ***")).toBe("Hello ");
+  });
+
+  it("strips opening strikethrough markers with no content", () => {
+    expect(closeOpenMarkers("~~")).toBe("");
+    expect(closeOpenMarkers("Hello ~~")).toBe("Hello ");
+  });
+});
+
+describe("createMarkerTracker", () => {
+  it("matches closeOpenMarkers at every reveal position for emphasis", () => {
+    const targets = [
+      "Hello **bold** and *italic* text",
+      "Mixed **bold *and italic*** end",
+      "~~strike~~ and **bold** done",
+      "* list\n* items\n**bold** end",
+      "Some ***bold italic*** here",
+    ];
+    for (const target of targets) {
+      const tracker = createMarkerTracker();
+      for (let len = 1; len <= target.length; len++) {
+        const incremental = tracker.closeAt(target, len);
+        const standalone = closeOpenMarkers(target.slice(0, len));
+        expect(incremental).toBe(standalone);
+      }
+    }
+  });
+
+  it("handles code fences incrementally", () => {
+    const tracker = createMarkerTracker();
+    const target = "```js\nconst x = 1\n```\nafter";
+
+    // Before fence is fully revealed — backticks stripped
+    expect(tracker.closeAt(target, 2)).toBe("");
+
+    // After content is visible, fence should be closed
+    tracker.reset();
+    expect(tracker.closeAt(target, 10)).toBe("```js\ncons\n```");
+
+    // Full text
+    tracker.reset();
+    expect(tracker.closeAt(target, target.length)).toBe(target);
+  });
+
+  it("resets when text gets shorter", () => {
+    const tracker = createMarkerTracker();
+    tracker.closeAt("Hello **bold", 12);
+
+    const result = tracker.closeAt("Hi", 2);
+    expect(result).toBe("Hi");
+  });
+});
+
+describe("useSmoothedText", () => {
+  let rafCallbacks: Array<FrameRequestCallback>;
+  let nextRafId: number;
+  let cancelRafSpy: ReturnType<typeof vi.spyOn>;
+  let mockTimestamp: number;
+
+  /** Step N frames at 60fps (16.67ms apart) */
+  function stepFrames(count: number) {
+    for (let i = 0; i < count; i++) {
+      mockTimestamp += 16.67;
+      const callbacks = [...rafCallbacks];
+      rafCallbacks = [];
+      act(() => {
+        for (const cb of callbacks) cb(mockTimestamp);
+      });
+    }
+  }
+
+  beforeEach(() => {
+    rafCallbacks = [];
+    nextRafId = 1;
+    mockTimestamp = 1000;
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      rafCallbacks.push(cb);
+      return nextRafId++;
+    });
+    cancelRafSpy = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation(() => {
+        rafCallbacks = [];
+      });
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+    } as MediaQueryList);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns target text immediately when already caught up", () => {
+    const { result } = renderHook(() => useSmoothedText("Hello world"));
+    expect(result.current).toBe("Hello world");
+  });
+
+  it("gradually reveals text as it grows", () => {
+    const { result, rerender } = renderHook(
+      ({ text }) => useSmoothedText(text),
+      { initialProps: { text: "Hi" } },
+    );
+
+    // Catch up to initial chunk
+    stepFrames(40);
+    expect(result.current).toBe("Hi");
+
+    // Simulate a large new chunk arriving
+    rerender({ text: "Hi, this is a longer streaming text!" });
+
+    // After several frames, text should be partially revealed
+    stepFrames(8);
+    expect(result.current.length).toBeGreaterThan("Hi".length);
+    expect(result.current.length).toBeLessThan(
+      "Hi, this is a longer streaming text!".length,
+    );
+
+    // Eventually catches up fully
+    stepFrames(200);
+    expect(result.current).toBe("Hi, this is a longer streaming text!");
+  });
+
+  it("continues draining buffer after text stops changing", () => {
+    const { result, rerender } = renderHook(
+      ({ text }) => useSmoothedText(text),
+      { initialProps: { text: "A" } },
+    );
+
+    stepFrames(40);
+    rerender({ text: "A bunch of remaining text here" });
+
+    // Partially reveal
+    stepFrames(5);
+    const partialLength = result.current.length;
+    expect(partialLength).toBeGreaterThan(1);
+    expect(partialLength).toBeLessThan("A bunch of remaining text here".length);
+
+    // Text stops changing — loop should continue draining
+    stepFrames(300);
+    expect(result.current).toBe("A bunch of remaining text here");
+  });
+
+  it("decelerates visibly at the tail", () => {
+    const { result, rerender } = renderHook(
+      ({ text }) => useSmoothedText(text),
+      { initialProps: { text: "X" } },
+    );
+
+    stepFrames(40);
+    rerender({ text: "X" + "a".repeat(60) });
+
+    // Let it get close to the end but not finish
+    stepFrames(80);
+    const nearEndLength = result.current.length;
+
+    // Measure how many chars are revealed in the next 30 frames
+    stepFrames(30);
+    const afterLength = result.current.length;
+    const charsInLast30Frames = afterLength - nearEndLength;
+
+    // At the tail, reveal rate should be noticeably slow
+    // 30 frames at 60fps = 500ms. At ~2 chars/sec, expect ≤ 3 chars
+    // Allow some tolerance for easing dynamics
+    expect(charsInLast30Frames).toBeLessThanOrEqual(8);
+  });
+
+  it("returns target text immediately when reduced motion is preferred", () => {
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: true,
+    } as MediaQueryList);
+
+    const { result } = renderHook(() => useSmoothedText("Instant text"));
+    act(() => {});
+    expect(result.current).toBe("Instant text");
+  });
+
+  it("handles growing text incrementally", () => {
+    const { result, rerender } = renderHook(
+      ({ text }) => useSmoothedText(text),
+      { initialProps: { text: "Hello" } },
+    );
+
+    // Catch up to first chunk
+    stepFrames(40);
+    expect(result.current).toBe("Hello");
+
+    // New chunk arrives
+    rerender({ text: "Hello world" });
+
+    // Should not lose already-revealed text
+    stepFrames(1);
+    expect(result.current.length).toBeGreaterThanOrEqual("Hello".length);
+
+    // Eventually catches up
+    stepFrames(200);
+    expect(result.current).toBe("Hello world");
+  });
+
+  it("resets when text gets shorter", () => {
+    const { result, rerender } = renderHook(
+      ({ text }) => useSmoothedText(text),
+      { initialProps: { text: "A very long first message" } },
+    );
+
+    // Catch up fully
+    stepFrames(200);
+    expect(result.current).toBe("A very long first message");
+
+    // New shorter text (new streaming session)
+    rerender({ text: "Short" });
+
+    // After catching up, should show the new text
+    stepFrames(200);
+    expect(result.current).toBe("Short");
+  });
+
+  it("cleans up animation frame on unmount", () => {
+    const { rerender, unmount } = renderHook(
+      ({ text }) => useSmoothedText(text),
+      { initialProps: { text: "A" } },
+    );
+    stepFrames(20);
+    // Grow text to start an active rAF loop
+    rerender({ text: "A longer text to animate" });
+    stepFrames(2);
+    unmount();
+    expect(cancelRafSpy).toHaveBeenCalled();
+  });
+
+  it("never splits a surrogate pair (emoji)", () => {
+    const { result, rerender } = renderHook(
+      ({ text }) => useSmoothedText(text),
+      { initialProps: { text: "A" } },
+    );
+
+    stepFrames(40);
+    // Text with emoji (surrogate pair: 2 UTF-16 code units)
+    rerender({ text: "A 😀 done" });
+
+    // Step through frames and verify no lone surrogate appears
+    for (let i = 0; i < 100; i++) {
+      const text = result.current;
+      // A lone high surrogate would produce a replacement character
+      // Check that every char in the output is valid
+      for (let j = 0; j < text.length; j++) {
+        const code = text.charCodeAt(j);
+        // High surrogate must be followed by low surrogate
+        if (code >= 0xd800 && code <= 0xdbff) {
+          const next = text.charCodeAt(j + 1);
+          expect(next).toBeGreaterThanOrEqual(0xdc00);
+          expect(next).toBeLessThanOrEqual(0xdfff);
+        }
+      }
+      stepFrames(1);
+    }
+
+    expect(result.current).toBe("A 😀 done");
+  });
+
+  it("calls onCaughtUp when already caught up on mount", () => {
+    const onCaughtUp = vi.fn();
+    renderHook(() => useSmoothedText("Hello", { onCaughtUp }));
+    // Effect runs synchronously after render in test environment
+    expect(onCaughtUp).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCaughtUp after animation catches up", () => {
+    const onCaughtUp = vi.fn();
+    const { rerender } = renderHook(
+      ({ text }) => useSmoothedText(text, { onCaughtUp }),
+      { initialProps: { text: "A" } },
+    );
+
+    stepFrames(40);
+    onCaughtUp.mockClear();
+
+    // Grow text to start animation
+    rerender({ text: "A bunch of new text" });
+
+    // Not caught up yet
+    stepFrames(5);
+    expect(onCaughtUp).not.toHaveBeenCalled();
+
+    // Eventually catches up
+    stepFrames(300);
+    expect(onCaughtUp).toHaveBeenCalled();
+  });
+
+  it("calls onCaughtUp with reduced motion", () => {
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: true,
+    } as MediaQueryList);
+
+    const onCaughtUp = vi.fn();
+    renderHook(() => useSmoothedText("Instant text", { onCaughtUp }));
+    expect(onCaughtUp).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire onCaughtUp when sealed is false", () => {
+    const onCaughtUp = vi.fn();
+    const { rerender } = renderHook(
+      ({ text }) => useSmoothedText(text, { onCaughtUp, sealed: false }),
+      { initialProps: { text: "A" } },
+    );
+
+    stepFrames(40);
+    onCaughtUp.mockClear();
+
+    // Grow text and let it catch up
+    rerender({ text: "A short text" });
+    stepFrames(300);
+
+    // Should NOT have fired because sealed is false
+    expect(onCaughtUp).not.toHaveBeenCalled();
+  });
+
+  it("fires onCaughtUp when sealed changes to true after catching up", () => {
+    const onCaughtUp = vi.fn();
+    const { rerender } = renderHook(
+      ({ text, sealed }) => useSmoothedText(text, { onCaughtUp, sealed }),
+      { initialProps: { text: "A", sealed: false } },
+    );
+
+    stepFrames(40);
+    onCaughtUp.mockClear();
+
+    // Grow text and let it catch up while unsealed
+    rerender({ text: "A short text", sealed: false });
+    stepFrames(300);
+    expect(onCaughtUp).not.toHaveBeenCalled();
+
+    // Now seal it — should fire because already caught up
+    rerender({ text: "A short text", sealed: true });
+    expect(onCaughtUp).toHaveBeenCalledTimes(1);
+  });
+
+  it("animates from position 0 when startRevealed is false", () => {
+    const { result } = renderHook(() =>
+      useSmoothedText("Hello world", { startRevealed: false }),
+    );
+
+    // First render should show empty text, not the full text
+    expect(result.current).toBe("");
+
+    // After some frames, text should start appearing
+    stepFrames(10);
+    expect(result.current.length).toBeGreaterThan(0);
+
+    // Eventually catches up
+    stepFrames(300);
+    expect(result.current).toBe("Hello world");
+  });
+
+  it("produces consistent speed regardless of frame rate", () => {
+    // Simulate at 60fps (16.67ms frames)
+    const { result: result60, rerender: rerender60 } = renderHook(
+      ({ text }) => useSmoothedText(text),
+      { initialProps: { text: "A" } },
+    );
+    stepFrames(40);
+    rerender60({ text: "A" + "x".repeat(50) });
+    // Step 10 frames at 60fps = 166.7ms
+    stepFrames(10);
+    const length60 = result60.current.length;
+
+    // Reset for 120fps test — simulate by halving the timestamp step
+    const { result: result120, rerender: rerender120 } = renderHook(
+      ({ text }) => useSmoothedText(text),
+      { initialProps: { text: "A" } },
+    );
+    // Step 40 frames at half interval to catch up
+    for (let i = 0; i < 40; i++) {
+      mockTimestamp += 8.33;
+      const cbs = [...rafCallbacks];
+      rafCallbacks = [];
+      act(() => {
+        for (const cb of cbs) cb(mockTimestamp);
+      });
+    }
+    rerender120({ text: "A" + "x".repeat(50) });
+    // Step 20 frames at 120fps = 166.7ms (same wall time)
+    for (let i = 0; i < 20; i++) {
+      mockTimestamp += 8.33;
+      const cbs = [...rafCallbacks];
+      rafCallbacks = [];
+      act(() => {
+        for (const cb of cbs) cb(mockTimestamp);
+      });
+    }
+    const length120 = result120.current.length;
+
+    // Both should reveal roughly the same amount in the same wall time
+    expect(Math.abs(length60 - length120)).toBeLessThanOrEqual(2);
+  });
+
+  it("factors trailingBufferHint into reveal rate to avoid tail deceleration", () => {
+    const { result, rerender } = renderHook(
+      ({ text, hint }) => useSmoothedText(text, { trailingBufferHint: hint }),
+      { initialProps: { text: "X", hint: 0 } },
+    );
+
+    stepFrames(40);
+    expect(result.current).toBe("X");
+
+    rerender({ text: "X" + "a".repeat(60), hint: 200 });
+
+    // With hint=200, the effective buffer (~260) keeps the rate high even
+    // as remaining text in this part shrinks, avoiding tail deceleration.
+    // Without a hint, 80+30 frames is not enough to finish 61 chars.
+    stepFrames(80);
+    expect(result.current).toBe("X" + "a".repeat(60));
+  });
+});

--- a/src/components/ai-chat/use-smoothed-text.ts
+++ b/src/components/ai-chat/use-smoothed-text.ts
@@ -1,0 +1,456 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+
+/** Target reveal rate scales with buffer size (chars per 16.67ms at 60fps baseline) */
+const RATE_FACTOR = 0.08;
+/** Smoothing factor for acceleration (slow ramp-up when chunks arrive) */
+const RATE_SMOOTHING_UP = 0.15;
+/** Smoothing factor for deceleration (fast slow-down as buffer drains) */
+const RATE_SMOOTHING_DOWN = 0.3;
+/** Minimum reveal rate — floor of ~2 chars/sec at the tail */
+const MIN_RATE = 0.033;
+/** Reference frame duration in ms (60fps baseline for normalizing delta time) */
+const FRAME_MS = 16.67;
+/** Maximum delta to prevent jumps after tab switches or long pauses */
+const MAX_DELTA_MS = 100;
+
+const MARKER_CHARS = /[*`~]/;
+
+/** UTF-16 high surrogate (first half of emoji / astral code point) */
+function isHighSurrogate(code: number) {
+  return code >= 0xd800 && code <= 0xdbff;
+}
+
+// ---------------------------------------------------------------------------
+// Shared markdown marker scanning and balancing
+// ---------------------------------------------------------------------------
+
+interface MarkerState {
+  inCodeFence: boolean;
+  inlineCodeOpenPos: number;
+  boldOpenPos: number;
+  italicOpenPos: number;
+  strikeOpenPos: number;
+}
+
+function initialMarkerState(): MarkerState {
+  return {
+    inCodeFence: false,
+    inlineCodeOpenPos: -1,
+    boldOpenPos: -1,
+    italicOpenPos: -1,
+    strikeOpenPos: -1,
+  };
+}
+
+/** Scan `text[from..limit)` for markdown markers, mutating `s` in-place. */
+function scanMarkers(
+  text: string,
+  from: number,
+  limit: number,
+  s: MarkerState,
+) {
+  for (let i = from; i < limit; ) {
+    const ch = text[i];
+
+    // Code fence ```
+    if (
+      s.inlineCodeOpenPos === -1 &&
+      ch === "`" &&
+      i + 2 < limit &&
+      text[i + 1] === "`" &&
+      text[i + 2] === "`"
+    ) {
+      s.inCodeFence = !s.inCodeFence;
+      i += 3;
+      if (s.inCodeFence) {
+        while (i < limit && text[i] !== "\n") i++;
+      }
+      continue;
+    }
+
+    if (s.inCodeFence) {
+      i++;
+      continue;
+    }
+
+    // Inline code `
+    if (ch === "`") {
+      s.inlineCodeOpenPos = s.inlineCodeOpenPos === -1 ? i : -1;
+      i++;
+      continue;
+    }
+
+    if (s.inlineCodeOpenPos >= 0) {
+      i++;
+      continue;
+    }
+
+    // Strikethrough ~~
+    if (ch === "~" && i + 1 < limit && text[i + 1] === "~") {
+      s.strikeOpenPos = s.strikeOpenPos === -1 ? i : -1;
+      i += 2;
+      continue;
+    }
+
+    // List marker: * at start of line followed by space — not emphasis
+    if (
+      ch === "*" &&
+      (i === 0 || text[i - 1] === "\n") &&
+      i + 1 < limit &&
+      text[i + 1] === " "
+    ) {
+      i += 2;
+      continue;
+    }
+
+    // *** bold+italic, ** bold, * italic
+    if (ch === "*") {
+      if (i + 2 < limit && text[i + 1] === "*" && text[i + 2] === "*") {
+        s.boldOpenPos = s.boldOpenPos === -1 ? i : -1;
+        s.italicOpenPos = s.italicOpenPos === -1 ? i : -1;
+        i += 3;
+      } else if (i + 1 < limit && text[i + 1] === "*") {
+        s.boldOpenPos = s.boldOpenPos === -1 ? i : -1;
+        i += 2;
+      } else {
+        s.italicOpenPos = s.italicOpenPos === -1 ? i : -1;
+        i++;
+      }
+      continue;
+    }
+
+    i++;
+  }
+}
+
+/**
+ * Build output string for `text[0..outputEnd)` by closing or stripping
+ * unclosed markers. Markers with content after them are closed; markers
+ * at the end with no content are stripped to avoid flashing raw syntax.
+ */
+function buildBalancedOutput(
+  text: string,
+  outputEnd: number,
+  s: MarkerState,
+): string {
+  let suffix = "";
+  let stripFrom = outputEnd;
+
+  if (s.inlineCodeOpenPos >= 0) {
+    if (hasNonMarkerContent(text, s.inlineCodeOpenPos, outputEnd)) {
+      suffix += "`";
+    } else {
+      stripFrom = Math.min(stripFrom, s.inlineCodeOpenPos);
+    }
+  }
+
+  if (s.italicOpenPos >= 0) {
+    if (hasNonMarkerContent(text, s.italicOpenPos, outputEnd)) {
+      suffix += "*";
+    } else {
+      stripFrom = Math.min(stripFrom, s.italicOpenPos);
+    }
+  }
+
+  if (s.boldOpenPos >= 0) {
+    if (hasNonMarkerContent(text, s.boldOpenPos, outputEnd)) {
+      suffix += "**";
+    } else {
+      stripFrom = Math.min(stripFrom, s.boldOpenPos);
+    }
+  }
+
+  if (s.strikeOpenPos >= 0) {
+    if (hasNonMarkerContent(text, s.strikeOpenPos, outputEnd)) {
+      suffix += "~~";
+    } else {
+      stripFrom = Math.min(stripFrom, s.strikeOpenPos);
+    }
+  }
+
+  if (s.inCodeFence) suffix += "\n```";
+
+  if (!suffix && stripFrom >= outputEnd) {
+    return outputEnd === text.length ? text : text.slice(0, outputEnd);
+  }
+  const base = text.slice(0, stripFrom);
+  return suffix ? base + suffix : base;
+}
+
+function hasNonMarkerContent(text: string, from: number, to = text.length) {
+  for (let i = from; i < to; i++) {
+    const ch = text[i];
+    if (ch !== "*" && ch !== "~" && ch !== "`") return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Standalone closeOpenMarkers (O(n) full scan)
+// ---------------------------------------------------------------------------
+
+/**
+ * Appends closing markers for any unclosed inline markdown syntax so
+ * that partially revealed text renders with formatting instead of
+ * showing raw syntax characters. Single O(n) scan per call.
+ *
+ * Handles: ** (bold), * (italic), *** (bold+italic), ` (inline code),
+ * ~~ (strikethrough), and ``` (code fences).
+ */
+export function closeOpenMarkers(text: string): string {
+  if (!MARKER_CHARS.test(text)) return text;
+
+  const s = initialMarkerState();
+  scanMarkers(text, 0, text.length, s);
+  return buildBalancedOutput(text, text.length, s);
+}
+
+// ---------------------------------------------------------------------------
+// Incremental marker tracker (amortised O(delta) per frame)
+// ---------------------------------------------------------------------------
+
+/**
+ * Incremental marker tracker — amortises `closeOpenMarkers` across frames.
+ *
+ * During progressive reveal, text grows monotonically. Instead of re-scanning
+ * the entire string every frame (O(n)), the tracker remembers its scan
+ * position and marker state, only scanning newly revealed characters (O(delta)).
+ *
+ * Trailing marker characters at the reveal boundary are excluded from the
+ * committed scan because they might be part of an incomplete multi-character
+ * marker (e.g. the first `*` of `**`). They are stripped from the output and
+ * re-scanned next frame once more context is available.
+ */
+export function createMarkerTracker() {
+  let scannedTo = 0;
+  const state = initialMarkerState();
+
+  function reset() {
+    scannedTo = 0;
+    state.inCodeFence = false;
+    state.inlineCodeOpenPos = -1;
+    state.boldOpenPos = -1;
+    state.italicOpenPos = -1;
+    state.strikeOpenPos = -1;
+  }
+
+  function closeAt(text: string, end: number): string {
+    if (end < scannedTo) reset();
+
+    if (end > scannedTo) {
+      // Exclude trailing marker chars from committed scan — they may be
+      // part of an incomplete multi-char marker (**, ***, ~~, ```)
+      let scanLimit = end;
+      while (
+        scanLimit > scannedTo &&
+        (text[scanLimit - 1] === "*" || text[scanLimit - 1] === "`")
+      ) {
+        scanLimit--;
+      }
+      // Exclude trailing ~ when it could be part of a ~~ pair.
+      // Uncommit a previously committed ~ first so both are re-scanned.
+      if (scanLimit > scannedTo && text[scanLimit - 1] === "~") {
+        if (scannedTo > 0 && text[scannedTo - 1] === "~") scannedTo--;
+        if (scanLimit - 2 >= scannedTo && text[scanLimit - 2] === "~") {
+          while (scanLimit > scannedTo && text[scanLimit - 1] === "~") {
+            scanLimit--;
+          }
+        }
+      }
+
+      scanMarkers(text, scannedTo, scanLimit, state);
+      scannedTo = scanLimit;
+    }
+
+    // Fast path: no open markers and no trailing marker chars to strip
+    const hasOpen =
+      state.inCodeFence ||
+      state.inlineCodeOpenPos >= 0 ||
+      state.boldOpenPos >= 0 ||
+      state.italicOpenPos >= 0 ||
+      state.strikeOpenPos >= 0;
+
+    if (!hasOpen) {
+      const outputEnd = Math.min(scannedTo, end);
+      return outputEnd === text.length ? text : text.slice(0, outputEnd);
+    }
+
+    return buildBalancedOutput(text, scannedTo, state);
+  }
+
+  return { reset, closeAt };
+}
+
+// ---------------------------------------------------------------------------
+// useSmoothedText hook
+// ---------------------------------------------------------------------------
+
+interface UseSmoothedTextOptions {
+  /** Fires when the animation catches up to the target text AND sealed is true. */
+  onCaughtUp?: () => void;
+  /**
+   * When true, the text part is finalized (won't receive more content).
+   * onCaughtUp only fires when sealed — this prevents premature release
+   * when the animation temporarily catches up between streaming chunks.
+   * @default true
+   */
+  sealed?: boolean;
+  /**
+   * When false, animation starts from position 0 instead of showing the
+   * initial text immediately. Use for queued text parts that mount with
+   * their full content already available.
+   * @default true
+   */
+  startRevealed?: boolean;
+  /**
+   * Extra buffer from subsequent text parts — keeps the reveal rate high
+   * across part boundaries instead of decelerating at each part's tail.
+   * @default 0
+   */
+  trailingBufferHint?: number;
+}
+
+/**
+ * Smooths streaming text by adaptively revealing characters using
+ * requestAnimationFrame with delta-time normalization — the animation
+ * speed is consistent regardless of monitor refresh rate.
+ *
+ * The reveal rate scales with buffer size — more buffered text means
+ * faster reveal, less means slower. Easing is asymmetric: slow to
+ * accelerate when new text arrives, fast to decelerate as the buffer
+ * drains, producing a visible slow-down at the tail (~2 chars/sec).
+ *
+ * The rAF loop is self-managing: it starts when new text arrives and
+ * stops when fully caught up. It does not depend on streaming state,
+ * so it naturally continues draining the buffer after streaming ends
+ * rather than jumping to the full text.
+ */
+export function useSmoothedText(
+  targetText: string,
+  options?: UseSmoothedTextOptions,
+) {
+  const sealed = options?.sealed ?? true;
+  const startRevealed = options?.startRevealed ?? true;
+  const trailingBufferHint = options?.trailingBufferHint ?? 0;
+
+  const [displayedText, setDisplayedText] = useState(
+    startRevealed ? targetText : "",
+  );
+  const displayedLengthRef = useRef(startRevealed ? targetText.length : 0);
+  const targetRef = useRef(targetText);
+  const rafRef = useRef(0);
+  const rateRef = useRef(0);
+  const accumulatorRef = useRef(0);
+  const lastTimestampRef = useRef(0);
+  const onCaughtUpRef = useRef(options?.onCaughtUp);
+  const sealedRef = useRef(sealed);
+  const trailingBufferHintRef = useRef(trailingBufferHint);
+  const trackerRef = useRef(createMarkerTracker());
+
+  // Sync refs before paint so the rAF loop always reads the latest values.
+  // useLayoutEffect runs after commit but before rAF callbacks.
+  useLayoutEffect(() => {
+    targetRef.current = targetText;
+  }, [targetText]);
+
+  useLayoutEffect(() => {
+    onCaughtUpRef.current = options?.onCaughtUp;
+  }, [options?.onCaughtUp]);
+
+  useLayoutEffect(() => {
+    sealedRef.current = sealed;
+  }, [sealed]);
+
+  useLayoutEffect(() => {
+    trailingBufferHintRef.current = trailingBufferHint;
+  }, [trailingBufferHint]);
+
+  useEffect(() => {
+    if (
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      cancelAnimationFrame(rafRef.current);
+      displayedLengthRef.current = targetText.length;
+      setDisplayedText(targetText);
+      onCaughtUpRef.current?.();
+      return;
+    }
+
+    // Reset if text got shorter (new streaming session)
+    if (displayedLengthRef.current > targetText.length) {
+      displayedLengthRef.current = 0;
+      rateRef.current = 0;
+      accumulatorRef.current = 0;
+      trackerRef.current.reset();
+    }
+
+    // Already caught up — show immediately, no loop needed
+    if (displayedLengthRef.current >= targetText.length) {
+      setDisplayedText(
+        trackerRef.current.closeAt(targetText, targetText.length),
+      );
+      if (sealedRef.current) {
+        onCaughtUpRef.current?.();
+      }
+      return;
+    }
+
+    const animate = (timestamp: DOMHighResTimeStamp) => {
+      const deltaMs =
+        lastTimestampRef.current > 0
+          ? Math.min(timestamp - lastTimestampRef.current, MAX_DELTA_MS)
+          : FRAME_MS;
+      lastTimestampRef.current = timestamp;
+      const normalizedDelta = deltaMs / FRAME_MS;
+
+      const target = targetRef.current;
+      const current = displayedLengthRef.current;
+      const remaining = target.length - current;
+
+      const totalBuffer = remaining + trailingBufferHintRef.current;
+      const targetRate =
+        totalBuffer > 0 ? Math.max(MIN_RATE, totalBuffer * RATE_FACTOR) : 0;
+
+      // Asymmetric easing: decelerate quickly for visible slow-down at
+      // the tail, accelerate slowly for smooth ramp-up on new chunks
+      const smoothingFactor =
+        targetRate < rateRef.current ? RATE_SMOOTHING_DOWN : RATE_SMOOTHING_UP;
+      const smoothingStep = 1 - Math.pow(1 - smoothingFactor, normalizedDelta);
+      rateRef.current += (targetRate - rateRef.current) * smoothingStep;
+
+      if (remaining > 0) {
+        accumulatorRef.current += rateRef.current * normalizedDelta;
+        const charsToAdd = Math.min(
+          Math.floor(accumulatorRef.current),
+          remaining,
+        );
+        if (charsToAdd > 0) {
+          accumulatorRef.current -= charsToAdd;
+          let newLength = current + charsToAdd;
+          // Avoid slicing in the middle of a surrogate pair (emoji, etc.)
+          if (
+            newLength < target.length &&
+            isHighSurrogate(target.charCodeAt(newLength - 1))
+          ) {
+            newLength++;
+          }
+          displayedLengthRef.current = newLength;
+          setDisplayedText(trackerRef.current.closeAt(target, newLength));
+        }
+        rafRef.current = requestAnimationFrame(animate);
+      } else if (sealedRef.current) {
+        onCaughtUpRef.current?.();
+      }
+    };
+
+    lastTimestampRef.current = 0;
+    rafRef.current = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [targetText, sealed]);
+
+  return displayedText;
+}


### PR DESCRIPTION
## Summary

Adds a character-by-character smooth reveal animation to AI chat streaming responses. Without this, streamed text chunks pop in all at once which feels abrupt. The animation uses a requestAnimationFrame loop with delta-time normalization and asymmetric easing (slow ramp-up, fast tail deceleration) to give a natural typewriter feel. Markdown marker balancing (`closeOpenMarkers`) prevents partial markers like stray asterisks from flashing mid-reveal, and the animation respects `prefers-reduced-motion`.

## Context

The AI SDK splits streaming responses into many text parts (23 observed in testing). Without queuing, these animate independently causing visual chaos. The `sealed` flag gates `onCaughtUp` to prevent premature release between streaming chunks. The incremental marker tracker was added as a performance optimization — it maintains scan state across frames for O(delta) cost instead of O(n). The scan logic and suffix-building are shared between the standalone `closeOpenMarkers` and the incremental tracker via extracted `scanMarkers` and `buildBalancedOutput` helpers.

Closes #1996