### PR TITLE
fix(detail-page-title): swap heading levels so page topic is h1

### DIFF
--- a/e2e/detail-pages.spec.ts
+++ b/e2e/detail-pages.spec.ts
@@ -7,9 +7,9 @@ test.describe("Experience Detail Pages", () => {
     // Verify Citadel page
     await page.goto("/experiences/citadel");
     await expect(
-      page.getByRole("heading", { level: 2, name: /experience.*citadel/i }),
+      page.getByRole("heading", { level: 1, name: /experience.*citadel/i }),
     ).toBeVisible();
-    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    await expect(page.getByRole("heading", { level: 2 })).toBeVisible();
     const timeElement = page.locator("time");
     await expect(timeElement).toBeVisible();
     await expect(timeElement).toContainText(/\d{4}/); // Should contain a year
@@ -17,20 +17,20 @@ test.describe("Experience Detail Pages", () => {
     // Verify Spotify page
     await page.goto("/experiences/spotify");
     await expect(
-      page.getByRole("heading", { level: 2, name: /experience.*spotify/i }),
+      page.getByRole("heading", { level: 1, name: /experience.*spotify/i }),
     ).toBeVisible();
-    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    await expect(page.getByRole("heading", { level: 2 })).toBeVisible();
     await expect(page.locator("time")).toBeVisible();
 
     // Verify Wunderman Thompson Commerce page
     await page.goto("/experiences/wunderman-thompson-commerce");
     await expect(
       page.getByRole("heading", {
-        level: 2,
+        level: 1,
         name: /experience.*wunderman thompson commerce/i,
       }),
     ).toBeVisible();
-    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    await expect(page.getByRole("heading", { level: 2 })).toBeVisible();
     await expect(page.locator("time")).toBeVisible();
   });
 
@@ -60,33 +60,33 @@ test.describe("Education Detail Pages", () => {
     await page.goto("/education/university-of-bristol");
     await expect(
       page.getByRole("heading", {
-        level: 2,
+        level: 1,
         name: /education.*university of bristol/i,
       }),
     ).toBeVisible();
-    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    await expect(page.getByRole("heading", { level: 2 })).toBeVisible();
     await expect(page.locator("time")).toBeVisible();
 
     // Verify University of Nottingham page
     await page.goto("/education/university-of-nottingham");
     await expect(
       page.getByRole("heading", {
-        level: 2,
+        level: 1,
         name: /education.*university of nottingham/i,
       }),
     ).toBeVisible();
-    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    await expect(page.getByRole("heading", { level: 2 })).toBeVisible();
     await expect(page.locator("time")).toBeVisible();
 
     // Verify Altrincham Grammar School page
     await page.goto("/education/altrincham-grammar-school-for-boys");
     await expect(
       page.getByRole("heading", {
-        level: 2,
+        level: 1,
         name: /education.*altrincham grammar school/i,
       }),
     ).toBeVisible();
-    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    await expect(page.getByRole("heading", { level: 2 })).toBeVisible();
     await expect(page.locator("time")).toBeVisible();
   });
 
@@ -124,25 +124,25 @@ test("should load experience and education pages correctly when accessed directl
   // Navigate directly to Citadel page
   await page.goto("/experiences/citadel");
   await expect(
-    page.getByRole("heading", { level: 2, name: /citadel/i }),
+    page.getByRole("heading", { level: 1, name: /citadel/i }),
   ).toBeVisible();
 
   // Navigate directly to Spotify page
   await page.goto("/experiences/spotify");
   await expect(
-    page.getByRole("heading", { level: 2, name: /spotify/i }),
+    page.getByRole("heading", { level: 1, name: /spotify/i }),
   ).toBeVisible();
 
   // Navigate directly to University of Bristol page
   await page.goto("/education/university-of-bristol");
   await expect(
-    page.getByRole("heading", { level: 2, name: /bristol/i }),
+    page.getByRole("heading", { level: 1, name: /bristol/i }),
   ).toBeVisible();
 
   // Navigate directly to University of Nottingham page
   await page.goto("/education/university-of-nottingham");
   await expect(
-    page.getByRole("heading", { level: 2, name: /nottingham/i }),
+    page.getByRole("heading", { level: 1, name: /nottingham/i }),
   ).toBeVisible();
 });
 
@@ -153,26 +153,26 @@ test("should display English and Chinese content for experience and education pa
   // Verify English experience page
   await page.goto("/experiences/citadel");
   await expect(
-    page.getByRole("heading", { level: 2, name: /experience/i }),
+    page.getByRole("heading", { level: 1, name: /experience/i }),
   ).toBeVisible();
 
   // Verify English education page
   await page.goto("/education/university-of-bristol");
   await expect(
-    page.getByRole("heading", { level: 2, name: /education/i }),
+    page.getByRole("heading", { level: 1, name: /education/i }),
   ).toBeVisible();
 
   // Now check Chinese content (will set NEXT_LOCALE=zh cookie)
   // Verify Chinese experience page
   await page.goto("/zh/experiences/citadel");
   await expect(
-    page.getByRole("heading", { level: 2, name: /工作/i }),
+    page.getByRole("heading", { level: 1, name: /工作/i }),
   ).toBeVisible();
 
   // Verify Chinese education page
   await page.goto("/zh/education/university-of-bristol");
   await expect(
-    page.getByRole("heading", { level: 2, name: /学习/i }),
+    page.getByRole("heading", { level: 1, name: /学习/i }),
   ).toBeVisible();
 });
 
