### PR TITLE
fix: include preference value in remove button aria-label

### DIFF
--- a/src/components/ai-chat/preference-panel.tsx
+++ b/src/components/ai-chat/preference-panel.tsx
@@ -278,7 +278,7 @@ function PreferenceChip({
         type="button"
         css={[buttonReset.base, flex.inlineCenter, styles.chipRemove]}
         onClick={onRemove}
-        aria-label={t({ en: "Remove", zh: "移除" })}
+        aria-label={`${t({ en: "Remove", zh: "移除" })} ${preference.value}`}
       >
         <XIcon size={10} />
       </button>


### PR DESCRIPTION
## Summary

Screen readers announced every preference chip's remove button as just "Remove" / "移除", making them indistinguishable when multiple chips are present. The aria-label now includes the preference value (e.g., "Remove Horror"), so each button is uniquely identifiable for assistive technology users.