### PR TITLE
fix: add autoplay parameter to YouTube trailer embed URL

### DIFF
--- a/src/components/movie-database/trailer-button.tsx
+++ b/src/components/movie-database/trailer-button.tsx
@@ -40,7 +40,7 @@ export function TrailerButton({
           css={styles.video}
           width="720"
           height="405"
-          src={`https://www.youtube.com/embed/${trailerId}?hl=${locale}`}
+          src={`https://www.youtube.com/embed/${trailerId}?autoplay=1&hl=${locale}`}
           title={iframeTitle}
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           allowFullScreen


### PR DESCRIPTION
## Summary

When a user clicks "Play trailer" on a movie or TV show detail page, the YouTube embed opens but the video doesn't auto-play -- the user has to click play a second time inside the YouTube player. The iframe already had `autoplay` in its permission policy (`allow` attribute), indicating autoplay was intended, but the `autoplay=1` URL parameter required by YouTube's IFrame Player API was missing. This adds it so the trailer starts playing immediately when the overlay opens.