### PR TITLE
fix: restore inert attribute on menu-button popup

### DIFF
--- a/src/components/shared/menu-button.test.tsx
+++ b/src/components/shared/menu-button.test.tsx
@@ -184,6 +184,46 @@ describe("MenuButton keyboard navigation", () => {
     expect(trigger).toHaveFocus();
   });
 
+  it("marks the popup inert while the menu is closed so its items are not tabbable or a11y-exposed", async () => {
+    const user = userEvent.setup();
+    render(
+      <RouterProvider>
+        <TestMenu />
+      </RouterProvider>,
+    );
+
+    const popup = screen.getByRole("menu");
+    expect(popup).toHaveAttribute("inert");
+
+    await user.click(screen.getByRole("button", { name: "Open menu" }));
+    expect(popup).not.toHaveAttribute("inert");
+
+    await user.keyboard("{Escape}");
+    expect(popup).toHaveAttribute("inert");
+  });
+
+  it("marks a group popup inert while closed so non-menu controls are also not tabbable", async () => {
+    const user = userEvent.setup();
+    render(
+      <MenuButton
+        buttonProps={{ type: "button", "aria-label": "Open group" }}
+        popupRole="group"
+        menuContent={
+          <div>
+            <button type="button">First</button>
+            <button type="button">Second</button>
+          </div>
+        }
+      />,
+    );
+
+    const popup = screen.getByRole("group");
+    expect(popup).toHaveAttribute("inert");
+
+    await user.click(screen.getByRole("button", { name: "Open group" }));
+    expect(popup).not.toHaveAttribute("inert");
+  });
+
   it("does not intercept arrow keys when popupRole is not 'menu'", async () => {
     const user = userEvent.setup();
 

--- a/src/components/shared/menu-button.tsx
+++ b/src/components/shared/menu-button.tsx
@@ -186,6 +186,7 @@ export function MenuButton({
               ref={popupRef}
               role={popupRole}
               aria-labelledby={popupRole ? `${targetId}-label` : undefined}
+              inert={!isMenuShown}
             >
               {children && <div css={styles.menuTitle}>{children}</div>}
               {menuContent}


### PR DESCRIPTION
## Summary

Restores `inert={!isMenuShown}` on the MenuButton popup div and the two tests verifying that behavior. PR #2077 (aria-current/aria-pressed) accidentally removed both the attribute and its tests, which were originally added in PR #2074. Without `inert`, keyboard focus can reach invisible menu items when the popup is closed, breaking the accessibility invariant that hidden content should not be focusable or exposed to assistive technology.