### PR TITLE
refactor: consolidate media detail state into discriminated union

### DIFF
--- a/src/components/ai-chat/media-detail-context.tsx
+++ b/src/components/ai-chat/media-detail-context.tsx
@@ -15,27 +15,43 @@ export interface FocusedPerson {
   profilePath?: string | null;
 }
 
+type FocusedDetail =
+  | { kind: "media"; media: FocusedMedia }
+  | { kind: "person"; person: FocusedPerson };
+
 interface MediaDetailState {
   focusedMedia: FocusedMedia | null;
-  setFocusedMedia: (media: FocusedMedia | null) => void;
   focusedPerson: FocusedPerson | null;
+  setFocusedMedia: (media: FocusedMedia | null) => void;
   setFocusedPerson: (person: FocusedPerson | null) => void;
 }
 
 const MediaDetailContext = createContext<MediaDetailState | null>(null);
 
 export function MediaDetailProvider({ children }: PropsWithChildren) {
-  const [focusedMedia, setFocusedMedia] = useState<FocusedMedia | null>(null);
-  const [focusedPerson, setFocusedPerson] = useState<FocusedPerson | null>(
+  const [focusedDetail, setFocusedDetail] = useState<FocusedDetail | null>(
     null,
   );
+
+  const setFocusedMedia = (media: FocusedMedia | null) => {
+    setFocusedDetail(media ? { kind: "media", media } : null);
+  };
+
+  const setFocusedPerson = (person: FocusedPerson | null) => {
+    setFocusedDetail(person ? { kind: "person", person } : null);
+  };
+
+  const focusedMedia =
+    focusedDetail?.kind === "media" ? focusedDetail.media : null;
+  const focusedPerson =
+    focusedDetail?.kind === "person" ? focusedDetail.person : null;
 
   return (
     <MediaDetailContext
       value={{
         focusedMedia,
-        setFocusedMedia,
         focusedPerson,
+        setFocusedMedia,
         setFocusedPerson,
       }}
     >

--- a/src/components/ai-chat/person-detail-content.tsx
+++ b/src/components/ai-chat/person-detail-content.tsx
@@ -253,7 +253,7 @@ function FilmographyScroller({
 }: {
   items: ReadonlyArray<MediaListItem>;
 }) {
-  const { setFocusedPerson, setFocusedMedia } = useMediaDetail();
+  const { setFocusedMedia } = useMediaDetail();
 
   return (
     <HorizontalScrollRow
@@ -276,7 +276,6 @@ function FilmographyScroller({
               onClick={
                 mediaType
                   ? () => {
-                      setFocusedPerson(null);
                       setFocusedMedia({
                         id: item.id,
                         mediaType,


### PR DESCRIPTION
## Summary

Consolidates the two parallel `useState`s in `MediaDetailContext` (`focusedMedia` and `focusedPerson`) into a single `useState<FocusedDetail | null>` backed by a discriminated union. The public context API is unchanged: `focusedMedia` and `focusedPerson` are exposed as derived getters off the union, so all six existing consumers (`media-detail-overlay`, `person-detail-overlay`, `media-detail-content`, `person-detail-content`, `tool-media-cards`, `tool-person-cards`, `recommended-media-row`) compile and behave identically without edits. The motivation is structural — the "at most one detail overlay open" invariant is now enforced by the state shape instead of relying on caller discipline, and adding a third detail kind later needs a new union variant rather than a new pairwise consistency rule. `FilmographyScroller` drops a now-redundant `setFocusedPerson(null)` call that was only needed under the old two-state shape; there is no behaviour change.