### PR TITLE
fix(ai-chat): give CountryList "+N more" button accessible name and focus handoff

### DIFF
--- a/src/components/ai-chat/tool-watch-providers.test.tsx
+++ b/src/components/ai-chat/tool-watch-providers.test.tsx
@@ -389,6 +389,83 @@ describe("ToolWatchProviders - provider search", () => {
     expect(screen.queryByText("+2 more")).not.toBeInTheDocument();
   });
 
+  it("gives the show-more button a localised accessible name with region context", () => {
+    const manyRegions = [
+      "US",
+      "GB",
+      "DE",
+      "FR",
+      "IT",
+      "ES",
+      "CA",
+      "AU",
+      "JP",
+      "BR",
+    ].map((code) => ({ country: code, types: ["flatrate" as const] }));
+
+    render(
+      <ToolWatchProviders
+        data={makeProviderSearchData({ regions: manyRegions })}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Show 2 more regions" }),
+    ).toBeInTheDocument();
+  });
+
+  it("uses singular phrasing when only one region remains hidden", () => {
+    const nineRegions = [
+      "US",
+      "GB",
+      "DE",
+      "FR",
+      "IT",
+      "ES",
+      "CA",
+      "AU",
+      "JP",
+    ].map((code) => ({ country: code, types: ["flatrate" as const] }));
+
+    render(
+      <ToolWatchProviders
+        data={makeProviderSearchData({ regions: nineRegions })}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Show 1 more region" }),
+    ).toBeInTheDocument();
+  });
+
+  it("moves focus to the first newly-revealed region after expansion", async () => {
+    const user = userEvent.setup();
+    const manyRegions = [
+      "US",
+      "GB",
+      "DE",
+      "FR",
+      "IT",
+      "ES",
+      "CA",
+      "AU",
+      "JP",
+      "BR",
+    ].map((code) => ({ country: code, types: ["flatrate" as const] }));
+
+    render(
+      <ToolWatchProviders
+        data={makeProviderSearchData({ regions: manyRegions })}
+      />,
+    );
+
+    await user.click(screen.getByText("+2 more"));
+
+    // Japan is the 9th region (index 8), which is the first one revealed
+    // when the button expands the list past INITIAL_VISIBLE_COUNT.
+    expect(screen.getByText("Japan")).toHaveFocus();
+  });
+
   it("shows not available message when regions is empty", () => {
     render(
       <ToolWatchProviders data={makeProviderSearchData({ regions: [] })} />,

--- a/src/components/ai-chat/tool-watch-providers.tsx
+++ b/src/components/ai-chat/tool-watch-providers.tsx
@@ -2,7 +2,7 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Fragment, useState } from "react";
+import { Fragment, useEffect, useRef, useState } from "react";
 import { useLocale } from "#src/hooks/use-locale.ts";
 import { t } from "#src/i18n.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
@@ -341,6 +341,9 @@ function CountryList({ countries }: { countries: ReadonlyArray<string> }) {
   const [expanded, setExpanded] = useState(false);
   const locale = useLocale();
   const displayNames = getRegionDisplayNames(locale);
+  // First newly-revealed country, given -1 tabindex so we can land focus
+  // there after expansion — the "+N more" button unmounts on click.
+  const firstRevealedRef = useRef<HTMLSpanElement>(null);
 
   const needsTruncation = countries.length > INITIAL_VISIBLE_COUNT;
   const visible =
@@ -349,12 +352,31 @@ function CountryList({ countries }: { countries: ReadonlyArray<string> }) {
       : countries.slice(0, INITIAL_VISIBLE_COUNT);
   const remaining = countries.length - INITIAL_VISIBLE_COUNT;
 
+  useEffect(() => {
+    if (expanded) {
+      firstRevealedRef.current?.focus();
+    }
+  }, [expanded]);
+
+  const expandAriaLabel =
+    remaining === 1
+      ? t({ en: "Show 1 more region", zh: "显示另外 1 个地区" })
+      : `${t({ en: "Show", zh: "显示另外" })} ${remaining} ${t({
+          en: "more regions",
+          zh: "个地区",
+        })}`;
+
   return (
     <p css={styles.countryList}>
       {visible.map((code, i) => (
         <Fragment key={code}>
           {i > 0 && " · "}
-          <span>{displayNames?.of(code) ?? code}</span>
+          <span
+            ref={i === INITIAL_VISIBLE_COUNT ? firstRevealedRef : undefined}
+            tabIndex={i === INITIAL_VISIBLE_COUNT ? -1 : undefined}
+          >
+            {displayNames?.of(code) ?? code}
+          </span>
         </Fragment>
       ))}
       {!expanded && needsTruncation && (
@@ -364,6 +386,7 @@ function CountryList({ countries }: { countries: ReadonlyArray<string> }) {
             type="button"
             onClick={() => setExpanded(true)}
             css={styles.showMoreButton}
+            aria-label={expandAriaLabel}
           >
             {`+${remaining} `}
             {t({ en: "more", zh: "更多" })}


### PR DESCRIPTION
## Problem

**Accessible name**: the `CountryList` "+N more" button in `tool-watch-providers.tsx` rendered only its visible text (`+N more` / `+N 更多`) as its accessible name. Screen-reader users heard "plus two more, button" with no indication of what they were expanding. The visible text is locked to `+N more` by the design constraint, so the fix is an `aria-label`, not a rewrite of the visible content.

**Focus drop**: clicking the button flipped `expanded → true`, which unmounted the button. Focus fell back to `document.body`, forcing keyboard/SR users to re-navigate from the top.

## Fix

- Localised `aria-label` on the button — singular/plural aware, built with the same `t({ en, zh })` template pattern the existing `regionBadge` in the same file uses: `"Show 1 more region"` / `"显示另外 1 个地区"` singular, `"Show N more regions"` / `"显示另外 N 个地区"` plural. Visible text unchanged.
- After `expanded` flips, a `useEffect` moves focus to the first newly-revealed region span (the one at index `INITIAL_VISIBLE_COUNT = 8`). That span carries `ref={firstRevealedRef}` and `tabIndex={-1}` so it's programmatically focusable without introducing a new tab stop for sighted users.
- A short comment on the ref explains why the span is programmatically focusable (it's the focus landing pad for the unmounted button) — a hidden invariant a future reader could easily "simplify" away.

## Terminology — "regions" not "countries"

Deliberate. The rest of the card already localises as `regions` / `地区` — `regionBadge`, `regions.length`, `getRegionDisplayNames`, `Intl.DisplayNames({ type: "region" })`. The aria-label reuses the same Chinese string `个地区` so the card has one consistent vocabulary for sighted and screen-reader users.

## Why not persist the button + toggle `aria-expanded`

That alternative would either require changing the visible text to "Show less" (breaks the design constraint) or leave a button that reads the same in both states (worse).

## Tests (3 new, in `tool-watch-providers.test.tsx`)

1. Plural accessible name — 10 regions → asserts `screen.getByRole("button", { name: "Show 2 more regions" })` is findable.
2. Singular accessible name — 9 regions → asserts button name is exactly `"Show 1 more region"` (pins the plural split against future collapse into one string).
3. Focus handoff — 10 regions, click the button, assert `screen.getByText("Japan")` (index 8, first newly revealed) `.toHaveFocus()`.

No mocks. Existing `"expands country list when clicking show more"` test uses `getByText("+2 more")` (text-node query) so it's unaffected by the new `aria-label`.

## Verification

- `pnpm lint:changed` — passed
- `pnpm format:changed` — unchanged (already formatted)
- `pnpm test` — 1004/1004 passed (was 1001; +3 new)
- `pnpm build` — full Next.js build succeeded, all 48 static pages generated, no type/lint errors