### PR TITLE
refactor: replace latest-ref pattern with useEffectEvent

### DIFF
--- a/src/components/ai-chat/chat-message-list.tsx
+++ b/src/components/ai-chat/chat-message-list.tsx
@@ -2,7 +2,7 @@
 
 import * as stylex from "@stylexjs/stylex";
 import type { ChatStatus, UIMessage } from "ai";
-import { type ReactNode, useEffect, useLayoutEffect, useRef } from "react";
+import { type ReactNode, useEffect, useEffectEvent, useRef } from "react";
 import {
   COMPACTION_TRIGGER_TOKENS,
   USAGE_WARNING_RATIO,
@@ -63,18 +63,22 @@ export function ChatMessageList({
   );
 
   const messagesListRef = useRef<HTMLDivElement | null>(null);
-  const isAtBottomRef = useRef(isAtBottom);
-  // Sync ref before paint so both the message-length effect and the streaming
-  // ResizeObserver callback always read the latest isAtBottom without needing
-  // it in their dep arrays.
-  useLayoutEffect(() => {
-    isAtBottomRef.current = isAtBottom;
-  }, [isAtBottom]);
+
+  // Reads the latest isAtBottom without needing it in effect dep arrays —
+  // changing scroll position should not restart the ResizeObserver or
+  // re-trigger the message-length scroll effect.
+  const scrollToBottomIfNeeded = useEffectEvent(() => {
+    if (isAtBottom) {
+      window.scrollTo({ top: document.documentElement.scrollHeight });
+    }
+  });
 
   useEffect(() => {
     if (messages.length === 0) return;
-    if (isAtBottomRef.current || lastMessageRole === "user") {
+    if (lastMessageRole === "user") {
       window.scrollTo({ top: document.documentElement.scrollHeight });
+    } else {
+      scrollToBottomIfNeeded();
     }
   }, [messages.length, lastMessageRole]);
 
@@ -85,9 +89,7 @@ export function ChatMessageList({
     if (!el) return;
 
     const observer = new ResizeObserver(() => {
-      if (isAtBottomRef.current) {
-        window.scrollTo({ top: document.documentElement.scrollHeight });
-      }
+      scrollToBottomIfNeeded();
     });
     observer.observe(el);
     return () => observer.disconnect();

--- a/src/components/ai-chat/use-smoothed-text.ts
+++ b/src/components/ai-chat/use-smoothed-text.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useEffectEvent, useRef, useState } from "react";
 
 /** Target reveal rate scales with buffer size (chars per 16.67ms at 60fps baseline) */
 const RATE_FACTOR = 0.08;
@@ -339,33 +339,21 @@ export function useSmoothedText(
     startRevealed ? targetText : "",
   );
   const displayedLengthRef = useRef(startRevealed ? targetText.length : 0);
-  const targetRef = useRef(targetText);
   const rafRef = useRef(0);
   const rateRef = useRef(0);
   const accumulatorRef = useRef(0);
   const lastTimestampRef = useRef(0);
-  const onCaughtUpRef = useRef(options?.onCaughtUp);
-  const sealedRef = useRef(sealed);
-  const trailingBufferHintRef = useRef(trailingBufferHint);
   const trackerRef = useRef(createMarkerTracker());
 
-  // Sync refs before paint so the rAF loop always reads the latest values.
-  // useLayoutEffect runs after commit but before rAF callbacks.
-  useLayoutEffect(() => {
-    targetRef.current = targetText;
-  }, [targetText]);
+  // Stable reference to onCaughtUp that always calls the latest callback
+  // without needing it in the effect's dependency array.
+  const onCaughtUp = useEffectEvent(() => {
+    options?.onCaughtUp?.();
+  });
 
-  useLayoutEffect(() => {
-    onCaughtUpRef.current = options?.onCaughtUp;
-  }, [options?.onCaughtUp]);
-
-  useLayoutEffect(() => {
-    sealedRef.current = sealed;
-  }, [sealed]);
-
-  useLayoutEffect(() => {
-    trailingBufferHintRef.current = trailingBufferHint;
-  }, [trailingBufferHint]);
+  // Stable getter for trailingBufferHint — read every rAF frame but
+  // should not restart the animation loop when it changes.
+  const getTrailingBufferHint = useEffectEvent(() => trailingBufferHint);
 
   useEffect(() => {
     if (
@@ -376,7 +364,7 @@ export function useSmoothedText(
       cancelAnimationFrame(rafRef.current);
       displayedLengthRef.current = targetText.length;
       setDisplayedText(targetText);
-      onCaughtUpRef.current?.();
+      onCaughtUp();
       return;
     }
 
@@ -393,8 +381,8 @@ export function useSmoothedText(
       setDisplayedText(
         trackerRef.current.closeAt(targetText, targetText.length),
       );
-      if (sealedRef.current) {
-        onCaughtUpRef.current?.();
+      if (sealed) {
+        onCaughtUp();
       }
       return;
     }
@@ -407,11 +395,11 @@ export function useSmoothedText(
       lastTimestampRef.current = timestamp;
       const normalizedDelta = deltaMs / FRAME_MS;
 
-      const target = targetRef.current;
+      const target = targetText;
       const current = displayedLengthRef.current;
       const remaining = target.length - current;
 
-      const totalBuffer = remaining + trailingBufferHintRef.current;
+      const totalBuffer = remaining + getTrailingBufferHint();
       const targetRate =
         totalBuffer > 0 ? Math.max(MIN_RATE, totalBuffer * RATE_FACTOR) : 0;
 
@@ -442,8 +430,8 @@ export function useSmoothedText(
           setDisplayedText(trackerRef.current.closeAt(target, newLength));
         }
         rafRef.current = requestAnimationFrame(animate);
-      } else if (sealedRef.current) {
-        onCaughtUpRef.current?.();
+      } else if (sealed) {
+        onCaughtUp();
       }
     };
 


### PR DESCRIPTION
## Summary

Replaces the manual latest-ref pattern (ref + `useLayoutEffect` sync) with `useEffectEvent` in `use-smoothed-text.ts` and `chat-message-list.tsx`. This project's React 19 canary ships `useEffectEvent`, which is the idiomatic way to read the latest value of a prop or callback inside an effect without adding it to the dependency array.

## Context

`use-smoothed-text.ts` had 4 refs and 4 `useLayoutEffect` syncs (`targetRef`, `onCaughtUpRef`, `sealedRef`, `trailingBufferHintRef`) so the rAF animation loop could read latest values. `targetText` and `sealed` were already in the effect's dep array, so they read from closure directly. `onCaughtUp` and `trailingBufferHint` are wrapped in `useEffectEvent` — one as a stable callback, the other as a stable getter.

`chat-message-list.tsx` had `isAtBottomRef` synced via `useLayoutEffect` so two effects (message-length scroll and ResizeObserver) could read it without re-subscribing. Replaced with a single `scrollToBottomIfNeeded` effect event.