### PR TITLE
refactor: derive chat tool outputs inline from messages

### DIFF
--- a/src/ai-chat/use-ai-chat.ts
+++ b/src/ai-chat/use-ai-chat.ts
@@ -6,10 +6,7 @@ import { DefaultChatTransport } from "ai";
 import { useEffect, useState } from "react";
 import { z } from "zod";
 import { isUIMessage } from "#src/ai-chat/is-ui-message.ts";
-import {
-  accumulateToolOutputs,
-  EMPTY_TOOL_OUTPUTS,
-} from "#src/components/ai-chat/map-tool-output.ts";
+import { accumulateToolOutputs } from "#src/components/ai-chat/map-tool-output.ts";
 import {
   getCachedPreferencesContext,
   loadPreferencesContext,
@@ -89,7 +86,6 @@ async function fetchSession(
 }
 
 export function useAIChat({ locale }: { locale: SupportedLocale }) {
-  const [toolOutputs, setToolOutputs] = useState(EMPTY_TOOL_OUTPUTS);
   const [previousSessionId, setPreviousSessionId] = useState<string | null>(
     null,
   );
@@ -125,7 +121,6 @@ export function useAIChat({ locale }: { locale: SupportedLocale }) {
     }),
     messageMetadataSchema,
     onFinish: ({ messages }) => {
-      setToolOutputs(accumulateToolOutputs(messages));
       const sessionId = findSessionIdFromMessages(messages);
       if (sessionId) {
         setStoredSessionId(locale, sessionId);
@@ -162,7 +157,6 @@ export function useAIChat({ locale }: { locale: SupportedLocale }) {
           setPreviousSessionId(null);
           return;
         }
-        setToolOutputs(accumulateToolOutputs(result.messages));
         chatResult.setMessages(result.messages);
         setPreviousSessionId(null);
       })
@@ -171,7 +165,7 @@ export function useAIChat({ locale }: { locale: SupportedLocale }) {
 
   return {
     ...chatResult,
-    toolOutputs,
+    toolOutputs: accumulateToolOutputs(chatResult.messages),
     previousSessionId,
     continueSession,
   };

--- a/src/components/ai-chat/chat-message-list.test.tsx
+++ b/src/components/ai-chat/chat-message-list.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { ChatUIMessage } from "#src/ai-chat/use-ai-chat.ts";
 import { render, screen } from "#src/test-utils.tsx";
 import { ChatMessageList } from "./chat-message-list";
-import { EMPTY_TOOL_OUTPUTS } from "./map-tool-output";
+import { accumulateToolOutputs } from "./map-tool-output";
 
 function createMessage(
   overrides: Partial<ChatUIMessage> &
@@ -18,7 +18,7 @@ const defaultProps = {
   errorLabel: "Something went wrong. Please try again.",
   error: undefined,
   isAtBottom: true,
-  toolOutputs: EMPTY_TOOL_OUTPUTS,
+  toolOutputs: accumulateToolOutputs([]),
 };
 
 describe("ChatMessageList", () => {

--- a/src/components/ai-chat/chat-message.test.tsx
+++ b/src/components/ai-chat/chat-message.test.tsx
@@ -2,6 +2,7 @@ import type { UIMessage } from "ai";
 import { describe, expect, it } from "vitest";
 import { render, screen } from "#src/test-utils.tsx";
 import { ChatMessage } from "./chat-message";
+import { accumulateToolOutputs } from "./map-tool-output";
 import { MediaDetailProvider } from "./media-detail-context";
 
 function createMessage(
@@ -13,6 +14,8 @@ function createMessage(
   };
 }
 
+const emptyToolOutputs = accumulateToolOutputs([]);
+
 describe("ChatMessage", () => {
   it("renders user message text", () => {
     render(
@@ -21,6 +24,7 @@ describe("ChatMessage", () => {
           role: "user",
           parts: [{ type: "text", text: "Hello there" }],
         })}
+        toolOutputs={emptyToolOutputs}
       />,
     );
     expect(screen.getByText("Hello there")).toBeInTheDocument();
@@ -33,6 +37,7 @@ describe("ChatMessage", () => {
           role: "assistant",
           parts: [{ type: "text", text: "Hi! How can I help?" }],
         })}
+        toolOutputs={emptyToolOutputs}
       />,
     );
     expect(screen.getByText("Hi! How can I help?")).toBeInTheDocument();
@@ -48,6 +53,7 @@ describe("ChatMessage", () => {
             { type: "text", text: "Second paragraph" },
           ],
         })}
+        toolOutputs={emptyToolOutputs}
       />,
     );
     expect(screen.getByText("First paragraph")).toBeInTheDocument();
@@ -61,6 +67,7 @@ describe("ChatMessage", () => {
           role: "assistant",
           parts: [{ type: "reasoning", text: "Thinking about this..." }],
         })}
+        toolOutputs={emptyToolOutputs}
       />,
     );
     expect(screen.getByText("Thinking about this...")).toBeInTheDocument();
@@ -73,6 +80,7 @@ describe("ChatMessage", () => {
           role: "assistant",
           parts: [{ type: "text", text: "This is **bold** and *italic*" }],
         })}