@@ -188,7 +188,7 @@ test.describe("Browser Back Navigation", () => {
     await page.getByRole("link", { name: /citadel/i }).click();
     // Wait for heading to appear (navigation may take time)
     await expect(
-      page.getByRole("heading", { level: 2, name: /citadel/i }),
+      page.getByRole("heading", { level: 1, name: /citadel/i }),
     ).toBeVisible({ timeout: 15000 });
 
     // Go back to homepage

--- a/e2e/homepage-portfolio.spec.ts
+++ b/e2e/homepage-portfolio.spec.ts
@@ -101,9 +101,9 @@ test.describe("Homepage Portfolio", () => {
     }) => {
       // Click Citadel experience card
       await page.getByRole("link", { name: /citadel/i }).click();
-      // Verify detail page content (h2 with company name)
+      // Verify detail page content (h1 with company name)
       await expect(
-        page.getByRole("heading", { level: 2, name: /citadel/i }),
+        page.getByRole("heading", { level: 1, name: /citadel/i }),
       ).toBeVisible({ timeout: 15000 });
 
       // Go back to homepage
@@ -113,7 +113,7 @@ test.describe("Homepage Portfolio", () => {
       // Click Spotify card
       await page.getByRole("link", { name: /spotify/i }).click();
       await expect(
-        page.getByRole("heading", { level: 2, name: /spotify/i }),
+        page.getByRole("heading", { level: 1, name: /spotify/i }),
       ).toBeVisible({ timeout: 15000 });
 
       // Go back to homepage
@@ -126,7 +126,7 @@ test.describe("Homepage Portfolio", () => {
         .click();
       await expect(
         page.getByRole("heading", {
-          level: 2,
+          level: 1,
           name: /wunderman thompson commerce/i,
         }),
       ).toBeVisible({ timeout: 15000 });
@@ -167,7 +167,7 @@ test.describe("Homepage Portfolio", () => {
       // Click University of Bristol card
       await page.getByRole("link", { name: /university of bristol/i }).click();
       await expect(
-        page.getByRole("heading", { level: 2, name: /bristol/i }),
+        page.getByRole("heading", { level: 1, name: /bristol/i }),
       ).toBeVisible({ timeout: 15000 });
 
       // Go back to homepage
@@ -179,7 +179,7 @@ test.describe("Homepage Portfolio", () => {
         .getByRole("link", { name: /university of nottingham/i })
         .click();
       await expect(
-        page.getByRole("heading", { level: 2, name: /nottingham/i }),
+        page.getByRole("heading", { level: 1, name: /nottingham/i }),
       ).toBeVisible({ timeout: 15000 });
 
       // Go back to homepage
@@ -191,7 +191,7 @@ test.describe("Homepage Portfolio", () => {
         .getByRole("link", { name: /altrincham grammar school/i })
         .click();
       await expect(
-        page.getByRole("heading", { level: 2, name: /altrincham/i }),
+        page.getByRole("heading", { level: 1, name: /altrincham/i }),
       ).toBeVisible({ timeout: 15000 });
     });
   });
@@ -249,7 +249,7 @@ test.describe("Homepage Portfolio", () => {
 
       // Verify detail page is in Chinese (工作 = work/experience)
       await expect(
-        page.getByRole("heading", { level: 2, name: /工作.*citadel/i }),
+        page.getByRole("heading", { level: 1, name: /工作.*citadel/i }),
       ).toBeVisible({ timeout: 15000 });
     });
   });

--- a/src/components/home/detail-page-title.test.tsx
+++ b/src/components/home/detail-page-title.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "#src/test-utils.tsx";
+import { DetailPageTitle } from "./detail-page-title";
+
+describe("DetailPageTitle", () => {
+  it("uses h1 for the page topic line and h2 for the role, in DOM order", () => {
+    render(
+      <DetailPageTitle
+        type="experience"
+        title="Citadel"
+        role="Software Engineer"
+        date="Aug 2021 - Now"
+      />,
+    );
+
+    const headings = screen.getAllByRole("heading");
+    expect(headings).toHaveLength(2);
+    expect(headings[0].tagName).toBe("H1");
+    expect(headings[0]).toHaveTextContent("Experience - Citadel");
+    expect(headings[1].tagName).toBe("H2");
+    expect(headings[1]).toHaveTextContent("Software Engineer");
+  });
+
+  it("uses the education type label when type is 'education'", () => {
+    render(
+      <DetailPageTitle
+        type="education"
+        title="University of Bristol"
+        role="MSc Advanced Computing"
+        date="2018 - 2019"
+      />,
+    );
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Education - University of Bristol",
+    );
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "MSc Advanced Computing",
+    );
+  });
+});

--- a/src/components/home/detail-page-title.tsx
+++ b/src/components/home/detail-page-title.tsx
@@ -18,10 +18,10 @@ export function DetailPageTitle({ date, role, title, type }: PageTitleProps) {
 
   return (
     <header css={[flex.col, styles.container]}>
-      <h2 css={styles.subtitle}>
+      <h1 css={styles.subtitle}>
         {typeLabel} - {title}
-      </h2>
-      <h1 css={styles.title}>{role}</h1>
+      </h1>
+      <h2 css={styles.title}>{role}</h2>
       <time css={styles.date}>{date}</time>
     </header>
   );


### PR DESCRIPTION
## Problem

`DetailPageTitle` renders a `<header>` with two headings — a muted top line like "Experience - Citadel" and a larger bottom line with the role/degree. Pre-fix, the top line was `<h2>` and the bottom line was `<h1>`. That inverts both the DOM/outline order (screen readers hit `h2 → h1` in sequence) and the semantic primacy — the `<h1>` was the role, but the page is *about* the organization, not the job title.

## Fix

Swap the heading tag names so the top line is `<h1>` and the bottom line is `<h2>`. The `stylex.create` rule names (`styles.subtitle` on the h1, `styles.title` on the h2) deliberately stay bound to the same DOM slots they were on before — the rule names describe visual treatment (muted-small vs. title-big), not semantic level, so visual rendering is pixel-identical. Rule names were intentionally NOT renamed to avoid churn.

## Coverage

Affects all six detail pages (three `experiences/*`, three `education/*`) via a single primitive-level change. Consumers don't change.

## Tests

New file `src/components/home/detail-page-title.test.tsx` with two tests:
- DOM order for the experience branch via `getAllByRole("heading")` with `tagName` checks
- `type === "education"` branch via `getByRole("heading", { level })`

Both assert level AND text content, so swapping the tags back in a future refactor would break the tests.

## Verification

- `pnpm lint:changed` — passed
- `pnpm format:changed` — unchanged (already formatted)
- `pnpm test` — 1003/1003 passed (+2 new)
- `pnpm build` — full Next.js build succeeded, all 48 static pages, no type/lint errors