### PR TITLE
fix(ai-chat): return structured errors from tools instead of throwing

### DIFF
--- a/src/ai-chat/tools/media-credits.ts
+++ b/src/ai-chat/tools/media-credits.ts
@@ -4,6 +4,7 @@ import {
   getMovieCredits,
   getTvShowCredits,
 } from "#src/_generated/tmdb-server-functions.ts";
+import { toolError } from "./tool-error";
 
 export const mediaCreditsInputSchema = z.object({
   media_id: z.number().describe("The TMDB ID of the movie or TV show."),
@@ -24,10 +25,19 @@ export function createMediaCreditsTool() {
     inputSchema: mediaCreditsInputSchema,
     execute: async ({ media_id, media_type }) => {
       const idString = media_id.toString();
-      const credits =
-        media_type === "tv"
-          ? await getTvShowCredits({ series_id: idString })
-          : await getMovieCredits({ movie_id: idString });
+      let credits;
+      try {
+        credits =
+          media_type === "tv"
+            ? await getTvShowCredits({ series_id: idString })
+            : await getMovieCredits({ movie_id: idString });
+      } catch (error) {
+        console.error("media_credits failed", error);
+        return toolError(
+          "tmdb_unavailable",
+          "TMDB cast and crew lookup is temporarily unavailable. Tell the user and suggest trying again shortly.",
+        );
+      }
 
       const cast = (credits.cast ?? []).slice(0, MAX_CAST).map((entry) => ({
         id: entry.id,

--- a/src/ai-chat/tools/person-credits.ts
+++ b/src/ai-chat/tools/person-credits.ts
@@ -2,6 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import { getPersonCombinedCredits } from "#src/_generated/tmdb-server-functions.ts";
 import { isRecord } from "#src/utils/type-guards.ts";
+import { toolError } from "./tool-error";
 
 export const personCreditsInputSchema = z.object({
   person_id: z.number().describe("The TMDB person ID from search results."),
@@ -61,9 +62,18 @@ export function createPersonCreditsTool() {
     description: TOOL_DESCRIPTION,
     inputSchema: personCreditsInputSchema,
     execute: async ({ person_id }) => {
-      const credits = await getPersonCombinedCredits({
-        person_id: person_id.toString(),
-      });
+      let credits;
+      try {
+        credits = await getPersonCombinedCredits({
+          person_id: person_id.toString(),
+        });
+      } catch (error) {
+        console.error("person_credits failed", error);
+        return toolError(
+          "tmdb_unavailable",
+          "TMDB filmography lookup is temporarily unavailable. Tell the user and suggest trying again shortly.",
+        );
+      }
 
       const seen = new Set<string>();
       const results: CreditResult[] = [];

--- a/src/ai-chat/tools/review-summary.test.ts
+++ b/src/ai-chat/tools/review-summary.test.ts
@@ -5,6 +5,7 @@ import {
   createReviewSummaryTool,
   reviewSummaryInputSchema,
 } from "./review-summary";
+import { isToolError } from "./tool-error";
 
 beforeAll(() => {
   process.env.TMDB_API_TOKEN = "test-token";
@@ -330,5 +331,62 @@ describe("review summary execute", () => {
     });
 
     expect(result.spiciness).toBe(5);
+  });
+});
+
+describe("review summary error handling", () => {
+  it("returns a tmdb_unavailable error when TMDB reviews fetch fails", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/reviews`, () =>
+        HttpResponse.json({ status_message: "Rate limited" }, { status: 429 }),
+      ),
+    );
+
+    const tool = createReviewSummaryTool("en");
+    const parsed = reviewSummaryInputSchema.parse({
+      id: 550,
+      media_type: "movie",
+      title: "Fight Club",
+    });
+    const result = await tool.execute!(parsed, executeContext);
+
+    expect(isToolError(result)).toBe(true);
+    if (isToolError(result)) {
+      expect(result.reason).toBe("tmdb_unavailable");
+    }
+  });
+
+  it("returns a summary_generation_failed error when the LLM call fails", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/reviews`, () =>
+        HttpResponse.json(
+          reviewsResponse(550, [
+            { author: "R1", content: "Great movie!", rating: 9 },
+          ]),
+        ),
+      ),
+      http.post(`${ANTHROPIC_BASE}/v1/messages`, () =>
+        HttpResponse.json(
+          {
+            type: "error",
+            error: { type: "invalid_request_error", message: "bad request" },
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const tool = createReviewSummaryTool("en");
+    const parsed = reviewSummaryInputSchema.parse({
+      id: 550,
+      media_type: "movie",
+      title: "Fight Club",
+    });
+    const result = await tool.execute!(parsed, executeContext);
+
+    expect(isToolError(result)).toBe(true);
+    if (isToolError(result)) {
+      expect(result.reason).toBe("summary_generation_failed");
+    }
   });
 });

--- a/src/ai-chat/tools/review-summary.ts
+++ b/src/ai-chat/tools/review-summary.ts
@@ -7,6 +7,7 @@ import {
 import type { SupportedLocale } from "#src/types.ts";
 import { isRecord } from "#src/utils/type-guards.ts";
 import { getAnthropicModel } from "../client";
+import { toolError } from "./tool-error";
 
 export const reviewSummaryInputSchema = z.object({
   id: z.number().describe("The TMDB ID of the movie or TV show."),
@@ -129,29 +130,25 @@ function buildSummarizationPrompt(
   ].join("\n");
 }
 
-interface ReviewSummaryResult {
-  id: number;
-  mediaType: "movie" | "tv";
-  title: string;
-  spiciness: number;
-  summary: string;
-  reviewCount: number;
-  averageRating: number | null;
-}
-
 export function createReviewSummaryTool(locale: SupportedLocale) {
   return tool({
     description: TOOL_DESCRIPTION,
     inputSchema: reviewSummaryInputSchema,
-    execute: async (
-      { id, media_type, title, spiciness },
-      { abortSignal },
-    ): Promise<ReviewSummaryResult> => {
+    execute: async ({ id, media_type, title, spiciness }, { abortSignal }) => {
       const idString = id.toString();
-      const response =
-        media_type === "tv"
-          ? await getTvShowReviews({ series_id: idString })
-          : await getMovieReviews({ movie_id: idString });
+      let response;
+      try {
+        response =
+          media_type === "tv"
+            ? await getTvShowReviews({ series_id: idString })
+            : await getMovieReviews({ movie_id: idString });
+      } catch (error) {
+        console.error("review_summary TMDB fetch failed", error);
+        return toolError(
+          "tmdb_unavailable",
+          "TMDB reviews are temporarily unavailable for this title. Tell the user and suggest trying again shortly.",
+        );
+      }
 
       const reviews = extractReviews(response.results);
 
@@ -179,18 +176,28 @@ export function createReviewSummaryTool(locale: SupportedLocale) {
         locale,
       );
 
-      const { text } = await generateText({
-        model: getAnthropicModel(),
-        prompt,
-        abortSignal,
-      });
+      let summaryText;
+      try {
+        const generation = await generateText({
+          model: getAnthropicModel(),
+          prompt,
+          abortSignal,
+        });
+        summaryText = generation.text;
+      } catch (error) {
+        console.error("review_summary generation failed", error);
+        return toolError(
+          "summary_generation_failed",
+          "Review summary generation is temporarily unavailable. Tell the user the reviews were fetched but the summary could not be generated — offer to try again.",
+        );
+      }
 
       return {
         id,
         mediaType: media_type,
         title,
         spiciness,
-        summary: text,
+        summary: summaryText,
         reviewCount: reviews.length,
         averageRating,
       };

--- a/src/ai-chat/tools/semantic-search.test.ts
+++ b/src/ai-chat/tools/semantic-search.test.ts
@@ -3,6 +3,7 @@ import {
   createSemanticSearchTool,
   semanticSearchInputSchema,
 } from "./semantic-search";
+import { isToolError } from "./tool-error";
 
 describe("semanticSearchInputSchema", () => {
   it("accepts a valid query-only input", () => {
@@ -108,5 +109,27 @@ describe("createSemanticSearchTool", () => {
     const enTool = createSemanticSearchTool("en");
     const zhTool = createSemanticSearchTool("zh");
     expect(enTool).not.toBe(zhTool);
+  });
+});
+
+describe("semantic search error handling", () => {
+  it("returns a structured tool error when the vector index is unavailable", async () => {
+    // UPSTASH_VECTOR_REST_URL is not set in the test environment, so
+    // getVectorIndex() throws. The tool should convert that into a
+    // structured error rather than propagating the exception.
+    const tool = createSemanticSearchTool("en");
+    const result = await tool.execute!(
+      { query: "mind-bending sci-fi" },
+      {
+        toolCallId: "test",
+        messages: [],
+        abortSignal: AbortSignal.timeout(5000),
+      },
+    );
+
+    expect(isToolError(result)).toBe(true);
+    if (isToolError(result)) {
+      expect(result.reason).toBe("vector_search_unavailable");
+    }
   });
 });

--- a/src/ai-chat/tools/semantic-search.ts
+++ b/src/ai-chat/tools/semantic-search.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { SupportedLocale } from "#src/types.ts";
 import { searchSimilar } from "#src/vector-db/search.ts";
 import { vectorSearchFiltersSchema } from "#src/vector-db/types.ts";
+import { toolError } from "./tool-error";
 
 export const semanticSearchInputSchema = z.object({
   query: z
@@ -51,7 +52,16 @@ export function createSemanticSearchTool(locale: SupportedLocale) {
   return tool({
     description: TOOL_DESCRIPTION,
     inputSchema: semanticSearchInputSchema,
-    execute: async ({ query, filters, topK }) =>
-      searchSimilar(query, locale, { filters, topK }),
+    execute: async ({ query, filters, topK }) => {
+      try {
+        return await searchSimilar(query, locale, { filters, topK });
+      } catch (error) {
+        console.error("semantic_search failed", error);
+        return toolError(
+          "vector_search_unavailable",
+          "Semantic search is temporarily unavailable. Tell the user and suggest falling back to tmdb_search with specific titles.",
+        );
+      }
+    },
   });
 }

--- a/src/ai-chat/tools/tmdb-search.test.ts
+++ b/src/ai-chat/tools/tmdb-search.test.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from "msw";
 import { beforeAll, describe, expect, it } from "vitest";
 import { server } from "#src/test-msw.ts";
 import { createTmdbSearchTool, tmdbSearchInputSchema } from "./tmdb-search";
+import { isToolError } from "./tool-error";
 
 beforeAll(() => {
   process.env.TMDB_API_TOKEN = "test-token";
@@ -286,6 +287,33 @@ describe("tmdb search execute", () => {
     expect(keys).toContain("media_type");
     expect(keys).toContain("title");
     expect(keys).toContain("overview");
+  });
+
+  it("returns a structured tool error when TMDB fails", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/search/multi`, () =>
+        HttpResponse.json(
+          { status_code: 25, status_message: "Rate limit exceeded" },
+          { status: 429 },
+        ),
+      ),
+    );
+
+    const tool = createTmdbSearchTool("en");
+    const result = await tool.execute!(
+      { query: "Dune" },
+      {
+        toolCallId: "test",
+        messages: [],
+        abortSignal: AbortSignal.timeout(5000),
+      },
+    );
+
+    expect(isToolError(result)).toBe(true);
+    if (isToolError(result)) {
+      expect(result.reason).toBe("tmdb_unavailable");
+      expect(result.message.length).toBeGreaterThan(0);
+    }
   });
 
   it("includes first_air_date for TV results", async () => {

--- a/src/ai-chat/tools/tmdb-search.ts
+++ b/src/ai-chat/tools/tmdb-search.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { searchMulti } from "#src/_generated/tmdb-server-functions.ts";
 import type { SupportedLocale } from "#src/types.ts";
 import type { ResponseType } from "#src/utils/tmdb-client.ts";
+import { toolError } from "./tool-error";
 
 // The TMDB OpenAPI spec flattens the multi-search union type, omitting fields
 // that only appear for specific media_type values. The API returns these fields
@@ -63,8 +64,16 @@ export function createTmdbSearchTool(locale: SupportedLocale) {
     description: TOOL_DESCRIPTION,
     inputSchema: tmdbSearchInputSchema,
     execute: async ({ query }) => {
-      const response = await searchMulti({ query, language: locale });
-      return response.results?.slice(0, MAX_RESULTS).map(mapResult) ?? [];
+      try {
+        const response = await searchMulti({ query, language: locale });
+        return response.results?.slice(0, MAX_RESULTS).map(mapResult) ?? [];
+      } catch (error) {
+        console.error("tmdb_search failed", error);
+        return toolError(
+          "tmdb_unavailable",
+          "TMDB search is temporarily unavailable. Tell the user and offer an alternative such as semantic_search or a different query.",
+        );
+      }
     },
   });
 }

--- a/src/ai-chat/tools/tool-error.ts
+++ b/src/ai-chat/tools/tool-error.ts
@@ -1,0 +1,25 @@
+import { isRecord } from "#src/utils/type-guards.ts";
+
+export const TOOL_ERROR_MARKER = "__toolError";
+
+export type ToolErrorReason =
+  | "tmdb_unavailable"
+  | "vector_search_unavailable"
+  | "summary_generation_failed";
+
+export interface ToolErrorResult {
+  [TOOL_ERROR_MARKER]: true;
+  reason: ToolErrorReason;
+  message: string;
+}
+
+export function toolError(
+  reason: ToolErrorReason,
+  message: string,
+): ToolErrorResult {
+  return { [TOOL_ERROR_MARKER]: true, reason, message };
+}
+
+export function isToolError(value: unknown): value is ToolErrorResult {
+  return isRecord(value) && value[TOOL_ERROR_MARKER] === true;
+}

--- a/src/ai-chat/tools/watch-providers.test.ts
+++ b/src/ai-chat/tools/watch-providers.test.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from "msw";
 import { beforeAll, describe, expect, it } from "vitest";
 import { server } from "#src/test-msw.ts";
+import { isToolError } from "./tool-error";
 import {
   createWatchProvidersTool,
   watchProvidersInputSchema,
@@ -408,6 +409,30 @@ describe("watch providers execute", () => {
     const firstProvider = result.providers!.flatrate[0];
     expect(firstProvider).toBeDefined();
     expect(Object.keys(firstProvider)).toEqual(["id", "name", "logoPath"]);
+  });
+});
+
+describe("watch providers error handling", () => {
+  it("returns a structured tool error when TMDB fails", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/watch/providers`, () =>
+        HttpResponse.json(
+          { status_message: "Service unavailable" },
+          { status: 503 },
+        ),
+      ),
+    );
+
+    const tool = createWatchProvidersTool();
+    const result = await tool.execute!(
+      { id: 550, media_type: "movie", region: "US" },
+      executeContext,
+    );
+
+    expect(isToolError(result)).toBe(true);
+    if (isToolError(result)) {
+      expect(result.reason).toBe("tmdb_unavailable");
+    }
   });
 });
 

--- a/src/ai-chat/tools/watch-providers.ts
+++ b/src/ai-chat/tools/watch-providers.ts
@@ -6,6 +6,7 @@ import {
 } from "#src/_generated/tmdb-server-functions.ts";
 import type { ResponseType } from "#src/utils/tmdb-client.ts";
 import { isRecord } from "#src/utils/type-guards.ts";
+import { toolError } from "./tool-error";
 
 export const watchProvidersInputSchema = z.object({
   id: z.number().describe("The TMDB ID of the movie or TV show."),
@@ -54,13 +55,6 @@ interface RegionProviders {
   buy: ProviderEntry[];
   ads: ProviderEntry[];
   free: ProviderEntry[];
-}
-
-interface WatchProvidersResult {
-  id: number;
-  mediaType: "movie" | "tv";
-  region: string;
-  providers: RegionProviders | null;
 }
 
 type AvailabilityType = "flatrate" | "rent" | "buy" | "ads" | "free";
@@ -191,13 +185,17 @@ export function createWatchProvidersTool() {
   return tool({
     description: TOOL_DESCRIPTION,
     inputSchema: watchProvidersInputSchema,
-    execute: async ({
-      id,
-      media_type,
-      region,
-      provider_name,
-    }): Promise<WatchProvidersResult | ProviderSearchResult> => {
-      const response = await fetchWatchProviders(id, media_type);
+    execute: async ({ id, media_type, region, provider_name }) => {
+      let response;
+      try {
+        response = await fetchWatchProviders(id, media_type);
+      } catch (error) {
+        console.error("watch_providers failed", error);
+        return toolError(
+          "tmdb_unavailable",
+          "TMDB watch provider lookup is temporarily unavailable. Tell the user and suggest trying again shortly or falling back to web_search for current streaming availability.",
+        );
+      }
 
       if (provider_name) {
         const { regions, logoPath } = searchProviderAcrossRegions(

--- a/src/components/ai-chat/chat-message.tsx
+++ b/src/components/ai-chat/chat-message.tsx
@@ -169,6 +169,7 @@ export function deriveMessageData(parts: UIMessage["parts"]) {
     toolName: string;
     state: string;
     input: unknown;
+    output: unknown;
   }> = [];
   let hasVisibleContent = false;
   let firstToolIndex = -1;
@@ -198,6 +199,7 @@ export function deriveMessageData(parts: UIMessage["parts"]) {
         toolName: name,
         state: part.state,
         input: "input" in part ? part.input : undefined,
+        output: "output" in part ? part.output : undefined,
       });
       hasVisibleContent = true;
     } else {

--- a/src/components/ai-chat/tool-activity-group.tsx
+++ b/src/components/ai-chat/tool-activity-group.tsx
@@ -15,6 +15,7 @@ interface ToolPartData {
   toolName: string;
   state: string;
   input: unknown;
+  output?: unknown;
 }
 
 interface ToolActivityGroupProps {
@@ -42,6 +43,7 @@ export function ToolActivityGroup({
             toolName={part.toolName}
             state={part.state}
             input={part.input}
+            output={part.output}
           />
         ))}
       </div>

--- a/src/components/ai-chat/tool-activity-line.tsx
+++ b/src/components/ai-chat/tool-activity-line.tsx
@@ -3,6 +3,7 @@
 import { CheckIcon } from "@phosphor-icons/react/dist/ssr/Check";
 import { WarningCircleIcon } from "@phosphor-icons/react/dist/ssr/WarningCircle";
 import * as stylex from "@stylexjs/stylex";
+import { isToolError } from "#src/ai-chat/tools/tool-error.ts";
 import { t } from "#src/i18n.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { truncate } from "#src/primitives/layout.stylex.ts";
@@ -54,15 +55,19 @@ interface ToolActivityLineProps {
   toolName: string;
   state: string;
   input: unknown;
+  output?: unknown;
 }
 
 export function ToolActivityLine({
   toolName,
   state,
   input,
+  output,
 }: ToolActivityLineProps) {
-  const isComplete = state === "output-available";
-  const isError = state === "output-error" || state === "output-denied";
+  const hasStructuredError = isToolError(output);
+  const isComplete = state === "output-available" && !hasStructuredError;
+  const isError =
+    state === "output-error" || state === "output-denied" || hasStructuredError;
   const isInProgress = !TERMINAL_STATES.has(state);
 
   let label: string;

--- a/src/components/ai-chat/tool-visual-output.tsx
+++ b/src/components/ai-chat/tool-visual-output.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
+import { isToolError } from "#src/ai-chat/tools/tool-error.ts";
 import { t } from "#src/i18n.ts";
 import { color, font, space } from "#src/tokens.stylex.ts";
 import type { MediaListItem, PersonListItem } from "#src/utils/types.ts";
@@ -120,7 +121,7 @@ export function ToolVisualOutput({
   }
 
   if (toolName === "review_summary") {
-    if (state === "output-error") {
+    if (state === "output-error" || isToolError(output)) {
       return (
         <p css={styles.error} role="alert">
           {t({


### PR DESCRIPTION
## Summary

- Wrap unguarded external calls in 6 AI chat tools (`tmdb-search`, `media-credits`, `person-credits`, `watch-providers`, `review-summary`, `semantic-search`) in try/catch and return a typed `ToolErrorResult` payload via a new `toolError()` helper instead of throwing out of `execute`.
- A thrown tool error previously propagated to the `streamText` wrapper in `src/app/api/ai-chat/route.ts` and emitted a terminal "Stream error" that killed the whole conversation. The LLM now receives a structured `{ __toolError: true, reason, message }` object and can respond gracefully ("I couldn't fetch X, want me to try Y?").
- Chat UI (`tool-activity-line`, `tool-visual-output`, `chat-message`, `tool-activity-group`) now shows an error icon when `isToolError(output)` is true, even while `state === "output-available"`, so failed tools are visually distinguishable from successful ones.

## Notes

- New helper `src/ai-chat/tools/tool-error.ts` exposes `toolError()` and `isToolError()`.
- Tests added for `tmdb-search`, `watch-providers`, `review-summary` (2 cases) and `semantic-search` using the existing MSW seam — no new mocks introduced.
- `media-credits` and `person-credits` have no pre-existing test files; scaffolding new ones was intentionally skipped to stay in scope.
- Unused `WatchProvidersResult` and `ReviewSummaryResult` type aliases were removed while touching those files.

## Test plan

- [x] `pnpm lint:changed`
- [x] `pnpm format:changed`
- [x] `pnpm test` (969/969 passing)
- [x] `pnpm build`
- [ ] Manually trigger a tool failure in chat (e.g. invalid TMDB query) and verify the conversation continues with a graceful fallback response and an error icon on the failed tool activity line.