### PR TITLE
feat: add frosted glass effect to assistant chat bubble

### DIFF
--- a/src/components/ai-chat/chat-message.tsx
+++ b/src/components/ai-chat/chat-message.tsx
@@ -323,7 +323,8 @@ const styles = stylex.create({
   },
   assistantBubble: {
     marginRight: "auto",
-    backgroundColor: color.backgroundRaised,
+    backgroundColor: `rgba(${color.backgroundRaisedChannels}, 0.6)`,
+    backdropFilter: "blur(12px)",
     color: color.textMain,
     borderRadius: border.radius_3,
     borderBottomLeftRadius: border.radius_1,


### PR DESCRIPTION
## Summary

Gives AI assistant chat bubbles a frosted glass appearance. The background is changed from the opaque `color.backgroundRaised` token to a translucent `rgba(${color.backgroundRaisedChannels}, 0.6)`, and `backdropFilter: "blur(12px)"` is added so content behind the bubble blurs through. This uses the existing `backgroundRaisedChannels` design token which already provides RGB channel values for both light and dark themes, making the translucency theme-aware with no additional token work needed.

## Context

The user wanted a translucent/frosted glass effect on AI agent responses in the chat UI. StyleX handles vendor prefixes internally so no explicit `WebkitBackdropFilter` is needed.