### PR TITLE
refactor: extract shared HorizontalScrollRow component

### DIFF
--- a/src/components/ai-chat/horizontal-scroll-row.tsx
+++ b/src/components/ai-chat/horizontal-scroll-row.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { useRef } from "react";
+import { useScrollFades } from "#src/hooks/use-scroll-fades.ts";
+import { scrollX } from "#src/primitives/layout.stylex.ts";
+import { color, space } from "#src/tokens.stylex.ts";
+import { HorizontalScrollButtons } from "./horizontal-scroll-buttons";
+
+interface HorizontalScrollRowProps {
+  children: React.ReactNode;
+  ariaLabel: string;
+  role?: "list" | "region";
+  wrapperCss?: React.Attributes["css"];
+  containerCss?: React.Attributes["css"];
+  fadeLeftCss?: React.Attributes["css"];
+  fadeRightCss?: React.Attributes["css"];
+  scrollButtonLeftCss?: React.Attributes["css"];
+  scrollButtonRightCss?: React.Attributes["css"];
+}
+
+export function HorizontalScrollRow({
+  children,
+  ariaLabel,
+  role = "list",
+  wrapperCss,
+  containerCss,
+  fadeLeftCss,
+  fadeRightCss,
+  scrollButtonLeftCss,
+  scrollButtonRightCss,
+}: HorizontalScrollRowProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const { showLeftFade, showRightFade } = useScrollFades(scrollRef);
+
+  return (
+    <div css={[styles.scrollWrapper, wrapperCss]}>
+      <div
+        ref={scrollRef}
+        css={[
+          scrollX.base,
+          scrollX.focusRing,
+          styles.scrollContainer,
+          containerCss,
+        ]}
+        role={role}
+        aria-label={ariaLabel}
+        tabIndex={0}
+      >
+        {children}
+      </div>
+      <div
+        css={[styles.fadeEdge, styles.fadeLeft, fadeLeftCss]}
+        style={{ opacity: showLeftFade ? 1 : 0 }}
+        aria-hidden="true"
+      />
+      <div
+        css={[styles.fadeEdge, styles.fadeRight, fadeRightCss]}
+        style={{ opacity: showRightFade ? 1 : 0 }}
+        aria-hidden="true"
+      />
+      <HorizontalScrollButtons
+        scrollRef={scrollRef}
+        showLeft={showLeftFade}
+        showRight={showRightFade}
+        leftCss={[styles.scrollButtonLeft, scrollButtonLeftCss]}
+        rightCss={[styles.scrollButtonRight, scrollButtonRightCss]}
+      />
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  scrollWrapper: {
+    position: "relative",
+    marginLeft: `calc(-1 * ${space._3})`,
+    marginRight: `calc(-1 * ${space._3})`,
+  },
+  scrollContainer: {
+    display: "flex",
+    gap: space._2,
+    scrollSnapType: "x mandatory",
+    padding: space._3,
+    scrollPaddingLeft: space._3,
+    scrollPaddingRight: space._3,
+  },
+  fadeEdge: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    width: space._8,
+    pointerEvents: "none",
+    transition: "opacity 0.2s ease",
+  },
+  fadeLeft: {
+    left: 0,
+    backgroundImage: `linear-gradient(to left, rgba(${color.backgroundRaisedChannels}, 0), rgba(${color.backgroundRaisedChannels}, 1))`,
+  },
+  fadeRight: {
+    right: 0,
+    backgroundImage: `linear-gradient(to right, rgba(${color.backgroundRaisedChannels}, 0), rgba(${color.backgroundRaisedChannels}, 1))`,
+  },
+  scrollButtonLeft: {
+    left: space._3,
+  },
+  scrollButtonRight: {
+    right: space._3,
+  },
+});

--- a/src/components/ai-chat/person-detail-content.tsx
+++ b/src/components/ai-chat/person-detail-content.tsx
@@ -5,9 +5,7 @@ import { useQueries } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { breakpoints } from "#src/breakpoints.stylex.ts";
 import { useLocale } from "#src/hooks/use-locale.ts";
-import { useScrollFades } from "#src/hooks/use-scroll-fades.ts";
 import { t } from "#src/i18n.ts";
