### PR TITLE
chore: remove showClearContextOnPlanAccept setting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,6 @@
     "defaultMode": "bypassPermissions",
     "deny": ["Read(./.env)", "Read(./.env.*)"]
   },
-  "showClearContextOnPlanAccept": true,
   "hooks": {
     "PreToolUse": [
       {


### PR DESCRIPTION
## Summary

Removes `showClearContextOnPlanAccept: true` from the Claude Code project config, reverting to the default behaviour where context is not cleared after accepting a plan. Newer models handle context better, so clearing it is no longer necessary — and preserving context avoids the cost of the agent re-exploring the codebase to confirm the plan after every acceptance.