### PR TITLE
fix: pass output prop in expanded tool activity group

### DIFF
--- a/src/components/ai-chat/tool-activity-group.tsx
+++ b/src/components/ai-chat/tool-activity-group.tsx
@@ -80,6 +80,7 @@ export function ToolActivityGroup({
               toolName={part.toolName}
               state={part.state}
               input={part.input}
+              output={part.output}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary

The expanded disclosure view of completed tool calls was missing the `output` prop on `ToolActivityLine`, causing structured tool errors to display as green checkmarks instead of warning icons. The non-collapsed (in-progress) branch already passed this prop correctly — the expanded branch simply omitted it, so `isToolError(undefined)` always returned false and masked the error state.