### PR TITLE
fix: tighten API referer validation to current Vercel deployment only

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,3 @@
 export const BASE_URL = "https://qingqi.dev";
 export const LOCALE_COOKIE_NAME = "NEXT_LOCALE";
-export const ALLOWED_REFERER = [BASE_URL, ".vercel.app"];
+export const ALLOWED_REFERER = [BASE_URL];

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -54,20 +54,27 @@ describe("proxy referer validation for API routes", () => {
     expect(await response.json()).toEqual({ error: "Unauthorized" });
   });
 
-  it("allows requests from Vercel preview deployments", () => {
+  it("allows requests from the current Vercel deployment", () => {
+    process.env.VERCEL_URL = "my-app-abc123.vercel.app";
     const response = proxy(
       apiRequest("/api/ai-chat", "https://my-app-abc123.vercel.app/search"),
     );
 
     expect(response.status).toBe(200);
+    delete process.env.VERCEL_URL;
   });
 
-  it("rejects requests from domains ending in vercel.app that are not subdomains", async () => {
+  it("rejects requests from other Vercel deployments", async () => {
+    process.env.VERCEL_URL = "my-app-abc123.vercel.app";
     const response = proxy(
-      apiRequest("/api/ai-chat", "https://evilvercel.app/search"),
+      apiRequest(
+        "/api/ai-chat",
+        "https://attacker-project-xyz789.vercel.app/search",
+      ),
     );
 
     expect(response.status).toBe(403);
     expect(await response.json()).toEqual({ error: "Unauthorized" });
+    delete process.env.VERCEL_URL;
   });
 });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -13,8 +13,14 @@ function validateReferer(request: NextRequest): NextResponse | null {
     const refererUrl = new URL(referer);
     const isLocalhost =
       refererUrl.hostname === "localhost" && refererUrl.protocol === "http:";
-    const isAllowedReferer = ALLOWED_REFERER.some((allowedReferer) =>
-      refererUrl.origin.endsWith(allowedReferer),
+    const vercelUrl = process.env.VERCEL_URL
+      ? `https://${process.env.VERCEL_URL}`
+      : null;
+    const allowedOrigins = vercelUrl
+      ? [...ALLOWED_REFERER, vercelUrl]
+      : ALLOWED_REFERER;
+    const isAllowedReferer = allowedOrigins.some(
+      (allowed) => refererUrl.origin === allowed,
     );
     if (!isLocalhost && !isAllowedReferer) {
       throw new Error("Unauthorized");


### PR DESCRIPTION
## Summary

The referer allow-list accepted any `*.vercel.app` origin via `.endsWith(".vercel.app")` suffix matching. An attacker could deploy their own Vercel project and make requests to the API to consume Anthropic API credits. This replaces the broad suffix match with exact origin equality using Vercel's `VERCEL_URL` system environment variable, so each deployment only accepts requests from its own origin.