+        toolOutputs={emptyToolOutputs}
       />,
     );
     expect(screen.getByText("bold").tagName).toBe("STRONG");
@@ -86,6 +94,7 @@ describe("ChatMessage", () => {
           role: "user",
           parts: [{ type: "text", text: "This is **not bold**" }],
         })}
+        toolOutputs={emptyToolOutputs}
       />,
     );
     expect(screen.getByText("This is **not bold**")).toBeInTheDocument();
@@ -98,6 +107,7 @@ describe("ChatMessage", () => {
           role: "assistant",
           parts: [{ type: "step-start" }, { type: "text", text: "After step" }],
         })}
+        toolOutputs={emptyToolOutputs}
       />,
     );
     expect(screen.getByText("After step")).toBeInTheDocument();
@@ -110,53 +120,56 @@ describe("ChatMessage", () => {
           role: "assistant",
           parts: [{ type: "step-start" }],
         })}
+        toolOutputs={emptyToolOutputs}
       />,
     );
     expect(container.innerHTML).toBe("");
   });
 
   it("renders present_media cards from search results lookup", () => {
+    const message = createMessage({
+      role: "assistant",
+      parts: [
+        { type: "text", text: "Here are some results:" },
+        {
+          type: "dynamic-tool",
+          toolName: "tmdb_search",
+          toolCallId: "search-call",
+          state: "output-available",
+          input: { query: "Inception" },
+          output: [
+            {
+              id: 1,
+              media_type: "movie",
+              title: "Inception",
+              poster_path: "/inception.jpg",
+              vote_average: 8.4,
+            },
+            {
+              id: 2,
+              media_type: "movie",
+              title: "Other Movie",
+              poster_path: "/other.jpg",
+              vote_average: 5.0,
+            },
+          ],
+        },
+        {
+          type: "dynamic-tool",
+          toolName: "present_media",
+          toolCallId: "present-call",
+          state: "output-available",
+          input: { media: [{ id: 1, media_type: "movie" }] },
+          output: { media: [{ id: 1, media_type: "movie" }] },
+        },
+        { type: "text", text: "Hope that helps!" },
+      ],
+    });
     render(
       <MediaDetailProvider>
         <ChatMessage
-          message={createMessage({
-            role: "assistant",
-            parts: [
-              { type: "text", text: "Here are some results:" },
-              {
-                type: "dynamic-tool",
-                toolName: "tmdb_search",
-                toolCallId: "search-call",
-                state: "output-available",
-                input: { query: "Inception" },
-                output: [
-                  {
-                    id: 1,
-                    media_type: "movie",
-                    title: "Inception",
-                    poster_path: "/inception.jpg",
-                    vote_average: 8.4,
-                  },
-                  {
-                    id: 2,
-                    media_type: "movie",
-                    title: "Other Movie",
-                    poster_path: "/other.jpg",
-                    vote_average: 5.0,
-                  },
-                ],
-              },
-              {
-                type: "dynamic-tool",
-                toolName: "present_media",
-                toolCallId: "present-call",
-                state: "output-available",
-                input: { media: [{ id: 1, media_type: "movie" }] },
-                output: { media: [{ id: 1, media_type: "movie" }] },
-              },
-              { type: "text", text: "Hope that helps!" },
-            ],
-          })}
+          message={message}
+          toolOutputs={accumulateToolOutputs([message])}
         />
       </MediaDetailProvider>,
     );
@@ -172,49 +185,51 @@ describe("ChatMessage", () => {
   });
 
   it("renders present_watch_providers card from watch_providers map", () => {
+    const message = createMessage({
+      role: "assistant",
+      parts: [
+        { type: "text", text: "Here's where you can watch it:" },
+        {
+          type: "dynamic-tool",
+          toolName: "watch_providers",
+          toolCallId: "wp-call",
+          state: "output-available",
+          input: { id: 550, media_type: "movie", region: "US" },
+          output: {
+            id: 550,
+            mediaType: "movie",
+            region: "US",
+            providers: {
+              link: "https://www.themoviedb.org/movie/550/watch?locale=US",
+              flatrate: [
+                {
+                  id: 8,
+                  name: "Netflix",
+                  logoPath: "/netflix.jpg",
+                },
+              ],
+              rent: [],
+              buy: [],
+              ads: [],
+              free: [],
+            },
+          },
+        },
+        {
+          type: "dynamic-tool",
+          toolName: "present_watch_providers",
+          toolCallId: "present-wp-call",
+          state: "output-available",
+          input: { id: 550, media_type: "movie", region: "US" },
+          output: { id: 550, media_type: "movie", region: "US" },
+        },
+      ],
+    });
     render(
       <MediaDetailProvider>
         <ChatMessage
-          message={createMessage({
-            role: "assistant",
-            parts: [
-              { type: "text", text: "Here's where you can watch it:" },
-              {
-                type: "dynamic-tool",
-                toolName: "watch_providers",
-                toolCallId: "wp-call",
-                state: "output-available",
-                input: { id: 550, media_type: "movie", region: "US" },
-                output: {
-                  id: 550,
-                  mediaType: "movie",
-                  region: "US",
-                  providers: {
-                    link: "https://www.themoviedb.org/movie/550/watch?locale=US",
-                    flatrate: [
-                      {
-                        id: 8,
-                        name: "Netflix",
-                        logoPath: "/netflix.jpg",
-                      },
-                    ],
-                    rent: [],
-                    buy: [],
-                    ads: [],
-                    free: [],
-                  },
-                },
-              },
-              {
-                type: "dynamic-tool",
-                toolName: "present_watch_providers",
-                toolCallId: "present-wp-call",
-                state: "output-available",
-                input: { id: 550, media_type: "movie", region: "US" },
-                output: { id: 550, media_type: "movie", region: "US" },
-              },
-            ],
-          })}
+          message={message}
+          toolOutputs={accumulateToolOutputs([message])}
         />
       </MediaDetailProvider>,
     );
@@ -250,6 +265,7 @@ describe("ChatMessage", () => {
             },
           ],
         })}
+        toolOutputs={emptyToolOutputs}
       />,
     );
 
