### PR TITLE
fix(ai-chat): forward tool output in expanded ToolActivityGroup

### DIFF
--- a/src/components/ai-chat/tool-activity-group.test.tsx
+++ b/src/components/ai-chat/tool-activity-group.test.tsx
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { render, screen, userEvent } from "#src/test-utils.tsx";
+import { toolError } from "#src/ai-chat/tools/tool-error.ts";
+import { render, screen, userEvent, within } from "#src/test-utils.tsx";
 import { ToolActivityGroup } from "./tool-activity-group";
+import { ToolActivityLine } from "./tool-activity-line";
+
+function getIconPath(root: HTMLElement | Element | null): string | null {
+  return root?.querySelector("svg path")?.getAttribute("d") ?? null;
+}
 
 const completeParts = [
   {
@@ -106,5 +112,96 @@ describe("ToolActivityGroup", () => {
     expect(screen.getByText("TMDB Search")).toBeInTheDocument();
     expect(screen.getByText("Semantic Search")).toBeInTheDocument();
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("forwards structured error output to lines in the expanded disclosure view", async () => {
+    const errorOutput = toolError("tmdb_unavailable", "TMDB went down");
+    const errorParts = [
+      {
+        toolCallId: "call-err",
+        toolName: "tmdb_search",
+        state: "output-available",
+        input: { query: "broken" },
+        output: errorOutput,
+      },
+    ] as const;
+
+    // Reference lines rendered standalone so we know what the error vs.
+    // success icon path looks like without depending on a brittle class name.
+    const { container: errorRef } = render(
+      <ToolActivityLine
+        toolName="tmdb_search"
+        state="output-available"
+        input={{ query: "broken" }}
+        output={errorOutput}
+      />,
+    );
+    const { container: okRef } = render(
+      <ToolActivityLine
+        toolName="tmdb_search"
+        state="output-available"
+        input={{ query: "broken" }}
+      />,
+    );
+    const errorIconPath = getIconPath(errorRef);
+    const okIconPath = getIconPath(okRef);
+    expect(errorIconPath).toBeTruthy();
+    expect(okIconPath).toBeTruthy();
+    expect(errorIconPath).not.toBe(okIconPath);
+
+    // Render the group, expand it, and verify the line inside the expanded
+    // view renders the error icon — i.e. `output` was forwarded. Scope all
+    // queries to the group's container so the standalone reference lines
+    // rendered above don't leak into the assertions.
+    const user = userEvent.setup();
+    const { container: groupContainer } = render(
+      <ToolActivityGroup toolParts={errorParts} />,
+    );
+    const group = within(groupContainer);
+    await user.click(group.getByRole("button"));
+
+    const expandedIconPath = getIconPath(
+      group.getByText("TMDB Search").closest("div"),
+    );
+    expect(expandedIconPath).toBe(errorIconPath);
+  });
+
+  it("forwards structured error output while tools are still in progress", () => {
+    const errorOutput = toolError("vector_search_unavailable", "index down");
+    const mixedParts = [
+      {
+        toolCallId: "call-err",
+        toolName: "semantic_search",
+        state: "output-available",
+        input: { query: "broken" },
+        output: errorOutput,
+      },
+      {
+        toolCallId: "call-progress",
+        toolName: "tmdb_search",
+        state: "input-streaming",
+        input: undefined,
+      },
+    ] as const;
+
+    const { container: errorRef } = render(
+      <ToolActivityLine
+        toolName="semantic_search"
+        state="output-available"
+        input={{ query: "broken" }}
+        output={errorOutput}
+      />,
+    );
+    const errorIconPath = getIconPath(errorRef);
+    expect(errorIconPath).toBeTruthy();
+
+    const { container: groupContainer } = render(
+      <ToolActivityGroup toolParts={mixedParts} />,
+    );
+    const group = within(groupContainer);
+    const groupIconPath = getIconPath(
+      group.getByText("Semantic Search").closest("div"),
+    );
+    expect(groupIconPath).toBe(errorIconPath);
   });
 });

--- a/src/components/ai-chat/tool-activity-group.tsx
+++ b/src/components/ai-chat/tool-activity-group.tsx
@@ -18,6 +18,21 @@ interface ToolPartData {
   output?: unknown;
 }
 
+// Shared renderer so the in-progress and disclosure-open views can't drift
+// on which props they forward to ToolActivityLine (e.g. dropping `output`
+// would silently flip structured tool errors back to success icons).
+function renderToolLine(part: ToolPartData) {
+  return (
+    <ToolActivityLine
+      key={part.toolCallId}
+      toolName={part.toolName}
+      state={part.state}
+      input={part.input}
+      output={part.output}
+    />
+  );
+}
+
 interface ToolActivityGroupProps {
   toolParts: ReadonlyArray<ToolPartData>;
   isStreaming?: boolean;
@@ -35,19 +50,7 @@ export function ToolActivityGroup({
     !isStreaming && toolParts.every((p) => TERMINAL_STATES.has(p.state));
 
   if (!allComplete) {
-    return (
-      <div css={styles.container}>
-        {toolParts.map((part) => (
-          <ToolActivityLine
-            key={part.toolCallId}
-            toolName={part.toolName}
-            state={part.state}
-            input={part.input}
-            output={part.output}
-          />
-        ))}
-      </div>
-    );
+    return <div css={styles.container}>{toolParts.map(renderToolLine)}</div>;
   }
 
   const count = toolParts.length;
@@ -73,16 +76,7 @@ export function ToolActivityGroup({
         <span>{summaryText}</span>
       </button>
       {isOpen && (
-        <div css={styles.expandedContent}>
-          {toolParts.map((part) => (
-            <ToolActivityLine
-              key={part.toolCallId}
-              toolName={part.toolName}
-              state={part.state}
-              input={part.input}
-            />
-          ))}
-        </div>
+        <div css={styles.expandedContent}>{toolParts.map(renderToolLine)}</div>
       )}
     </div>
   );


### PR DESCRIPTION
## Problem

`ToolActivityGroup` renders `<ToolActivityLine>` twice — once while tools are in progress, and once inside the disclosure-open branch when the user expands a finished group. The in-progress branch forwarded `output`; the disclosure-open branch did not.

Result: after the assistant finished and the user clicked to expand the group, every line rendered with a check icon even for tools that had returned a structured error via `toolError(...)` — because `isToolError(undefined)` is false. Failed tool calls silently looked successful post-expansion.

## Fix

Extracted a module-level `renderToolLine(part)` helper that forwards all five props (`toolCallId` as key, `toolName`, `state`, `input`, `output`) from a `ToolPartData` to `<ToolActivityLine>`. Both branches now use `toolParts.map(renderToolLine)`, so they can no longer diverge — any future prop addition to `ToolActivityLine` lands in one place. A one-line JSDoc on the helper explains the anti-drift motivation.

Why extract (rather than a one-line `output` add): the duplication at two already-diverged call sites is the root cause. A helper prevents the exact same regression next time someone adds a prop.

## Tests

Two new tests in `tool-activity-group.test.tsx` (+2 → 10 tests in that file):

1. `"forwards structured error output to lines in the expanded disclosure view"` — real user flow: build an error output via `toolError("tmdb_unavailable", "TMDB went down")`, render the group, click the disclosure button to expand, assert the expanded line's SVG path `d` equals a standalone reference `<ToolActivityLine>` rendered with the same error output. SVG path comparison (not phosphor class names) to survive icon library churn.
2. `"forwards structured error output while tools are still in progress"` — parallel contract test for the in-progress branch, with one errored tool and one in-flight tool. Ensures the refactor didn't regress the branch that was already working.

Both tests use `within(groupContainer)` scope and traverse from the text label via `closest("div")` to avoid matching the disclosure button's caret SVG. Explicit sanity assertion that the error-vs-ok reference paths differ, so upstream icon churn can't silently make the test trivially pass. No mocks.

## Verification

- `pnpm lint:changed` — passed
- `pnpm format:changed` — one reformat (expanded content div onto a single line)
- `pnpm test` — 1003/1003 passed (was 1001; +2 new)
- `pnpm build` — full Next.js build succeeded, all 48 static pages generated, no type/lint errors