### PR TITLE
fix: use locale-aware canonical URLs in metadata

### DIFF
--- a/src/app/[locale]/(home)/(details)/education/altrincham-grammar-school-for-boys/page.tsx
+++ b/src/app/[locale]/(home)/(details)/education/altrincham-grammar-school-for-boys/page.tsx
@@ -19,7 +19,9 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     }),
     alternates: {
       canonical: new URL(
-        "/education/altrincham-grammar-school-for-boys",
+        params.locale === "zh"
+          ? "/zh/education/altrincham-grammar-school-for-boys"
+          : "/education/altrincham-grammar-school-for-boys",
         BASE_URL,
       ).toString(),
       languages: {

--- a/src/app/[locale]/(home)/(details)/education/university-of-bristol/page.tsx
+++ b/src/app/[locale]/(home)/(details)/education/university-of-bristol/page.tsx
@@ -20,7 +20,9 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     }),
     alternates: {
       canonical: new URL(
-        "/education/university-of-bristol",
+        params.locale === "zh"
+          ? "/zh/education/university-of-bristol"
+          : "/education/university-of-bristol",
         BASE_URL,
       ).toString(),
       languages: {

--- a/src/app/[locale]/(home)/(details)/education/university-of-nottingham/page.tsx
+++ b/src/app/[locale]/(home)/(details)/education/university-of-nottingham/page.tsx
@@ -19,7 +19,9 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     }),
     alternates: {
       canonical: new URL(
-        "/education/university-of-nottingham",
+        params.locale === "zh"
+          ? "/zh/education/university-of-nottingham"
+          : "/education/university-of-nottingham",
         BASE_URL,
       ).toString(),
       languages: {

--- a/src/app/[locale]/(home)/(details)/experiences/citadel/page.tsx
+++ b/src/app/[locale]/(home)/(details)/experiences/citadel/page.tsx
@@ -18,7 +18,12 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
       zh: "了解石清琪在 Citadel 担任软件工程师的经历，他使用 React、TypeScript 和 AG Grid 为金融行业开发仪表盘 Web 应用。",
     }),
     alternates: {
-      canonical: new URL("/experiences/citadel", BASE_URL).toString(),
+      canonical: new URL(
+        params.locale === "zh"
+          ? "/zh/experiences/citadel"
+          : "/experiences/citadel",
+        BASE_URL,
+      ).toString(),
       languages: {
         en: new URL("/experiences/citadel", BASE_URL).toString(),
         zh: new URL("/zh/experiences/citadel", BASE_URL).toString(),

--- a/src/app/[locale]/(home)/(details)/experiences/spotify/page.tsx
+++ b/src/app/[locale]/(home)/(details)/experiences/spotify/page.tsx
@@ -18,7 +18,12 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
       zh: "了解石清琪在 Spotify 担任软件工程师 II 的经验，他构建了一个广告活动管理平台，并为公司范围内的一些项目做出了贡献。",
     }),
     alternates: {
-      canonical: new URL("/experiences/spotify", BASE_URL).toString(),
+      canonical: new URL(
+        params.locale === "zh"
+          ? "/zh/experiences/spotify"
+          : "/experiences/spotify",
+        BASE_URL,
+      ).toString(),
       languages: {
         en: new URL("/experiences/spotify", BASE_URL).toString(),
         zh: new URL("/zh/experiences/spotify", BASE_URL).toString(),

--- a/src/app/[locale]/(home)/(details)/experiences/wunderman-thompson-commerce/page.tsx
+++ b/src/app/[locale]/(home)/(details)/experiences/wunderman-thompson-commerce/page.tsx
@@ -19,7 +19,9 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     }),
     alternates: {
       canonical: new URL(
-        "/experiences/wunderman-thompson-commerce",
+        params.locale === "zh"
+          ? "/zh/experiences/wunderman-thompson-commerce"
+          : "/experiences/wunderman-thompson-commerce",
         BASE_URL,
       ).toString(),
       languages: {

--- a/src/app/[locale]/(home)/layout.tsx
+++ b/src/app/[locale]/(home)/layout.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     description,
     applicationName: t({ en: "Qingqi Shi", zh: "石清琪" }),
     alternates: {
-      canonical: new URL("/", BASE_URL).toString(),
+      canonical: url,
       languages: {
         en: new URL("/", BASE_URL).toString(),
         zh: new URL("/zh", BASE_URL).toString(),

--- a/src/app/[locale]/calculator/layout.tsx
+++ b/src/app/[locale]/calculator/layout.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     title,
     description,
     alternates: {
-      canonical: new URL("/calculator", BASE_URL).toString(),
+      canonical: url,
       languages: {
         en: new URL("/calculator", BASE_URL).toString(),
         zh: new URL("/zh/calculator", BASE_URL).toString(),

--- a/src/app/[locale]/component-library/layout.tsx
+++ b/src/app/[locale]/component-library/layout.tsx
@@ -33,7 +33,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     },
     description,
     alternates: {
-      canonical: new URL("/component-library", BASE_URL).toString(),
+      canonical: url,
       languages: {
         en: new URL("/component-library", BASE_URL).toString(),
         zh: new URL("/zh/component-library", BASE_URL).toString(),

--- a/src/app/[locale]/movie-database/[type]/[id]/layout.tsx
+++ b/src/app/[locale]/movie-database/[type]/[id]/layout.tsx
@@ -57,7 +57,7 @@ export async function generateMetadata({
       title,
       description,
       alternates: {
-        canonical: new URL(`/movie-database/movie/${id}`, BASE_URL).toString(),
+        canonical: url,
         languages: {
           en: new URL(`/movie-database/movie/${id}`, BASE_URL).toString(),
           zh: new URL(`/zh/movie-database/movie/${id}`, BASE_URL).toString(),
@@ -100,7 +100,7 @@ export async function generateMetadata({
       title,
       description,
       alternates: {
-        canonical: new URL(`/movie-database/tv/${id}`, BASE_URL).toString(),
+        canonical: url,
         languages: {
           en: new URL(`/movie-database/tv/${id}`, BASE_URL).toString(),
           zh: new URL(`/zh/movie-database/tv/${id}`, BASE_URL).toString(),

--- a/src/app/[locale]/movie-database/ai-mode/layout.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/layout.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata(props: {
     title,
     description,
     alternates: {
-      canonical: new URL("/movie-database/ai-mode", BASE_URL).toString(),
+      canonical: url,
       languages: {
         en: new URL("/movie-database/ai-mode", BASE_URL).toString(),
         zh: new URL("/zh/movie-database/ai-mode", BASE_URL).toString(),

--- a/src/app/[locale]/movie-database/layout.tsx
+++ b/src/app/[locale]/movie-database/layout.tsx
@@ -34,7 +34,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     },
     description,
     alternates: {
-      canonical: new URL("/movie-database", BASE_URL).toString(),
+      canonical: url,
       languages: {
         en: new URL("/movie-database", BASE_URL).toString(),
         zh: new URL("/zh/movie-database", BASE_URL).toString(),


### PR DESCRIPTION
## Summary

Every `generateMetadata` under `src/app/[locale]/**` returned `alternates.canonical` as a hardcoded English URL. `/zh/experiences/spotify` was declaring `/experiences/spotify` as its canonical, so Google would treat the Chinese variant as a duplicate of the English one and de-index it. Canonical is now the locale-specific URL so each language version self-references correctly.

## Context

`alternates.languages` (hreflang) was already locale-aware and didn't need changes — the issue was only with `canonical`, which serves a different purpose (URL deduplication rather than cross-language equivalence).