### PR TITLE
fix: add loading skeletons and error fallbacks to detail overlay images

### DIFF
--- a/src/components/ai-chat/media-detail-content.tsx
+++ b/src/components/ai-chat/media-detail-content.tsx
@@ -4,6 +4,7 @@ import { ChatTextIcon } from "@phosphor-icons/react/dist/ssr/ChatText";
 import { PlayIcon } from "@phosphor-icons/react/dist/ssr/Play";
 import * as stylex from "@stylexjs/stylex";
 import { useQueries } from "@tanstack/react-query";
+import { useState } from "react";
 import { useLocale } from "#src/hooks/use-locale.ts";
 import { t } from "#src/i18n.ts";
 import { imageCover } from "#src/primitives/layout.stylex.ts";
@@ -226,17 +227,34 @@ function PosterImage({
   alt: string;
 }) {
   const { src, srcSet } = buildSrcSet(baseUrl, sizes, path);
+  const [loaded, setLoaded] = useState(false);
+  const [errored, setErrored] = useState(false);
+
+  if (errored) {
+    return (
+      <div css={[imageCover.base, styles.imageFallback]}>{alt.charAt(0)}</div>
+    );
+  }
+
   return (
-    // TMDB images are already optimized by the provider — no need for next/image
-    // eslint-disable-next-line @next/next/no-img-element
-    <img
-      css={imageCover.base}
-      alt={alt}
-      src={src}
-      srcSet={srcSet}
-      sizes="90px"
-      decoding="async"
-    />
+    <>
+      {!loaded && <Skeleton css={skeletonStyles.poster} />}
+      {/* TMDB images are already optimized by the provider — no need for next/image */}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        css={imageCover.base}
+        alt={alt}
+        src={src}
+        srcSet={srcSet}
+        sizes="90px"
+        decoding="async"
+        onLoad={() => setLoaded(true)}
+        onError={() => setErrored(true)}
+        ref={(el) => {
+          if (el?.complete && el.naturalWidth > 0) setLoaded(true);
+        }}
+      />
+    </>
   );
 }
 
@@ -252,8 +270,14 @@ function BackdropImage({
   alt: string;
 }) {
   const { src, srcSet } = buildSrcSet(baseUrl, sizes, path);
+  const [loaded, setLoaded] = useState(false);
+  const [errored, setErrored] = useState(false);
+
+  if (errored) return null;
+
   return (
     <div css={styles.backdropContainer}>
+      {!loaded && <Skeleton css={skeletonStyles.backdropOverlay} />}
       {/* TMDB images are already optimized by the provider — no need for next/image */}
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
@@ -263,6 +287,11 @@ function BackdropImage({
         srcSet={srcSet}
         sizes="600px"
         decoding="async"
+        onLoad={() => setLoaded(true)}
+        onError={() => setErrored(true)}
+        ref={(el) => {
+          if (el?.complete && el.naturalWidth > 0) setLoaded(true);
+        }}
       />
       <div role="presentation" css={styles.backdropGradient} />
     </div>
@@ -305,6 +334,7 @@ const styles = stylex.create({
     alignItems: "flex-end",
   },
   posterWrapper: {
+    position: "relative",
     flexShrink: 0,
     width: "90px",
     aspectRatio: ratio.poster,
@@ -389,6 +419,15 @@ const styles = stylex.create({
     transition:
       "background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease",
   },
+  imageFallback: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: color.backgroundRaised,
+    color: color.textMuted,
+    fontSize: font.uiHeading1,
+    fontWeight: font.weight_7,
+  },
 });
 
 const skeletonStyles = stylex.create({
@@ -397,9 +436,14 @@ const skeletonStyles = stylex.create({
     aspectRatio: ratio.wide,
     borderRadius: 0,
   },
+  backdropOverlay: {
+    position: "absolute",
+    inset: 0,
+    borderRadius: 0,
+  },
   poster: {
-    width: "100%",
-    height: "100%",
+    position: "absolute",
+    inset: 0,
     borderRadius: 0,
   },
 });

--- a/src/components/ai-chat/person-detail-content.tsx
+++ b/src/components/ai-chat/person-detail-content.tsx
@@ -124,16 +124,31 @@ function ProfileImage({
   alt: string;
 }) {
   const { src, srcSet } = buildSrcSet(baseUrl, sizes, path);
+  const [loaded, setLoaded] = useState(false);
+  const [errored, setErrored] = useState(false);
+
+  if (errored) {
+    return <div css={styles.profileFallback}>{alt.charAt(0)}</div>;
+  }
+
   return (
-    // eslint-disable-next-line @next/next/no-img-element
-    <img
-      css={styles.photo}
-      alt={alt}
-      src={src}
-      srcSet={srcSet}
-      sizes="90px"
-      decoding="async"
-    />
+    <>
+      {!loaded && <Skeleton css={skeletonStyles.photo} />}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        css={styles.photo}
+        alt={alt}
+        src={src}
+        srcSet={srcSet}
+        sizes="90px"
+        decoding="async"
+        onLoad={() => setLoaded(true)}
+        onError={() => setErrored(true)}
+        ref={(el) => {
+          if (el?.complete && el.naturalWidth > 0) setLoaded(true);
+        }}
+      />
+    </>
   );
 }
 
@@ -323,6 +338,7 @@ const styles = stylex.create({
     alignItems: "flex-start",
   },
   photoWrapper: {
+    position: "relative",
     flexShrink: 0,
     width: "90px",
     aspectRatio: "1",
@@ -373,6 +389,17 @@ const styles = stylex.create({
       default: "none",
       ":hover": "underline",
     },
+  },
+  profileFallback: {
+    width: "100%",
+    height: "100%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: color.backgroundHover,
+    color: color.textMuted,
+    fontSize: font.uiHeading1,
+    fontWeight: font.weight_7,
   },
   errorText: {
     margin: 0,
@@ -439,8 +466,8 @@ const filmStyles = stylex.create({
 
 const skeletonStyles = stylex.create({
   photo: {
-    width: "100%",
-    height: "100%",
+    position: "absolute",
+    inset: 0,
     borderRadius: 0,
   },
 });


### PR DESCRIPTION
## Summary

Poster, backdrop, and profile images in the media and person detail overlays rendered as blank space while loading and showed the browser's broken image icon on failure. This is especially noticeable on mobile where connections are slower and the overlay is the primary way users inspect media details.

Adds the same loading/error state pattern already established in `poster-image.tsx` and `compact-person-card.tsx`: skeleton placeholders during loading, character-initial fallbacks on error for poster and profile images, and silent removal for the decorative backdrop image. Includes the ref callback for already-cached images to prevent a flash of skeleton when the browser cache serves instantly.