@@ -327,6 +343,7 @@ describe("ChatMessage", () => {
             },
           ],
         })}
+        toolOutputs={emptyToolOutputs}
       />,
     );
 

--- a/src/components/ai-chat/chat-message.tsx
+++ b/src/components/ai-chat/chat-message.tsx
@@ -18,24 +18,17 @@ import {
   shadow,
   space,
 } from "#src/tokens.stylex.ts";
-import type { MediaListItem, PersonListItem } from "#src/utils/types.ts";
 import { CompactionNotice } from "./compaction-notice";
-import {
-  buildPersonResultsMap,
-  buildSearchResultsMap,
-  buildWatchProvidersMap,
-  type ToolOutputMaps,
-} from "./map-tool-output";
+import type { ToolOutputMaps } from "./map-tool-output";
 import { SmoothedMarkdownContent } from "./smoothed-markdown-content";
 import { ToolActivityGroup } from "./tool-activity-group";
 import { ToolVisualOutput } from "./tool-visual-output";
-import type { WatchProviderOutput } from "./tool-watch-providers";
 
 interface ChatMessageProps {
   message: UIMessage;
   isStreaming?: boolean;
   isLastAssistantMessage?: boolean;
-  toolOutputs?: ToolOutputMaps;
+  toolOutputs: ToolOutputMaps;
 }
 
 export function ChatMessage({
@@ -48,9 +41,6 @@ export function ChatMessage({
   const [releasedTextParts, setReleasedTextParts] = useState(1);
 
   const {
-    searchResultsMap: localSearchResults,
-    personResultsMap: localPersonResults,
-    watchProvidersMap: localWatchProviders,
     toolParts,
     hasVisibleContent,
     firstToolIndex,
@@ -58,22 +48,6 @@ export function ChatMessage({
     textPartCount,
     textPartTrailingBuffers,
   } = deriveMessageData(message.parts);
-
-  // Merge accumulated tool outputs with this message's own maps. Local maps
-  // cover tool outputs that resolved in the current streaming message before
-  // the accumulated cache updated.
-  const searchResultsMap = mergeMaps(
-    toolOutputs?.searchResultsMap,
-    localSearchResults,
-  );
-  const personResultsMap = mergeMaps(
-    toolOutputs?.personResultsMap,
-    localPersonResults,
-  );
-  const watchProvidersMap = mergeMaps(
-    toolOutputs?.watchProvidersMap,
-    localWatchProviders,
-  );
 
   if (!hasVisibleContent) return null;
 
@@ -168,9 +142,9 @@ export function ChatMessage({
                   state={part.state}
                   input={toolInput}
                   output={toolOutput}
-                  searchResultsMap={searchResultsMap}
-                  personResultsMap={personResultsMap}
-                  watchProvidersMap={watchProvidersMap}
+                  searchResultsMap={toolOutputs.searchResultsMap}
+                  personResultsMap={toolOutputs.personResultsMap}
+                  watchProvidersMap={toolOutputs.watchProvidersMap}
                   isLastAssistantMessage={isLastAssistantMessage}
                 />
               )}
@@ -190,9 +164,6 @@ function isCompactionPart(part: TextUIPart): boolean {
 }
 
 export function deriveMessageData(parts: UIMessage["parts"]) {
-  const searchResultsMap = new Map<string, MediaListItem>();
-  const personResultsMap = new Map<number, PersonListItem>();
-  const watchProvidersMap = new Map<string, WatchProviderOutput>();
   const toolParts: Array<{
     toolCallId: string;
     toolName: string;
@@ -229,41 +200,6 @@ export function deriveMessageData(parts: UIMessage["parts"]) {
         input: "input" in part ? part.input : undefined,
       });
       hasVisibleContent = true;
-
-      if (
-        "output" in part &&
-        part.state === "output-available" &&
-        (name === "tmdb_search" ||
-          name === "semantic_search" ||
-          name === "person_credits")
-      ) {
-        const partMap = buildSearchResultsMap(name, part.output);
-        for (const [key, value] of partMap) {
-          searchResultsMap.set(key, value);
-        }
-      }
-
-      if (
-        "output" in part &&
-        part.state === "output-available" &&
-        (name === "tmdb_search" || name === "media_credits")
-      ) {
-        const partPersonMap = buildPersonResultsMap(name, part.output);
-        for (const [key, value] of partPersonMap) {
-          personResultsMap.set(key, value);
-        }
-      }
-
-      if (
-        "output" in part &&
-        part.state === "output-available" &&
-        name === "watch_providers"
-      ) {
-        const partWpMap = buildWatchProvidersMap(part.output);
-        for (const [key, value] of partWpMap) {
-          watchProvidersMap.set(key, value);
-        }
-      }
     } else {
       if (isTextUIPart(part)) {
         textPartCount++;
@@ -284,9 +220,6 @@ export function deriveMessageData(parts: UIMessage["parts"]) {
   }
 
   return {
-    searchResultsMap,
-    personResultsMap,
-    watchProvidersMap,
     toolParts,
     hasVisibleContent,
     firstToolIndex,
@@ -294,23 +227,6 @@ export function deriveMessageData(parts: UIMessage["parts"]) {
     textPartCount,
     textPartTrailingBuffers,
   };
-}
-
-/**
- * Merges a cumulative map from prior messages with a local map from the current
- * message. Local entries take precedence over cumulative ones.
- */
-function mergeMaps<K, V>(
-  cumulative: ReadonlyMap<K, V> | undefined,
-  local: ReadonlyMap<K, V>,
-): ReadonlyMap<K, V> {
-  if (!cumulative || cumulative.size === 0) return local;
-  if (local.size === 0) return cumulative;
-  const merged = new Map(cumulative);
-  for (const [key, value] of local) {
-    merged.set(key, value);
-  }
-  return merged;
 }
 
 const styles = stylex.create({

--- a/src/components/ai-chat/map-tool-output.ts
+++ b/src/components/ai-chat/map-tool-output.ts
@@ -14,12 +14,6 @@ export interface ToolOutputMaps {
   watchProvidersMap: ReadonlyMap<string, WatchProviderOutput>;
 }
 
-export const EMPTY_TOOL_OUTPUTS: ToolOutputMaps = {
-  searchResultsMap: new Map(),
-  personResultsMap: new Map(),
-  watchProvidersMap: new Map(),
-};
-
 export function accumulateToolOutputs(
   messages: ReadonlyArray<UIMessage>,
 ): ToolOutputMaps {


### PR DESCRIPTION
## Summary

`useAIChat` previously kept `toolOutputs` in `useState` and refreshed it only in `onFinish` and on session-resume, so the accumulated search/person/watch-provider maps lagged behind `chatResult.messages` throughout streaming. `ChatMessage` papered over the staleness by re-walking every message's own tool parts on every render and merging a per-message local map with the incoming accumulated map via a custom `mergeMaps` helper — duplicating the exact work `accumulateToolOutputs` already performs, and violating "UI is a pure function of state" by mirroring derivable data in state. This drops the `useState` and returns `toolOutputs: accumulateToolOutputs(chatResult.messages)` directly from the hook; the AI SDK updates `chatResult.messages` on every streaming event, so the derived maps are always current and React Compiler handles memoisation. `ChatMessage` consequently drops the `mergeMaps` helper, the three `build*ResultsMap` loops inside `deriveMessageData`, and the optional-`toolOutputs` branch — the prop is now required because every caller in the tree already has it. Tests that previously relied on the local-map fallback now pass `toolOutputs={accumulateToolOutputs([message])}`, exercising the same scenario through the real accumulation path.