### PR TITLE
refactor: extract shared TmdbImage component

### DIFF
--- a/src/components/ai-chat/compact-person-card.tsx
+++ b/src/components/ai-chat/compact-person-card.tsx
@@ -2,15 +2,13 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useState } from "react";
 import { t } from "#src/i18n.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { buttonReset } from "#src/primitives/reset.stylex.ts";
 import { border, color, font, space } from "#src/tokens.stylex.ts";
-import { buildSrcSet } from "#src/utils/tmdb-image.ts";
 import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
 import type { PersonListItem } from "#src/utils/types.ts";
-import { Skeleton } from "../shared/skeleton";
+import { TmdbImage } from "../movie-database/tmdb-image";
 
 interface CompactPersonCardProps {
   person: PersonListItem;
@@ -29,38 +27,25 @@ function ProfilePhoto({
   alt: string;
 }) {
   const { data: config } = useSuspenseQuery(tmdbQueries.configuration);
-  const [loaded, setLoaded] = useState(false);
-  const [errored, setErrored] = useState(false);
 
-  if (!config.images?.base_url || !config.images?.profile_sizes || errored) {
+  if (!config.images?.base_url || !config.images?.profile_sizes) {
     return <div css={[flex.center, styles.photoFallback]}>{alt.charAt(0)}</div>;
   }
 
-  const { src, srcSet } = buildSrcSet(
-    config.images.secure_base_url ?? config.images.base_url,
-    config.images.profile_sizes,
-    profilePath,
-  );
-
   return (
-    <>
-      {!loaded && <Skeleton css={styles.photoSkeleton} />}
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        css={styles.photo}
-        alt={alt}
-        src={src}
-        srcSet={srcSet}
-        sizes="80px"
-        loading="lazy"
-        decoding="async"
-        onLoad={() => setLoaded(true)}
-        onError={() => setErrored(true)}
-        ref={(el) => {
-          if (el?.complete && el.naturalWidth > 0) setLoaded(true);
-        }}
-      />
-    </>
+    <TmdbImage
+      baseUrl={config.images.secure_base_url ?? config.images.base_url}
+      sizeConfig={config.images.profile_sizes}
+      path={profilePath}
+      alt={alt}
+      sizes="80px"
+      imgCss={styles.photo}
+      skeletonCss={styles.photoSkeleton}
+      errorFallback={
+        <div css={[flex.center, styles.photoFallback]}>{alt.charAt(0)}</div>
+      }
+      loading="lazy"
+    />
   );
 }
 

--- a/src/components/ai-chat/media-detail-content.tsx
+++ b/src/components/ai-chat/media-detail-content.tsx
@@ -4,7 +4,6 @@ import { ChatTextIcon } from "@phosphor-icons/react/dist/ssr/ChatText";
 import { PlayIcon } from "@phosphor-icons/react/dist/ssr/Play";
 import * as stylex from "@stylexjs/stylex";
 import { useQueries } from "@tanstack/react-query";
-import { useState } from "react";
 import { useLocale } from "#src/hooks/use-locale.ts";
 import { t } from "#src/i18n.ts";
 import { imageCover } from "#src/primitives/layout.stylex.ts";
@@ -18,8 +17,8 @@ import {
   space,
 } from "#src/tokens.stylex.ts";
 import { formatRuntime } from "#src/utils/format-runtime.ts";
-import { buildSrcSet } from "#src/utils/tmdb-image.ts";
 import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
+import { TmdbImage } from "../movie-database/tmdb-image";
 import { Button } from "../shared/button";
 import { Skeleton } from "../shared/skeleton";
 import { useChatActions } from "./chat-actions-context";
@@ -226,35 +225,19 @@ function PosterImage({
   path: string;
   alt: string;
 }) {
-  const { src, srcSet } = buildSrcSet(baseUrl, sizes, path);
-  const [loaded, setLoaded] = useState(false);
-  const [errored, setErrored] = useState(false);
-
-  if (errored) {
-    return (
-      <div css={[imageCover.base, styles.imageFallback]}>{alt.charAt(0)}</div>
-    );
-  }
-
   return (
-    <>
-      {!loaded && <Skeleton css={skeletonStyles.poster} />}
-      {/* TMDB images are already optimized by the provider — no need for next/image */}
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        css={imageCover.base}
-        alt={alt}
-        src={src}
-        srcSet={srcSet}
-        sizes="90px"
-        decoding="async"
-        onLoad={() => setLoaded(true)}
-        onError={() => setErrored(true)}
-        ref={(el) => {
-          if (el?.complete && el.naturalWidth > 0) setLoaded(true);
-        }}
-      />
-    </>
+    <TmdbImage
+      baseUrl={baseUrl}
+      sizeConfig={sizes}
+      path={path}
+      alt={alt}
+      sizes="90px"
+      imgCss={imageCover.base}
+      skeletonCss={skeletonStyles.poster}
+      errorFallback={
+        <div css={[imageCover.base, styles.imageFallback]}>{alt.charAt(0)}</div>
+      }
+    />
   );
 }
 
@@ -269,29 +252,16 @@ function BackdropImage({
   path: string;
   alt: string;
 }) {
-  const { src, srcSet } = buildSrcSet(baseUrl, sizes, path);
-  const [loaded, setLoaded] = useState(false);
-  const [errored, setErrored] = useState(false);
-
-  if (errored) return null;
-
   return (
     <div css={styles.backdropContainer}>
-      {!loaded && <Skeleton css={skeletonStyles.backdropOverlay} />}
-      {/* TMDB images are already optimized by the provider — no need for next/image */}
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        css={styles.backdropImage}
+      <TmdbImage
+        baseUrl={baseUrl}
+        sizeConfig={sizes}
+        path={path}
         alt={alt}
-        src={src}
-        srcSet={srcSet}
         sizes="600px"
-        decoding="async"
-        onLoad={() => setLoaded(true)}
-        onError={() => setErrored(true)}
-        ref={(el) => {
-          if (el?.complete && el.naturalWidth > 0) setLoaded(true);
-        }}
+        imgCss={styles.backdropImage}
+        skeletonCss={skeletonStyles.backdropOverlay}
       />
       <div role="presentation" css={styles.backdropGradient} />
     </div>

--- a/src/components/ai-chat/person-detail-content.tsx
+++ b/src/components/ai-chat/person-detail-content.tsx
@@ -9,9 +9,9 @@ import { t } from "#src/i18n.ts";
 import { buttonReset } from "#src/primitives/reset.stylex.ts";
 import { border, color, font, layer, space } from "#src/tokens.stylex.ts";
 import { calculateAge } from "#src/utils/calculate-age.ts";
-import { buildSrcSet } from "#src/utils/tmdb-image.ts";
 import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
 import type { MediaListItem } from "#src/utils/types.ts";
+import { TmdbImage } from "../movie-database/tmdb-image";
 import { Skeleton } from "../shared/skeleton";
 import { CompactMediaCard } from "./compact-media-card";
 import { HorizontalScrollRow } from "./horizontal-scroll-row";
@@ -122,32 +122,17 @@ function ProfileImage({
   path: string;
   alt: string;
 }) {
-  const { src, srcSet } = buildSrcSet(baseUrl, sizes, path);
-  const [loaded, setLoaded] = useState(false);
-  const [errored, setErrored] = useState(false);
-
-  if (errored) {
-    return <div css={styles.profileFallback}>{alt.charAt(0)}</div>;
-  }
-
   return (
-    <>
-      {!loaded && <Skeleton css={skeletonStyles.photo} />}
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        css={styles.photo}
-        alt={alt}
-        src={src}
-        srcSet={srcSet}
-        sizes="90px"
-        decoding="async"
-        onLoad={() => setLoaded(true)}
-        onError={() => setErrored(true)}
-        ref={(el) => {
-          if (el?.complete && el.naturalWidth > 0) setLoaded(true);
-        }}
-      />
-    </>
+    <TmdbImage
+      baseUrl={baseUrl}
+      sizeConfig={sizes}
+      path={path}
+      alt={alt}
+      sizes="90px"
+      imgCss={styles.photo}
+      skeletonCss={skeletonStyles.photo}
+      errorFallback={<div css={styles.profileFallback}>{alt.charAt(0)}</div>}
+    />
   );
 }
 

--- a/src/components/movie-database/poster-image.tsx
+++ b/src/components/movie-database/poster-image.tsx
@@ -2,14 +2,12 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useState } from "react";
-import { Skeleton } from "#src/components/shared/skeleton.tsx";
 import { t } from "#src/i18n.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { imageCover } from "#src/primitives/layout.stylex.ts";
 import { color, font, layer } from "#src/tokens.stylex.ts";
-import { buildSrcSet } from "#src/utils/tmdb-image.ts";
 import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
+import { TmdbImage } from "./tmdb-image.tsx";
 
 interface PosterImageProps {
   posterPath: string;
@@ -24,10 +22,7 @@ interface PosterImageProps {
 export function PosterImage({ posterPath, alt }: PosterImageProps) {
   const { data: config } = useSuspenseQuery(tmdbQueries.configuration);
 
-  const [imgLoaded, setImgLoaded] = useState(false);
-  const [imgErrored, setImgErrored] = useState(false);
-
-  if (!config.images?.base_url || !config.images?.poster_sizes || imgErrored) {
+  if (!config.images?.base_url || !config.images?.poster_sizes) {
     return (
       <div css={[imageCover.base, flex.center, styles.errored]}>
         <div>{alt}</div>
@@ -36,35 +31,26 @@ export function PosterImage({ posterPath, alt }: PosterImageProps) {
     );
   }
 
-  const { src, srcSet } = buildSrcSet(
-    config.images.secure_base_url ?? config.images.base_url,
-    config.images.poster_sizes,
-    posterPath,
-  );
-
   return (
-    <>
-      {!imgLoaded && <Skeleton fill css={[flex.center, styles.errored]} />}
-      {/* Disabling no-img-element rule as the images here are from a third party provider and is already
-      optimized */}
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        css={imageCover.base}
-        alt={alt}
-        src={src}
-        srcSet={srcSet}
-        sizes="auto,(max-width: 326px) 100vw,(max-width: 485px) 50vw,(max-width: 644px) 33.3vw,(max-width: 767px) 25vw,(max-width: 969px) 33.3vw,(max-width: 1079px) 25vw,(max-width: 1259px) 33.3vw,(max-width: 1571px) 25vw,362px"
-        loading="lazy"
-        decoding="async"
-        onLoad={() => setImgLoaded(true)}
-        onError={() => setImgErrored(true)}
-        ref={(el) => {
-          if (el && el.complete && el.naturalWidth > 0) {
-            setImgLoaded(true);
-          }
-        }}
-      />
-    </>
+    <TmdbImage
+      baseUrl={config.images.secure_base_url ?? config.images.base_url}
+      sizeConfig={config.images.poster_sizes}
+      path={posterPath}
+      alt={alt}
+      sizes="auto,(max-width: 326px) 100vw,(max-width: 485px) 50vw,(max-width: 644px) 33.3vw,(max-width: 767px) 25vw,(max-width: 969px) 33.3vw,(max-width: 1079px) 25vw,(max-width: 1259px) 33.3vw,(max-width: 1571px) 25vw,362px"
+      imgCss={imageCover.base}
+      skeletonFill
+      skeletonCss={[flex.center, styles.errored]}
+      errorFallback={
+        <div css={[imageCover.base, flex.center, styles.errored]}>
+          <div>{alt}</div>
+          <div css={styles.errorText}>
+            {t({ en: "No Poster", zh: "无海报" })}
+          </div>
+        </div>
+      }
+      loading="lazy"
+    />
   );
 }
 

--- a/src/components/movie-database/tmdb-image.tsx
+++ b/src/components/movie-database/tmdb-image.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { Skeleton } from "#src/components/shared/skeleton.tsx";
+import { buildSrcSet } from "#src/utils/tmdb-image.ts";
+
+interface TmdbImageProps {
+  baseUrl: string;
+  sizeConfig: ReadonlyArray<string>;
+  path: string;
+  alt: string;
+  sizes: string;
+  imgCss?: React.Attributes["css"];
+  skeletonCss?: React.Attributes["css"];
+  skeletonFill?: boolean;
+  errorFallback?: ReactNode;
+  loading?: "lazy" | "eager";
+}
+
+/**
+ * Shared component for rendering TMDB images with loading skeleton and error fallback.
+ * Handles loaded/errored state, the ref callback for detecting cached images,
+ * and srcSet generation.
+ */
+export function TmdbImage({
+  baseUrl,
+  sizeConfig,
+  path,
+  alt,
+  sizes,
+  imgCss,
+  skeletonCss,
+  skeletonFill,
+  errorFallback = null,
+  loading = "lazy",
+}: TmdbImageProps) {
+  const { src, srcSet } = buildSrcSet(baseUrl, sizeConfig, path);
+  const [loaded, setLoaded] = useState(false);
+  const [errored, setErrored] = useState(false);
+
+  if (errored) {
+    return <>{errorFallback}</>;
+  }
+
+  return (
+    <>
+      {!loaded && <Skeleton fill={skeletonFill} css={[skeletonCss]} />}
+      {/* TMDB images are already optimized by the provider — no need for next/image */}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        css={[imgCss]}
+        alt={alt}
+        src={src}
+        srcSet={srcSet}
+        sizes={sizes}
+        loading={loading}
+        decoding="async"
+        onLoad={() => setLoaded(true)}
+        onError={() => setErrored(true)}
+        ref={(el) => {
+          if (el?.complete && el.naturalWidth > 0) setLoaded(true);
+        }}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

- Extract a shared `TmdbImage` component that encapsulates the duplicated TMDB image loading pattern (loaded/errored state, `buildSrcSet`, skeleton fallback, ref callback for cache detection)
- Refactor 5 components to use it: `PosterImage`, `MediaDetailContent` (PosterImage + BackdropImage), `PersonDetailContent` (ProfileImage), and `CompactPersonCard` (ProfilePhoto)
- Net reduction of 8 lines while consolidating identical state machines and ref patterns into a single reusable component

## Test plan

- [x] All 964 unit tests pass
- [x] Lint clean
- [x] Format clean
- [x] Full build succeeds
- [x] All instances of the duplicated pattern addressed (verified via grep)