### PR TITLE
fix: match person cards shape in streaming skeleton

### DIFF
--- a/src/components/ai-chat/tool-person-cards-skeleton.tsx
+++ b/src/components/ai-chat/tool-person-cards-skeleton.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { breakpoints } from "#src/breakpoints.stylex.ts";
+import { border, space } from "#src/tokens.stylex.ts";
+import { Skeleton } from "../shared/skeleton";
+
+const SKELETON_COUNT = 5;
+const STAGGER_DELAY = 100;
+
+export function ToolPersonCardsSkeleton() {
+  return (
+    <div css={styles.scrollWrapper}>
+      <div css={styles.scrollContainer}>
+        {Array.from({ length: SKELETON_COUNT }, (_, i) => (
+          <div key={i} css={styles.cardWrapper}>
+            <Skeleton fill delay={i * STAGGER_DELAY} css={styles.skeleton} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  scrollWrapper: {
+    position: "relative",
+    marginLeft: `calc(-1 * ${space._3})`,
+    marginRight: `calc(-1 * ${space._3})`,
+  },
+  scrollContainer: {
+    display: "flex",
+    gap: space._2,
+    overflowX: "hidden",
+    paddingBottom: space._1,
+    paddingLeft: space._3,
+    paddingRight: space._3,
+  },
+  cardWrapper: {
+    flexShrink: 0,
+    width: "80px",
+    aspectRatio: "1",
+    [breakpoints.sm]: {
+      width: "90px",
+    },
+    [breakpoints.md]: {
+      width: "100px",
+    },
+  },
+  skeleton: {
+    aspectRatio: "1",
+    borderRadius: border.radius_round,
+  },
+});

--- a/src/components/ai-chat/tool-visual-output.tsx
+++ b/src/components/ai-chat/tool-visual-output.tsx
@@ -13,6 +13,7 @@ import {
 import { ToolMediaCards } from "./tool-media-cards";
 import { ToolMediaCardsSkeleton } from "./tool-media-cards-skeleton";
 import { ToolPersonCards } from "./tool-person-cards";
+import { ToolPersonCardsSkeleton } from "./tool-person-cards-skeleton";
 import {
   parseReviewSummaryOutput,
   ToolReviewSummary,
@@ -75,7 +76,7 @@ export function ToolVisualOutput({
     }
 
     if (state === "input-streaming") {
-      return <ToolMediaCardsSkeleton />;
+      return <ToolPersonCardsSkeleton />;
     }
 
     if (state === "input-available" || state === "output-available") {


### PR DESCRIPTION
## Summary

The `present_person` tool call previously rendered `ToolMediaCardsSkeleton` while its arguments were streaming, so users saw tall poster-shaped placeholders (130–175px wide rectangles) that then snapped into small circular avatars (80–100px wide) once the data arrived. Because the skeleton is shown for the full duration of the LLM token stream, the shape and size mismatch caused a jarring pop-in on every people search. This adds a dedicated `ToolPersonCardsSkeleton` that mirrors `CompactPersonCard`'s actual layout — the same 80/90/100px responsive widths, `aspectRatio: 1`, and circular `border.radius_round` — and wires it into the `input-streaming` branch of `present_person` in `ToolVisualOutput`. The skeleton's scroll container structure and 5-item, 100ms staggered fill match `ToolMediaCardsSkeleton` so both placeholders feel consistent.