### PR TITLE
fix: use deferred media type for not-found label consistency

### DIFF
--- a/src/components/movie-database/media-list.tsx
+++ b/src/components/movie-database/media-list.tsx
@@ -35,7 +35,7 @@ export function MediaList({ initialPage }: MediaListProps) {
   const queryResult = useSuspenseInfiniteQuery(tmdbQueryOptions);
 
   const notFoundLabel =
-    mediaType === "tv"
+    deferredMediaType === "tv"
       ? t({
           en: "No TV shows found that match the criteria, please update the filters",
           zh: "没有找到符合条件的电视剧，请更新筛选条件",


### PR DESCRIPTION
## Summary

The `notFoundLabel` in `MediaList` was reading the non-deferred `mediaType` while the query reads `deferredMediaType`. During a transition between Movies and TV Shows, the label could update immediately to "No TV shows found" while the grid still displayed stale movie data from the pending deferred query. Switching to `deferredMediaType` ensures the label and query data transition atomically.