### PR TITLE
fix(playground): stop WebGL pipeline teardown on debug/theme toggles

### DIFF
--- a/src/components/playground/loop.ts
+++ b/src/components/playground/loop.ts
@@ -148,11 +148,12 @@ function createPingPongFBOs(gl: WebGL2RenderingContext, w: number, h: number) {
 export interface LoopControls {
   cleanup: () => void;
   setDebug: (options: DebugOptions) => void;
+  setIsDark: (next: boolean) => void;
 }
 
 export function start(
   { gl, pathtraceProgram, displayProgram, canvas, bufferInfo }: Context,
-  { isDark }: { isDark: boolean },
+  { isDark: initialIsDark }: { isDark: boolean },
   initialDebug: DebugOptions,
   onStats?: (stats: FrameStats) => void,
 ): LoopControls {
@@ -160,6 +161,7 @@ export function start(
 
   let debug = initialDebug;
   let prevDebugKey = JSON.stringify(debug);
+  let isDark = initialIsDark;
 
   const dpr = window.devicePixelRatio;
 
@@ -351,6 +353,9 @@ export function start(
     },
     setDebug: (options: DebugOptions) => {
       debug = options;
+    },
+    setIsDark: (next: boolean) => {
+      isDark = next;
     },
   };
 }

--- a/src/components/playground/playground-canvas.tsx
+++ b/src/components/playground/playground-canvas.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useMediaQuery } from "#src/hooks/use-media-query.ts";
 import { useTheme } from "#src/hooks/use-theme.ts";
 import type { DebugMode, DebugOptions, FrameStats, LoopControls } from "./loop";
@@ -161,7 +161,42 @@ export function PlaygroundCanvas() {
   const isDark = theme === "system" ? preferDark : theme === "dark";
   const [stats, setStats] = useState<FrameStats | null>(null);
   const [debug, setDebug] = useState<DebugOptions>(DEFAULT_DEBUG);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
   const controlsRef = useRef<LoopControls | null>(null);
+
+  // Captures the initial state values the mount effect should seed the
+  // loop with. Using refs keeps the mount effect's dep array empty so it
+  // doesn't tear down and rebuild the WebGL pipeline — and wipe the
+  // progressive-sample accumulation — every time `debug` or `isDark`
+  // changes. Subsequent updates are pushed into the running loop via
+  // `controls.setDebug` / `controls.setIsDark` below.
+  const initialDebugRef = useRef(debug);
+  const initialIsDarkRef = useRef(isDark);
+
+  useEffect(() => {
+    const el = canvasRef.current;
+    if (!el) return;
+    const context = init(el, vs, pathtracerFs, displayFs);
+    if (!context) return;
+    const controls = start(
+      context,
+      { isDark: initialIsDarkRef.current },
+      initialDebugRef.current,
+      setStats,
+    );
+    controlsRef.current = controls;
+    return () => {
+      controls.cleanup();
+      controlsRef.current = null;
+    };
+  }, []);
+
+  // Push theme changes into the running loop imperatively so the dark-mode
+  // toggle updates the `u_dark` uniform on the next frame without tearing
+  // down the accumulated samples.
+  useEffect(() => {
+    controlsRef.current?.setIsDark(isDark);
+  }, [isDark]);
 
   const handleDebugChange = (next: DebugOptions) => {
     setDebug(next);
@@ -170,19 +205,7 @@ export function PlaygroundCanvas() {
 
   return (
     <>
-      <canvas
-        ref={(el) => {
-          if (el) {
-            const context = init(el, vs, pathtracerFs, displayFs);
-            if (context) {
-              const controls = start(context, { isDark }, debug, setStats);
-              controlsRef.current = controls;
-              return controls.cleanup;
-            }
-          }
-        }}
-        css={styles.canvas}
-      />
+      <canvas ref={canvasRef} css={styles.canvas} />
       {stats && (
         <StatsOverlay
           stats={stats}


### PR DESCRIPTION
## Summary

`PlaygroundCanvas` was tearing down its WebGL pipeline on every debug-flag or theme toggle. The mount lived in an inline ref callback that closed over `debug` and `isDark`; React Compiler memoized the callback against those deps, so any state change produced a new callback identity — React ran the old cleanup (killing the RAF loop, disconnecting the ResizeObserver, releasing GPU resources) and remounted a fresh pipeline. Progressive-sample accumulation reset each time.

## Changes

- **`src/components/playground/playground-canvas.tsx`** — replaced the inline ref callback with `useRef<HTMLCanvasElement>(null)` + mount-time `useEffect(() => { ... }, [])` that calls `init` + `start` and returns `controls.cleanup()` on unmount (nulls `controlsRef.current`). `initialDebugRef` / `initialIsDarkRef` carry first-render values into the empty-deps effect without adding dep tracking. A second `useEffect(() => { controlsRef.current?.setIsDark(isDark); }, [isDark])` syncs theme changes into the running loop.
- **`src/components/playground/loop.ts`** — `LoopControls` gains `setIsDark(next: boolean)`. `start()` introduces a loop-local `let isDark = initialIsDark`; the `u_dark` uniform read happens inside the per-frame `render()` closure so mutations flow through. `setIsDark` mutates the `let` without resetting `frameIndex`, matching `setDebug`'s semantic so samples survive theme toggles (shader uses `u_dark` only as a `mix` factor — no precomputed per-theme resources need resetting).

## Design notes

Chose the "plumb `setIsDark`" option over the "accept re-init on theme change" alternative because it's consistent with how `setDebug` already works, preserves sample accumulation across theme toggles, and is a tiny additive change to `loop.ts`. `LoopControls` has a single consumer (`playground-canvas.tsx`), so the interface addition is non-breaking.

## Test plan

- [x] `pnpm lint:changed`
- [x] `pnpm format:changed`
- [x] `pnpm test` (979/979 pass)
- [x] `pnpm build`
- [ ] Manual: toggle debug flag — pipeline should not reinitialize, samples continue accumulating
- [ ] Manual: toggle theme — pipeline should not reinitialize, `u_dark` mix updates live, samples continue accumulating

No new tests added — the WebGL loop is hard to unit-test and the fix is verifiable by reading (empty-deps effect guarantees mount-once, imperative setters mirror `setDebug`).