### PR TITLE
perf: replace raf polling with resize observer in chat list

### DIFF
--- a/src/components/ai-chat/chat-message-list.tsx
+++ b/src/components/ai-chat/chat-message-list.tsx
@@ -2,7 +2,7 @@
 
 import * as stylex from "@stylexjs/stylex";
 import type { ChatStatus, UIMessage } from "ai";
-import { type ReactNode, useEffect } from "react";
+import { type ReactNode, useEffect, useLayoutEffect, useRef } from "react";
 import {
   COMPACTION_TRIGGER_TOKENS,
   USAGE_WARNING_RATIO,
@@ -62,31 +62,36 @@ export function ChatMessageList({
     (m) => m.role === "assistant",
   );
 
+  const messagesListRef = useRef<HTMLDivElement | null>(null);
+  const isAtBottomRef = useRef(isAtBottom);
+  // Sync ref before paint so both the message-length effect and the streaming
+  // ResizeObserver callback always read the latest isAtBottom without needing
+  // it in their dep arrays.
+  useLayoutEffect(() => {
+    isAtBottomRef.current = isAtBottom;
+  }, [isAtBottom]);
+
   useEffect(() => {
     if (messages.length === 0) return;
-    if (isAtBottom || lastMessageRole === "user") {
+    if (isAtBottomRef.current || lastMessageRole === "user") {
       window.scrollTo({ top: document.documentElement.scrollHeight });
     }
-  }, [messages.length, lastMessageRole, isAtBottom]);
+  }, [messages.length, lastMessageRole]);
 
   useEffect(() => {
     if (status !== "streaming") return;
+    if (typeof ResizeObserver === "undefined") return;
+    const el = messagesListRef.current;
+    if (!el) return;
 
-    let rafId: number;
-    let lastScrollHeight = document.documentElement.scrollHeight;
-
-    const tick = () => {
-      const currentScrollHeight = document.documentElement.scrollHeight;
-      if (isAtBottom && currentScrollHeight !== lastScrollHeight) {
-        window.scrollTo({ top: currentScrollHeight });
-        lastScrollHeight = currentScrollHeight;
+    const observer = new ResizeObserver(() => {
+      if (isAtBottomRef.current) {
+        window.scrollTo({ top: document.documentElement.scrollHeight });
       }
-      rafId = requestAnimationFrame(tick);
-    };
-
-    rafId = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(rafId);
-  }, [status, isAtBottom]);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [status]);
 
   const showTypingIndicator = status === "submitted" || status === "streaming";
   const isTypingIndicatorExiting = status !== "submitted";
@@ -100,6 +105,7 @@ export function ChatMessageList({
         <div css={styles.emptyStateWrapper}>{emptyState}</div>
       ) : (
         <div
+          ref={messagesListRef}
           role="log"
           aria-label={messagesLabel}
           css={[flex.col, styles.messagesList]}


### PR DESCRIPTION
## Summary

`ChatMessageList` previously ran a `requestAnimationFrame` loop for the full duration of every streaming response, polling `document.documentElement.scrollHeight` on each frame to decide whether to scroll the user to the bottom. That's a per-frame cost during streaming regardless of whether the DOM actually grew between frames. It also kept `isAtBottom` in the message-length scroll effect's dep array, so user scroll changes retriggered that effect and raced with the streaming loop. This replaces the rAF loop with a `ResizeObserver` attached to the `role="log"` messages container — the observer fires only when the list's box actually grows (token arrives → DOM reflow → callback), and `isAtBottom` is read through a "latest value" ref so neither effect needs it in its dep array. The ref sync lives in a `useLayoutEffect` declared before both consumer effects, matching the established pattern in `src/components/ai-chat/use-smoothed-text.ts`, so the render body stays pure and both effects read the up-to-date value without re-running on scroll. A `typeof ResizeObserver === "undefined"` guard mirrors `src/hooks/use-scroll-fades.ts` so the existing streaming test continues to run under jsdom.