### PR TITLE
refactor: move node_modules symlink config to .worktreeinclude

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,9 +3,6 @@
     "defaultMode": "bypassPermissions",
     "deny": ["Read(./.env)", "Read(./.env.*)"]
   },
-  "worktree": {
-    "symlinkDirectories": ["node_modules"]
-  },
   "showClearContextOnPlanAccept": true,
   "hooks": {
     "PreToolUse": [

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,2 +1,3 @@
 .claude/settings.local.json
 .env.local
+node_modules


### PR DESCRIPTION
## Summary

Moves `node_modules` from `worktree.symlinkDirectories` in `.claude/settings.json` to `.worktreeinclude`. The `.worktreeinclude` mechanism copies files into worktrees rather than symlinking them, avoiding symlink-related issues with `node_modules`.