### PR TITLE
fix: reset path tracer accumulation on theme change

### DIFF
--- a/src/components/playground/loop.ts
+++ b/src/components/playground/loop.ts
@@ -162,6 +162,7 @@ export function start(
   let debug = initialDebug;
   let prevDebugKey = JSON.stringify(debug);
   let isDark = initialIsDark;
+  let prevIsDark = initialIsDark;
 
   const dpr = window.devicePixelRatio;
 
@@ -271,12 +272,14 @@ export function start(
     if (
       curMouseX !== lastPointerX ||
       curMouseY !== lastPointerY ||
-      debugKey !== prevDebugKey
+      debugKey !== prevDebugKey ||
+      isDark !== prevIsDark
     ) {
       frameIndex = 0;
       lastPointerX = curMouseX;
       lastPointerY = curMouseY;
       prevDebugKey = debugKey;
+      prevIsDark = isDark;
     }
 
     gpuTimer?.begin();


### PR DESCRIPTION
## Summary

The playground path tracer uses progressive accumulation, blending each new frame with previous samples. When the theme toggles between light and dark, the `u_dark` shader uniform changes the lighting model, but stale samples from the previous theme remained in the accumulation buffer — producing a ghosted blend until enough new frames dominated. Adding `isDark` change detection to the existing reset logic (which already handles pointer movement and debug option changes) clears the accumulation buffer immediately on theme switch.