### PR TITLE
fix(ai-chat): add loading/error states to session-restore banner

### DIFF
--- a/src/ai-chat/use-ai-chat.ts
+++ b/src/ai-chat/use-ai-chat.ts
@@ -85,10 +85,14 @@ async function fetchSession(
   throw new Error(`Failed to fetch session: ${response.status}`);
 }
 
+type ContinueSessionStatus = "idle" | "pending" | "error";
+
 export function useAIChat({ locale }: { locale: SupportedLocale }) {
   const [previousSessionId, setPreviousSessionId] = useState<string | null>(
     null,
   );
+  const [continueSessionStatus, setContinueSessionStatus] =
+    useState<ContinueSessionStatus>("idle");
 
   const chatResult = useChat<ChatUIMessage>({
     transport: new DefaultChatTransport<ChatUIMessage>({
@@ -150,17 +154,35 @@ export function useAIChat({ locale }: { locale: SupportedLocale }) {
 
   const continueSession = () => {
     if (!previousSessionId) return;
+    // De-dupe rapid clicks — the previous in-flight fetch will resolve the
+    // banner one way or another.
+    if (continueSessionStatus === "pending") return;
+    setContinueSessionStatus("pending");
     fetchSession(previousSessionId)
       .then((result) => {
         if (!result) {
+          // 404: session gone server-side. Forget it and start fresh.
           clearStoredSessionId(locale);
           setPreviousSessionId(null);
+          setContinueSessionStatus("idle");
           return;
         }
         chatResult.setMessages(result.messages);
         setPreviousSessionId(null);
+        setContinueSessionStatus("idle");
       })
-      .catch(console.error);
+      .catch((error) => {
+        // Network / 5xx: surface to the user instead of silently freezing
+        // the banner. The user can retry or dismiss.
+        console.error("Failed to restore session", error);
+        setContinueSessionStatus("error");
+      });
+  };
+
+  const dismissPreviousSession = () => {
+    clearStoredSessionId(locale);
+    setPreviousSessionId(null);
+    setContinueSessionStatus("idle");
   };
 
   return {
@@ -168,5 +190,7 @@ export function useAIChat({ locale }: { locale: SupportedLocale }) {
     toolOutputs: accumulateToolOutputs(chatResult.messages),
     previousSessionId,
     continueSession,
+    continueSessionStatus,
+    dismissPreviousSession,
   };
 }

--- a/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
@@ -53,6 +53,8 @@ export function AIChatView({
     toolOutputs,
     previousSessionId,
     continueSession,
+    continueSessionStatus,
+    dismissPreviousSession,
   } = useAIChatContext();
   const [attachedMedia, setAttachedMedia] = useState<AttachedMedia | null>(
     null,
@@ -96,7 +98,12 @@ export function AIChatView({
         }}
       >
         {previousSessionId && messages.length === 0 && (
-          <SessionRestoreBanner onContinue={continueSession} />
+          <SessionRestoreBanner
+            onContinue={continueSession}
+            onDismiss={dismissPreviousSession}
+            isPending={continueSessionStatus === "pending"}
+            hasError={continueSessionStatus === "error"}
+          />
         )}
         <ChatMessageList
           messages={messages}

--- a/src/components/ai-chat/session-restore-banner.test.tsx
+++ b/src/components/ai-chat/session-restore-banner.test.tsx
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent } from "#src/test-utils.tsx";
+import { SessionRestoreBanner } from "./session-restore-banner";
+
+describe("SessionRestoreBanner", () => {
+  it("shows the default prompt and both action buttons in the idle state", () => {
+    render(<SessionRestoreBanner onContinue={() => {}} onDismiss={() => {}} />);
+
+    expect(
+      screen.getByText("You have a previous conversation"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Continue" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeEnabled();
+  });
+
+  it("fires onContinue when the continue button is clicked", async () => {
+    const user = userEvent.setup();
+    const onContinue = vi.fn();
+    render(
+      <SessionRestoreBanner onContinue={onContinue} onDismiss={() => {}} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onDismiss when the dismiss button is clicked", async () => {
+    const user = userEvent.setup();
+    const onDismiss = vi.fn();
+    render(
+      <SessionRestoreBanner onContinue={() => {}} onDismiss={onDismiss} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables both buttons and shows the pending label while a restore is in flight", async () => {
+    const user = userEvent.setup();
+    const onContinue = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      <SessionRestoreBanner
+        onContinue={onContinue}
+        onDismiss={onDismiss}
+        isPending
+      />,
+    );
+
+    const continueButton = screen.getByRole("button", { name: "Continuing…" });
+    const dismissButton = screen.getByRole("button", { name: "Dismiss" });
+
+    expect(continueButton).toBeDisabled();
+    expect(continueButton).toHaveAttribute("aria-busy", "true");
+    expect(dismissButton).toBeDisabled();
+
+    // Rapid-click dedupe: disabled buttons don't fire handlers, which is the
+    // point — the hook's in-flight guard is belt-and-braces on top of this.
+    await user.click(continueButton);
+    await user.click(dismissButton);
+    expect(onContinue).not.toHaveBeenCalled();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("shows an error message and a Try again label when the restore fails", () => {
+    render(
+      <SessionRestoreBanner
+        onContinue={() => {}}
+        onDismiss={() => {}}
+        hasError
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "Couldn't restore that conversation. Try again or dismiss.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeEnabled();
+  });
+
+  it("surfaces the error as a live region so screen readers announce it", () => {
+    render(
+      <SessionRestoreBanner
+        onContinue={() => {}}
+        onDismiss={() => {}}
+        hasError
+      />,
+    );
+
+    // role=alert makes SR announce the failure without the user having to
+    // re-focus the banner. Without this the failure would be silent for
+    // assistive-tech users the same way it was silent for sighted ones.
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("lets the user retry after an error by clicking Try again", async () => {
+    const user = userEvent.setup();
+    const onContinue = vi.fn();
+    render(
+      <SessionRestoreBanner
+        onContinue={onContinue}
+        onDismiss={() => {}}
+        hasError
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ai-chat/session-restore-banner.tsx
+++ b/src/components/ai-chat/session-restore-banner.tsx
@@ -8,26 +8,55 @@ import { border, color, font, space } from "#src/tokens.stylex.ts";
 
 interface SessionRestoreBannerProps {
   onContinue: () => void;
+  onDismiss: () => void;
+  isPending?: boolean;
+  hasError?: boolean;
 }
 
 export function SessionRestoreBanner({
   onContinue,
+  onDismiss,
+  isPending = false,
+  hasError = false,
 }: SessionRestoreBannerProps) {
+  const message = hasError
+    ? t({
+        en: "Couldn't restore that conversation. Try again or dismiss.",
+        zh: "无法恢复之前的对话。请重试或关闭。",
+      })
+    : t({
+        en: "You have a previous conversation",
+        zh: "你有一段之前的对话",
+      });
+
+  const continueLabel = isPending
+    ? t({ en: "Continuing…", zh: "恢复中…" })
+    : hasError
+      ? t({ en: "Try again", zh: "重试" })
+      : t({ en: "Continue", zh: "继续" });
+
   return (
-    <div css={[flex.row, styles.banner]}>
-      <p css={styles.text}>
-        {t({
-          en: "You have a previous conversation",
-          zh: "你有一段之前的对话",
-        })}
-      </p>
-      <button
-        type="button"
-        css={[buttonReset.base, styles.continueButton]}
-        onClick={onContinue}
-      >
-        {t({ en: "Continue", zh: "继续" })}
-      </button>
+    <div css={[flex.row, styles.banner]} role={hasError ? "alert" : undefined}>
+      <p css={[styles.text, hasError && styles.errorText]}>{message}</p>
+      <div css={[flex.row, styles.actions]}>
+        <button
+          type="button"
+          css={[buttonReset.base, styles.dismissButton]}
+          onClick={onDismiss}
+          disabled={isPending}
+        >
+          {t({ en: "Dismiss", zh: "关闭" })}
+        </button>
+        <button
+          type="button"
+          css={[buttonReset.base, styles.continueButton]}
+          onClick={onContinue}
+          disabled={isPending}
+          aria-busy={isPending || undefined}
+        >
+          {continueLabel}
+        </button>
+      </div>
     </div>
   );
 }
@@ -48,6 +77,33 @@ const styles = stylex.create({
     margin: 0,
     fontSize: font.uiBody,
     color: color.textMuted,
+    flex: 1,
+  },
+  errorText: {
+    color: color.textMain,
+  },
+  actions: {
+    gap: space._2,
+    alignItems: "center",
+    flexShrink: 0,
+  },
+  dismissButton: {
+    fontSize: font.uiBodySmall,
+    lineHeight: font.lineHeight_3,
+    paddingBlock: space._1,
+    paddingInline: space._3,
+    borderRadius: border.radius_round,
+    backgroundColor: "transparent",
+    color: {
+      default: color.textMuted,
+      ":hover": color.textMain,
+      ":disabled": color.textMuted,
+    },
+    cursor: {
+      default: "pointer",
+      ":disabled": "not-allowed",
+    },
+    transition: "color 0.15s ease",
   },
   continueButton: {
     fontSize: font.uiBodySmall,
@@ -58,9 +114,17 @@ const styles = stylex.create({
     backgroundColor: {
       default: color.controlActive,
       ":hover": color.controlActiveHover,
+      ":disabled": color.controlActive,
     },
     color: color.textOnActive,
-    cursor: "pointer",
-    transition: "background-color 0.15s ease",
+    cursor: {
+      default: "pointer",
+      ":disabled": "not-allowed",
+    },
+    opacity: {
+      default: 1,
+      ":disabled": 0.6,
+    },
+    transition: "background-color 0.15s ease, opacity 0.15s ease",
   },
 });


### PR DESCRIPTION
## Summary

The session-restore banner previously had no UX for a failed `continueSession()` — a network hiccup or 5xx silently logged to console and left the banner frozen with no feedback. This PR adds loading, error, and persistent-dismiss states entirely on the client (the server route is untouched).

## Changes

- **`src/ai-chat/use-ai-chat.ts`**: Added a `continueSessionStatus: "idle" | "pending" | "error"` state machine. `continueSession()` dedupes rapid clicks via a pending early-return, flips state through the transitions, drops storage on 404 (session-gone), and sets `error` on network/5xx so retry can use the same `sessionId`. New `dismissPreviousSession()` calls `clearStoredSessionId(locale) + setPreviousSessionId(null) + setContinueSessionStatus("idle")` — clearing localStorage so the banner does not silently re-show on the next mount. The deliberate set-state-during-render auto-dismiss is preserved untouched.
- **`src/components/ai-chat/session-restore-banner.tsx`**: Props grew to `{ onContinue, onDismiss, isPending?, hasError? }`. Renders Continue + Dismiss buttons. Pending state disables both buttons (primary DOM-level click guard), sets `aria-busy="true"` on Continue, swaps label to "Continuing…". Error state adds `role="alert"` (only in the error branch to avoid noisy live-region churn), swaps copy to "Couldn't restore that conversation. Try again or dismiss.", and swaps the Continue label to "Try again". All strings via the project's inline `t({ en, zh })` pattern.
- **`src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx`**: Wires the two new hook fields and the derived `isPending`/`hasError` booleans through to the banner.
- **`src/components/ai-chat/session-restore-banner.test.tsx`** (new): 7 tests covering idle copy/buttons, continue click, dismiss click, pending disabled + `aria-busy` + label + rapid-click dedupe via disabled buttons, error copy + "Try again" label + re-enabled state, error `role="alert"` live region, and the retry-after-error flow.

## Notes

Hook-level `renderHook` tests were not added — there is no existing harness for `useChat` + `DefaultChatTransport`, the state machine is ~15 lines of plain transitions, and the banner tests cover every visible behavior.

## Test plan

- [x] `pnpm lint:changed`
- [x] `pnpm format:changed`
- [x] `pnpm test` (986/986 passing)
- [x] `pnpm build`
- [x] No `any`, no type assertions, no mocks, no manual memoization