### PR TITLE
fix: move scroll-to-top from effect to event handlers

### DIFF
--- a/src/components/movie-database/media-filters-provider.tsx
+++ b/src/components/movie-database/media-filters-provider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname, useSearchParams } from "next/navigation";
-import { useEffect, useState, type PropsWithChildren } from "react";
+import { useEffect, useRef, useState, type PropsWithChildren } from "react";
 import { getScrollBehavior } from "#src/utils/get-scroll-behavior.ts";
 import type {
   GenreFilterType,
@@ -47,6 +47,12 @@ export function MediaFiltersProvider({
     mediaType: initialMediaType,
   }));
 
+  const initialMountRef = useRef(true);
+
+  const scrollToTop = () => {
+    window.scrollTo({ behavior: getScrollBehavior(), top: 0 });
+  };
+
   const toggleGenre = (genreId: string) => {
     setMediaFilters((prev) => {
       const newGenres = new Set(prev.genres);
@@ -57,6 +63,7 @@ export function MediaFiltersProvider({
       }
       return { ...prev, genres: newGenres };
     });
+    scrollToTop();
   };
 
   const toggleGenreUrl = (genreId: string) => {
@@ -75,6 +82,7 @@ export function MediaFiltersProvider({
     setMediaFilters((prev) => {
       return { ...prev, genreFilterType: type };
     });
+    scrollToTop();
   };
 
   const setGenreFilterTypeUrl = (type: GenreFilterType) => {
@@ -89,6 +97,7 @@ export function MediaFiltersProvider({
 
   const setSort = (sort: Sort) => {
     setMediaFilters((prev) => ({ ...prev, sort }));
+    scrollToTop();
   };
 
   const setSortUrl = (sort: Sort) => {
@@ -113,6 +122,7 @@ export function MediaFiltersProvider({
       sort: "popularity.desc",
       mediaType: type,
     });
+    scrollToTop();
   };
 
   const reset = () => {
@@ -122,6 +132,7 @@ export function MediaFiltersProvider({
       sort: "popularity.desc",
       mediaType: prev.mediaType,
     }));
+    scrollToTop();
   };
 
   const resetUrl = () => {
@@ -144,6 +155,11 @@ export function MediaFiltersProvider({
   };
 
   useEffect(() => {
+    if (initialMountRef.current) {
+      initialMountRef.current = false;
+      return;
+    }
+
     const url = new URL(window.location.href);
     // Clear any existing params
     url.searchParams.delete("genre");
@@ -172,7 +188,6 @@ export function MediaFiltersProvider({
     }
 
     window.history.replaceState({}, "", url);
-    window.scrollTo({ behavior: getScrollBehavior(), top: 0 });
   }, [mediaFilters]);
 
   return (


### PR DESCRIPTION
## Summary

Fixes an unwanted scroll-to-top on initial page load in the movie database filters page. The `window.scrollTo` call was inside a `useEffect` that syncs filter state to the URL, which meant it fired on mount — breaking anchor links and scroll restoration when loading pages with filter params in the URL.

Moves `scrollToTop()` into the 5 filter action handlers (`toggleGenre`, `setGenreFilterType`, `setSort`, `setMediaType`, `reset`) so it only fires in response to explicit user interactions. Adds an `initialMountRef` guard to skip the first effect run, since the URL already has the correct params from initialization. This follows the React principle that side effects for user actions belong in event handlers, not effects.