### PR TITLE
docs: document silent lockfile corruption after git rebase

### DIFF
--- a/.claude/skills/merge-dependabot/SKILL.md
+++ b/.claude/skills/merge-dependabot/SKILL.md
@@ -35,6 +35,8 @@ Force-push is safe — these are bot-owned branches. If the force-push fails wit
 
 If the rebase has lockfile conflicts: delete `pnpm-lock.yaml`, run `pnpm install`, stage and continue. For non-lockfile conflicts that aren't straightforward, skip the PR.
 
+A clean-looking rebase can still produce a subtly-broken `pnpm-lock.yaml` (e.g., a duplicate YAML mapping key) when both sides added overlapping entries — git won't flag a conflict but `pnpm install` in Step 3 will warn `Ignoring broken lockfile ... duplicated mapping key`. If that happens, delete `pnpm-lock.yaml`, re-run `pnpm install`, commit the regenerated lockfile, and push.
+
 ### Step 2 — Understand the change
 
 PR titles can be stale. Always check `gh pr diff <number>` for the real `from`/`to` versions and whether the package is in `dependencies` (prod) or `devDependencies` (dev).


### PR DESCRIPTION
## Summary

Documents an edge case in the merge-dependabot skill where a `git rebase` can complete without conflict markers yet still leave `pnpm-lock.yaml` in a broken state. The existing Step 1 only described recovery from overt lockfile conflicts; a new paragraph explains that a clean-looking rebase can silently produce a duplicate YAML mapping key, and that the `pnpm install` WARN in Step 3 (`Ignoring broken lockfile ... duplicated mapping key`) is the signal to apply the same delete-and-regenerate recovery.

## Context

The silent-corruption case was hit while processing Dependabot PR #2051 (prettier 3.8.1 → 3.8.2). PR #2052 (@types/node bump) had been merged immediately before, introducing a new `@types/node@25.6.0` entry into the lockfile. The rebase of #2051 onto the updated master succeeded without any conflict markers, but left a duplicate mapping key for that entry. The breakage only surfaced as a `pnpm install` WARN about a duplicated mapping key — a signal the existing documentation did not mention.