### PR TITLE
perf: read flow gradient colors from ref instead of re-initialising WebGL

### DIFF
--- a/src/components/shared/flow-gradient/flow-gradient.tsx
+++ b/src/components/shared/flow-gradient/flow-gradient.tsx
@@ -1,13 +1,26 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
+import { useEffect, useRef } from "react";
 import { useMediaQuery } from "#src/hooks/use-media-query.ts";
 import { useTheme } from "#src/hooks/use-theme.ts";
 import { motionConstants } from "#src/primitives/motion.stylex.ts";
 import { color, layer } from "#src/tokens.stylex.ts";
-import { init, start } from "./loop";
+import { init, start, type ColorOptions } from "./loop";
 import fs from "./shaders/fs.glsl";
 import vs from "./shaders/vs.glsl";
+
+const DARK_COLORS = {
+  colorBackground: [0, 0, 0],
+} satisfies ColorOptions;
+
+const LIGHT_COLORS = {
+  colorBackground: [1, 1, 1],
+  colorTop: [0.6, 0.5, 0.7],
+  colorBottom: [0.4, 0.4, 1],
+  colorAltTop: [1, 0.3, 0.3],
+  colorAltBottom: [1, 0.3, 0.3],
+} satisfies ColorOptions;
 
 export function FlowGradient() {
   const [theme] = useTheme();
@@ -18,27 +31,28 @@ export function FlowGradient() {
   );
   const isDark = theme === "system" ? preferDark : theme === "dark";
 
+  const colorsRef = useRef<ColorOptions>(isDark ? DARK_COLORS : LIGHT_COLORS);
+  const contextRef = useRef<ReturnType<typeof init>>(undefined);
+
+  useEffect(() => {
+    colorsRef.current = isDark ? DARK_COLORS : LIGHT_COLORS;
+  }, [isDark]);
+
+  useEffect(() => {
+    const context = contextRef.current;
+    if (!context) return;
+    return start(context, colorsRef, { reducedMotion: prefersReducedMotion });
+  }, [prefersReducedMotion]);
+
   return (
     <canvas
       ref={(el) => {
         if (el) {
-          const context = init(el, vs, fs);
-          if (context) {
-            return start(
-              context,
-              isDark
-                ? { colorBackground: [0, 0, 0] }
-                : {
-                    colorBackground: [1, 1, 1],
-                    colorTop: [0.6, 0.5, 0.7],
-                    colorBottom: [0.4, 0.4, 1],
-                    colorAltTop: [1, 0.3, 0.3],
-                    colorAltBottom: [1, 0.3, 0.3],
-                  },
-              { reducedMotion: prefersReducedMotion },
-            );
-          }
+          contextRef.current = init(el, vs, fs);
         }
+        return () => {
+          contextRef.current = undefined;
+        };
       }}
       css={styles.canvas}
     />

--- a/src/components/shared/flow-gradient/loop.ts
+++ b/src/components/shared/flow-gradient/loop.ts
@@ -178,29 +178,17 @@ function createAnimationLoop({
   };
 }
 
-interface Options {
+export interface ColorOptions {
   colorTop?: [number, number, number];
   colorBottom?: [number, number, number];
   colorAltTop?: [number, number, number];
   colorAltBottom?: [number, number, number];
   colorBackground?: [number, number, number];
-  amplitudes?: {
-    mobile: number;
-    tablet: number;
-    laptop: number;
-    desktop: number;
-  };
 }
 
 export function start(
   { gl, programInfo, canvas }: Context,
-  {
-    colorTop = [0, 0, 0.2],
-    colorBottom = [0, 0, 0.8],
-    colorAltTop = [1, 0, 0],
-    colorAltBottom = [1, 0, 0],
-    colorBackground = [0.953, 0.929, 0.929],
-  }: Options,
+  colorsRef: { current: ColorOptions },
   { reducedMotion = false } = {},
 ) {
   const abortController = new AbortController();
@@ -256,6 +244,14 @@ export function start(
       pointerState.ripplePhase =
         Math.floor(pointerState.ripplePhase * 1000) / 1000;
     }
+
+    const {
+      colorTop = [0, 0, 0.2],
+      colorBottom = [0, 0, 0.8],
+      colorAltTop = [1, 0, 0],
+      colorAltBottom = [1, 0, 0],
+      colorBackground = [0.953, 0.929, 0.929],
+    } = colorsRef.current;
 
     const uniforms = {
       u_resolution: [gl.canvas.width, gl.canvas.height],


### PR DESCRIPTION
## Summary

The flow gradient ref callback closed over `isDark`, so React Compiler treated it as a dependency — every theme toggle produced a new callback identity, causing React 19 ref cleanup to tear down and re-run `init()` (shader compile + link) and `start()`.

This replaces the inline color values with a `colorsRef` whose `.current` is synced via a `useEffect` on `isDark` changes. Because `useRef` returns a stable object, the ref callback's identity no longer changes on theme toggle, so the WebGL pipeline is initialised once and the animation loop simply reads the latest colors each frame.

Depends on #2104 (strict lint rules) which enables the `react-hooks/refs` rule that catches ref mutations during render.