### PR TITLE
perf(ai-chat): stop rebuilding ExpandableBiography ResizeObserver on toggle

### DIFF
--- a/src/components/ai-chat/person-detail-content.tsx
+++ b/src/components/ai-chat/person-detail-content.tsx
@@ -143,6 +143,11 @@ function ExpandableBiography({ text }: { text: string }) {
   const [isClamped, setIsClamped] = useState(false);
   const paragraphRef = useRef<HTMLParagraphElement>(null);
 
+  // Observe layout changes on the paragraph itself. `measure` reads live
+  // DOM (scrollHeight vs clientHeight) rather than closing over `expanded`,
+  // so the observer never needs to be torn down and rebuilt on toggle —
+  // the natural ResizeObserver fire from the clamp class flipping already
+  // delivers the measurement. Empty deps: set up once per mount.
   useEffect(() => {
     const el = paragraphRef.current;
     if (!el) return;
@@ -156,7 +161,7 @@ function ExpandableBiography({ text }: { text: string }) {
     const observer = new ResizeObserver(measure);
     observer.observe(el);
     return () => observer.disconnect();
-  }, [expanded]);
+  }, []);
 
   return (
     <div>


### PR DESCRIPTION
## Summary

`ExpandableBiography` (in `src/components/ai-chat/person-detail-content.tsx`) owned a `ResizeObserver` inside a `useEffect` whose dep array was `[expanded]`. Every time the user toggled the bio open/closed, the effect tore down the observer and rebuilt a new one — but the `measure` callback only reads `scrollHeight`/`clientHeight` from the live DOM via `paragraphRef`, so it never actually closed over `expanded`. The dep was vestigial and the churn was pure waste.

Fix: drop the dep to `[]` so the observer is attached once on mount and disconnected once on unmount. When the user toggles, React re-renders, the `biographyClamped` class (`display: -webkit-box`, `-webkit-line-clamp: 6`, `overflow: hidden`) is applied or removed, the paragraph's content box changes, and the already-attached `ResizeObserver` fires naturally on the next layout tick — same measurement path, no observer rebuild. The initial synchronous `measure()` call inside the effect is preserved because `ResizeObserver.observe()` doesn't fire synchronously on attach, so first-mount measurement still depends on it.

Added a short comment above the effect explaining why the dep array is empty (measure reads live DOM, not the `expanded` closure) so a future refactor has the context and doesn't "fix" it back.

`react-hooks/exhaustive-deps` is satisfied — the effect only references `paragraphRef` (ref) and `setIsClamped` (state setter), both stable.

## Test plan

- [x] `pnpm lint:changed`
- [x] `pnpm format:changed`
- [x] `pnpm test` (979/979 passing)
- [x] `pnpm build`