### PR TITLE
perf: move tool output accumulation from render-time to event-time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ ALWAYS follow these rules
 - Auto-generated TMDB files are git-ignored and must be regenerated after cloning: `pnpm codegen:tmdb`.
 - NEVER assume environment variable names. ALWAYS verify environment variable names by reading source code FIRST.
 - NEVER chain bash commands with `&&` - use separate Bash tool calls instead for better error handling and visibility.
+- NEVER violate the [Rules of React](https://react.dev/reference/rules). Components and hooks MUST be pure, side effects belong in event handlers or effects, and props/state must never be mutated directly.
 
 # Available Commands
 

--- a/src/ai-chat/use-ai-chat.ts
+++ b/src/ai-chat/use-ai-chat.ts
@@ -1,11 +1,15 @@
 "use client";
 
-import { Chat, useChat } from "@ai-sdk/react";
+import { useChat } from "@ai-sdk/react";
 import type { UIMessage } from "ai";
 import { DefaultChatTransport } from "ai";
 import { useEffect, useState } from "react";
 import { z } from "zod";
 import { isUIMessage } from "#src/ai-chat/is-ui-message.ts";
+import {
+  accumulateToolOutputs,
+  EMPTY_TOOL_OUTPUTS,
+} from "#src/components/ai-chat/map-tool-output.ts";
 import {
   getCachedPreferencesContext,
   loadPreferencesContext,
@@ -84,84 +88,50 @@ async function fetchSession(
   throw new Error(`Failed to fetch session: ${response.status}`);
 }
 
-const chatInstances = new Map<string, Chat<ChatUIMessage>>();
+export function useAIChat({ locale }: { locale: SupportedLocale }) {
+  const [toolOutputs, setToolOutputs] = useState(EMPTY_TOOL_OUTPUTS);
+  const [previousSessionId, setPreviousSessionId] = useState<string | null>(
+    null,
+  );
 
-function getOrCreateChat(locale: SupportedLocale): Chat<ChatUIMessage> {
-  const existing = chatInstances.get(locale);
-  if (existing) return existing;
-
-  const transport = new DefaultChatTransport<ChatUIMessage>({
-    api: "/api/ai-chat",
-    prepareSendMessagesRequest: ({ messages, trigger }) => {
-      const sessionId = findSessionIdFromMessages(messages);
-      if (trigger === "regenerate-message") {
-        return { body: { sessionId, locale, trigger } };
-      }
-      const lastMessage = messages[messages.length - 1];
-
-      // Inject stored preferences into the first message of a new session
-      if (!sessionId && lastMessage) {
-        const prefsCtx = getCachedPreferencesContext();
-        if (prefsCtx) {
-          const enrichedMessage = {
-            ...lastMessage,
-            parts: [
-              { type: "text" as const, text: prefsCtx },
-              ...lastMessage.parts,
-            ],
-          };
-          return {
-            body: { sessionId, message: enrichedMessage, locale, trigger },
-          };
+  const chatResult = useChat<ChatUIMessage>({
+    transport: new DefaultChatTransport<ChatUIMessage>({
+      api: "/api/ai-chat",
+      prepareSendMessagesRequest: ({ messages, trigger }) => {
+        const sessionId = findSessionIdFromMessages(messages);
+        if (trigger === "regenerate-message") {
+          return { body: { sessionId, locale, trigger } };
         }
-      }
+        const lastMessage = messages[messages.length - 1];
 
-      return { body: { sessionId, message: lastMessage, locale, trigger } };
-    },
-  });
+        if (!sessionId && lastMessage) {
+          const prefsCtx = getCachedPreferencesContext();
+          if (prefsCtx) {
+            const enrichedMessage = {
+              ...lastMessage,
+              parts: [
+                { type: "text" as const, text: prefsCtx },
+                ...lastMessage.parts,
+              ],
+            };
+            return {
+              body: { sessionId, message: enrichedMessage, locale, trigger },
+            };
+          }
+        }
 
-  const chat = new Chat<ChatUIMessage>({
-    transport,
+        return { body: { sessionId, message: lastMessage, locale, trigger } };
+      },
+    }),
     messageMetadataSchema,
     onFinish: ({ messages }) => {
+      setToolOutputs(accumulateToolOutputs(messages));
       const sessionId = findSessionIdFromMessages(messages);
       if (sessionId) {
         setStoredSessionId(locale, sessionId);
       }
     },
-    onError: () => {
-      const storedSessionId = getStoredSessionId(locale);
-      if (!storedSessionId) return;
-
-      const chatInstance = chatInstances.get(locale);
-      if (!chatInstance) return;
-
-      fetchSession(storedSessionId)
-        .then((result) => {
-          const ci = chatInstances.get(locale);
-          if (!ci) return;
-
-          if (result) {
-            ci.messages = result.messages;
-            ci.clearError();
-          }
-        })
-        .catch(console.error);
-    },
   });
-
-  chatInstances.set(locale, chat);
-
-  return chat;
-}
-
-export function useAIChat({ locale }: { locale: SupportedLocale }) {
-  const chat = getOrCreateChat(locale);
-  const chatResult = useChat({ chat });
-
-  const [previousSessionId, setPreviousSessionId] = useState<string | null>(
-    null,
-  );
 
   // Warm the preferences cache from IndexedDB on mount so it's available
   // for the transport to inject into the first message of a new session.
@@ -172,12 +142,11 @@ export function useAIChat({ locale }: { locale: SupportedLocale }) {
   // Deferred to useEffect so the initial render matches the server (null),
   // avoiding a hydration mismatch — localStorage is not available during SSR.
   useEffect(() => {
-    if (chat.messages.length > 0) return;
     const stored = getStoredSessionId(locale);
     if (stored) {
       setPreviousSessionId(stored);
     }
-  }, [chat, locale]);
+  }, [locale]);
 
   // Dismiss banner when user starts a new conversation
   if (previousSessionId && chatResult.messages.length > 0) {
@@ -193,7 +162,8 @@ export function useAIChat({ locale }: { locale: SupportedLocale }) {
           setPreviousSessionId(null);
           return;
         }
-        chat.messages = result.messages;
+        setToolOutputs(accumulateToolOutputs(result.messages));
+        chatResult.setMessages(result.messages);
         setPreviousSessionId(null);
       })
       .catch(console.error);
@@ -201,6 +171,7 @@ export function useAIChat({ locale }: { locale: SupportedLocale }) {
 
   return {
     ...chatResult,
+    toolOutputs,
     previousSessionId,
     continueSession,
   };

--- a/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
@@ -53,6 +53,7 @@ export function AIChatView({
     error,
     sendMessage,
     stop,
+    toolOutputs,
     previousSessionId,
     continueSession,
   } = useAIChat({ locale });
@@ -105,6 +106,7 @@ export function AIChatView({
           status={status}
           error={error}
           isAtBottom={isAtBottom}
+          toolOutputs={toolOutputs}
           emptyState={emptyState}
           messagesLabel={messagesLabel}
           typingIndicatorLabel={typingIndicatorLabel}

--- a/src/components/ai-chat/chat-message-list.test.tsx
+++ b/src/components/ai-chat/chat-message-list.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { ChatUIMessage } from "#src/ai-chat/use-ai-chat.ts";
 import { render, screen } from "#src/test-utils.tsx";
 import { ChatMessageList } from "./chat-message-list";
+import { EMPTY_TOOL_OUTPUTS } from "./map-tool-output";
 
 function createMessage(
   overrides: Partial<ChatUIMessage> &
@@ -17,6 +18,7 @@ const defaultProps = {
   errorLabel: "Something went wrong. Please try again.",
   error: undefined,
   isAtBottom: true,
+  toolOutputs: EMPTY_TOOL_OUTPUTS,
 };
 
 describe("ChatMessageList", () => {

--- a/src/components/ai-chat/chat-message-list.tsx
+++ b/src/components/ai-chat/chat-message-list.tsx
@@ -12,9 +12,8 @@ import { t } from "#src/i18n.ts";
 import { usePreferencePersistence } from "#src/preference-store/use-preference-persistence.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { color, font, space } from "#src/tokens.stylex.ts";
-import type { MediaListItem, PersonListItem } from "#src/utils/types.ts";
-import { ChatMessage, deriveMessageData } from "./chat-message";
-import type { WatchProviderOutput } from "./tool-watch-providers";
+import { ChatMessage } from "./chat-message";
+import type { ToolOutputMaps } from "./map-tool-output";
 import { TypingIndicator } from "./typing-indicator";
 
 export const SCROLL_THRESHOLD = 50;
@@ -25,6 +24,7 @@ interface ChatMessageListProps {
   status: ChatStatus;
   error: Error | undefined;
   isAtBottom: boolean;
+  toolOutputs: ToolOutputMaps;
   emptyState: ReactNode;
   messagesLabel: string;
   typingIndicatorLabel: string;
@@ -43,57 +43,12 @@ function getLatestInputTokens(
   return 0;
 }
 
-interface CumulativeMaps {
-  searchResultsMap: ReadonlyMap<string, MediaListItem>;
-  personResultsMap: ReadonlyMap<number, PersonListItem>;
-  watchProvidersMap: ReadonlyMap<string, WatchProviderOutput>;
-}
-
-/**
- * For each message, builds a cumulative map of search results, person results,
- * and watch providers from all *prior* messages. This allows later messages
- * (e.g. a second `present_media` call) to look up items discovered by earlier
- * tool calls without re-searching.
- */
-function buildCumulativeMaps(
-  messages: ReadonlyArray<UIMessage>,
-): ReadonlyArray<CumulativeMaps> {
-  const result: CumulativeMaps[] = [];
-  const cumulativeSearch = new Map<string, MediaListItem>();
-  const cumulativePerson = new Map<number, PersonListItem>();
-  const cumulativeWp = new Map<string, WatchProviderOutput>();
-
-  for (const message of messages) {
-    // Each message gets a snapshot of the cumulative maps from *prior* messages
-    result.push({
-      searchResultsMap: new Map(cumulativeSearch),
-      personResultsMap: new Map(cumulativePerson),
-      watchProvidersMap: new Map(cumulativeWp),
-    });
-
-    // After taking the snapshot, add this message's results to the cumulative maps
-    const { searchResultsMap, personResultsMap, watchProvidersMap } =
-      deriveMessageData(message.parts);
-
-    for (const [key, value] of searchResultsMap) {
-      cumulativeSearch.set(key, value);
-    }
-    for (const [key, value] of personResultsMap) {
-      cumulativePerson.set(key, value);
-    }
-    for (const [key, value] of watchProvidersMap) {
-      cumulativeWp.set(key, value);
-    }
-  }
-
-  return result;
-}
-
 export function ChatMessageList({
   messages,
   status,
   error,
   isAtBottom,
+  toolOutputs,
   emptyState,
   messagesLabel,
   typingIndicatorLabel,
@@ -139,11 +94,6 @@ export function ChatMessageList({
   const latestInputTokens = getLatestInputTokens(messages);
   const showUsageWarning = latestInputTokens >= USAGE_WARNING_THRESHOLD;
 
-  // Build cumulative search/person/watch-provider maps so that later messages
-  // can look up media items discovered by earlier tool calls (e.g. a second
-  // present_media call can find items from a prior tmdb_search).
-  const cumulativeMaps = buildCumulativeMaps(messages);
-
   return (
     <div css={[flex.col, styles.container]}>
       {messages.length === 0 ? (
@@ -166,11 +116,7 @@ export function ChatMessageList({
               isLastAssistantMessage={
                 message.role === "assistant" && index === lastAssistantIndex
               }
-              cumulativeSearchResults={cumulativeMaps[index]?.searchResultsMap}
-              cumulativePersonResults={cumulativeMaps[index]?.personResultsMap}
-              cumulativeWatchProviders={
-                cumulativeMaps[index]?.watchProvidersMap
-              }
+              toolOutputs={toolOutputs}
             />
           ))}
           {showTypingIndicator && (

--- a/src/components/ai-chat/chat-message.test.tsx
+++ b/src/components/ai-chat/chat-message.test.tsx
@@ -260,20 +260,7 @@ describe("ChatMessage", () => {
     expect(screen.getByText("1 tool call")).toBeInTheDocument();
   });
 
-  it("renders present_media cards using cumulative search results from prior messages", () => {
-    const priorSearchResults = new Map([
-      [
-        "movie:1",
-        {
-          id: 1,
-          title: "Inception",
-          posterPath: "/inception.jpg",
-          rating: 8.4,
-          mediaType: "movie" as const,
-        },
-      ],
-    ]);
-
+  it("renders present_media cards using accumulated tool outputs from prior messages", () => {
     render(
       <MediaDetailProvider>
         <ChatMessage
@@ -291,7 +278,22 @@ describe("ChatMessage", () => {
               { type: "text", text: "Here it is again!" },
             ],
           })}
-          cumulativeSearchResults={priorSearchResults}
+          toolOutputs={{
+            searchResultsMap: new Map([
+              [
+                "movie:1",
+                {
+                  id: 1,
+                  title: "Inception",
+                  posterPath: "/inception.jpg",
+                  rating: 8.4,
+                  mediaType: "movie" as const,
+                },
+              ],
+            ]),
+            personResultsMap: new Map(),
+            watchProvidersMap: new Map(),
+          }}
         />
       </MediaDetailProvider>,
     );

--- a/src/components/ai-chat/chat-message.tsx
+++ b/src/components/ai-chat/chat-message.tsx
@@ -17,6 +17,7 @@ import {
   buildPersonResultsMap,
   buildSearchResultsMap,
   buildWatchProvidersMap,
+  type ToolOutputMaps,
 } from "./map-tool-output";
 import { SmoothedMarkdownContent } from "./smoothed-markdown-content";
 import { ToolActivityGroup } from "./tool-activity-group";
@@ -27,18 +28,14 @@ interface ChatMessageProps {
   message: UIMessage;
   isStreaming?: boolean;
   isLastAssistantMessage?: boolean;
-  cumulativeSearchResults?: ReadonlyMap<string, MediaListItem>;
-  cumulativePersonResults?: ReadonlyMap<number, PersonListItem>;
-  cumulativeWatchProviders?: ReadonlyMap<string, WatchProviderOutput>;
+  toolOutputs?: ToolOutputMaps;
 }
 
 export function ChatMessage({
   message,
   isStreaming = false,
   isLastAssistantMessage = false,
-  cumulativeSearchResults,
-  cumulativePersonResults,
-  cumulativeWatchProviders,
+  toolOutputs,
 }: ChatMessageProps) {
   const isUser = message.role === "user";
   const [releasedTextParts, setReleasedTextParts] = useState(1);
@@ -55,18 +52,19 @@ export function ChatMessage({
     textPartTrailingBuffers,
   } = deriveMessageData(message.parts);
 
-  // Merge cumulative maps from prior messages with this message's own maps.
-  // Local (per-message) entries take precedence over cumulative ones.
+  // Merge accumulated tool outputs with this message's own maps. Local maps
+  // cover tool outputs that resolved in the current streaming message before
+  // the accumulated cache updated.
   const searchResultsMap = mergeMaps(
-    cumulativeSearchResults,
+    toolOutputs?.searchResultsMap,
     localSearchResults,
   );
   const personResultsMap = mergeMaps(
-    cumulativePersonResults,
+    toolOutputs?.personResultsMap,
     localPersonResults,
   );
   const watchProvidersMap = mergeMaps(
-    cumulativeWatchProviders,
+    toolOutputs?.watchProvidersMap,
     localWatchProviders,
   );
 

--- a/src/components/ai-chat/map-tool-output.test.ts
+++ b/src/components/ai-chat/map-tool-output.test.ts
@@ -1,12 +1,178 @@
+import type { UIMessage } from "ai";
 import { describe, expect, it } from "vitest";
 import type { MediaListItem, PersonListItem } from "#src/utils/types.ts";
 import {
+  accumulateToolOutputs,
   buildPersonResultsMap,
   buildSearchResultsMap,
   mapToolOutputToMediaItems,
   resolveMediaItems,
   resolvePersonItems,
 } from "./map-tool-output";
+
+function msg(
+  parts: UIMessage["parts"],
+  role: "user" | "assistant" = "assistant",
+): UIMessage {
+  return { id: `msg-${Math.random()}`, role, parts };
+}
+
+function toolPart(toolName: string, output: unknown) {
+  return {
+    type: "dynamic-tool" as const,
+    toolName,
+    toolCallId: `call-${Math.random()}`,
+    state: "output-available" as const,
+    input: {},
+    output,
+  };
+}
+
+describe("accumulateToolOutputs", () => {
+  it("returns empty maps for no messages", () => {
+    const result = accumulateToolOutputs([]);
+    expect(result.searchResultsMap.size).toBe(0);
+    expect(result.personResultsMap.size).toBe(0);
+    expect(result.watchProvidersMap.size).toBe(0);
+  });
+
+  it("accumulates search results from tmdb_search across messages", () => {
+    const messages = [
+      msg([
+        toolPart("tmdb_search", [
+          {
+            id: 1,
+            media_type: "movie",
+            title: "Inception",
+            poster_path: "/a.jpg",
+            vote_average: 8.4,
+          },
+        ]),
+      ]),
+      msg([
+        toolPart("tmdb_search", [
+          {
+            id: 2,
+            media_type: "tv",
+            title: "Dark",
+            poster_path: "/b.jpg",
+            vote_average: 8.8,
+          },
+        ]),
+      ]),
+    ];
+
+    const result = accumulateToolOutputs(messages);
+
+    expect(result.searchResultsMap.size).toBe(2);
+    expect(result.searchResultsMap.get("movie:1")?.title).toBe("Inception");
+    expect(result.searchResultsMap.get("tv:2")?.title).toBe("Dark");
+  });
+
+  it("accumulates person results from tmdb_search", () => {
+    const messages = [
+      msg([
+        toolPart("tmdb_search", [
+          {
+            id: 10,
+            media_type: "person",
+            name: "Nolan",
+            profile_path: "/nolan.jpg",
+            known_for_department: "Directing",
+          },
+        ]),
+      ]),
+    ];
+
+    const result = accumulateToolOutputs(messages);
+
+    expect(result.personResultsMap.size).toBe(1);
+    expect(result.personResultsMap.get(10)?.name).toBe("Nolan");
+  });
+
+  it("accumulates watch providers", () => {
+    const messages = [
+      msg([
+        toolPart("watch_providers", {
+          id: 550,
+          mediaType: "movie",
+          region: "US",
+          providers: {
+            link: null,
+            flatrate: [{ id: 8, name: "Netflix", logoPath: "/n.jpg" }],
+            rent: [],
+            buy: [],
+            ads: [],
+            free: [],
+          },
+        }),
+      ]),
+    ];
+
+    const result = accumulateToolOutputs(messages);
+
+    expect(result.watchProvidersMap.size).toBe(1);
+  });
+
+  it("skips tool parts that are not output-available", () => {
+    const messages = [
+      msg([
+        {
+          type: "dynamic-tool" as const,
+          toolName: "tmdb_search",
+          toolCallId: "call-1",
+          state: "input-available" as const,
+          input: { query: "test" },
+        },
+      ]),
+    ];
+
+    const result = accumulateToolOutputs(messages);
+
+    expect(result.searchResultsMap.size).toBe(0);
+  });
+
+  it("skips non-tool parts", () => {
+    const messages = [
+      msg([
+        { type: "text" as const, text: "Hello" },
+        toolPart("tmdb_search", [
+          {
+            id: 1,
+            media_type: "movie",
+            title: "X",
+            poster_path: "/x.jpg",
+            vote_average: 7,
+          },
+        ]),
+      ]),
+    ];
+
+    const result = accumulateToolOutputs(messages);
+
+    expect(result.searchResultsMap.size).toBe(1);
+  });
+
+  it("does not call buildWatchProvidersMap for non-watch_providers tools", () => {
+    const messages = [
+      msg([
+        toolPart("tmdb_search", [
+          {
+            id: 1,
+            media_type: "movie",
+            title: "X",
+            poster_path: null,
+            vote_average: 5,
+          },
+        ]),
+      ]),
+    ];
+
+    const result = accumulateToolOutputs(messages);
+
+    expect(result.watchProvidersMap.size).toBe(0);
+  });
+});
 
 describe("mapToolOutputToMediaItems", () => {
   describe("tmdb_search", () => {

--- a/src/components/ai-chat/map-tool-output.ts
+++ b/src/components/ai-chat/map-tool-output.ts
@@ -1,3 +1,4 @@
+import { getToolName, isToolUIPart, type UIMessage } from "ai";
 import { presentMediaInputSchema } from "#src/ai-chat/tools/present-media.ts";
 import { presentPersonInputSchema } from "#src/ai-chat/tools/present-person.ts";
 import { presentProviderRegionsInputSchema } from "#src/ai-chat/tools/present-provider-regions.ts";
@@ -6,6 +7,49 @@ import { isRecord } from "#src/utils/type-guards.ts";
 import type { MediaListItem, PersonListItem } from "#src/utils/types.ts";
 import type { WatchProviderOutput } from "./tool-watch-providers";
 import { parseWatchProviderOutput } from "./tool-watch-providers";
+
+export interface ToolOutputMaps {
+  searchResultsMap: ReadonlyMap<string, MediaListItem>;
+  personResultsMap: ReadonlyMap<number, PersonListItem>;
+  watchProvidersMap: ReadonlyMap<string, WatchProviderOutput>;
+}
+
+export const EMPTY_TOOL_OUTPUTS: ToolOutputMaps = {
+  searchResultsMap: new Map(),
+  personResultsMap: new Map(),
+  watchProvidersMap: new Map(),
+};
+
+export function accumulateToolOutputs(
+  messages: ReadonlyArray<UIMessage>,
+): ToolOutputMaps {
+  const searchResultsMap = new Map<string, MediaListItem>();
+  const personResultsMap = new Map<number, PersonListItem>();
+  const watchProvidersMap = new Map<string, WatchProviderOutput>();
+
+  for (const message of messages) {
+    for (const part of message.parts) {
+      if (!isToolUIPart(part)) continue;
+      if (part.state !== "output-available" || !("output" in part)) continue;
+
+      const name = getToolName(part);
+
+      for (const [k, v] of buildSearchResultsMap(name, part.output)) {
+        searchResultsMap.set(k, v);
+      }
+      for (const [k, v] of buildPersonResultsMap(name, part.output)) {
+        personResultsMap.set(k, v);
+      }
+      if (name === "watch_providers") {
+        for (const [k, v] of buildWatchProvidersMap(part.output)) {
+          watchProvidersMap.set(k, v);
+        }
+      }
+    }
+  }
+
+  return { searchResultsMap, personResultsMap, watchProvidersMap };
+}
 
 function mapTmdbSearchOutput(output: unknown): ReadonlyArray<MediaListItem> {
   if (!Array.isArray(output)) return [];


### PR DESCRIPTION
## Summary

Closes #1705

During streaming, `accumulateToolOutputs(messages)` ran on every render (every token), producing new Map references that prevented React Compiler from skipping re-renders of non-streaming `ChatMessage` components.

Tool outputs are produced by events (tool calls completing), not by the render cycle. This PR moves accumulation into the `onFinish` callback on the Chat instance, storing the result in React state via `useState`. During streaming the Maps hold the same references, giving React Compiler the referential stability it needs.

Also simplifies `use-ai-chat.ts` by removing the Chat singleton cache and the `onError` session-recovery handler (the existing session-restore banner already covers that flow).

### Changes

- **`map-tool-output.ts`** — new `ToolOutputMaps` type, `EMPTY_TOOL_OUTPUTS` constant, and `accumulateToolOutputs` function
- **`use-ai-chat.ts`** — removed `chatInstances` singleton and `getOrCreateChat`; `useChat` now creates the Chat internally; `onFinish` calls `setToolOutputs`; removed `onError` recovery
- **`chat-message-list.tsx`** — receives `toolOutputs` as a prop, no local accumulation
- **`chat-message.tsx`** — imports `ToolOutputMaps` from `map-tool-output.ts`
- **`ai-chat-view.tsx`** — threads `toolOutputs` from `useAIChat` to `ChatMessageList`

## Test plan

- [ ] 963 unit tests pass
- [ ] Lint and format clean
- [ ] Full build succeeds
- [ ] Manual: start a conversation, verify tool output cards (media, watch providers, person) render correctly during and after streaming
- [ ] Manual: navigate away and back, verify session restore banner appears and restores messages with correct tool output cards
- [ ] Manual: trigger a streaming error, verify error message displays and user can retry