### PR TITLE
fix: suppress live region announcements during chat streaming

### DIFF
--- a/src/components/ai-chat/chat-message-list.tsx
+++ b/src/components/ai-chat/chat-message-list.tsx
@@ -109,6 +109,7 @@ export function ChatMessageList({
         <div
           ref={messagesListRef}
           role="log"
+          aria-live={status === "streaming" ? "off" : "polite"}
           aria-label={messagesLabel}
           css={[flex.col, styles.messagesList]}
         >


### PR DESCRIPTION
## Summary

The chat message list uses `role="log"` which implicitly sets `aria-live="polite"`. During streaming, the smoothed text animation updates the DOM on every animation frame, causing screen readers to rapid-fire partial announcements of incomplete text. Setting `aria-live="off"` during streaming suppresses these intermediate announcements, and reverting to `"polite"` when streaming completes lets the screen reader announce the final message cleanly.