### PR TITLE
fix: derive MediaTypeToggle active state from filter context

### DIFF
--- a/src/components/movie-database/media-type-toggle.test.tsx
+++ b/src/components/movie-database/media-type-toggle.test.tsx
@@ -1,0 +1,101 @@
+import { PathnameContext } from "next/dist/shared/lib/hooks-client-context.shared-runtime";
+import type { ReactNode } from "react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent } from "#src/test-utils.tsx";
+import { MediaFiltersProvider } from "./media-filters-provider";
+import { MediaTypeToggle } from "./media-type-toggle";
+
+// jsdom gaps: AnchorButton's press-handlers hook needs pointer-capture,
+// and the provider's scroll-to-top path reads reduced-motion via matchMedia.
+beforeAll(() => {
+  HTMLElement.prototype.setPointerCapture = vi.fn();
+  HTMLElement.prototype.releasePointerCapture = vi.fn();
+  if (!window.matchMedia) {
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      media: "",
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    });
+  }
+});
+
+function Harness({ children }: { children: ReactNode }) {
+  return (
+    <PathnameContext value="/movie-database">
+      <MediaFiltersProvider>{children}</MediaFiltersProvider>
+    </PathnameContext>
+  );
+}
+
+function getMoviesButton() {
+  return screen.getByRole("link", { name: "Movies" });
+}
+
+function getTvButton() {
+  return screen.getByRole("link", { name: "TV Shows" });
+}
+
+describe("MediaTypeToggle", () => {
+  it("marks Movies active by default", () => {
+    render(
+      <Harness>
+        <MediaTypeToggle />
+      </Harness>,
+    );
+
+    expect(getMoviesButton().className).toContain("active");
+    expect(getTvButton().className).not.toContain("active");
+  });
+
+  it("updates the active button when the user switches to TV Shows", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness>
+        <MediaTypeToggle />
+      </Harness>,
+    );
+
+    await user.click(getTvButton());
+
+    // Before the fix, reading `mediaType` from `useSearchParams()` left this
+    // assertion stuck on Movies because the provider commits via
+    // `window.history.replaceState`, which Next's SearchParamsContext
+    // does not observe. Reading from `useMediaFilters()` resolves the drift.
+    expect(getTvButton().className).toContain("active");
+    expect(getMoviesButton().className).not.toContain("active");
+  });
+
+  it("switches back to Movies when toggled again", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness>
+        <MediaTypeToggle />
+      </Harness>,
+    );
+
+    await user.click(getTvButton());
+    expect(getTvButton().className).toContain("active");
+
+    await user.click(getMoviesButton());
+    expect(getMoviesButton().className).toContain("active");
+    expect(getTvButton().className).not.toContain("active");
+  });
+
+  it("honors defaultFilters.mediaType on first paint", () => {
+    render(
+      <PathnameContext value="/movie-database">
+        <MediaFiltersProvider defaultFilters={{ mediaType: "tv" }}>
+          <MediaTypeToggle />
+        </MediaFiltersProvider>
+      </PathnameContext>,
+    );
+
+    expect(getTvButton().className).toContain("active");
+    expect(getMoviesButton().className).not.toContain("active");
+  });
+});

--- a/src/components/movie-database/media-type-toggle.tsx
+++ b/src/components/movie-database/media-type-toggle.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
 import { useMediaFilters } from "#src/hooks/use-media-filters.ts";
 import { t } from "#src/i18n.ts";
 import { AnchorButton } from "../shared/anchor-button";
@@ -12,11 +11,14 @@ interface MediaTypeToggleProps {
 }
 
 export function MediaTypeToggle({ shortLabels }: MediaTypeToggleProps) {
-  const searchParams = useSearchParams();
-  const { setMediaType, setMediaTypeUrl } = useMediaFilters();
+  // Read `mediaType` from the filters context rather than `useSearchParams()`.
+  // The provider commits filter changes via `window.history.replaceState`,
+  // which Next's `SearchParamsContext` does not observe — so reading from
+  // `useSearchParams()` here would leave the active highlight stuck on the
+  // previous choice until the next real navigation.
+  const { mediaType, setMediaType, setMediaTypeUrl } = useMediaFilters();
 
-  const currentType = searchParams.get("type");
-  const isTv = currentType === "tv";
+  const isTv = mediaType === "tv";
   const isMovies = !isTv;
 
   const handleMovieClick = (e: React.MouseEvent) => {


### PR DESCRIPTION
## Summary

`MediaTypeToggle` was reading its active state from `useSearchParams().get("type")`, but the filter provider commits URL changes via `window.history.replaceState(...)` — which Next's `SearchParamsContext` does not observe. After clicking the toggle, the URL and the grid updated but the highlighted button stayed stuck on the previous value.

The fix reads `mediaType` from `useMediaFilters()` — the same context every other filter sibling already uses — so the active state derives from React state that IS updated on commit. The provider's `replaceState` behavior is intentional (it avoids a full RSC re-render on each toggle click), so fixing the consumer is the right shape.

## Changes

- `src/components/movie-database/media-type-toggle.tsx` — removed the `useSearchParams` import and `searchParams.get("type")` read; `isTv`/`isMovies` now derive from `mediaType === "tv"`. Click handlers, anchor `href`s, and JSX are unchanged. Added a short comment explaining why we read from context rather than the search-params hook.
- `src/components/movie-database/media-type-toggle.test.tsx` (new) — 4 regression tests driving the real `MediaFiltersProvider` (no provider mocks):
  1. Movies active by default
  2. Click TV → TV active, Movies not
  3. Click back → Movies active again
  4. `defaultFilters={{ mediaType: "tv" }}` → TV active on first paint

  The harness wraps renders in `<PathnameContext>` (the provider's `buildUrl` calls `usePathname()`) and stubs jsdom gaps (`setPointerCapture`/`releasePointerCapture`/`matchMedia`) in `beforeAll`, matching existing test precedent.

## Test plan

- [x] `pnpm lint:changed`
- [x] `pnpm format:changed`
- [x] `pnpm test` (983/983 passing)
- [x] `pnpm build`