### PR TITLE
fix: disable suggestion chips while chat is streaming

### DIFF
--- a/src/components/ai-chat/suggestion-chips.test.tsx
+++ b/src/components/ai-chat/suggestion-chips.test.tsx
@@ -75,4 +75,84 @@ describe("SuggestionChips", () => {
     expect(onSelect).toHaveBeenCalledTimes(1);
     expect(onSelect).toHaveBeenCalledWith("Recommend a thriller");
   });
+
+  describe("disabled state", () => {
+    it("renders every chip as a disabled button when `disabled` is true", () => {
+      render(
+        <SuggestionChips
+          suggestions={["Recommend a thriller", "What's trending?"]}
+          groupLabel="Suggested prompts"
+          onSelect={vi.fn()}
+          disabled
+        />,
+      );
+
+      expect(
+        screen.getByRole("button", { name: "Recommend a thriller" }),
+      ).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "What's trending?" }),
+      ).toBeDisabled();
+    });
+
+    it("does not fire onSelect when a disabled chip is clicked", async () => {
+      const user = userEvent.setup();
+      const onSelect = vi.fn();
+
+      render(
+        <SuggestionChips
+          suggestions={["Recommend a thriller"]}
+          groupLabel="Suggested prompts"
+          onSelect={onSelect}
+          disabled
+        />,
+      );
+
+      // This is the core regression: before the fix, chips had no
+      // disabled state at all, so a mid-stream click would silently
+      // route into `send()` and be swallowed by `if (isLoading) return`.
+      // With the fix, the native `disabled` attribute blocks onClick
+      // entirely — no silent no-op, no confusing phantom click.
+      await user.click(
+        screen.getByRole("button", { name: "Recommend a thriller" }),
+      );
+
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it("does not fall back to ChatActionsContext.sendMessage when disabled", async () => {
+      const user = userEvent.setup();
+      const { sendMessage } = renderDisabledChipsWithContext([
+        "Recommend a thriller",
+      ]);
+
+      await user.click(
+        screen.getByRole("button", { name: "Recommend a thriller" }),
+      );
+
+      expect(sendMessage).not.toHaveBeenCalled();
+    });
+  });
 });
+
+function renderDisabledChipsWithContext(suggestions: ReadonlyArray<string>) {
+  // Mirrors `renderChips` but sets `disabled` so the context-fallback
+  // branch of SuggestionChips is exercised in the disabled state.
+  const sendMessage = vi.fn();
+  const result = render(
+    <ChatActionsContext
+      value={{
+        sendMessage,
+        attachedMedia: null,
+        setAttachedMedia: vi.fn(),
+      }}
+    >
+      <SuggestionChips
+        suggestions={suggestions}
+        groupLabel="Suggested prompts"
+        disabled
+      />
+    </ChatActionsContext>,
+  );
+  return { ...result, sendMessage };
+}

--- a/src/components/ai-chat/suggestion-chips.tsx
+++ b/src/components/ai-chat/suggestion-chips.tsx
@@ -10,12 +10,20 @@ interface SuggestionChipsProps {
   suggestions: ReadonlyArray<string>;
   groupLabel: string;
   onSelect?: (text: string) => void;
+  /**
+   * When true, all chips are rendered in a disabled state. Mirrors the
+   * ChatTextarea `disabled` behavior so callers can signal "chat is busy —
+   * don't queue another send" consistently across both inputs instead of
+   * letting clicks silently no-op.
+   */
+  disabled?: boolean;
 }
 
 export function SuggestionChips({
   suggestions,
   groupLabel,
   onSelect,
+  disabled,
 }: SuggestionChipsProps) {
   const chatActions = use(ChatActionsContext);
   const handleSelect = onSelect ?? chatActions?.sendMessage;
@@ -32,6 +40,7 @@ export function SuggestionChips({
           type="button"
           css={styles.chip}
           onClick={() => handleSelect?.(text)}
+          disabled={disabled}
         >
           {text}
         </button>
@@ -51,23 +60,33 @@ const styles = stylex.create({
     borderColor: {
       default: color.controlTrack,
       ":hover": color.controlActive,
+      ":disabled": color.controlTrack,
     },
     borderRadius: border.radius_round,
     backgroundColor: {
       default: "transparent",
       ":hover": color.controlActive,
+      ":disabled": "transparent",
     },
     color: {
       default: color.textMuted,
       ":hover": color.textOnActive,
+      ":disabled": color.textMuted,
     },
     fontFamily: font.family,
     fontSize: font.uiBodySmall,
     lineHeight: font.lineHeight_3,
     paddingBlock: space._1,
     paddingInline: space._3,
-    cursor: "pointer",
+    cursor: {
+      default: "pointer",
+      ":disabled": "not-allowed",
+    },
+    opacity: {
+      default: 1,
+      ":disabled": 0.5,
+    },
     transition:
-      "background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease",
+      "background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease, opacity 0.15s ease",
   },
 });

--- a/src/components/movie-database/hero-chat-input.tsx
+++ b/src/components/movie-database/hero-chat-input.tsx
@@ -45,6 +45,7 @@ export function HeroChatInput({
           suggestions={suggestions}
           groupLabel={suggestionsGroupLabel}
           onSelect={send}
+          disabled={isLoading}
         />
       </div>
     </>


### PR DESCRIPTION
## Summary

Make `HeroChatInput`'s suggestion chips visually reflect the loading state so users get clear feedback mid-stream, matching the sibling `ChatTextarea` in the same surface which was already wired `disabled={isLoading}`. `SuggestionChips` now accepts an optional `disabled` prop that sets the native HTML `disabled` attribute on each chip's `<button>` (blocking click and keyboard activation at the DOM level) and applies muted styling via `:disabled` StyleX entries ordered after `:hover` so hovering a disabled chip doesn't relight it. `HeroChatInput` passes `disabled={isLoading}` through; the existing `send()` isLoading guard is kept as belt-and-braces.

## Context

Approach (a) — visual disable plus native click block — was chosen over the alternative of still navigating to ai-mode on click while skipping `send()`, for visual consistency with `ChatTextarea` and to avoid a new product decision about what to do on arrival with an uninjected message. The `ai-mode/page.tsx` call site (via `AIChatView`'s `emptyState`) is left untouched because it only renders when `messages.length === 0` and so is unreachable during a loading stream; the new prop is optional so that call site passes through unchanged.