### PR TITLE
fix: add safe-area-inset-right to mobile filter bar padding

### DIFF
--- a/src/components/movie-database/filters-container.tsx
+++ b/src/components/movie-database/filters-container.tsx
@@ -60,7 +60,7 @@ const styles = stylex.create({
     zIndex: layer.overlay,
     justifyContent: "space-between",
     paddingLeft: `calc(${space._3} + env(safe-area-inset-left))`,
-    paddingRight: `calc(${space._3} + var(--removed-body-scroll-bar-size, 0px))`,
+    paddingRight: `calc(${space._3} + env(safe-area-inset-right, 0px) + var(--removed-body-scroll-bar-size, 0px))`,
     marginBottom: space._3,
   },
 });


### PR DESCRIPTION
## Summary

The mobile filter bar container included `env(safe-area-inset-left)` in its left padding but omitted `env(safe-area-inset-right)` from the right, causing filter bar content to be clipped by the notch area on landscape-oriented notched devices. Every sibling container on the same page (`hero-section`, `media-virtuoso-grid`, and the desktop filter inner container) already includes the right safe area inset — the mobile container was the only one missing it.