### PR TITLE
fix: re-measure biography clamp on resize with ResizeObserver

### DIFF
--- a/src/components/ai-chat/person-detail-content.tsx
+++ b/src/components/ai-chat/person-detail-content.tsx
@@ -2,7 +2,7 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { useQueries } from "@tanstack/react-query";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { breakpoints } from "#src/breakpoints.stylex.ts";
 import { useLocale } from "#src/hooks/use-locale.ts";
 import { useScrollFades } from "#src/hooks/use-scroll-fades.ts";
@@ -142,15 +142,27 @@ const LINE_CLAMP = 6;
 function ExpandableBiography({ text }: { text: string }) {
   const [expanded, setExpanded] = useState(false);
   const [isClamped, setIsClamped] = useState(false);
+  const paragraphRef = useRef<HTMLParagraphElement>(null);
+
+  useEffect(() => {
+    const el = paragraphRef.current;
+    if (!el) return;
+
+    const measure = () => {
+      setIsClamped(el.scrollHeight > el.clientHeight);
+    };
+
+    measure();
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [expanded]);
 
   return (
     <div>
       <p
-        ref={(el) => {
-          if (el) {
-            setIsClamped(el.scrollHeight > el.clientHeight);
-          }
-        }}
+        ref={paragraphRef}
         css={[styles.biography, !expanded && styles.biographyClamped]}
       >
         {text}


### PR DESCRIPTION
## Summary

The expandable biography in the person detail overlay measures whether the text is clamped using a one-shot ref callback that only fires on mount. If the user resizes the browser or rotates their device while the overlay is open, the measurement becomes stale — a long biography that was previously clamped may no longer need clamping at a wider viewport (leaving a stale "Read more" button), or a biography that fit previously may now overflow without offering a way to expand it.

This replaces the one-shot measurement with a `ResizeObserver` that re-measures whenever the paragraph element resizes, following the same pattern already established in `use-scroll-fades.ts`.