-import { scrollX } from "#src/primitives/layout.stylex.ts";
 import { buttonReset } from "#src/primitives/reset.stylex.ts";
 import { border, color, font, layer, space } from "#src/tokens.stylex.ts";
 import { calculateAge } from "#src/utils/calculate-age.ts";
@@ -16,7 +14,7 @@ import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
 import type { MediaListItem } from "#src/utils/types.ts";
 import { Skeleton } from "../shared/skeleton";
 import { CompactMediaCard } from "./compact-media-card";
-import { HorizontalScrollButtons } from "./horizontal-scroll-buttons";
+import { HorizontalScrollRow } from "./horizontal-scroll-row";
 import { useMediaDetail, type FocusedPerson } from "./media-detail-context";
 
 const MAX_CREDITS = 20;
@@ -270,65 +268,44 @@ function FilmographyScroller({
 }: {
   items: ReadonlyArray<MediaListItem>;
 }) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const { showLeftFade, showRightFade } = useScrollFades(scrollRef);
   const { setFocusedPerson, setFocusedMedia } = useMediaDetail();
 
   return (
-    <div css={filmStyles.scrollWrapper}>
-      <div
-        ref={scrollRef}
-        css={[scrollX.base, scrollX.focusRing, filmStyles.scrollContainer]}
-        role="list"
-        aria-label={t({ en: "Filmography", zh: "作品列表" })}
-        tabIndex={0}
-      >
-        {items.map((item) => {
-          const { mediaType } = item;
-          return (
-            <div
-              key={`${mediaType}-${item.id}`}
-              css={filmStyles.cardWrapper}
-              role="listitem"
-            >
-              <CompactMediaCard
-                media={item}
-                onClick={
-                  mediaType
-                    ? () => {
-                        setFocusedPerson(null);
-                        setFocusedMedia({
-                          id: item.id,
-                          mediaType,
-                          title: item.title,
-                          posterPath: item.posterPath,
-                        });
-                      }
-                    : undefined
-                }
-              />
-            </div>
-          );
-        })}
-      </div>
-      <div
-        css={[filmStyles.fadeEdge, filmStyles.fadeLeft]}
-        style={{ opacity: showLeftFade ? 1 : 0 }}
-        aria-hidden="true"
-      />
-      <div
-        css={[filmStyles.fadeEdge, filmStyles.fadeRight]}
-        style={{ opacity: showRightFade ? 1 : 0 }}
-        aria-hidden="true"
-      />
-      <HorizontalScrollButtons
-        scrollRef={scrollRef}
-        showLeft={showLeftFade}
-        showRight={showRightFade}
-        leftCss={filmStyles.scrollButtonLeft}
-        rightCss={filmStyles.scrollButtonRight}
-      />
-    </div>
+    <HorizontalScrollRow
+      ariaLabel={t({ en: "Filmography", zh: "作品列表" })}
+      wrapperCss={filmStyles.scrollWrapper}
+      containerCss={filmStyles.scrollContainer}
+      scrollButtonLeftCss={filmStyles.scrollButtonLeft}
+      scrollButtonRightCss={filmStyles.scrollButtonRight}
+    >
+      {items.map((item) => {
+        const { mediaType } = item;
+        return (
+          <div
+            key={`${mediaType}-${item.id}`}
+            css={filmStyles.cardWrapper}
+            role="listitem"
+          >
+            <CompactMediaCard
+              media={item}
+              onClick={
+                mediaType
+                  ? () => {
+                      setFocusedPerson(null);
+                      setFocusedMedia({
+                        id: item.id,
+                        mediaType,
+                        title: item.title,
+                        posterPath: item.posterPath,
+                      });
+                    }
+                  : undefined
+              }
+            />
+          </div>
+        );
+      })}
+    </HorizontalScrollRow>
   );
 }
 
