### PR TITLE
fix: add scroll buttons to person cards and filmography scroller

### DIFF
--- a/src/components/ai-chat/person-detail-content.tsx
+++ b/src/components/ai-chat/person-detail-content.tsx
@@ -16,6 +16,7 @@ import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
 import type { MediaListItem } from "#src/utils/types.ts";
 import { Skeleton } from "../shared/skeleton";
 import { CompactMediaCard } from "./compact-media-card";
+import { HorizontalScrollButtons } from "./horizontal-scroll-buttons";
 import { useMediaDetail, type FocusedPerson } from "./media-detail-context";
 
 const MAX_CREDITS = 20;
@@ -305,6 +306,13 @@ function FilmographyScroller({
         style={{ opacity: showRightFade ? 1 : 0 }}
         aria-hidden="true"
       />
+      <HorizontalScrollButtons
+        scrollRef={scrollRef}
+        showLeft={showLeftFade}
+        showRight={showRightFade}
+        leftCss={filmStyles.scrollButtonLeft}
+        rightCss={filmStyles.scrollButtonRight}
+      />
     </div>
   );
 }
@@ -423,6 +431,12 @@ const filmStyles = stylex.create({
   fadeRight: {
     right: 0,
     backgroundImage: `linear-gradient(to right, rgba(${color.backgroundRaisedChannels}, 0), rgba(${color.backgroundRaisedChannels}, 1))`,
+  },
+  scrollButtonLeft: {
+    left: space._4,
+  },
+  scrollButtonRight: {
+    right: space._4,
   },
   cardWrapper: {
     flexShrink: 0,

--- a/src/components/ai-chat/tool-person-cards.tsx
+++ b/src/components/ai-chat/tool-person-cards.tsx
@@ -9,6 +9,7 @@ import { scrollX } from "#src/primitives/layout.stylex.ts";
 import { color, space } from "#src/tokens.stylex.ts";
 import type { PersonListItem } from "#src/utils/types.ts";
 import { CompactPersonCard } from "./compact-person-card";
+import { HorizontalScrollButtons } from "./horizontal-scroll-buttons";
 import { useMediaDetail } from "./media-detail-context";
 
 interface ToolPersonCardsProps {
@@ -60,6 +61,13 @@ export function ToolPersonCards({ items }: ToolPersonCardsProps) {
         style={{ opacity: showRightFade ? 1 : 0 }}
         aria-hidden="true"
       />
+      <HorizontalScrollButtons
+        scrollRef={scrollRef}
+        showLeft={showLeftFade}
+        showRight={showRightFade}
+        leftCss={styles.scrollButtonLeft}
+        rightCss={styles.scrollButtonRight}
+      />
     </div>
   );
 }
@@ -93,6 +101,12 @@ const styles = stylex.create({
   fadeRight: {
     right: 0,
     backgroundImage: `linear-gradient(to right, rgba(${color.backgroundRaisedChannels}, 0), rgba(${color.backgroundRaisedChannels}, 1))`,
+  },
+  scrollButtonLeft: {
+    left: space._3,
+  },
+  scrollButtonRight: {
+    right: space._3,
   },
   cardWrapper: {
     flexShrink: 0,


### PR DESCRIPTION
## Summary

- Add `HorizontalScrollButtons` to `ToolPersonCards` and `FilmographyScroller` in `PersonDetailContent`, matching the pattern already used by `ToolMediaCards` and `RecommendedMediaRow`
- Desktop mouse users previously had no visible way to scroll these horizontal card rows, making content appear truncated or broken
- Button positions use `space._3` / `space._4` to align with each container's content padding

## Test plan

- [ ] Open AI chat on desktop, search for a person (e.g. actor) — verify left/right arrow buttons appear on hover over the person cards row
- [ ] Open a person detail overlay with filmography — verify arrow buttons appear on hover over the filmography row
- [ ] Verify buttons are hidden on touch-only devices (or with `@media (hover: none)`)
- [ ] Verify buttons respect `prefers-reduced-motion` (instant scroll vs smooth)
- [ ] Confirm existing scroll button behavior on `ToolMediaCards` and `RecommendedMediaRow` is unchanged