### PR TITLE
fix: batch accessibility and resilience improvements

### DIFF
--- a/src/app/[locale]/(home)/layout.tsx
+++ b/src/app/[locale]/(home)/layout.tsx
@@ -86,7 +86,9 @@ export default async function Layout({
       <div css={styles.container}>
         <div css={styles.wrapperInner}>
           <BackgroundLines />
-          <main css={styles.main}>{children}</main>
+          <main id="main-content" css={styles.main}>
+            {children}
+          </main>
           <Footer locale={validatedLocale} />
         </div>
       </div>

--- a/src/app/[locale]/calculator/layout.tsx
+++ b/src/app/[locale]/calculator/layout.tsx
@@ -52,7 +52,11 @@ export default function Layout({
   children: React.ReactNode;
   params: Promise<{ locale: string }>;
 }) {
-  return <main css={styles.container}>{children}</main>;
+  return (
+    <main id="main-content" css={styles.container}>
+      {children}
+    </main>
+  );
 }
 
 const styles = stylex.create({

--- a/src/app/[locale]/component-library/layout.tsx
+++ b/src/app/[locale]/component-library/layout.tsx
@@ -58,7 +58,9 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div css={styles.container}>
-      <main css={styles.main}>{children}</main>
+      <main id="main-content" css={styles.main}>
+        {children}
+      </main>
     </div>
   );
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -8,6 +8,7 @@ import { SerwistProvider } from "#src/components/serwist-provider.tsx";
 import { PortalTargetProvider } from "#src/components/shared/fixed-element-portal-target.tsx";
 import { HeaderSkeleton } from "#src/components/shared/header-skeleton.tsx";
 import { Header } from "#src/components/shared/header.tsx";
+import { SkipToContent } from "#src/components/shared/skip-to-content.tsx";
 import { I18nProvider } from "#src/i18n/i18n-provider.tsx";
 import { setLocale } from "#src/i18n/server-locale.ts";
 import { themeHack } from "#src/utils/theme-hack.ts";
@@ -85,6 +86,7 @@ export default async function RootLayout({
           >
             {/* eslint-disable-next-line @eslint-react/dom-no-dangerously-set-innerhtml -- Intentional inline script for theme initialization before hydration */}
             <script dangerouslySetInnerHTML={{ __html: themeHack }} />
+            <SkipToContent />
             <ViewTransition>
               <PortalTargetProvider>
                 <Suspense fallback={<HeaderSkeleton />}>

--- a/src/app/[locale]/movie-database/(list)/layout.tsx
+++ b/src/app/[locale]/movie-database/(list)/layout.tsx
@@ -33,7 +33,7 @@ export default async function Layout({
       })}
     >
       <DotGridBackground />
-      <main>
+      <main id="main-content">
         <HeroSection />
         <Suspense
           fallback={

--- a/src/app/[locale]/movie-database/[type]/[id]/layout.tsx
+++ b/src/app/[locale]/movie-database/[type]/[id]/layout.tsx
@@ -138,7 +138,7 @@ export default async function Layout({
   const validatedLocale: SupportedLocale = validateLocale(locale);
   return (
     <>
-      <main>{children}</main>
+      <main id="main-content">{children}</main>
       <div css={styles.container}>
         <div css={styles.wrapperInner}>
           <Footer locale={validatedLocale} />

--- a/src/app/[locale]/movie-database/ai-mode/layout.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/layout.tsx
@@ -56,7 +56,9 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       })}
     >
       <DotGridBackground />
-      <main css={styles.container}>{children}</main>
+      <main id="main-content" css={styles.container}>
+        {children}
+      </main>
     </RetryableErrorBoundary>
   );
 }

--- a/src/components/ai-chat/chat-message-list.tsx
+++ b/src/components/ai-chat/chat-message-list.tsx
@@ -54,7 +54,7 @@ export function ChatMessageList({
   typingIndicatorLabel,
   errorLabel,
 }: ChatMessageListProps) {
-  usePreferencePersistence(messages);
+  const hasPersistenceError = usePreferencePersistence(messages);
 
   const lastMessageRole =
     messages.length > 0 ? messages[messages.length - 1]?.role : undefined;
@@ -145,6 +145,14 @@ export function ChatMessageList({
           {t({
             en: "The conversation is getting lengthy",
             zh: "对话越来越长",
+          })}
+        </p>
+      )}
+      {hasPersistenceError && (
+        <p css={styles.usageWarning} role="status">
+          {t({
+            en: "Your preferences couldn't be saved to this browser. They'll apply for this conversation only.",
+            zh: "你的偏好无法保存到此浏览器。它们仅在本次对话中生效。",
           })}
         </p>
       )}

--- a/src/components/ai-chat/tool-visual-output.tsx
+++ b/src/components/ai-chat/tool-visual-output.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
 import { isToolError } from "#src/ai-chat/tools/tool-error.ts";
 import { t } from "#src/i18n.ts";
 import { color, font, space } from "#src/tokens.stylex.ts";
@@ -61,7 +63,13 @@ export function ToolVisualOutput({
     if (state === "input-available" || state === "output-available") {
       const items = resolveMediaItems(input, searchResultsMap);
       if (items.length === 0) return null;
-      return <ToolMediaCards items={items} />;
+      return (
+        <ErrorBoundary fallback={<ErrorText />}>
+          <Suspense fallback={<ToolMediaCardsSkeleton />}>
+            <ToolMediaCards items={items} />
+          </Suspense>
+        </ErrorBoundary>
+      );
     }
 
     return null;
@@ -83,7 +91,13 @@ export function ToolVisualOutput({
     if (state === "input-available" || state === "output-available") {
       const items = resolvePersonItems(input, personResultsMap);
       if (items.length === 0) return null;
-      return <ToolPersonCards items={items} />;
+      return (
+        <ErrorBoundary fallback={<ErrorText />}>
+          <Suspense fallback={<ToolPersonCardsSkeleton />}>
+            <ToolPersonCards items={items} />
+          </Suspense>
+        </ErrorBoundary>
+      );
     }
 
     return null;
@@ -114,7 +128,13 @@ export function ToolVisualOutput({
           ? resolveWatchProviders(input, watchProvidersMap)
           : resolveProviderRegions(input, watchProvidersMap);
       if (!data) return null;
-      return <ToolWatchProviders data={data} />;
+      return (
+        <ErrorBoundary fallback={<ErrorText />}>
+          <Suspense fallback={<ToolWatchProvidersSkeleton />}>
+            <ToolWatchProviders data={data} />
+          </Suspense>
+        </ErrorBoundary>
+      );
     }
 
     return null;
@@ -148,6 +168,14 @@ export function ToolVisualOutput({
   }
 
   return null;
+}
+
+function ErrorText() {
+  return (
+    <p css={styles.error} role="alert">
+      {t({ en: "Failed to load results", zh: "加载结果失败" })}
+    </p>
+  );
 }
 
 const styles = stylex.create({

--- a/src/components/movie-database/media-virtuoso-grid.tsx
+++ b/src/components/movie-database/media-virtuoso-grid.tsx
@@ -6,7 +6,8 @@ import { useState } from "react";
 import { VirtuosoGrid } from "react-virtuoso";
 import { Grid } from "#src/components/movie-database/grid.tsx";
 import { useViewportHeight } from "#src/hooks/use-viewport-height.ts";
-import { color, ratio, space } from "#src/tokens.stylex.ts";
+import { t } from "#src/i18n.ts";
+import { color, font, ratio, space } from "#src/tokens.stylex.ts";
 import type { MediaListItem } from "#src/utils/types.ts";
 import { Skeleton } from "../shared/skeleton";
 import { MediaCard } from "./media-card";
@@ -22,7 +23,13 @@ export function MediaVirtuosoGrid({
   virtuosoKey,
   notFoundLabel,
 }: MediaVirtuosoGridProps) {
-  const { data: items, fetchNextPage, hasNextPage, isFetching } = queryResult;
+  const {
+    data: items,
+    fetchNextPage,
+    hasNextPage,
+    isFetching,
+    isFetchNextPageError,
+  } = queryResult;
   const height = useViewportHeight();
   const [initialItemCount] = useState(items.length);
 
@@ -31,26 +38,45 @@ export function MediaVirtuosoGrid({
   }
 
   return (
-    <VirtuosoGrid
-      key={virtuosoKey}
-      data={items}
-      components={gridComponents}
-      itemContent={(index) => {
-        const item = items[index];
-        if (!item) {
-          return <Skeleton css={styles.skeleton} delay={index * 100} />;
-        }
-        return <MediaCard media={item} allowFollow={index < 20} />;
-      }}
-      endReached={() => {
-        if (hasNextPage && !isFetching) {
-          void fetchNextPage();
-        }
-      }}
-      increaseViewportBy={height}
-      initialItemCount={initialItemCount}
-      useWindowScroll
-    />
+    <>
+      <VirtuosoGrid
+        key={virtuosoKey}
+        data={items}
+        components={gridComponents}
+        itemContent={(index) => {
+          const item = items[index];
+          if (!item) {
+            return <Skeleton css={styles.skeleton} delay={index * 100} />;
+          }
+          return <MediaCard media={item} allowFollow={index < 20} />;
+        }}
+        endReached={() => {
+          if (hasNextPage && !isFetching && !isFetchNextPageError) {
+            void fetchNextPage();
+          }
+        }}
+        increaseViewportBy={height}
+        initialItemCount={initialItemCount}
+        useWindowScroll
+      />
+      {isFetchNextPageError && (
+        <div css={styles.errorContainer}>
+          <p css={styles.errorText}>
+            {t({
+              en: "Failed to load more results.",
+              zh: "加载更多结果失败。",
+            })}
+          </p>
+          <button
+            type="button"
+            css={styles.retryButton}
+            onClick={() => void fetchNextPage()}
+          >
+            {t({ en: "Try again", zh: "重试" })}
+          </button>
+        </div>
+      )}
+    </>
   );
 }
 
@@ -72,5 +98,32 @@ const styles = stylex.create({
     paddingRight: `calc(${space._3} + env(safe-area-inset-right))`,
     color: color.textMuted,
     textAlign: "center",
+  },
+  errorContainer: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: space._2,
+    paddingBlock: space._5,
+    paddingInline: space._3,
+  },
+  errorText: {
+    margin: 0,
+    fontSize: font.uiBody,
+    color: color.textMuted,
+  },
+  retryButton: {
+    background: "none",
+    borderWidth: 0,
+    padding: `${space._1} ${space._3}`,
+    font: "inherit",
+    fontSize: font.uiBody,
+    fontWeight: font.weight_6,
+    color: color.controlActive,
+    cursor: "pointer",
+    textDecoration: {
+      default: "none",
+      ":hover": "underline",
+    },
   },
 });

--- a/src/components/shared/menu-button.test.tsx
+++ b/src/components/shared/menu-button.test.tsx
@@ -184,6 +184,46 @@ describe("MenuButton keyboard navigation", () => {
     expect(trigger).toHaveFocus();
   });
 
+  it("marks the popup inert while the menu is closed so its items are not tabbable or a11y-exposed", async () => {
+    const user = userEvent.setup();
+    render(
+      <RouterProvider>
+        <TestMenu />
+      </RouterProvider>,
+    );
+
+    const popup = screen.getByRole("menu");
+    expect(popup).toHaveAttribute("inert");
+
+    await user.click(screen.getByRole("button", { name: "Open menu" }));
+    expect(popup).not.toHaveAttribute("inert");
+
+    await user.keyboard("{Escape}");
+    expect(popup).toHaveAttribute("inert");
+  });
+
+  it("marks a group popup inert while closed so non-menu controls are also not tabbable", async () => {
+    const user = userEvent.setup();
+    render(
+      <MenuButton
+        buttonProps={{ type: "button", "aria-label": "Open group" }}
+        popupRole="group"
+        menuContent={
+          <div>
+            <button type="button">First</button>
+            <button type="button">Second</button>
+          </div>
+        }
+      />,
+    );
+
+    const popup = screen.getByRole("group");
+    expect(popup).toHaveAttribute("inert");
+
+    await user.click(screen.getByRole("button", { name: "Open group" }));
+    expect(popup).not.toHaveAttribute("inert");
+  });
+
   it("does not intercept arrow keys when popupRole is not 'menu'", async () => {
     const user = userEvent.setup();
 

--- a/src/components/shared/menu-button.tsx
+++ b/src/components/shared/menu-button.tsx
@@ -186,6 +186,7 @@ export function MenuButton({
               ref={popupRef}
               role={popupRole}
               aria-labelledby={popupRole ? `${targetId}-label` : undefined}
+              inert={!isMenuShown}
             >
               {children && <div css={styles.menuTitle}>{children}</div>}
               {menuContent}

--- a/src/components/shared/skip-to-content.tsx
+++ b/src/components/shared/skip-to-content.tsx
@@ -1,0 +1,31 @@
+import * as stylex from "@stylexjs/stylex";
+import { t } from "#src/i18n.ts";
+import { border, color, font, layer, space } from "#src/tokens.stylex.ts";
+
+export function SkipToContent() {
+  return (
+    <a href="#main-content" css={styles.link}>
+      {t({ en: "Skip to content", zh: "跳转到内容" })}
+    </a>
+  );
+}
+
+const styles = stylex.create({
+  link: {
+    position: "fixed",
+    top: space._2,
+    left: space._2,
+    zIndex: layer.tooltip,
+    padding: `${space._1} ${space._3}`,
+    backgroundColor: color.controlActive,
+    color: color.textOnActive,
+    fontSize: font.uiBody,
+    fontWeight: font.weight_6,
+    borderRadius: border.radius_2,
+    textDecoration: "none",
+    transform: {
+      default: "translateY(-200%)",
+      ":focus-visible": "translateY(0)",
+    },
+  },
+});

--- a/src/preference-store/use-preference-persistence.ts
+++ b/src/preference-store/use-preference-persistence.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { getToolName, isToolUIPart, type UIMessage } from "ai";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { savePreferenceInputSchema } from "#src/ai-chat/tools/save-preference.ts";
 import { loadPreferencesContext, mergePreferences } from "./preference-store";
 
@@ -9,11 +9,15 @@ import { loadPreferencesContext, mergePreferences } from "./preference-store";
  * Observes chat messages for `save_preference` tool calls and persists
  * detected preferences to IndexedDB. Each tool call ID is processed at most
  * once.
+ *
+ * Returns `true` if any IndexedDB write failed during this session, signaling
+ * that the user should be warned their preferences may not have been saved.
  */
 export function usePreferencePersistence(
   messages: ReadonlyArray<UIMessage>,
-): void {
+): boolean {
   const processedRef = useRef(new Set<string>());
+  const [hasPersistenceError, setHasPersistenceError] = useState(false);
 
   useEffect(() => {
     const processed = processedRef.current;
@@ -33,11 +37,16 @@ export function usePreferencePersistence(
         if (!parsed.success) continue;
 
         mergePreferences(parsed.data.preferences)
-          .then(() => loadPreferencesContext())
+          .then(() => {
+            setHasPersistenceError(false);
+            return loadPreferencesContext();
+          })
           .catch(() => {
-            // IndexedDB write failed — preference is lost but non-critical
+            setHasPersistenceError(true);
           });
       }
     }
   }, [messages]);
+
+  return hasPersistenceError;
 }


### PR DESCRIPTION
## Summary

Bundles five independent fixes addressing accessibility regressions, error resilience gaps, and a missing WCAG requirement.

- **Restore `inert` on MenuButton popup** — re-adds the `inert={!isMenuShown}` attribute accidentally removed by PR #2077, along with its two tests
- **Suspense + ErrorBoundary for chat tool cards** — wraps all three tool card branches in `tool-visual-output.tsx` with error boundaries and suspense fallbacks so a single broken card cannot crash the chat UI
- **Skip-to-content link (WCAG 2.4.1)** — adds a visually hidden anchor that appears on `:focus-visible`, wired to `id="main-content"` on every `<main>` element across all layout files
- **Error state + retry for infinite scroll** — replaces the silent retry loop in `media-virtuoso-grid.tsx` with a visible error message and "Try again" button
- **Surface preference persistence errors** — exposes a `hasPersistenceError` boolean from `use-preference-persistence.ts` and renders a bilingual warning banner with `role="status"` in the chat message list