### PR TITLE
refactor: extract shared selectMediaListItems helper

### DIFF
--- a/src/utils/tmdb-queries.ts
+++ b/src/utils/tmdb-queries.ts
@@ -39,6 +39,38 @@ function isMovieListResult(result: MediaResult): result is MovieResult {
   return "title" in result;
 }
 
+interface PaginatedMediaData {
+  pages: ReadonlyArray<{
+    results?: ReadonlyArray<MediaResult>;
+  }>;
+}
+
+function selectMediaListItems(
+  data: PaginatedMediaData,
+  mediaType: "movie" | "tv",
+): MediaListItem[] {
+  const items = data.pages
+    .flatMap<MediaResult>((page) => page.results ?? [])
+    .map<MediaListItem>((media) =>
+      isMovieListResult(media)
+        ? {
+            id: media.id,
+            title: media.title,
+            posterPath: media.poster_path,
+            rating: media.vote_average,
+            mediaType,
+          }
+        : {
+            id: media.id,
+            title: media.name,
+            posterPath: media.poster_path,
+            rating: media.vote_average,
+            mediaType,
+          },
+    );
+  return Array.from(new Map(items.map((media) => [media.id, media])).values());
+}
+
 export const mediaList = (params: MovieListParams | TvShowListParams) => {
   return infiniteQueryOptions({
     queryKey: [{ query: "mediaList", ...tmdbScope, ...params }],
@@ -62,31 +94,7 @@ export const mediaList = (params: MovieListParams | TvShowListParams) => {
       firstPage.page > 1 ? firstPage.page - 1 : undefined,
     getNextPageParam: (lastPage) =>
       lastPage.total_pages > lastPage.page ? lastPage.page + 1 : undefined,
-    select: (data) => {
-      const mediaList = data.pages
-        .flatMap<MediaResult>((page) => page.results ?? [])
-        .map<MediaListItem>((media) =>
-          isMovieListResult(media)
-            ? {
-                id: media.id,
-                title: media.title,
-                posterPath: media.poster_path,
-                rating: media.vote_average,
-                mediaType: params.type,
-              }
-            : {
-                id: media.id,
-                title: media.name,
-                posterPath: media.poster_path,
-                rating: media.vote_average,
-                mediaType: params.type,
-              },
-        );
-      // Removes duplicates
-      return Array.from(
-        new Map(mediaList.map((media) => [media.id, media])).values(),
-      );
-    },
+    select: (data) => selectMediaListItems(data, params.type),
   });
 };
 
@@ -128,31 +136,7 @@ export const similarMedia = (params: SimilarMediaParams) => {
       firstPage.page > 1 ? firstPage.page - 1 : undefined,
     getNextPageParam: (lastPage) =>
       lastPage.total_pages > lastPage.page ? lastPage.page + 1 : undefined,
-    select: (data) => {
-      const mediaList = data.pages
-        .flatMap<MediaResult>((page) => page.results ?? [])
-        .map<MediaListItem>((media) =>
-          isMovieListResult(media)
-            ? {
-                id: media.id,
-                title: media.title,
-                posterPath: media.poster_path,
-                rating: media.vote_average,
-                mediaType: params.type,
-              }
-            : {
-                id: media.id,
-                title: media.name,
-                posterPath: media.poster_path,
-                rating: media.vote_average,
-                mediaType: params.type,
-              },
-        );
-      // Removes duplicates
-      return Array.from(
-        new Map(mediaList.map((media) => [media.id, media])).values(),
-      );
-    },
+    select: (data) => selectMediaListItems(data, params.type),
   });
 };
 


### PR DESCRIPTION
## Summary

`mediaList` and `similarMedia` in `src/utils/tmdb-queries.ts` had identical `select` transformers — 24 lines each of `flatMap` + `isMovieListResult` branch + `Map`-keyed dedupe — differing only in which `params.type` they closed over. This lifts the body into a file-private `selectMediaListItems(data, mediaType)` helper paired with a local `PaginatedMediaData` structural interface, and collapses both `select` implementations to one-liners that pass through `params.type`. The `queryFn` movie-vs-tv branching, the dedupe semantics, and the field mapping (`title` for movies, `name` for TV shows) are unchanged — this is a verbatim extraction.