### PR TITLE
fix: respect prefers-reduced-motion for imperative scrollTo calls

### DIFF
--- a/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
@@ -20,6 +20,7 @@ import { ScrollToBottomButton } from "#src/components/ai-chat/scroll-to-bottom-b
 import { SessionRestoreBanner } from "#src/components/ai-chat/session-restore-banner.tsx";
 import { border, color, layer, space } from "#src/tokens.stylex.ts";
 import type { SupportedLocale } from "#src/types.ts";
+import { getScrollBehavior } from "#src/utils/get-scroll-behavior.ts";
 
 interface AIChatViewProps {
   locale: SupportedLocale;
@@ -74,7 +75,7 @@ export function AIChatView({
   const scrollToBottom = () => {
     window.scrollTo({
       top: document.documentElement.scrollHeight,
-      behavior: "smooth",
+      behavior: getScrollBehavior(),
     });
     setIsAtBottom(true);
   };

--- a/src/components/movie-database/media-filters-provider.tsx
+++ b/src/components/movie-database/media-filters-provider.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect, useState, type PropsWithChildren } from "react";
+import { getScrollBehavior } from "#src/utils/get-scroll-behavior.ts";
 import type {
   GenreFilterType,
   MediaType,
@@ -171,7 +172,7 @@ export function MediaFiltersProvider({
     }
 
     window.history.replaceState({}, "", url);
-    window.scrollTo({ behavior: "smooth", top: 0 });
+    window.scrollTo({ behavior: getScrollBehavior(), top: 0 });
   }, [mediaFilters]);
 
   return (

--- a/src/utils/get-scroll-behavior.test.ts
+++ b/src/utils/get-scroll-behavior.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { getScrollBehavior } from "./get-scroll-behavior";
+
+describe("getScrollBehavior", () => {
+  const originalMatchMedia = window.matchMedia;
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('returns "smooth" when user has no motion preference', () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+
+    expect(getScrollBehavior()).toBe("smooth");
+  });
+
+  it('returns "instant" when user prefers reduced motion', () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true });
+
+    expect(getScrollBehavior()).toBe("instant");
+  });
+
+  it("queries the correct media query", () => {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false });
+
+    getScrollBehavior();
+
+    expect(window.matchMedia).toHaveBeenCalledWith(
+      "(prefers-reduced-motion: reduce)",
+    );
+  });
+});

--- a/src/utils/get-scroll-behavior.ts
+++ b/src/utils/get-scroll-behavior.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns `"smooth"` or `"instant"` based on the user's
+ * `prefers-reduced-motion` media query.
+ *
+ * Call this at scroll-time (not at mount) so it always reflects the
+ * current system setting — the user can toggle reduced-motion while
+ * the page is open.
+ */
+export function getScrollBehavior(): ScrollBehavior {
+  return typeof window !== "undefined" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ? "instant"
+    : "smooth";
+}


### PR DESCRIPTION
## Summary

Users who enable "Reduce motion" in their OS accessibility settings still experience smooth-scroll animations in two places: the scroll-to-bottom button in the AI chat, and the scroll-to-top when movie database filters change. The codebase already respects `prefers-reduced-motion` for CSS animations, CSS transitions, the flow gradient WebGL animation, text reveal animation, and view transitions — but these two imperative `window.scrollTo()` calls were missed because CSS media queries don't affect JavaScript scroll behavior.

Adds a shared `getScrollBehavior()` utility that checks `matchMedia("(prefers-reduced-motion: reduce)")` at call-time and returns `"instant"` instead of `"smooth"` when the user has reduced motion enabled. This follows the same pattern already used in `use-smoothed-text.ts` and `animate-to-target.tsx`.