@@ -429,35 +406,16 @@ const styles = stylex.create({
 
 const filmStyles = stylex.create({
   scrollWrapper: {
-    position: "relative",
     marginLeft: `calc(-1 * ${space._4})`,
     marginRight: `calc(-1 * ${space._4})`,
   },
   scrollContainer: {
-    display: "flex",
-    gap: space._2,
-    scrollSnapType: "x mandatory",
+    paddingTop: 0,
+    paddingBottom: space._1,
     paddingLeft: space._4,
     paddingRight: space._4,
-    paddingBottom: space._1,
     scrollPaddingLeft: space._4,
     scrollPaddingRight: space._4,
-  },
-  fadeEdge: {
-    position: "absolute",
-    top: 0,
-    bottom: 0,
-    width: space._8,
-    pointerEvents: "none",
-    transition: "opacity 0.2s ease",
-  },
-  fadeLeft: {
-    left: 0,
-    backgroundImage: `linear-gradient(to left, rgba(${color.backgroundRaisedChannels}, 0), rgba(${color.backgroundRaisedChannels}, 1))`,
-  },
-  fadeRight: {
-    right: 0,
-    backgroundImage: `linear-gradient(to right, rgba(${color.backgroundRaisedChannels}, 0), rgba(${color.backgroundRaisedChannels}, 1))`,
   },
   scrollButtonLeft: {
     left: space._4,

--- a/src/components/ai-chat/recommended-media-row.tsx
+++ b/src/components/ai-chat/recommended-media-row.tsx
@@ -1,15 +1,12 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
-import { useRef } from "react";
 import { breakpoints } from "#src/breakpoints.stylex.ts";
-import { useScrollFades } from "#src/hooks/use-scroll-fades.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
-import { scrollX } from "#src/primitives/layout.stylex.ts";
 import { color, font, space } from "#src/tokens.stylex.ts";
 import type { MediaListItem } from "#src/utils/types.ts";
 import { CompactMediaCard } from "./compact-media-card";
-import { HorizontalScrollButtons } from "./horizontal-scroll-buttons";
+import { HorizontalScrollRow } from "./horizontal-scroll-row";
 import { useMediaDetail } from "./media-detail-context";
 
 interface RecommendedMediaRowProps {
@@ -21,8 +18,6 @@ export function RecommendedMediaRow({
   title,
   items,
 }: RecommendedMediaRowProps) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const { showLeftFade, showRightFade } = useScrollFades(scrollRef);
   const { setFocusedMedia } = useMediaDetail();
 
   if (items.length === 0) return null;
@@ -30,55 +25,39 @@ export function RecommendedMediaRow({
   return (
     <section css={[flex.col, styles.section]}>
       <h2 css={styles.title}>{title}</h2>
-      <div css={styles.scrollWrapper}>
-        <div
-          ref={scrollRef}
-          css={[scrollX.base, scrollX.focusRing, styles.scrollContainer]}
-          role="region"
-          aria-label={title}
-          tabIndex={0}
-        >
-          {items.map((item) => {
-            const { mediaType } = item;
-            return (
-              <div key={item.id} css={styles.cardWrapper}>
-                <CompactMediaCard
-                  media={item}
-                  onClick={
-                    mediaType
-                      ? () => {
-                          setFocusedMedia({
-                            id: item.id,
-                            mediaType,
-                            title: item.title,
-                            posterPath: item.posterPath,
-                          });
-                        }
-                      : undefined
-                  }
-                />
-              </div>
-            );
-          })}
-        </div>
-        <div
-          css={[styles.fadeEdge, styles.fadeLeft]}
-          style={{ opacity: showLeftFade ? 1 : 0 }}
-          aria-hidden="true"
-        />
-        <div
-          css={[styles.fadeEdge, styles.fadeRight]}
-          style={{ opacity: showRightFade ? 1 : 0 }}
-          aria-hidden="true"
-        />
-        <HorizontalScrollButtons
-          scrollRef={scrollRef}
-          showLeft={showLeftFade}
-          showRight={showRightFade}
-          leftCss={styles.scrollButtonLeft}
-          rightCss={styles.scrollButtonRight}
-        />
-      </div>
+      <HorizontalScrollRow
+        ariaLabel={title}
+        role="region"
+        wrapperCss={styles.scrollWrapper}
+        containerCss={styles.scrollContainer}
+        fadeLeftCss={styles.fadeLeft}
+        fadeRightCss={styles.fadeRight}
+        scrollButtonLeftCss={styles.scrollButtonLeft}
+        scrollButtonRightCss={styles.scrollButtonRight}
+      >
+        {items.map((item) => {
+          const { mediaType } = item;
+          return (
+            <div key={item.id} css={styles.cardWrapper}>
+              <CompactMediaCard
+                media={item}
+                onClick={
+                  mediaType
+                    ? () => {
+                        setFocusedMedia({
+                          id: item.id,
+                          mediaType,
+                          title: item.title,
+                          posterPath: item.posterPath,
+                        });
+                      }
+                    : undefined
+                }
+              />
+            </div>
+          );
+        })}
+      </HorizontalScrollRow>
     </section>
   );
 }
@@ -104,34 +83,21 @@ const styles = stylex.create({
     margin: 0,
   },
   scrollWrapper: {
-    position: "relative",
     marginLeft: `calc(-1 * ${contentInsetLeft})`,
     marginRight: `calc(-1 * ${contentInsetRight})`,
   },
   scrollContainer: {
-    display: "flex",
-    gap: space._2,
-    scrollSnapType: "x mandatory",
+    paddingTop: 0,
     paddingBottom: space._1,
     paddingLeft: contentInsetLeft,
     paddingRight: contentInsetRight,
     scrollPaddingLeft: contentInsetLeft,
     scrollPaddingRight: contentInsetRight,
   },
-  fadeEdge: {
-    position: "absolute",
-    top: 0,
-    bottom: 0,
-    width: space._8,
-    pointerEvents: "none",
-    transition: "opacity 0.2s ease",
-  },
   fadeLeft: {
-    left: 0,
     backgroundImage: `linear-gradient(to left, rgba(${color.backgroundMainChannels}, 0), rgba(${color.backgroundMainChannels}, 1))`,
   },
   fadeRight: {
-    right: 0,
     backgroundImage: `linear-gradient(to right, rgba(${color.backgroundMainChannels}, 0), rgba(${color.backgroundMainChannels}, 1))`,
   },
   scrollButtonLeft: {

--- a/src/components/ai-chat/tool-media-cards.tsx
+++ b/src/components/ai-chat/tool-media-cards.tsx
@@ -1,15 +1,11 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
-import { useRef } from "react";
 import { breakpoints } from "#src/breakpoints.stylex.ts";
-import { useScrollFades } from "#src/hooks/use-scroll-fades.ts";
 import { t } from "#src/i18n.ts";
-import { scrollX } from "#src/primitives/layout.stylex.ts";
-import { color, space } from "#src/tokens.stylex.ts";
 import type { MediaListItem } from "#src/utils/types.ts";
 import { CompactMediaCard } from "./compact-media-card";
-import { HorizontalScrollButtons } from "./horizontal-scroll-buttons";
+import { HorizontalScrollRow } from "./horizontal-scroll-row";
 import { useMediaDetail } from "./media-detail-context";
 
 interface ToolMediaCardsProps {
@@ -17,105 +13,45 @@ interface ToolMediaCardsProps {
 }
 
 export function ToolMediaCards({ items }: ToolMediaCardsProps) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const { showLeftFade, showRightFade } = useScrollFades(scrollRef);
   const { setFocusedMedia } = useMediaDetail();
 
   if (items.length === 0) return null;
 
   return (
-    <div css={styles.scrollWrapper}>
-      <div
-        ref={scrollRef}
-        css={[scrollX.base, scrollX.focusRing, styles.scrollContainer]}
-        role="list"
-        aria-label={t({ en: "Search results", zh: "搜索结果" })}
-        tabIndex={0}
-      >
-        {items.map((item) => {
-          const { mediaType } = item;
-          return (
-            <div
-              key={`${item.mediaType ?? "unknown"}-${item.id}`}
-              css={styles.cardWrapper}
-              role="listitem"
-            >
-              <CompactMediaCard
-                media={item}
-                onClick={
-                  mediaType
-                    ? () => {
-                        setFocusedMedia({
-                          id: item.id,
-                          mediaType,
-                          title: item.title,
-                          posterPath: item.posterPath,
-                        });
-                      }
-                    : undefined
-                }
-              />
-            </div>
-          );
-        })}
-      </div>
-      <div
-        css={[styles.fadeEdge, styles.fadeLeft]}
-        style={{ opacity: showLeftFade ? 1 : 0 }}
-        aria-hidden="true"
-      />
-      <div
-        css={[styles.fadeEdge, styles.fadeRight]}
-        style={{ opacity: showRightFade ? 1 : 0 }}
-        aria-hidden="true"
-      />
-      <HorizontalScrollButtons
-        scrollRef={scrollRef}
-        showLeft={showLeftFade}
-        showRight={showRightFade}
-        leftCss={styles.scrollButtonLeft}
-        rightCss={styles.scrollButtonRight}
-      />
-    </div>
+    <HorizontalScrollRow
+      ariaLabel={t({ en: "Search results", zh: "搜索结果" })}
+    >
+      {items.map((item) => {
+        const { mediaType } = item;
+        return (
+          <div
+            key={`${item.mediaType ?? "unknown"}-${item.id}`}
+            css={styles.cardWrapper}
+            role="listitem"
+          >
+            <CompactMediaCard
+              media={item}
+              onClick={
+                mediaType
+                  ? () => {
+                      setFocusedMedia({
+                        id: item.id,
+                        mediaType,
+                        title: item.title,
+                        posterPath: item.posterPath,
+                      });
+                    }
+                  : undefined
+              }
+            />
+          </div>
+        );
+      })}
+    </HorizontalScrollRow>
   );
 }
 
 const styles = stylex.create({
-  scrollWrapper: {
-    position: "relative",
-    marginLeft: `calc(-1 * ${space._3})`,
-    marginRight: `calc(-1 * ${space._3})`,
-  },
-  scrollContainer: {
-    display: "flex",
-    gap: space._2,
-    scrollSnapType: "x mandatory",
-    padding: space._3,
-    scrollPaddingLeft: space._3,
-    scrollPaddingRight: space._3,
-  },
-  fadeEdge: {
-    position: "absolute",
-    top: 0,
-    bottom: 0,
-    width: space._8,
-    pointerEvents: "none",
-    transition: "opacity 0.2s ease",
-  },
-  fadeLeft: {
-    left: 0,
-    backgroundImage: `linear-gradient(to left, rgba(${color.backgroundRaisedChannels}, 0), rgba(${color.backgroundRaisedChannels}, 1))`,
-  },
-  fadeRight: {
-    right: 0,
-    backgroundImage: `linear-gradient(to right, rgba(${color.backgroundRaisedChannels}, 0), rgba(${color.backgroundRaisedChannels}, 1))`,
-  },
-  scrollButtonLeft: {
-    left: space._3,
-  },
-  scrollButtonRight: {
-    right: space._3,
-  },
   cardWrapper: {
     flexShrink: 0,
     scrollSnapAlign: "start",

--- a/src/components/ai-chat/tool-person-cards.tsx
+++ b/src/components/ai-chat/tool-person-cards.tsx
@@ -1,15 +1,11 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
-import { useRef } from "react";
 import { breakpoints } from "#src/breakpoints.stylex.ts";
-import { useScrollFades } from "#src/hooks/use-scroll-fades.ts";
 import { t } from "#src/i18n.ts";
-import { scrollX } from "#src/primitives/layout.stylex.ts";
-import { color, space } from "#src/tokens.stylex.ts";
 import type { PersonListItem } from "#src/utils/types.ts";
 import { CompactPersonCard } from "./compact-person-card";
-import { HorizontalScrollButtons } from "./horizontal-scroll-buttons";
+import { HorizontalScrollRow } from "./horizontal-scroll-row";
 import { useMediaDetail } from "./media-detail-context";
 
 interface ToolPersonCardsProps {
@@ -17,97 +13,37 @@ interface ToolPersonCardsProps {
 }
 
 export function ToolPersonCards({ items }: ToolPersonCardsProps) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const { showLeftFade, showRightFade } = useScrollFades(scrollRef);
   const { setFocusedPerson } = useMediaDetail();
 
   if (items.length === 0) return null;
 
   return (
-    <div css={styles.scrollWrapper}>
-      <div
-        ref={scrollRef}
-        css={[scrollX.base, scrollX.focusRing, styles.scrollContainer]}
-        role="list"
-        aria-label={t({ en: "People results", zh: "人物结果" })}
-        tabIndex={0}
-      >
-        {items.map((person) => (
-          <div
-            key={`person-${person.id}`}
-            css={styles.cardWrapper}
-            role="listitem"
-          >
-            <CompactPersonCard
-              person={person}
-              onClick={() => {
-                setFocusedPerson({
-                  id: person.id,
-                  name: person.name,
-                  profilePath: person.profilePath,
-                });
-              }}
-            />
-          </div>
-        ))}
-      </div>
-      <div
-        css={[styles.fadeEdge, styles.fadeLeft]}
-        style={{ opacity: showLeftFade ? 1 : 0 }}
-        aria-hidden="true"
-      />
-      <div
-        css={[styles.fadeEdge, styles.fadeRight]}
-        style={{ opacity: showRightFade ? 1 : 0 }}
-        aria-hidden="true"
-      />
-      <HorizontalScrollButtons
-        scrollRef={scrollRef}
-        showLeft={showLeftFade}
-        showRight={showRightFade}
-        leftCss={styles.scrollButtonLeft}
-        rightCss={styles.scrollButtonRight}
-      />
-    </div>
+    <HorizontalScrollRow
+      ariaLabel={t({ en: "People results", zh: "人物结果" })}
+    >
+      {items.map((person) => (
+        <div
+          key={`person-${person.id}`}
+          css={styles.cardWrapper}
+          role="listitem"
+        >
+          <CompactPersonCard
+            person={person}
+            onClick={() => {
+              setFocusedPerson({
+                id: person.id,
+                name: person.name,
+                profilePath: person.profilePath,
+              });
+            }}
+          />
+        </div>
+      ))}
+    </HorizontalScrollRow>
   );
 }
 
 const styles = stylex.create({
-  scrollWrapper: {
-    position: "relative",
-    marginLeft: `calc(-1 * ${space._3})`,
-    marginRight: `calc(-1 * ${space._3})`,
-  },
-  scrollContainer: {
-    display: "flex",
-    gap: space._2,
-    scrollSnapType: "x mandatory",
-    padding: space._3,
-    scrollPaddingLeft: space._3,
-    scrollPaddingRight: space._3,
-  },
-  fadeEdge: {
-    position: "absolute",
-    top: 0,
-    bottom: 0,
-    width: space._8,
-    pointerEvents: "none",
-    transition: "opacity 0.2s ease",
-  },
-  fadeLeft: {
-    left: 0,
-    backgroundImage: `linear-gradient(to left, rgba(${color.backgroundRaisedChannels}, 0), rgba(${color.backgroundRaisedChannels}, 1))`,
-  },
-  fadeRight: {
-    right: 0,
-    backgroundImage: `linear-gradient(to right, rgba(${color.backgroundRaisedChannels}, 0), rgba(${color.backgroundRaisedChannels}, 1))`,
-  },
-  scrollButtonLeft: {
-    left: space._3,
-  },
-  scrollButtonRight: {
-    right: space._3,
-  },
   cardWrapper: {
     flexShrink: 0,
     scrollSnapAlign: "start",


### PR DESCRIPTION
## Summary

Extracts duplicated horizontal scroll infrastructure into a shared `HorizontalScrollRow` component. Four AI chat components each independently implemented the same ~55 lines of scroll boilerplate (scroll ref, fade state, wrapper div, flex scroll container with snap, fade gradient overlays, scroll buttons). This duplication meant scroll behavior fixes had to be applied in four separate places. The new component accepts optional StyleX CSS overrides for the parts that vary per consumer, reducing each call site to a simple declarative wrapper and ensuring future scroll behavior changes propagate uniformly.

## Context

The shared component uses the same `React.Attributes["css"]` typing pattern as the existing `HorizontalScrollButtons` component. The two simplest consumers (ToolMediaCards, ToolPersonCards) need zero style overrides — they just pass children and an aria-label. RecommendedMediaRow overrides fade gradient colors (backgroundMainChannels vs backgroundRaisedChannels) and inset distances. FilmographyScroller overrides inset from space._3 to space._4. Net reduction of ~120 lines.