### PR TITLE
fix: restore menu inert, add chat error boundaries, add skip-to-content

### DIFF
--- a/src/app/[locale]/(home)/layout.tsx
+++ b/src/app/[locale]/(home)/layout.tsx
@@ -86,7 +86,9 @@ export default async function Layout({
       <div css={styles.container}>
         <div css={styles.wrapperInner}>
           <BackgroundLines />
-          <main css={styles.main}>{children}</main>
+          <main id="main-content" css={styles.main}>
+            {children}
+          </main>
           <Footer locale={validatedLocale} />
         </div>
       </div>

--- a/src/app/[locale]/calculator/layout.tsx
+++ b/src/app/[locale]/calculator/layout.tsx
@@ -52,7 +52,11 @@ export default function Layout({
   children: React.ReactNode;
   params: Promise<{ locale: string }>;
 }) {
-  return <main css={styles.container}>{children}</main>;
+  return (
+    <main id="main-content" css={styles.container}>
+      {children}
+    </main>
+  );
 }
 
 const styles = stylex.create({

--- a/src/app/[locale]/component-library/layout.tsx
+++ b/src/app/[locale]/component-library/layout.tsx
@@ -58,7 +58,9 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div css={styles.container}>
-      <main css={styles.main}>{children}</main>
+      <main id="main-content" css={styles.main}>
+        {children}
+      </main>
     </div>
   );
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -8,6 +8,7 @@ import { SerwistProvider } from "#src/components/serwist-provider.tsx";
 import { PortalTargetProvider } from "#src/components/shared/fixed-element-portal-target.tsx";
 import { HeaderSkeleton } from "#src/components/shared/header-skeleton.tsx";
 import { Header } from "#src/components/shared/header.tsx";
+import { SkipToContent } from "#src/components/shared/skip-to-content.tsx";
 import { I18nProvider } from "#src/i18n/i18n-provider.tsx";
 import { setLocale } from "#src/i18n/server-locale.ts";
 import { themeHack } from "#src/utils/theme-hack.ts";
@@ -85,6 +86,7 @@ export default async function RootLayout({
           >
             {/* eslint-disable-next-line @eslint-react/dom-no-dangerously-set-innerhtml -- Intentional inline script for theme initialization before hydration */}
             <script dangerouslySetInnerHTML={{ __html: themeHack }} />
+            <SkipToContent />
             <ViewTransition>
               <PortalTargetProvider>
                 <Suspense fallback={<HeaderSkeleton />}>

--- a/src/app/[locale]/movie-database/(list)/layout.tsx
+++ b/src/app/[locale]/movie-database/(list)/layout.tsx
@@ -33,7 +33,7 @@ export default async function Layout({
       })}
     >
       <DotGridBackground />
-      <main>
+      <main id="main-content">
         <HeroSection />
         <Suspense
           fallback={

--- a/src/app/[locale]/movie-database/[type]/[id]/layout.tsx
+++ b/src/app/[locale]/movie-database/[type]/[id]/layout.tsx
@@ -138,7 +138,7 @@ export default async function Layout({
   const validatedLocale: SupportedLocale = validateLocale(locale);
   return (
     <>
-      <main>{children}</main>
+      <main id="main-content">{children}</main>
       <div css={styles.container}>
         <div css={styles.wrapperInner}>
           <Footer locale={validatedLocale} />

--- a/src/app/[locale]/movie-database/ai-mode/layout.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/layout.tsx
@@ -56,7 +56,9 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       })}
     >
       <DotGridBackground />
-      <main css={styles.container}>{children}</main>
+      <main id="main-content" css={styles.container}>
+        {children}
+      </main>
     </RetryableErrorBoundary>
   );
 }

--- a/src/components/ai-chat/tool-visual-output.tsx
+++ b/src/components/ai-chat/tool-visual-output.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
 import { isToolError } from "#src/ai-chat/tools/tool-error.ts";
 import { t } from "#src/i18n.ts";
 import { color, font, space } from "#src/tokens.stylex.ts";
@@ -61,7 +63,13 @@ export function ToolVisualOutput({
     if (state === "input-available" || state === "output-available") {
       const items = resolveMediaItems(input, searchResultsMap);
       if (items.length === 0) return null;
-      return <ToolMediaCards items={items} />;
+      return (
+        <ErrorBoundary fallback={<ErrorText />}>
+          <Suspense fallback={<ToolMediaCardsSkeleton />}>
+            <ToolMediaCards items={items} />
+          </Suspense>
+        </ErrorBoundary>
+      );
     }
 
     return null;
@@ -83,7 +91,13 @@ export function ToolVisualOutput({
     if (state === "input-available" || state === "output-available") {
       const items = resolvePersonItems(input, personResultsMap);
       if (items.length === 0) return null;
-      return <ToolPersonCards items={items} />;
+      return (
+        <ErrorBoundary fallback={<ErrorText />}>
+          <Suspense fallback={<ToolPersonCardsSkeleton />}>
+            <ToolPersonCards items={items} />
+          </Suspense>
+        </ErrorBoundary>
+      );
     }
 
     return null;
@@ -114,7 +128,13 @@ export function ToolVisualOutput({
           ? resolveWatchProviders(input, watchProvidersMap)
           : resolveProviderRegions(input, watchProvidersMap);
       if (!data) return null;
-      return <ToolWatchProviders data={data} />;
+      return (
+        <ErrorBoundary fallback={<ErrorText />}>
+          <Suspense fallback={<ToolWatchProvidersSkeleton />}>
+            <ToolWatchProviders data={data} />
+          </Suspense>
+        </ErrorBoundary>
+      );
     }
 
     return null;
@@ -148,6 +168,14 @@ export function ToolVisualOutput({
   }
 
   return null;
+}
+
+function ErrorText() {
+  return (
+    <p css={styles.error} role="alert">
+      {t({ en: "Failed to load results", zh: "加载结果失败" })}
+    </p>
+  );
 }
 
 const styles = stylex.create({

--- a/src/components/shared/menu-button.test.tsx
+++ b/src/components/shared/menu-button.test.tsx
@@ -184,6 +184,46 @@ describe("MenuButton keyboard navigation", () => {
     expect(trigger).toHaveFocus();
   });
 
+  it("marks the popup inert while the menu is closed so its items are not tabbable or a11y-exposed", async () => {
+    const user = userEvent.setup();
+    render(
+      <RouterProvider>
+        <TestMenu />
+      </RouterProvider>,
+    );
+
+    const popup = screen.getByRole("menu");
+    expect(popup).toHaveAttribute("inert");
+
+    await user.click(screen.getByRole("button", { name: "Open menu" }));
+    expect(popup).not.toHaveAttribute("inert");
+
+    await user.keyboard("{Escape}");
+    expect(popup).toHaveAttribute("inert");
+  });
+
+  it("marks a group popup inert while closed so non-menu controls are also not tabbable", async () => {
+    const user = userEvent.setup();
+    render(
+      <MenuButton
+        buttonProps={{ type: "button", "aria-label": "Open group" }}
+        popupRole="group"
+        menuContent={
+          <div>
+            <button type="button">First</button>
+            <button type="button">Second</button>
+          </div>
+        }
+      />,
+    );
+
+    const popup = screen.getByRole("group");
+    expect(popup).toHaveAttribute("inert");
+
+    await user.click(screen.getByRole("button", { name: "Open group" }));
+    expect(popup).not.toHaveAttribute("inert");
+  });
+
   it("does not intercept arrow keys when popupRole is not 'menu'", async () => {
     const user = userEvent.setup();
 

--- a/src/components/shared/menu-button.tsx
+++ b/src/components/shared/menu-button.tsx
@@ -186,6 +186,7 @@ export function MenuButton({
               ref={popupRef}
               role={popupRole}
               aria-labelledby={popupRole ? `${targetId}-label` : undefined}
+              inert={!isMenuShown}
             >
               {children && <div css={styles.menuTitle}>{children}</div>}
               {menuContent}

--- a/src/components/shared/skip-to-content.tsx
+++ b/src/components/shared/skip-to-content.tsx
@@ -1,0 +1,31 @@
+import * as stylex from "@stylexjs/stylex";
+import { t } from "#src/i18n.ts";
+import { border, color, font, layer, space } from "#src/tokens.stylex.ts";
+
+export function SkipToContent() {
+  return (
+    <a href="#main-content" css={styles.link}>
+      {t({ en: "Skip to content", zh: "跳转到内容" })}
+    </a>
+  );
+}
+
+const styles = stylex.create({
+  link: {
+    position: "fixed",
+    top: space._2,
+    left: space._2,
+    zIndex: layer.tooltip,
+    padding: `${space._1} ${space._3}`,
+    backgroundColor: color.controlActive,
+    color: color.textOnActive,
+    fontSize: font.uiBody,
+    fontWeight: font.weight_6,
+    borderRadius: border.radius_2,
+    textDecoration: "none",
+    transform: {
+      default: "translateY(-200%)",
+      ":focus-visible": "translateY(0)",
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Bundles three independent accessibility and resilience fixes.

- **Restore `inert` on MenuButton popup** — the attribute was accidentally removed by PR #2077, leaving closed-menu items tabbable and exposed to assistive technology
- **Add Suspense + ErrorBoundary to chat tool cards** — wraps `present_media`, `present_person`, and `present_watch_providers`/`present_provider_regions` so a TMDB API failure degrades only the affected card instead of crashing the entire chat
- **Add skip-to-content link (WCAG 2.4.1)** — adds a visually hidden anchor that appears on `:focus-visible`, targeting `#main-content` across all six layout files