### PR TITLE
fix(ai-chat): await preferences cache before first sendMessage

### DIFF
--- a/src/ai-chat/use-ai-chat.ts
+++ b/src/ai-chat/use-ai-chat.ts
@@ -9,7 +9,7 @@ import { isUIMessage } from "#src/ai-chat/is-ui-message.ts";
 import { accumulateToolOutputs } from "#src/components/ai-chat/map-tool-output.ts";
 import {
   getCachedPreferencesContext,
-  loadPreferencesContext,
+  getPreferencesContextReady,
 } from "#src/preference-store/preference-store.ts";
 import type { SupportedLocale } from "#src/types.ts";
 
@@ -130,9 +130,23 @@ export function useAIChat({ locale }: { locale: SupportedLocale }) {
 
   // Warm the preferences cache from IndexedDB on mount so it's available
   // for the transport to inject into the first message of a new session.
+  // Uses the shared ready-promise so the sendMessage wrapper below reuses
+  // this in-flight load instead of kicking off a duplicate IDB read.
   useEffect(() => {
-    loadPreferencesContext().catch(() => {});
+    getPreferencesContextReady().catch(() => {});
   }, []);
+
+  // Wrap sendMessage so the first send always waits for the preferences
+  // cache to be populated. Without this, a user who hits Enter before the
+  // mount-time IDB load resolves would silently lose saved preferences for
+  // the entire session — the transport only injects preferences on the
+  // first message, so a missed first send can never be recovered.
+  async function sendMessage(
+    ...args: Parameters<typeof chatResult.sendMessage>
+  ) {
+    await getPreferencesContextReady().catch(() => null);
+    return chatResult.sendMessage(...args);
+  }
 
   // Deferred to useEffect so the initial render matches the server (null),
   // avoiding a hydration mismatch — localStorage is not available during SSR.
@@ -165,6 +179,7 @@ export function useAIChat({ locale }: { locale: SupportedLocale }) {
 
   return {
     ...chatResult,
+    sendMessage,
     toolOutputs: accumulateToolOutputs(chatResult.messages),
     previousSessionId,
     continueSession,

--- a/src/preference-store/preference-store.test.ts
+++ b/src/preference-store/preference-store.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import type { StoredPreference } from "./preference-store";
 import {
   formatPreferencesContext,
+  getCachedPreferencesContext,
+  getPreferencesContextReady,
   isStoredPreference,
   makeId,
 } from "./preference-store";
@@ -211,5 +213,47 @@ describe("formatPreferencesContext", () => {
     expect(ctx).toContain("PG-13 (content_rating)");
     expect(ctx).toContain("Korean (language)");
     expect(ctx).toContain("time travel (keyword)");
+  });
+});
+
+describe("getPreferencesContextReady", () => {
+  // No real IndexedDB in jsdom — openDB throws, loadPreferencesContext's
+  // catch branch swallows it, cachedContext stays null, cacheLoaded flips
+  // to true. We don't care which branch the load takes; we only care that
+  // the coordination contract holds.
+
+  it("returns null synchronously from getCachedPreferencesContext before any load resolves", () => {
+    // This assertion must run first, before any other test in this describe
+    // block has triggered a load. It guards the "null until ready" invariant
+    // that the race-safe wrapper in useAIChat relies on.
+    expect(getCachedPreferencesContext()).toBeNull();
+  });
+
+  it("shares a single in-flight promise across concurrent callers", async () => {
+    const p1 = getPreferencesContextReady();
+    const p2 = getPreferencesContextReady();
+    // Same reference → no duplicate IndexedDB work for concurrent callers.
+    // This is the core of the race-safe coordination: the useEffect warm-up
+    // and the sendMessage wrapper both hit this function and must coalesce.
+    expect(p1).toBe(p2);
+
+    await Promise.all([p1, p2]);
+    // After resolution the cache is populated (null here because the jsdom
+    // environment has no IndexedDB, so loadPreferencesContext's error path
+    // runs — but crucially `getCachedPreferencesContext()` now reflects a
+    // settled load, not the "not yet loaded" pre-state).
+    expect(getCachedPreferencesContext()).toBeNull();
+  });
+
+  it("resolves immediately on subsequent calls after the initial load", async () => {
+    // After the previous test's load settled, the in-flight promise is
+    // already resolved. A fresh call should return instantly without
+    // kicking off another IndexedDB round-trip.
+    const start = Date.now();
+    const result = await getPreferencesContextReady();
+    const elapsed = Date.now() - start;
+    expect(result).toBeNull();
+    // Generous bound — the point is "not a fresh IDB open", not a tight SLA.
+    expect(elapsed).toBeLessThan(50);
   });
 });

--- a/src/preference-store/preference-store.ts
+++ b/src/preference-store/preference-store.ts
@@ -163,6 +163,7 @@ export async function clearPreferences(): Promise<void> {
 
 let cachedContext: string | null = null;
 let cacheLoaded = false;
+let inFlightLoad: Promise<string | null> | null = null;
 
 export function formatPreferencesContext(
   prefs: ReadonlyArray<StoredPreference>,
@@ -193,16 +194,36 @@ export function formatPreferencesContext(
 /**
  * Load preferences from IndexedDB and update the in-memory cache.
  * Returns the formatted context string, or null if no preferences are stored.
+ * The in-flight promise is tracked module-side so concurrent callers can
+ * coordinate on a single load via `getPreferencesContextReady`.
  */
-export async function loadPreferencesContext(): Promise<string | null> {
-  try {
-    const prefs = await getAllPreferences();
-    cachedContext = formatPreferencesContext(prefs);
-  } catch {
-    cachedContext = null;
-  }
-  cacheLoaded = true;
-  return cachedContext;
+export function loadPreferencesContext(): Promise<string | null> {
+  const p = (async () => {
+    try {
+      const prefs = await getAllPreferences();
+      cachedContext = formatPreferencesContext(prefs);
+    } catch {
+      cachedContext = null;
+    }
+    cacheLoaded = true;
+    return cachedContext;
+  })();
+  inFlightLoad = p;
+  return p;
+}
+
+/**
+ * Returns a promise that resolves once the preference cache is populated
+ * (or a load has settled). If no load has been started yet, one is kicked
+ * off here. Safe to await before reading `getCachedPreferencesContext()`.
+ *
+ * This is the race-safe coordination point: concurrent callers share the
+ * same in-flight load so the first chat message can reliably wait for
+ * preferences without triggering duplicate IndexedDB reads.
+ */
+export function getPreferencesContextReady(): Promise<string | null> {
+  if (inFlightLoad) return inFlightLoad;
+  return loadPreferencesContext();
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes a race between the mount-time preferences-cache warm-up in `useAIChat` and the user's first chat send. The transport's `prepareSendMessagesRequest` reads `getCachedPreferencesContext()` synchronously, which returns `null` until the IndexedDB read resolves. Previously, a user who hit Enter before the warm-up settled would silently lose all saved preferences for the entire session — the transport only injects preferences on the first message of a new session, so a missed first send can never be recovered.

## Approach

Fix the race at the `sendMessage` boundary rather than making the transport async.

- **`src/preference-store/preference-store.ts`** — Added a module-level `inFlightLoad: Promise<string | null> | null` and a new exported `getPreferencesContextReady()`. `loadPreferencesContext()` now unconditionally assigns its returned promise into `inFlightLoad` so concurrent callers coordinate on the same reference. Direct `loadPreferencesContext()` callers (the write-refresh flows in `use-preferences.ts` / `use-preference-persistence.ts`) keep their existing semantics — each direct call just replaces the in-flight slot with a fresh load.
- **`src/ai-chat/use-ai-chat.ts`** — Mount-time warm-up now calls `getPreferencesContextReady()` (so it shares the in-flight promise instead of kicking off its own). `sendMessage` is wrapped in a local async function that awaits `getPreferencesContextReady().catch(() => null)` before forwarding to the underlying AI SDK `sendMessage`. The wrapper is substituted into the returned hook object via `{ ...chatResult, sendMessage }`. Typed with `Parameters<typeof chatResult.sendMessage>` — no `any`, no type assertions.
- **`src/preference-store/preference-store.test.ts`** — 3 new tests in a `getPreferencesContextReady` describe block covering the coordination contract: (1) `getCachedPreferencesContext()` returns `null` synchronously before any load resolves, (2) concurrent callers receive the same promise reference, (3) post-load calls resolve immediately without re-opening IDB.

`prepareSendMessagesRequest` is unchanged — still synchronous, still gated on `!sessionId`. Subsequent sends after the first pay only a resolved-promise microtask.

## Test plan

- [x] `pnpm lint:changed`
- [x] `pnpm format:changed`
- [x] `pnpm test` (967/967 passing)
- [x] `pnpm build`
- [x] No `any`, no type assertions, no mocks, no manual memoization