### PR TITLE
fix: require functional sanity tests for prod dependency upgrades

### DIFF
--- a/.claude/skills/merge-dependabot/SKILL.md
+++ b/.claude/skills/merge-dependabot/SKILL.md
@@ -67,7 +67,7 @@ If a check fails due to the upgrade, attempt a fix. If the fix isn't clear, skip
 1. Search the codebase for imports of the package to identify affected features and pages
 2. Start `pnpm dev` in the background
 3. Visit affected pages AND exercise the specific functionality that invokes the upgraded package. Loading a page is not enough — you must trigger the code path that imports and runs the package. For example:
-   - **ai-sdk / @ai-sdk/***: Send a message in the AI chat and verify a streamed response appears
+   - **ai-sdk / @ai-sdk/\***: Send a message in the AI chat and verify a streamed response appears
    - **react / react-dom**: Interact with stateful components (click buttons, toggle UI, submit forms)
    - **@tanstack/react-query**: Navigate to a page that fetches data and verify the data loads
    - For other packages: grep for imports, understand what the code does, and interact with that feature


### PR DESCRIPTION
## Summary

Tightens the merge-dependabot skill's sanity test instructions to require triggering real functionality rather than just visiting a page. A page-load check provides no validation that an upgraded package's code paths actually work — for example, loading the AI mode page exercises Next.js but not the ai-sdk.

## Context

During a real dependabot merge run, the ai-sdk production dependency was upgraded and the sanity test only loaded the AI mode page without sending a chat message. The user correctly pointed out this provided zero validation of the ai-sdk upgrade. The updated instructions now explicitly require exercising the feature associated with the upgraded package (e.g., sending a chat message when testing an ai-sdk upgrade).