### PR TITLE
fix: mark menu-button popup as inert when closed

### DIFF
--- a/src/components/shared/menu-button.test.tsx
+++ b/src/components/shared/menu-button.test.tsx
@@ -184,6 +184,46 @@ describe("MenuButton keyboard navigation", () => {
     expect(trigger).toHaveFocus();
   });
 
+  it("marks the popup inert while the menu is closed so its items are not tabbable or a11y-exposed", async () => {
+    const user = userEvent.setup();
+    render(
+      <RouterProvider>
+        <TestMenu />
+      </RouterProvider>,
+    );
+
+    const popup = screen.getByRole("menu");
+    expect(popup).toHaveAttribute("inert");
+
+    await user.click(screen.getByRole("button", { name: "Open menu" }));
+    expect(popup).not.toHaveAttribute("inert");
+
+    await user.keyboard("{Escape}");
+    expect(popup).toHaveAttribute("inert");
+  });
+
+  it("marks a group popup inert while closed so non-menu controls are also not tabbable", async () => {
+    const user = userEvent.setup();
+    render(
+      <MenuButton
+        buttonProps={{ type: "button", "aria-label": "Open group" }}
+        popupRole="group"
+        menuContent={
+          <div>
+            <button type="button">First</button>
+            <button type="button">Second</button>
+          </div>
+        }
+      />,
+    );
+
+    const popup = screen.getByRole("group");
+    expect(popup).toHaveAttribute("inert");
+
+    await user.click(screen.getByRole("button", { name: "Open group" }));
+    expect(popup).not.toHaveAttribute("inert");
+  });
+
   it("does not intercept arrow keys when popupRole is not 'menu'", async () => {
     const user = userEvent.setup();
 

--- a/src/components/shared/menu-button.tsx
+++ b/src/components/shared/menu-button.tsx
@@ -186,6 +186,7 @@ export function MenuButton({
               ref={popupRef}
               role={popupRole}
               aria-labelledby={popupRole ? `${targetId}-label` : undefined}
+              inert={!isMenuShown}
             >
               {children && <div css={styles.menuTitle}>{children}</div>}
               {menuContent}


### PR DESCRIPTION
## Summary

`MenuButton` keeps its popup wrapper mounted while closed so the `AnimateToTarget` FLIP close animation can play. Because the popup stays in the DOM, its focusable descendants remained in the tab order and exposed to screen readers even when visually closed — affecting `LocaleSelector` in the header (every page), `MobileFiltersButton`, `GenreFilterButton`, and `TmdbCredit`. The fix adds `inert={!isMenuShown}` to the popup wrapper `<div>` (the one carrying `ref={popupRef}` and `role={popupRole}`), which removes the subtree from tab order and from the a11y tree without touching layout/opacity/visibility, so the close animation is unaffected. A single primitive-level change fixes every `MenuButton` consumer — no changes in `LocaleSelector`, `MobileFiltersButton`, `GenreFilterButton`, or `TmdbCredit`.

## Context

Alternatives considered and rejected:

- Unmounting or `display: none` — kills the close animation
- `visibility: hidden` — hides the popup during the fade
- `aria-hidden` — leaves descendants tabbable
- Per-child `tabindex="-1"` — does not affect the a11y tree

`inert` is the only option that fixes both tab order and a11y tree without breaking the animation. React 19 types accept it natively.

Placement matters: the attribute is on the inner `popupRef` div, not the outer `menuContainer`, so the trigger button stays interactive and the semantic element (`role={popupRole}`) carries the closed-state signal.

Two new tests in `menu-button.test.tsx` cover `popupRole="menu"` and `popupRole="group"`, asserting `inert` is present initially, removed on open, and re-added after Escape. Existing focus-on-open tests (autoFocus target, first-menu-item focus) still pass, proving focus restoration is unaffected by the inert toggle.

Verification: `pnpm build:tsc` clean, `pnpm lint:changed` passed, `pnpm format:changed` unchanged, `pnpm test` 1003/1003 (+2 new), `pnpm build` succeeded with all 48 static pages generated.