### PR TITLE
refactor: extract shared ChatTextarea component

### DIFF
--- a/src/components/ai-chat/chat-input-bar.tsx
+++ b/src/components/ai-chat/chat-input-bar.tsx
@@ -4,11 +4,11 @@ import { ArrowUpIcon } from "@phosphor-icons/react/dist/ssr/ArrowUp";
 import { StopIcon } from "@phosphor-icons/react/dist/ssr/Stop";
 import { XIcon } from "@phosphor-icons/react/dist/ssr/X";
 import * as stylex from "@stylexjs/stylex";
-import { useRef, useState } from "react";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { truncate } from "#src/primitives/layout.stylex.ts";
 import { buttonReset } from "#src/primitives/reset.stylex.ts";
 import { border, color, font, space } from "#src/tokens.stylex.ts";
+import { ChatTextarea, chatTextareaStyles } from "../shared/chat-textarea";
 import type { AttachedMedia } from "./chat-actions-context";
 
 interface ChatInputBarProps {
@@ -34,131 +34,75 @@ export function ChatInputBar({
   onStop,
   onClearAttachment,
 }: ChatInputBarProps) {
-  const [text, setText] = useState("");
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const isLoading = status === "submitted" || status === "streaming";
-  const trimmed = text.trim();
-
-  function resetTextarea() {
-    setText("");
-    const textarea = textareaRef.current;
-    if (textarea) {
-      textarea.style.height = "auto";
-    }
-  }
-
-  function send() {
-    if (!trimmed || isLoading) return;
-    onSend(trimmed);
-    resetTextarea();
-    textareaRef.current?.focus();
-  }
-
-  function handleChange(event: React.ChangeEvent<HTMLTextAreaElement>) {
-    setText(event.target.value);
-    const textarea = event.target;
-    textarea.style.height = "auto";
-    textarea.style.height = `${textarea.scrollHeight}px`;
-  }
-
-  function handleSubmit(event: React.FormEvent) {
-    event.preventDefault();
-    send();
-  }
-
-  function handleKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
-    // Skip during IME composition (e.g. Chinese/Japanese/Korean input) —
-    // Enter should confirm the composed characters, not submit the message.
-    if (event.nativeEvent.isComposing) return;
-
-    if (event.key === "Enter" && !event.shiftKey) {
-      event.preventDefault();
-      send();
-    }
-  }
-
-  function handleStop() {
-    onStop();
-    textareaRef.current?.focus();
-  }
 
   return (
-    <form onSubmit={handleSubmit} css={[flex.wrap, styles.container]}>
-      {attachedMedia && (
-        <div css={styles.attachmentRow}>
-          <span css={[truncate.base, styles.attachmentTag]}>
-            {attachedMedia.title}
-            <button
-              type="button"
-              aria-label={removeAttachmentLabel}
-              onClick={onClearAttachment}
-              css={[
-                flex.inlineCenter,
-                buttonReset.base,
-                styles.attachmentDismiss,
-              ]}
-            >
-              <XIcon size={12} aria-hidden="true" />
-            </button>
-          </span>
-        </div>
-      )}
-      <textarea
-        ref={textareaRef}
-        value={text}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        placeholder={placeholder}
-        aria-label={placeholder}
-        rows={1}
-        disabled={isLoading}
-        css={styles.textarea}
-        autoComplete="off"
-        enterKeyHint="send"
-      />
-      {isLoading ? (
-        <button
-          type="button"
-          aria-label={stopLabel}
-          onClick={handleStop}
-          css={[
-            flex.inlineCenter,
-            buttonReset.base,
-            styles.iconButton,
-            styles.iconButtonActive,
-          ]}
-        >
-          <StopIcon weight="fill" role="presentation" />
-        </button>
-      ) : (
-        <button
-          type="submit"
-          aria-label={sendLabel}
-          disabled={!trimmed}
-          css={[
-            flex.inlineCenter,
-            buttonReset.base,
-            styles.iconButton,
-            !!trimmed && styles.iconButtonActive,
-          ]}
-        >
-          <ArrowUpIcon weight="bold" role="presentation" />
-        </button>
-      )}
-    </form>
+    <ChatTextarea
+      placeholder={placeholder}
+      sendLabel={sendLabel}
+      onSubmit={onSend}
+      disabled={isLoading}
+      autoGrow
+      beforeTextarea={
+        attachedMedia && (
+          <div css={styles.attachmentRow}>
+            <span css={[truncate.base, styles.attachmentTag]}>
+              {attachedMedia.title}
+              <button
+                type="button"
+                aria-label={removeAttachmentLabel}
+                onClick={onClearAttachment}
+                css={[
+                  flex.inlineCenter,
+                  buttonReset.base,
+                  styles.attachmentDismiss,
+                ]}
+              >
+                <XIcon size={12} aria-hidden="true" />
+              </button>
+            </span>
+          </div>
+        )
+      }
+      actionButton={({ trimmedText, focusTextarea }) =>
+        isLoading ? (
+          <button
+            type="button"
+            aria-label={stopLabel}
+            onClick={() => {
+              onStop();
+              focusTextarea();
+            }}
+            css={[
+              flex.inlineCenter,
+              buttonReset.base,
+              chatTextareaStyles.iconButton,
+              chatTextareaStyles.iconButtonActive,
+            ]}
+          >
+            <StopIcon weight="fill" role="presentation" />
+          </button>
+        ) : (
+          <button
+            type="submit"
+            aria-label={sendLabel}
+            disabled={!trimmedText}
+            css={[
+              flex.inlineCenter,
+              buttonReset.base,
+              chatTextareaStyles.iconButton,
+              !!trimmedText && chatTextareaStyles.iconButtonActive,
+            ]}
+          >
+            <ArrowUpIcon weight="bold" role="presentation" />
+          </button>
+        )
+      }
+    />
   );
 }
 
 const styles = stylex.create({
-  container: {
-    width: "100%",
-    gap: space._1,
-    backgroundColor: color.backgroundRaised,
-    borderRadius: border.radius_3,
-    paddingBlock: space._2,
-    paddingLeft: space._3,
-    paddingRight: space._2,
-  },
   attachmentRow: {
     width: "100%",
     display: "flex",
@@ -188,38 +132,5 @@ const styles = stylex.create({
     },
     color: color.textMuted,
     transition: "background-color 0.15s ease",
-  },
-  textarea: {
-    flexGrow: 1,
-    resize: "none",
-    borderWidth: 0,
-    borderStyle: "none",
-    outline: "none",
-    backgroundColor: "transparent",
-    color: color.textMain,
-    fontFamily: font.family,
-    fontSize: font.uiBody,
-    lineHeight: font.lineHeight_4,
-    padding: 0,
-    maxHeight: "200px",
-    overflowY: "auto",
-    "::placeholder": {
-      color: color.textMuted,
-    },
-  },
-  iconButton: {
-    flexShrink: 0,
-    width: "1.75rem",
-    height: "1.75rem",
-    borderRadius: border.radius_round,
-    cursor: { default: "pointer", ":disabled": "default" },
-    backgroundColor: color.controlTrack,
-    color: color.textMuted,
-    opacity: { default: null, ":disabled": 0.5 },
-    transition: "background-color 0.15s ease, color 0.15s ease",
-  },
-  iconButtonActive: {
-    backgroundColor: color.controlActive,
-    color: color.textOnActive,
   },
 });

--- a/src/components/movie-database/hero-chat-input.tsx
+++ b/src/components/movie-database/hero-chat-input.tsx
@@ -1,14 +1,11 @@
 "use client";
 
-import { ArrowUpIcon } from "@phosphor-icons/react/dist/ssr/ArrowUp";
 import * as stylex from "@stylexjs/stylex";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
 import { useAIChatContext } from "#src/ai-chat/ai-chat-context.tsx";
-import { flex } from "#src/primitives/flex.stylex.ts";
-import { buttonReset } from "#src/primitives/reset.stylex.ts";
-import { border, color, font, space } from "#src/tokens.stylex.ts";
+import { space } from "#src/tokens.stylex.ts";
 import { SuggestionChips } from "../ai-chat/suggestion-chips";
+import { ChatTextarea } from "../shared/chat-textarea";
 
 interface HeroChatInputProps {
   placeholder: string;
@@ -25,10 +22,8 @@ export function HeroChatInput({
   suggestions,
   suggestionsGroupLabel,
 }: HeroChatInputProps) {
-  const [text, setText] = useState("");
   const router = useRouter();
   const { sendMessage, status } = useAIChatContext();
-  const trimmed = text.trim();
   const isLoading = status === "submitted" || status === "streaming";
 
   function send(message: string) {
@@ -37,51 +32,14 @@ export function HeroChatInput({
     router.push(aiModeHref);
   }
 
-  function handleSubmit(event: React.FormEvent) {
-    event.preventDefault();
-    if (!trimmed) return;
-    send(trimmed);
-  }
-
-  function handleKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (event.nativeEvent.isComposing) return;
-
-    if (event.key === "Enter" && !event.shiftKey) {
-      event.preventDefault();
-      if (trimmed) {
-        send(trimmed);
-      }
-    }
-  }
-
   return (
     <>
-      <form onSubmit={handleSubmit} css={[flex.wrap, styles.container]}>
-        <textarea
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder={placeholder}
-          aria-label={placeholder}
-          rows={1}
-          css={styles.textarea}
-          autoComplete="off"
-          enterKeyHint="send"
-        />
-        <button
-          type="submit"
-          aria-label={sendLabel}
-          disabled={!trimmed || isLoading}
-          css={[
-            flex.inlineCenter,
-            buttonReset.base,
-            styles.iconButton,
-            !!trimmed && styles.iconButtonActive,
-          ]}
-        >
-          <ArrowUpIcon weight="bold" role="presentation" />
-        </button>
-      </form>
+      <ChatTextarea
+        placeholder={placeholder}
+        sendLabel={sendLabel}
+        onSubmit={send}
+        disabled={isLoading}
+      />
       <div css={styles.suggestions}>
         <SuggestionChips
           suggestions={suggestions}
@@ -94,46 +52,6 @@ export function HeroChatInput({
 }
 
 const styles = stylex.create({
-  container: {
-    width: "100%",
-    gap: space._1,
-    backgroundColor: color.backgroundRaised,
-    borderRadius: border.radius_3,
-    paddingBlock: space._2,
-    paddingLeft: space._3,
-    paddingRight: space._2,
-  },
-  textarea: {
-    flexGrow: 1,
-    resize: "none",
-    borderWidth: 0,
-    borderStyle: "none",
-    outline: "none",
-    backgroundColor: "transparent",
-    color: color.textMain,
-    fontFamily: font.family,
-    fontSize: font.uiBody,
-    lineHeight: font.lineHeight_4,
-    padding: 0,
-    "::placeholder": {
-      color: color.textMuted,
-    },
-  },
-  iconButton: {
-    flexShrink: 0,
-    width: "1.75rem",
-    height: "1.75rem",
-    borderRadius: border.radius_round,
-    cursor: { default: "pointer", ":disabled": "default" },
-    backgroundColor: color.controlTrack,
-    color: color.textMuted,
-    opacity: { default: null, ":disabled": 0.5 },
-    transition: "background-color 0.15s ease, color 0.15s ease",
-  },
-  iconButtonActive: {
-    backgroundColor: color.controlActive,
-    color: color.textOnActive,
-  },
   suggestions: {
     marginTop: space._3,
   },

--- a/src/components/shared/chat-textarea.tsx
+++ b/src/components/shared/chat-textarea.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { ArrowUpIcon } from "@phosphor-icons/react/dist/ssr/ArrowUp";
+import * as stylex from "@stylexjs/stylex";
+import { useRef, useState, type ReactNode } from "react";
+import { flex } from "#src/primitives/flex.stylex.ts";
+import { buttonReset } from "#src/primitives/reset.stylex.ts";
+import { border, color, font, space } from "#src/tokens.stylex.ts";
+
+interface ActionButtonContext {
+  trimmedText: string;
+  focusTextarea: () => void;
+}
+
+interface ChatTextareaProps {
+  placeholder: string;
+  sendLabel: string;
+  onSubmit: (text: string) => void;
+  disabled?: boolean;
+  autoGrow?: boolean;
+  /** Content rendered before the textarea (e.g. attachment row). */
+  beforeTextarea?: ReactNode;
+  /**
+   * Override the default send button. Receives context with the current trimmed
+   * text and a function to focus the textarea.
+   */
+  actionButton?: (context: ActionButtonContext) => ReactNode;
+}
+
+export function ChatTextarea({
+  placeholder,
+  sendLabel,
+  onSubmit,
+  disabled = false,
+  autoGrow = false,
+  beforeTextarea,
+  actionButton,
+}: ChatTextareaProps) {
+  const [text, setText] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const trimmed = text.trim();
+
+  function resetHeight() {
+    if (autoGrow && textareaRef.current) {
+      textareaRef.current.style.height = "auto";
+    }
+  }
+
+  function focusTextarea() {
+    textareaRef.current?.focus();
+  }
+
+  function submit() {
+    if (!trimmed || disabled) return;
+    onSubmit(trimmed);
+    setText("");
+    resetHeight();
+    focusTextarea();
+  }
+
+  function handleChange(event: React.ChangeEvent<HTMLTextAreaElement>) {
+    setText(event.target.value);
+    if (autoGrow) {
+      const textarea = event.target;
+      textarea.style.height = "auto";
+      textarea.style.height = `${textarea.scrollHeight}px`;
+    }
+  }
+
+  function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    submit();
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
+    // Skip during IME composition (e.g. Chinese/Japanese/Korean input) —
+    // Enter should confirm the composed characters, not submit the message.
+    if (event.nativeEvent.isComposing) return;
+
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      submit();
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} css={[flex.wrap, styles.container]}>
+      {beforeTextarea}
+      <textarea
+        ref={textareaRef}
+        value={text}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        aria-label={placeholder}
+        rows={1}
+        disabled={disabled}
+        css={[styles.textarea, autoGrow && styles.textareaAutoGrow]}
+        autoComplete="off"
+        enterKeyHint="send"
+      />
+      {actionButton ? (
+        actionButton({ trimmedText: trimmed, focusTextarea })
+      ) : (
+        <button
+          type="submit"
+          aria-label={sendLabel}
+          disabled={!trimmed || disabled}
+          css={[
+            flex.inlineCenter,
+            buttonReset.base,
+            styles.iconButton,
+            !!trimmed && styles.iconButtonActive,
+          ]}
+        >
+          <ArrowUpIcon weight="bold" role="presentation" />
+        </button>
+      )}
+    </form>
+  );
+}
+
+/** Shared icon-button styles for custom action buttons composed by consumers. */
+export const chatTextareaStyles = stylex.create({
+  iconButton: {
+    flexShrink: 0,
+    width: "1.75rem",
+    height: "1.75rem",
+    borderRadius: border.radius_round,
+    cursor: { default: "pointer", ":disabled": "default" },
+    backgroundColor: color.controlTrack,
+    color: color.textMuted,
+    opacity: { default: null, ":disabled": 0.5 },
+    transition: "background-color 0.15s ease, color 0.15s ease",
+  },
+  iconButtonActive: {
+    backgroundColor: color.controlActive,
+    color: color.textOnActive,
+  },
+});
+
+const styles = stylex.create({
+  container: {
+    width: "100%",
+    gap: space._1,
+    backgroundColor: color.backgroundRaised,
+    borderRadius: border.radius_3,
+    paddingBlock: space._2,
+    paddingLeft: space._3,
+    paddingRight: space._2,
+  },
+  textarea: {
+    flexGrow: 1,
+    resize: "none",
+    borderWidth: 0,
+    borderStyle: "none",
+    outline: "none",
+    backgroundColor: "transparent",
+    color: color.textMain,
+    fontFamily: font.family,
+    fontSize: font.uiBody,
+    lineHeight: font.lineHeight_4,
+    padding: 0,
+    "::placeholder": {
+      color: color.textMuted,
+    },
+  },
+  textareaAutoGrow: {
+    maxHeight: "200px",
+    overflowY: "auto",
+  },
+  iconButton: {
+    flexShrink: 0,
+    width: "1.75rem",
+    height: "1.75rem",
+    borderRadius: border.radius_round,
+    cursor: { default: "pointer", ":disabled": "default" },
+    backgroundColor: color.controlTrack,
+    color: color.textMuted,
+    opacity: { default: null, ":disabled": 0.5 },
+    transition: "background-color 0.15s ease, color 0.15s ease",
+  },
+  iconButtonActive: {
+    backgroundColor: color.controlActive,
+    color: color.textOnActive,
+  },
+});


### PR DESCRIPTION
## Summary

- Extract a shared `ChatTextarea` component from `HeroChatInput` and `ChatInputBar`, consolidating duplicated textarea handling logic (text state, IME-aware keydown, form submit, auto-grow, icon button styles)
- Consumers customize via `beforeTextarea` slot, `actionButton` render function, `autoGrow`, and `disabled` props
- Net reduction of 171 lines while keeping IME composition handling in one place

## Test plan

- [x] All 964 unit tests pass
- [x] Lint clean
- [x] Format clean
- [x] Full build succeeds
- [x] Only 2 components use this pattern (verified via `isComposing` grep)