### PR TITLE
fix: stop calculator Enter shortcut from hijacking focused buttons

### DIFF
--- a/src/components/calculator/calculator.test.tsx
+++ b/src/components/calculator/calculator.test.tsx
@@ -94,6 +94,42 @@ describe("Calculator error recovery", () => {
   });
 });
 
+describe("Calculator keyboard activation", () => {
+  it("appends the focused digit button's value on Enter instead of evaluating", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    screen.getByRole("button", { name: "5" }).focus();
+    await user.keyboard("{Enter}");
+
+    expect(getDisplay()).toHaveTextContent("5");
+  });
+
+  it("activates the focused operator button on Enter", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    await pressButtons(user, ["1"]);
+    screen.getByRole("button", { name: "Add" }).focus();
+    await user.keyboard("{Enter}");
+
+    expect(getDisplay()).toHaveTextContent("1 +");
+  });
+
+  it("still evaluates the expression when Enter is pressed with the container focused", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    await pressButtons(user, ["2", "Add", "3"]);
+    expect(getDisplay()).toHaveTextContent("2 + 3");
+
+    screen.getByRole("application").focus();
+    await user.keyboard("{Enter}");
+
+    expect(getDisplay()).toHaveTextContent("5");
+  });
+});
+
 describe("Calculator Backspace", () => {
   it("deletes the last digit of a multi-digit number", async () => {
     const user = userEvent.setup();

--- a/src/components/calculator/calculator.tsx
+++ b/src/components/calculator/calculator.tsx
@@ -75,6 +75,13 @@ export function Calculator() {
       return;
     }
 
+    // Enter on a focused CalculatorButton must fire the button's own click,
+    // not the container's "=" shortcut — otherwise tabbing to "5" and pressing
+    // Enter evaluates the expression instead of appending "5".
+    if (key === "Enter" && event.target !== event.currentTarget) {
+      return;
+    }
+
     const keyMap: Record<string, string> = {
       "0": "0",
       "1": "1",


### PR DESCRIPTION
## Summary

The container-level `onKeyDown` mapped Enter to `"="` for type-anywhere convenience, but when a user tabbed into a child button, Enter bubbled up and evaluated the expression instead of letting native button activation synthesize the click. Adds an early-return guard so Enter from a descendant is ignored by the container, while Enter on the container itself still runs the `"="` shortcut.

## Context

The guard checks `event.target !== event.currentTarget` rather than `instanceof HTMLButtonElement` so any future focusable descendant inherits the correct behavior automatically. Only Enter needs the guard — other keys in the keyMap (digits, operators, Backspace, Escape) have no native button activation, so the type-anywhere feature for them is preserved intact.