### PR TITLE
fix: implement WAI-ARIA menu keyboard contract in MenuButton

### DIFF
--- a/src/components/shared/menu-button.test.tsx
+++ b/src/components/shared/menu-button.test.tsx
@@ -1,0 +1,254 @@
+import { AppRouterContext } from "next/dist/shared/lib/app-router-context.shared-runtime";
+import type { ReactNode } from "react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent } from "#src/test-utils.tsx";
+import { MenuButton } from "./menu-button";
+import { MenuItem } from "./menu-item";
+
+// jsdom doesn't implement these APIs used by Button's press animation hook
+// or AnimateToTarget's reduced-motion check + web-animations call. Stub
+// them so the component tree can mount without tripping on platform gaps.
+beforeAll(() => {
+  HTMLElement.prototype.setPointerCapture = vi.fn();
+  HTMLElement.prototype.releasePointerCapture = vi.fn();
+  HTMLElement.prototype.animate = vi.fn().mockReturnValue({
+    cancel: vi.fn(),
+    finish: vi.fn(),
+    onfinish: null,
+    oncancel: null,
+  });
+  if (!window.matchMedia) {
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      media: "",
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    });
+  }
+});
+
+// MenuItem calls useRouter() at render time, which requires the Next.js
+// App Router context. The keyboard-navigation tests don't exercise routing,
+// so a no-op router stub is enough to let the component mount.
+const stubRouter = {
+  back: vi.fn(),
+  forward: vi.fn(),
+  refresh: vi.fn(),
+  push: vi.fn(),
+  replace: vi.fn(),
+  prefetch: vi.fn(),
+};
+
+function RouterProvider({ children }: { children: ReactNode }) {
+  return <AppRouterContext value={stubRouter}>{children}</AppRouterContext>;
+}
+
+function TestMenu({
+  autoFocusIndex,
+  popupRole,
+}: {
+  autoFocusIndex?: number;
+  popupRole?: "menu" | "group" | undefined;
+}) {
+  return (
+    <MenuButton
+      buttonProps={{ type: "button", "aria-label": "Open menu" }}
+      popupRole={popupRole}
+      menuContent={
+        <div>
+          <MenuItem href="/a" autoFocus={autoFocusIndex === 0}>
+            Item A
+          </MenuItem>
+          <MenuItem href="/b" autoFocus={autoFocusIndex === 1}>
+            Item B
+          </MenuItem>
+          <MenuItem href="/c" autoFocus={autoFocusIndex === 2}>
+            Item C
+          </MenuItem>
+        </div>
+      }
+    />
+  );
+}
+
+function getMenuItems() {
+  return screen.getAllByRole("menuitem");
+}
+
+describe("MenuButton keyboard navigation", () => {
+  it("moves focus to the first menu item when the menu opens", async () => {
+    const user = userEvent.setup();
+    render(
+      <RouterProvider>
+        <TestMenu />
+      </RouterProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open menu" }));
+
+    const items = getMenuItems();
+    expect(items[0]).toHaveFocus();
+  });
+
+  it("moves focus to the item marked as autoFocus when the menu opens", async () => {
+    const user = userEvent.setup();
+    render(
+      <RouterProvider>
+        <TestMenu autoFocusIndex={1} />
+      </RouterProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open menu" }));
+
+    const items = getMenuItems();
+    expect(items[1]).toHaveFocus();
+  });
+
+  it("cycles focus forward with ArrowDown", async () => {
+    const user = userEvent.setup();
+    render(
+      <RouterProvider>
+        <TestMenu />
+      </RouterProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open menu" }));
+    const items = getMenuItems();
+
+    await user.keyboard("{ArrowDown}");
+    expect(items[1]).toHaveFocus();
+
+    await user.keyboard("{ArrowDown}");
+    expect(items[2]).toHaveFocus();
+
+    // Wraps around to the first item
+    await user.keyboard("{ArrowDown}");
+    expect(items[0]).toHaveFocus();
+  });
+
+  it("cycles focus backward with ArrowUp", async () => {
+    const user = userEvent.setup();
+    render(
+      <RouterProvider>
+        <TestMenu />
+      </RouterProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open menu" }));
+    const items = getMenuItems();
+
+    // Wraps from first to last
+    await user.keyboard("{ArrowUp}");
+    expect(items[2]).toHaveFocus();
+
+    await user.keyboard("{ArrowUp}");
+    expect(items[1]).toHaveFocus();
+  });
+
+  it("jumps to first item on Home and last item on End", async () => {
+    const user = userEvent.setup();
+    render(
+      <RouterProvider>
+        <TestMenu autoFocusIndex={1} />
+      </RouterProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open menu" }));
+    const items = getMenuItems();
+    expect(items[1]).toHaveFocus();
+
+    await user.keyboard("{End}");
+    expect(items[2]).toHaveFocus();
+
+    await user.keyboard("{Home}");
+    expect(items[0]).toHaveFocus();
+  });
+
+  it("returns focus to the trigger on Escape", async () => {
+    const user = userEvent.setup();
+    render(
+      <RouterProvider>
+        <TestMenu />
+      </RouterProvider>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Open menu" });
+    await user.click(trigger);
+    expect(getMenuItems()[0]).toHaveFocus();
+
+    await user.keyboard("{Escape}");
+    expect(trigger).toHaveFocus();
+  });
+
+  it("does not intercept arrow keys when popupRole is not 'menu'", async () => {
+    const user = userEvent.setup();
+
+    // Using role="group" should leave arrow keys as no-ops — the popup
+    // doesn't advertise a menu contract, so MenuButton must not meddle.
+    render(
+      <MenuButton
+        buttonProps={{ type: "button", "aria-label": "Open group" }}
+        popupRole="group"
+        menuContent={
+          <div>
+            <button type="button">First</button>
+            <button type="button">Second</button>
+          </div>
+        }
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Open group" });
+    await user.click(trigger);
+
+    // Focus stayed on the trigger — no auto-move into the popup for groups.
+    expect(trigger).toHaveFocus();
+
+    // Arrow keys should not move focus anywhere; trigger remains focused.
+    await user.keyboard("{ArrowDown}");
+    expect(trigger).toHaveFocus();
+  });
+});
+
+describe("MenuItem", () => {
+  it("renders as a menuitem with the auto-focus data attribute", () => {
+    render(
+      <RouterProvider>
+        <MenuItem href="/x" autoFocus>
+          Focusable item
+        </MenuItem>
+      </RouterProvider>,
+    );
+
+    const item = screen.getByRole("menuitem", { name: "Focusable item" });
+    expect(item).toHaveAttribute("data-menu-autofocus", "true");
+  });
+
+  it("omits the data attribute when autoFocus is false", () => {
+    render(
+      <RouterProvider>
+        <MenuItem href="/x">Plain item</MenuItem>
+      </RouterProvider>,
+    );
+
+    const item = screen.getByRole("menuitem", { name: "Plain item" });
+    expect(item).not.toHaveAttribute("data-menu-autofocus");
+  });
+
+  it("takes the active item out of the tab order", () => {
+    render(
+      <RouterProvider>
+        <MenuItem href="/x" isActive>
+          Active item
+        </MenuItem>
+      </RouterProvider>,
+    );
+
+    const item = screen.getByRole("menuitem", { name: "Active item" });
+    expect(item).toHaveAttribute("tabindex", "-1");
+  });
+});

--- a/src/components/shared/menu-button.tsx
+++ b/src/components/shared/menu-button.tsx
@@ -55,6 +55,7 @@ export function MenuButton({
 }: PropsWithChildren<MenuButtonProps>) {
   const [isMenuShown, setIsMenuShown] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const popupRef = useRef<HTMLDivElement>(null);
 
   const outsideClickedRef = useRef(false);
   useEffect(() => {
@@ -62,6 +63,19 @@ export function MenuButton({
       outsideClickedRef.current = false;
     }
   }, [isMenuShown]);
+
+  // When a menu opens, move focus into it per WAI-ARIA Authoring Practices.
+  // Prefer the item flagged with `data-menu-autofocus="true"` (e.g. "start
+  // on the choice I'd switch to"), otherwise the first menu item.
+  useEffect(() => {
+    if (!isMenuShown || popupRole !== "menu") return;
+    const popup = popupRef.current;
+    if (!popup) return;
+    const target =
+      popup.querySelector<HTMLElement>('[data-menu-autofocus="true"]') ??
+      popup.querySelector<HTMLElement>('[role="menuitem"]');
+    target?.focus();
+  }, [isMenuShown, popupRole]);
 
   const targetId = useId();
 
@@ -87,6 +101,50 @@ export function MenuButton({
             e.stopPropagation();
             setIsMenuShown(false);
             document.getElementById(targetId)?.focus();
+            return;
+          }
+
+          // Arrow / Home / End navigation only applies to the menu pattern.
+          if (popupRole !== "menu" || !isMenuShown) return;
+          if (
+            e.key !== "ArrowDown" &&
+            e.key !== "ArrowUp" &&
+            e.key !== "Home" &&
+            e.key !== "End"
+          ) {
+            return;
+          }
+
+          const popup = popupRef.current;
+          if (!popup) return;
+          const items = Array.from(
+            popup.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+          );
+          if (items.length === 0) return;
+
+          e.preventDefault();
+          e.stopPropagation();
+
+          const currentIndex = items.findIndex(
+            (item) => item === document.activeElement,
+          );
+
+          if (e.key === "ArrowDown") {
+            const next =
+              currentIndex === -1
+                ? items[0]
+                : items[(currentIndex + 1) % items.length];
+            next?.focus();
+          } else if (e.key === "ArrowUp") {
+            const prev =
+              currentIndex === -1
+                ? items[items.length - 1]
+                : items[(currentIndex - 1 + items.length) % items.length];
+            prev?.focus();
+          } else if (e.key === "Home") {
+            items[0]?.focus();
+          } else if (e.key === "End") {
+            items[items.length - 1]?.focus();
           }
         }}
         onBlur={(e) => {
@@ -125,6 +183,7 @@ export function MenuButton({
             targetId={targetId}
           >
             <div
+              ref={popupRef}
               role={popupRole}
               aria-labelledby={popupRole ? `${targetId}-label` : undefined}
             >

--- a/src/components/shared/menu-item.tsx
+++ b/src/components/shared/menu-item.tsx
@@ -32,9 +32,7 @@ export function MenuItem({
       aria-label={ariaLabel}
       role="menuitem"
       css={[flex.between, styles.item, isActive && styles.itemActive]}
-      ref={(el) => {
-        if (autoFocus) el?.focus();
-      }}
+      data-menu-autofocus={autoFocus ? "true" : undefined}
       tabIndex={isActive ? -1 : 0}
       onClick={(e) => {
         e.preventDefault();


### PR DESCRIPTION
## Summary

`MenuButton` renders popups with `role="menu"` but never implemented the WAI-ARIA menu keyboard contract. Focus didn't move into the menu on open, arrow keys didn't cycle items, and Home/End didn't jump. `MenuItem` also had a brittle inline ref callback (`ref={(el) => autoFocus && el?.focus()}`) that fired on every render and could steal focus while the menu was hidden.

## Changes

- **`src/components/shared/menu-button.tsx`** — Added `popupRef` and an effect (gated on `isMenuShown && popupRole === "menu"`) that focuses `[data-menu-autofocus="true"]` or the first `[role="menuitem"]` when the menu opens. Extended `onKeyDown` to handle ArrowDown/ArrowUp/Home/End with wrap-around. `preventDefault`/`stopPropagation` only fire when the handler actually consumes a key. Non-menu popups (`popupRole="group"` or `undefined`) are explicitly early-returned so existing callers are unaffected. Escape handling is unchanged.
- **`src/components/shared/menu-item.tsx`** — Removed the render-time ref callback; replaced with `data-menu-autofocus={autoFocus ? "true" : undefined}`, read by `MenuButton` at open time.
- **`src/components/shared/menu-button.test.tsx`** (new) — 10 tests covering first-item-on-open, data-attribute-driven autoFocus, ArrowDown/ArrowUp cycling with wrap, Home/End, Escape-returns-focus-to-trigger, and a negative test that `popupRole="group"` popups are NOT intercepted. Uses jsdom stubs for `setPointerCapture`/`releasePointerCapture`/`Element.animate`/`matchMedia` (matching existing test precedent). Inline `AppRouterContext` provider scoped to this file to satisfy `MenuItem`'s `useRouter()` call. React 19 context shorthand used.

## Callers audit

- `locale-selector.tsx` — default `popupRole="menu"` (receives the fix).
- `tmdb-credit.tsx` — `undefined` (unaffected, early-returns).
- `genre-filter-button.tsx`, `mobile-filters-button.tsx` — `"group"` (unaffected, early-returns).

## Test plan

- [x] `pnpm lint:changed`
- [x] `pnpm format:changed`
- [x] `pnpm test` — 974/974 passing
- [x] `pnpm build`
- [x] Manual check of locale selector keyboard navigation