### PR TITLE
feat: add horizontal scroll buttons to media recommendation rows

### DIFF
--- a/src/components/ai-chat/horizontal-scroll-buttons.tsx
+++ b/src/components/ai-chat/horizontal-scroll-buttons.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { CaretLeftIcon } from "@phosphor-icons/react/dist/ssr/CaretLeft";
+import { CaretRightIcon } from "@phosphor-icons/react/dist/ssr/CaretRight";
+import * as stylex from "@stylexjs/stylex";
+import { t } from "#src/i18n.ts";
+import { motionConstants } from "#src/primitives/motion.stylex.ts";
+import { buttonReset } from "#src/primitives/reset.stylex.ts";
+import { border, color, shadow } from "#src/tokens.stylex.ts";
+import { getScrollBehavior } from "#src/utils/get-scroll-behavior.ts";
+
+const HOVER_NONE = "@media (hover: none)";
+
+interface HorizontalScrollButtonsProps {
+  scrollRef: React.RefObject<HTMLElement | null>;
+  showLeft: boolean;
+  showRight: boolean;
+  leftCss?: React.Attributes["css"];
+  rightCss?: React.Attributes["css"];
+}
+
+export function HorizontalScrollButtons({
+  scrollRef,
+  showLeft,
+  showRight,
+  leftCss,
+  rightCss,
+}: HorizontalScrollButtonsProps) {
+  const scroll = (direction: -1 | 1) => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollBy({
+      left: direction * el.clientWidth,
+      behavior: getScrollBehavior(),
+    });
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label={t({ en: "Scroll left", zh: "向左滚动" })}
+        aria-hidden={!showLeft}
+        tabIndex={showLeft ? 0 : -1}
+        onClick={() => scroll(-1)}
+        css={[
+          buttonReset.base,
+          styles.button,
+          showLeft ? styles.visible : styles.hidden,
+          leftCss,
+        ]}
+      >
+        <CaretLeftIcon weight="bold" role="presentation" />
+      </button>
+      <button
+        type="button"
+        aria-label={t({ en: "Scroll right", zh: "向右滚动" })}
+        aria-hidden={!showRight}
+        tabIndex={showRight ? 0 : -1}
+        onClick={() => scroll(1)}
+        css={[
+          buttonReset.base,
+          styles.button,
+          showRight ? styles.visible : styles.hidden,
+          rightCss,
+        ]}
+      >
+        <CaretRightIcon weight="bold" role="presentation" />
+      </button>
+    </>
+  );
+}
+
+const styles = stylex.create({
+  button: {
+    position: "absolute",
+    top: "50%",
+    transform: "translateY(-50%)",
+    zIndex: 1,
+    display: {
+      default: "inline-flex",
+      [HOVER_NONE]: "none",
+    },
+    alignItems: "center",
+    justifyContent: "center",
+    width: "2rem",
+    height: "2rem",
+    borderRadius: border.radius_round,
+    backgroundColor: color.backgroundRaised,
+    color: {
+      default: color.textMuted,
+      ":hover": color.textMain,
+    },
+    boxShadow: shadow._2,
+    transition: {
+      default: "opacity 0.2s ease",
+      [motionConstants.REDUCED_MOTION]: "none",
+    },
+  },
+  visible: {
+    opacity: 1,
+    pointerEvents: "auto",
+  },
+  hidden: {
+    opacity: 0,
+    pointerEvents: "none",
+  },
+});

--- a/src/components/ai-chat/recommended-media-row.tsx
+++ b/src/components/ai-chat/recommended-media-row.tsx
@@ -9,6 +9,7 @@ import { scrollX } from "#src/primitives/layout.stylex.ts";
 import { color, font, space } from "#src/tokens.stylex.ts";
 import type { MediaListItem } from "#src/utils/types.ts";
 import { CompactMediaCard } from "./compact-media-card";
+import { HorizontalScrollButtons } from "./horizontal-scroll-buttons";
 import { useMediaDetail } from "./media-detail-context";
 
 interface RecommendedMediaRowProps {
@@ -70,6 +71,13 @@ export function RecommendedMediaRow({
           style={{ opacity: showRightFade ? 1 : 0 }}
           aria-hidden="true"
         />
+        <HorizontalScrollButtons
+          scrollRef={scrollRef}
+          showLeft={showLeftFade}
+          showRight={showRightFade}
+          leftCss={styles.scrollButtonLeft}
+          rightCss={styles.scrollButtonRight}
+        />
       </div>
     </section>
   );
@@ -125,6 +133,12 @@ const styles = stylex.create({
   fadeRight: {
     right: 0,
     backgroundImage: `linear-gradient(to right, rgba(${color.backgroundMainChannels}, 0), rgba(${color.backgroundMainChannels}, 1))`,
+  },
+  scrollButtonLeft: {
+    left: contentInsetLeft,
+  },
+  scrollButtonRight: {
+    right: contentInsetRight,
   },
   cardWrapper: {
     flexShrink: 0,

--- a/src/components/ai-chat/tool-media-cards.tsx
+++ b/src/components/ai-chat/tool-media-cards.tsx
@@ -9,6 +9,7 @@ import { scrollX } from "#src/primitives/layout.stylex.ts";
 import { color, space } from "#src/tokens.stylex.ts";
 import type { MediaListItem } from "#src/utils/types.ts";
 import { CompactMediaCard } from "./compact-media-card";
+import { HorizontalScrollButtons } from "./horizontal-scroll-buttons";
 import { useMediaDetail } from "./media-detail-context";
 
 interface ToolMediaCardsProps {
@@ -68,6 +69,13 @@ export function ToolMediaCards({ items }: ToolMediaCardsProps) {
         style={{ opacity: showRightFade ? 1 : 0 }}
         aria-hidden="true"
       />
+      <HorizontalScrollButtons
+        scrollRef={scrollRef}
+        showLeft={showLeftFade}
+        showRight={showRightFade}
+        leftCss={styles.scrollButtonLeft}
+        rightCss={styles.scrollButtonRight}
+      />
     </div>
   );
 }
@@ -101,6 +109,12 @@ const styles = stylex.create({
   fadeRight: {
     right: 0,
     backgroundImage: `linear-gradient(to right, rgba(${color.backgroundRaisedChannels}, 0), rgba(${color.backgroundRaisedChannels}, 1))`,
+  },
+  scrollButtonLeft: {
+    left: space._3,
+  },
+  scrollButtonRight: {
+    right: space._3,
   },
   cardWrapper: {
     flexShrink: 0,


### PR DESCRIPTION
## Summary

Desktop users with standard mice had no way to scroll through the horizontally-scrollable media recommendation rows in the AI chat view. This adds a reusable `HorizontalScrollButtons` component — a pair of left/right arrow buttons that are hidden on touch devices via `@media (hover: none)`, fade in/out based on scroll position, and scroll by one page-width on click while respecting `prefers-reduced-motion`. The component is integrated into both the `RecommendedMediaRow` and `ToolMediaCards` scroll containers.

## Context

The buttons reuse `useScrollFades` hook state already present in both consumers. `getScrollBehavior()` is called at click-time per its documented contract. Positioning is handled via composable `leftCss`/`rightCss` StyleX style props so each consumer can offset buttons to match their own content insets, keeping them within the visible area rather than being clipped by the containers' negative-margin insets.

Closes #2007