### PR TITLE
fix: read copyright year from client clock instead of build timestamp

### DIFF
--- a/src/components/home/current-year.tsx
+++ b/src/components/home/current-year.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function CurrentYear() {
+  const [year, setYear] = useState(() => new Date().getFullYear());
+
+  useEffect(() => {
+    setYear(new Date().getFullYear());
+  }, []);
+
+  return <>{year}</>;
+}

--- a/src/components/home/footer.test.tsx
+++ b/src/components/home/footer.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "#src/test-utils.tsx";
+import { CurrentYear } from "./current-year";
+import { Footer } from "./footer";
+
+describe("CurrentYear", () => {
+  it("renders the current year from the runtime clock", () => {
+    const { container } = render(<CurrentYear />);
+    expect(container.textContent).toBe(String(new Date().getFullYear()));
+  });
+});
+
+describe("Footer", () => {
+  it("displays the current copyright year", () => {
+    render(<Footer locale="en" />);
+    const year = new Date().getFullYear();
+    expect(screen.getByText(`© ${year}`)).toBeInTheDocument();
+  });
+});

--- a/src/components/home/footer.tsx
+++ b/src/components/home/footer.tsx
@@ -5,12 +5,11 @@ import { flex, justify } from "#src/primitives/flex.stylex.ts";
 import { font, space } from "#src/tokens.stylex.ts";
 import type { SupportedLocale } from "#src/types.ts";
 import { Anchor } from "../shared/anchor";
+import { CurrentYear } from "./current-year";
 
 interface FooterProps {
   locale: SupportedLocale;
 }
-
-const CURRENT_YEAR = new Date().getFullYear();
 
 export function Footer({ locale }: FooterProps) {
   return (
@@ -40,7 +39,9 @@ export function Footer({ locale }: FooterProps) {
       <div css={[styles.section, styles.copyrightSection]}>
         <small>
           <span css={styles.name}>{t({ en: "Qingqi Shi", zh: "石清琪" })}</span>
-          <span css={styles.copyright}>© {CURRENT_YEAR}</span>
+          <span css={styles.copyright}>
+            © <CurrentYear />
+          </span>
         </small>
       </div>
     </footer>


### PR DESCRIPTION
## Summary

The footer's copyright year was computed by a module-level `const CURRENT_YEAR = new Date().getFullYear()` in a server component. Because the site is statically generated, this value froze at build time — if the site isn't rebuilt after January 1st, the year stays stale (e.g. "© 2025" in January 2026). This extracts a tiny `CurrentYear` client component that reads the year from the user's clock after hydration via `useState` + `useEffect`, so the displayed year is always current. The footer itself remains a server component; only the year sub-tree hydrates on the client.

## Context

`useState(() => new Date().getFullYear())` seeds the initial render with the build-time year (matching SSR output, so no hydration mismatch), then `useEffect` updates it to the runtime year post-mount. For ~364 days/year this is a no-op; during the January window it silently corrects itself.

An inline `new Date()` in render was ruled out because the project uses React Compiler (`babel-plugin-react-compiler`), which requires render purity, and the `@eslint-react/purity` lint rule enforces the same constraint. Alternatives like ISR/revalidate would affect the entire layout's caching semantics, and making the full footer a client component would needlessly increase the client bundle.

Two new tests verify `CurrentYear` renders the runtime year and `Footer` displays the correct copyright string. No mocks.