### PR TITLE
refactor: unify preference panel dialog shell with DetailOverlay

### DIFF
--- a/src/components/ai-chat/detail-overlay.tsx
+++ b/src/components/ai-chat/detail-overlay.tsx
@@ -35,11 +35,13 @@ interface DetailOverlayProps {
    */
   hideCloseButton?: boolean;
   /**
-   * When true, the card becomes a flex column with `overflow: hidden`. The
-   * consumer is responsible for making a child scrollable (e.g. a body with
-   * `flex: 1; overflow-y: auto`). Defaults to false: the entire card scrolls.
+   * Controls how the card handles overflow.
+   * - `"scroll"` (default): the entire card scrolls vertically.
+   * - `"flex-column"`: the card becomes a flex column with `overflow: hidden`.
+   *   The consumer is responsible for making a child scrollable (e.g. a body
+   *   with `flex: 1; overflow-y: auto`).
    */
-  flexColumn?: boolean;
+  layout?: "scroll" | "flex-column";
   /**
    * Ref of the element to focus when the dialog opens. Defaults to the
    * built-in close button (or the first focusable child when
@@ -55,7 +57,7 @@ export function DetailOverlay({
   width = "default",
   height = "default",
   hideCloseButton = false,
-  flexColumn = false,
+  layout = "scroll",
   initialFocusRef,
   children,
 }: PropsWithChildren<DetailOverlayProps>) {
@@ -92,7 +94,9 @@ export function DetailOverlay({
               height === "compact"
                 ? styles.cardCompact
                 : styles.cardTallDefault,
-              flexColumn ? styles.cardFlexColumn : styles.cardScrollable,
+              layout === "flex-column"
+                ? styles.cardFlexColumn
+                : styles.cardScrollable,
             ]}
             role="dialog"
             aria-modal="true"

--- a/src/components/ai-chat/detail-overlay.tsx
+++ b/src/components/ai-chat/detail-overlay.tsx
@@ -2,7 +2,7 @@
 
 import { XIcon } from "@phosphor-icons/react/dist/ssr/X";
 import * as stylex from "@stylexjs/stylex";
-import type { PropsWithChildren } from "react";
+import type { PropsWithChildren, RefObject } from "react";
 import { useRef } from "react";
 import { createPortal } from "react-dom";
 import { RemoveScroll } from "react-remove-scroll";
@@ -20,12 +20,43 @@ interface DetailOverlayProps {
   isOpen: boolean;
   onClose: () => void;
   "aria-label": string;
+  /**
+   * Override the card's max width. Defaults to a wider reading-friendly size
+   * suitable for detail content.
+   */
+  width?: "default" | "narrow";
+  /**
+   * Override the card's max height. Defaults to `90vh` (`85vh` on md+).
+   */
+  height?: "default" | "compact";
+  /**
+   * Hide the built-in floating close button. Use when the consumer renders its
+   * own header with a close affordance.
+   */
+  hideCloseButton?: boolean;
+  /**
+   * When true, the card becomes a flex column with `overflow: hidden`. The
+   * consumer is responsible for making a child scrollable (e.g. a body with
+   * `flex: 1; overflow-y: auto`). Defaults to false: the entire card scrolls.
+   */
+  flexColumn?: boolean;
+  /**
+   * Ref of the element to focus when the dialog opens. Defaults to the
+   * built-in close button (or the first focusable child when
+   * `hideCloseButton` is set).
+   */
+  initialFocusRef?: RefObject<HTMLElement | null>;
 }
 
 export function DetailOverlay({
   isOpen,
   onClose,
   "aria-label": ariaLabel,
+  width = "default",
+  height = "default",
+  hideCloseButton = false,
+  flexColumn = false,
+  initialFocusRef,
   children,
 }: PropsWithChildren<DetailOverlayProps>) {
   const portalTarget = usePortalTarget();
@@ -36,7 +67,8 @@ export function DetailOverlay({
     isOpen,
     dialogRef,
     onClose,
-    initialFocusRef: closeButtonRef,
+    initialFocusRef:
+      initialFocusRef ?? (hideCloseButton ? undefined : closeButtonRef),
   });
 
   if (!isOpen || !portalTarget) {
@@ -54,20 +86,29 @@ export function DetailOverlay({
         <div css={[fixedFill.all, styles.cardContainer]}>
           <div
             ref={dialogRef}
-            css={styles.card}
+            css={[
+              styles.card,
+              width === "narrow" ? styles.cardNarrow : styles.cardDefault,
+              height === "compact"
+                ? styles.cardCompact
+                : styles.cardTallDefault,
+              flexColumn ? styles.cardFlexColumn : styles.cardScrollable,
+            ]}
             role="dialog"
             aria-modal="true"
             aria-label={ariaLabel}
           >
-            <button
-              ref={closeButtonRef}
-              type="button"
-              css={[buttonReset.base, flex.inlineCenter, styles.closeButton]}
-              onClick={onClose}
-              aria-label={t({ en: "Close", zh: "关闭" })}
-            >
-              <XIcon size={20} aria-hidden="true" />
-            </button>
+            {!hideCloseButton && (
+              <button
+                ref={closeButtonRef}
+                type="button"
+                css={[buttonReset.base, flex.inlineCenter, styles.closeButton]}
+                onClick={onClose}
+                aria-label={t({ en: "Close", zh: "关闭" })}
+              >
+                <XIcon size={20} aria-hidden="true" />
+              </button>
+            )}
             {children}
           </div>
         </div>
@@ -112,12 +153,9 @@ const styles = stylex.create({
   },
   card: {
     position: "relative",
-    width: { default: "100%", [breakpoints.md]: "min(600px, 90vw)" },
-    maxHeight: { default: "90vh", [breakpoints.md]: "85vh" },
+    width: "100%",
     backgroundColor: color.backgroundRaised,
     borderRadius: border.radius_4,
-    overflow: "hidden",
-    overflowY: "auto",
     pointerEvents: "all",
     animationName: {
       default: slideUp,
@@ -126,6 +164,27 @@ const styles = stylex.create({
     animationDuration: "300ms",
     animationTimingFunction: easing,
     animationFillMode: "backwards",
+  },
+  cardDefault: {
+    maxWidth: { default: "100%", [breakpoints.md]: "min(600px, 90vw)" },
+  },
+  cardNarrow: {
+    maxWidth: { default: "100%", [breakpoints.md]: "min(480px, 90vw)" },
+  },
+  cardTallDefault: {
+    maxHeight: { default: "90vh", [breakpoints.md]: "85vh" },
+  },
+  cardCompact: {
+    maxHeight: { default: "80vh", [breakpoints.md]: "70vh" },
+  },
+  cardScrollable: {
+    overflow: "hidden",
+    overflowY: "auto",
+  },
+  cardFlexColumn: {
+    display: "flex",
+    flexDirection: "column",
+    overflow: "hidden",
   },
   closeButton: {
     position: "absolute",

--- a/src/components/ai-chat/preference-panel.tsx
+++ b/src/components/ai-chat/preference-panel.tsx
@@ -127,7 +127,7 @@ function PreferencePanel({
       aria-label={t({ en: "Your preferences", zh: "你的偏好" })}
       width="narrow"
       height="compact"
-      flexColumn
+      layout="flex-column"
       hideCloseButton
       initialFocusRef={closeButtonRef}
     >

--- a/src/components/ai-chat/preference-panel.tsx
+++ b/src/components/ai-chat/preference-panel.tsx
@@ -8,19 +8,13 @@ import { TrashIcon } from "@phosphor-icons/react/dist/ssr/Trash";
 import { XIcon } from "@phosphor-icons/react/dist/ssr/X";
 import * as stylex from "@stylexjs/stylex";
 import { useRef, useState } from "react";
-import { createPortal } from "react-dom";
-import { RemoveScroll } from "react-remove-scroll";
-import { breakpoints } from "#src/breakpoints.stylex.ts";
-import { usePortalTarget } from "#src/contexts/portal-context.tsx";
-import { useDialogFocus } from "#src/hooks/use-dialog-focus.ts";
 import { t } from "#src/i18n.ts";
 import type { StoredPreference } from "#src/preference-store/preference-store.ts";
 import { usePreferences } from "#src/preference-store/use-preferences.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
-import { fixedFill } from "#src/primitives/layout.stylex.ts";
-import { motionConstants } from "#src/primitives/motion.stylex.ts";
 import { buttonReset } from "#src/primitives/reset.stylex.ts";
-import { border, color, font, layer, space } from "#src/tokens.stylex.ts";
+import { border, color, font, space } from "#src/tokens.stylex.ts";
+import { DetailOverlay } from "./detail-overlay";
 
 const CATEGORY_ORDER: ReadonlyArray<StoredPreference["category"]> = [
   "genre",
@@ -105,21 +99,8 @@ function PreferencePanel({
   onRemove,
   onClearAll,
 }: PreferencePanelProps) {
-  const portalTarget = usePortalTarget();
-  const dialogRef = useRef<HTMLDivElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const [confirmingClear, setConfirmingClear] = useState(false);
-
-  useDialogFocus({
-    isOpen,
-    dialogRef,
-    onClose,
-    initialFocusRef: closeButtonRef,
-  });
-
-  if (!isOpen || !portalTarget) {
-    return null;
-  }
 
   const grouped = new Map<StoredPreference["category"], StoredPreference[]>();
   for (const pref of preferences) {
@@ -139,116 +120,105 @@ function PreferencePanel({
     }
   };
 
-  return createPortal(
-    <>
-      <div
-        css={[fixedFill.all, styles.backdrop]}
-        onClick={onClose}
-        aria-hidden="true"
-      />
-      <RemoveScroll allowPinchZoom forwardProps>
-        <div css={[fixedFill.all, styles.panelContainer]}>
-          <div
-            ref={dialogRef}
-            css={styles.panel}
-            role="dialog"
-            aria-modal="true"
-            aria-label={t({ en: "Your preferences", zh: "你的偏好" })}
-          >
-            <div css={[flex.between, styles.header]}>
-              <h2 css={styles.title}>
-                {t({ en: "Your Preferences", zh: "你的偏好" })}
-              </h2>
-              <button
-                ref={closeButtonRef}
-                type="button"
-                css={[buttonReset.base, flex.inlineCenter, styles.closeButton]}
-                onClick={onClose}
-                aria-label={t({ en: "Close", zh: "关闭" })}
-              >
-                <XIcon size={18} />
-              </button>
-            </div>
+  return (
+    <DetailOverlay
+      isOpen={isOpen}
+      onClose={onClose}
+      aria-label={t({ en: "Your preferences", zh: "你的偏好" })}
+      width="narrow"
+      height="compact"
+      flexColumn
+      hideCloseButton
+      initialFocusRef={closeButtonRef}
+    >
+      <div css={[flex.between, styles.header]}>
+        <h2 css={styles.title}>
+          {t({ en: "Your Preferences", zh: "你的偏好" })}
+        </h2>
+        <button
+          ref={closeButtonRef}
+          type="button"
+          css={[buttonReset.base, flex.inlineCenter, styles.closeButton]}
+          onClick={onClose}
+          aria-label={t({ en: "Close", zh: "关闭" })}
+        >
+          <XIcon size={18} />
+        </button>
+      </div>
 
-            <div css={[flex.row, styles.infoBanner]}>
-              <InfoIcon size={16} css={styles.infoIcon} role="presentation" />
-              <p css={styles.infoText}>
+      <div css={[flex.row, styles.infoBanner]}>
+        <InfoIcon size={16} css={styles.infoIcon} role="presentation" />
+        <p css={styles.infoText}>
+          {t({
+            en: "Preferences are stored locally on your device. They help the AI personalise recommendations. Nothing is sent to a server.",
+            zh: "偏好仅存储在你的设备上，用于帮助 AI 个性化推荐，不会发送至服务器。",
+          })}
+        </p>
+      </div>
+
+      <div css={styles.body}>
+        {preferences.length === 0 ? (
+          <div css={[flex.center, styles.emptyState]}>
+            <p css={styles.emptyText}>
+              {t({
+                en: "No preferences yet. Chat with the AI and it will learn what you like.",
+                zh: "还没有偏好记录。和 AI 聊天，它会了解你的喜好。",
+              })}
+            </p>
+          </div>
+        ) : (
+          CATEGORY_ORDER.filter((cat) => grouped.has(cat)).map((category) => (
+            <CategorySection
+              key={category}
+              category={category}
+              preferences={grouped.get(category) ?? []}
+              onRemove={onRemove}
+            />
+          ))
+        )}
+      </div>
+
+      {preferences.length > 0 && (
+        <div css={styles.footer}>
+          {confirmingClear ? (
+            <div css={[flex.row, styles.confirmRow]}>
+              <p css={styles.confirmText}>
                 {t({
-                  en: "Preferences are stored locally on your device. They help the AI personalise recommendations. Nothing is sent to a server.",
-                  zh: "偏好仅存储在你的设备上，用于帮助 AI 个性化推荐，不会发送至服务器。",
+                  en: "Clear all preferences?",
+                  zh: "清除所有偏好？",
                 })}
               </p>
+              <button
+                type="button"
+                css={[buttonReset.base, styles.confirmButton]}
+                onClick={() => void handleClearAll()}
+              >
+                {t({ en: "Yes, clear", zh: "确认清除" })}
+              </button>
+              <button
+                type="button"
+                css={[buttonReset.base, styles.cancelButton]}
+                onClick={() => setConfirmingClear(false)}
+              >
+                {t({ en: "Cancel", zh: "取消" })}
+              </button>
             </div>
-
-            <div css={styles.body}>
-              {preferences.length === 0 ? (
-                <div css={[flex.center, styles.emptyState]}>
-                  <p css={styles.emptyText}>
-                    {t({
-                      en: "No preferences yet. Chat with the AI and it will learn what you like.",
-                      zh: "还没有偏好记录。和 AI 聊天，它会了解你的喜好。",
-                    })}
-                  </p>
-                </div>
-              ) : (
-                CATEGORY_ORDER.filter((cat) => grouped.has(cat)).map(
-                  (category) => (
-                    <CategorySection
-                      key={category}
-                      category={category}
-                      preferences={grouped.get(category) ?? []}
-                      onRemove={onRemove}
-                    />
-                  ),
-                )
-              )}
-            </div>
-
-            {preferences.length > 0 && (
-              <div css={styles.footer}>
-                {confirmingClear ? (
-                  <div css={[flex.row, styles.confirmRow]}>
-                    <p css={styles.confirmText}>
-                      {t({
-                        en: "Clear all preferences?",
-                        zh: "清除所有偏好？",
-                      })}
-                    </p>
-                    <button
-                      type="button"
-                      css={[buttonReset.base, styles.confirmButton]}
-                      onClick={() => void handleClearAll()}
-                    >
-                      {t({ en: "Yes, clear", zh: "确认清除" })}
-                    </button>
-                    <button
-                      type="button"
-                      css={[buttonReset.base, styles.cancelButton]}
-                      onClick={() => setConfirmingClear(false)}
-                    >
-                      {t({ en: "Cancel", zh: "取消" })}
-                    </button>
-                  </div>
-                ) : (
-                  <button
-                    type="button"
-                    css={[buttonReset.base, flex.row, styles.clearButton]}
-                    onClick={() => setConfirmingClear(true)}
-                  >
-                    <TrashIcon size={14} role="presentation" />
-                    {t({
-                      en: "Clear all preferences",
-                      zh: "清除所有偏好",
-                    })}
-                  </button>
-                )}
-              </div>
-            )}
-          </div>
+          ) : (
+            <button
+              type="button"
+              css={[buttonReset.base, flex.row, styles.clearButton]}
+              onClick={() => setConfirmingClear(true)}
+            >
+              <TrashIcon size={14} role="presentation" />
+              {t({
+                en: "Clear all preferences",
+                zh: "清除所有偏好",
+              })}
+            </button>
+          )}
         </div>
-      </RemoveScroll>
-    </>,
-    portalTarget,
+      )}
+    </DetailOverlay>
   );
 }
 
@@ -316,57 +286,7 @@ function PreferenceChip({
   );
 }
 
-const fadeIn = stylex.keyframes({
-  from: { opacity: 0 },
-});
-
-const slideUp = stylex.keyframes({
-  from: { transform: "translateY(100%)" },
-});
-
-const panelEasing = "cubic-bezier(0.32, 0.72, 0, 1)";
-
 const styles = stylex.create({
-  backdrop: {
-    backgroundColor: "rgba(0, 0, 0, 0.6)",
-    zIndex: layer.overlay,
-    pointerEvents: "all",
-    animationName: fadeIn,
-    animationDuration: "200ms",
-    animationTimingFunction: panelEasing,
-    animationFillMode: "backwards",
-  },
-  panelContainer: {
-    zIndex: layer.tooltip,
-    pointerEvents: "none",
-    display: "flex",
-    alignItems: "flex-end",
-    justifyContent: "center",
-    padding: space._2,
-    paddingTop: space._8,
-    [breakpoints.md]: {
-      alignItems: "center",
-      padding: space._5,
-    },
-  },
-  panel: {
-    position: "relative",
-    display: "flex",
-    flexDirection: "column",
-    width: { default: "100%", [breakpoints.md]: "min(480px, 90vw)" },
-    maxHeight: { default: "80vh", [breakpoints.md]: "70vh" },
-    backgroundColor: color.backgroundRaised,
-    borderRadius: border.radius_4,
-    overflow: "hidden",
-    pointerEvents: "all",
-    animationName: {
-      default: slideUp,
-      [motionConstants.REDUCED_MOTION]: "none",
-    },
-    animationDuration: "300ms",
-    animationTimingFunction: panelEasing,
-    animationFillMode: "backwards",
-  },
   header: {
     paddingTop: space._4,
     paddingBottom: space._3,

--- a/src/components/shared/overlay.tsx
+++ b/src/components/shared/overlay.tsx
@@ -23,6 +23,15 @@ interface OverlayProps {
   "aria-label"?: string;
 }
 
+/**
+ * Full-screen, ViewTransition-driven overlay used for immersive content such
+ * as embedded video trailers. This is intentionally distinct from
+ * `DetailOverlay` (ai-chat/detail-overlay.tsx), which is a centred bottom-sheet
+ * dialog with CSS keyframe animations, a focus-trapping close button, and a
+ * bounded card. Prefer `DetailOverlay` for panel/detail content; use `Overlay`
+ * only when the content should occupy the full viewport with React
+ * ViewTransition-based enter/exit.
+ */
 export function Overlay({
   children,
   isOpen,


### PR DESCRIPTION
## Summary

The AI-chat `PreferencePanel` reimplemented the same bottom-sheet dialog shell as `DetailOverlay` — identical `cubic-bezier(0.32, 0.72, 0, 1)` easing, identical `fadeIn`/`slideUp` keyframes, and a duplicated portal + backdrop + `RemoveScroll` + `useDialogFocus` plumbing. Any future improvement (focus-restore, reduced-motion, safe-area, a11y) had to be made in two places and updates to `DetailOverlay` silently missed `PreferencePanel`.

This extends `DetailOverlay` with a minimal composition API (`width: "default" | "narrow"`, `height: "default" | "compact"`, `hideCloseButton`, `flexColumn`, `initialFocusRef`) — all additive with safe defaults that preserve existing behavior for `MediaDetailOverlay` and `PersonDetailOverlay`. `PreferencePanel` now consumes `DetailOverlay` and drops its duplicated shell (553 → 473 lines), inheriting all future improvements automatically.

`shared/overlay.tsx` is intentionally left as a separate pattern — it uses React's `<ViewTransition>` for native page-transition-style enter/exit and occupies the full viewport for the trailer video flow, which would require a large behavior-breaking rewrite to collapse. A JSDoc block now documents why it's distinct so future cleanup knows not to merge it.

## Context

Each new prop on `DetailOverlay` maps to one independent structural concern (width, height, whether a close button is built-in, whether the card becomes a flex column) rather than a single boolean escape hatch. One intentional cosmetic consequence: the preference panel's backdrop is now 0.7 opacity instead of 0.6, unified with `DetailOverlay`'s value — this was exactly the kind of silent drift the unification set out to fix.

Verified with the full unit suite (964 tests passing, including `detail-overlay.test.tsx` covering open/close, Escape, backdrop click, close-button click, focus-on-open, and focus-trap), `pnpm build:tsc`, and `pnpm lint:changed`.