### PR TITLE
refactor: extract max-inline-size into a layout design token

### DIFF
--- a/src/app/[locale]/(home)/layout.tsx
+++ b/src/app/[locale]/(home)/layout.tsx
@@ -10,7 +10,7 @@ import { FlowGradient } from "#src/components/shared/flow-gradient/flow-gradient
 import { BASE_URL } from "#src/constants.ts";
 import { i18nConfig } from "#src/i18n-config.ts";
 import { t } from "#src/i18n.ts";
-import { color, layer, space } from "#src/tokens.stylex.ts";
+import { color, layer, layout, space } from "#src/tokens.stylex.ts";
 import type { PageProps, SupportedLocale } from "#src/types.ts";
 import { validateLocale } from "#src/utils/validate-locale.ts";
 import { glowTokens } from "./layout.stylex";
@@ -96,7 +96,7 @@ export default async function Layout({
 
 const styles = stylex.create({
   container: {
-    maxInlineSize: "1140px",
+    maxInlineSize: layout.maxInlineSize,
     marginBlock: 0,
     marginInline: "auto",
     paddingBlock: 0,

--- a/src/app/[locale]/component-library/layout.tsx
+++ b/src/app/[locale]/component-library/layout.tsx
@@ -2,7 +2,7 @@ import * as stylex from "@stylexjs/stylex";
 import type { Metadata } from "next";
 import { BASE_URL } from "#src/constants.ts";
 import { t } from "#src/i18n.ts";
-import { controlSize, space } from "#src/tokens.stylex.ts";
+import { controlSize, layout, space } from "#src/tokens.stylex.ts";
 import type { PageProps } from "#src/types.ts";
 import { validateLocale } from "#src/utils/validate-locale.ts";
 
@@ -65,7 +65,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
 const styles = stylex.create({
   container: {
-    maxInlineSize: "1140px",
+    maxInlineSize: layout.maxInlineSize,
     marginBlock: 0,
     marginInline: "auto",
     paddingBlock: 0,

--- a/src/app/[locale]/movie-database/[type]/[id]/layout.tsx
+++ b/src/app/[locale]/movie-database/[type]/[id]/layout.tsx
@@ -8,7 +8,7 @@ import {
 import { Footer } from "#src/components/home/footer.tsx";
 import { BASE_URL } from "#src/constants.ts";
 import { t } from "#src/i18n.ts";
-import { space } from "#src/tokens.stylex.ts";
+import { layout, space } from "#src/tokens.stylex.ts";
 import type { SupportedLocale } from "#src/types.ts";
 import { validateLocale } from "#src/utils/validate-locale.ts";
 import type { PageProps } from "./types";
@@ -150,7 +150,7 @@ export default async function Layout({
 
 const styles = stylex.create({
   container: {
-    maxInlineSize: "1140px",
+    maxInlineSize: layout.maxInlineSize,
     marginBlock: 0,
     marginInline: "auto",
     paddingBlock: 0,

--- a/src/app/[locale]/movie-database/ai-mode/layout.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/layout.tsx
@@ -4,7 +4,7 @@ import { DotGridBackground } from "#src/components/ai-chat/dot-grid-background.t
 import { RetryableErrorBoundary } from "#src/components/shared/retryable-error-boundary.tsx";
 import { BASE_URL } from "#src/constants.ts";
 import { t } from "#src/i18n.ts";
-import { space } from "#src/tokens.stylex.ts";
+import { layout, space } from "#src/tokens.stylex.ts";
 
 export async function generateMetadata(props: {
   params: Promise<{ locale: string }>;
@@ -66,7 +66,7 @@ const styles = stylex.create({
     display: "flex",
     flexDirection: "column",
     minHeight: `calc(100dvh - ${space._10} - env(safe-area-inset-top))`,
-    maxInlineSize: "1140px",
+    maxInlineSize: layout.maxInlineSize,
     marginBlock: 0,
     marginInline: "auto",
     paddingBlock: 0,

--- a/src/components/movie-database/filters-container.tsx
+++ b/src/components/movie-database/filters-container.tsx
@@ -2,7 +2,7 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 import { breakpoints } from "#src/breakpoints.stylex.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
-import { layer, space } from "#src/tokens.stylex.ts";
+import { layer, layout, space } from "#src/tokens.stylex.ts";
 
 interface FiltersContainerProps {
   desktopChildren?: ReactNode;
@@ -44,7 +44,7 @@ const styles = stylex.create({
   },
   desktopInnerContainer: {
     inlineSize: "100%",
-    maxInlineSize: "1140px",
+    maxInlineSize: layout.maxInlineSize,
     marginInline: "auto",
     paddingLeft: `calc(${space._3} + env(safe-area-inset-left))`,
     paddingRight: `calc(${space._3} + env(safe-area-inset-right))`,

--- a/src/components/movie-database/hero-section.tsx
+++ b/src/components/movie-database/hero-section.tsx
@@ -2,7 +2,7 @@ import * as stylex from "@stylexjs/stylex";
 import { breakpoints } from "#src/breakpoints.stylex.ts";
 import { getLocale } from "#src/i18n/server-locale.ts";
 import { t } from "#src/i18n.ts";
-import { color, font, space } from "#src/tokens.stylex.ts";
+import { color, font, layout, space } from "#src/tokens.stylex.ts";
 import { getLocalePath } from "#src/utils/pathname.ts";
 import { HeroChatInput } from "./hero-chat-input";
 
@@ -54,7 +54,7 @@ export function HeroSection() {
 
 const styles = stylex.create({
   section: {
-    maxInlineSize: "1140px",
+    maxInlineSize: layout.maxInlineSize,
     marginInline: "auto",
     paddingBlockStart: { default: space._9, [breakpoints.md]: space._10 },
     paddingBlockEnd: { default: space._5, [breakpoints.md]: space._8 },

--- a/src/components/movie-database/media-detail-hero.tsx
+++ b/src/components/movie-database/media-detail-hero.tsx
@@ -5,7 +5,14 @@ import { breakpoints } from "#src/breakpoints.stylex.ts";
 import { skeletonTokens } from "#src/components/shared/skeleton.stylex.ts";
 import { Skeleton } from "#src/components/shared/skeleton.tsx";
 import { t } from "#src/i18n.ts";
-import { border, color, controlSize, font, space } from "#src/tokens.stylex.ts";
+import {
+  border,
+  color,
+  controlSize,
+  font,
+  layout,
+  space,
+} from "#src/tokens.stylex.ts";
 import { BackdropImage } from "./backdrop-image.tsx";
 
 interface MediaDetailHeroProps {
@@ -64,7 +71,7 @@ export function MediaDetailHero({
 
 const styles = stylex.create({
   container: {
-    maxInlineSize: "1140px",
+    maxInlineSize: layout.maxInlineSize,
     marginBlock: 0,
     marginInline: "auto",
     marginBottom: space._10,

--- a/src/components/movie-database/media-virtuoso-grid.tsx
+++ b/src/components/movie-database/media-virtuoso-grid.tsx
@@ -6,7 +6,7 @@ import { useState } from "react";
 import { VirtuosoGrid } from "react-virtuoso";
 import { Grid } from "#src/components/movie-database/grid.tsx";
 import { useViewportHeight } from "#src/hooks/use-viewport-height.ts";
-import { color, ratio, space } from "#src/tokens.stylex.ts";
+import { color, layout, ratio, space } from "#src/tokens.stylex.ts";
 import type { MediaListItem } from "#src/utils/types.ts";
 import { Skeleton } from "../shared/skeleton";
 import { MediaCard } from "./media-card";
@@ -65,7 +65,7 @@ const styles = stylex.create({
     overflow: "hidden",
   },
   notFound: {
-    maxInlineSize: "1140px",
+    maxInlineSize: layout.maxInlineSize,
     marginBlock: 0,
     marginInline: "auto",
     paddingLeft: `calc(${space._3} + env(safe-area-inset-left))`,

--- a/src/components/movie-database/similar-media.tsx
+++ b/src/components/movie-database/similar-media.tsx
@@ -7,7 +7,7 @@ import {
   getTvShowRecommendations,
 } from "#src/_generated/tmdb-server-functions.ts";
 import { t } from "#src/i18n.ts";
-import { ratio, space } from "#src/tokens.stylex.ts";
+import { layout, ratio, space } from "#src/tokens.stylex.ts";
 import type { SupportedLocale } from "#src/types.ts";
 import { getQueryClient } from "#src/utils/get-query-client.ts";
 import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
@@ -99,7 +99,7 @@ export function SimilarMedia({
 
 const styles = stylex.create({
   container: {
-    maxInlineSize: "1140px",
+    maxInlineSize: layout.maxInlineSize,
     marginBlock: 0,
     marginInline: "auto",
     paddingBlock: 0,

--- a/src/components/shared/header-skeleton.tsx
+++ b/src/components/shared/header-skeleton.tsx
@@ -1,6 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 import { flex } from "#src/primitives/flex.stylex.ts";
-import { controlSize, layer, space } from "#src/tokens.stylex.ts";
+import { controlSize, layer, layout, space } from "#src/tokens.stylex.ts";
 import { Skeleton } from "./skeleton";
 import { skeletonTokens } from "./skeleton.stylex";
 
@@ -30,7 +30,7 @@ const styles = stylex.create({
     paddingRight: "var(--removed-body-scroll-bar-size, 0px)",
   },
   nav: {
-    maxInlineSize: "1140px",
+    maxInlineSize: layout.maxInlineSize,
     marginBlock: 0,
     marginInline: "auto",
     paddingBlock: 0,

--- a/src/components/shared/header.tsx
+++ b/src/components/shared/header.tsx
@@ -5,7 +5,7 @@ import { LocaleSelector } from "#src/components/shared/locale-selector.tsx";
 import { ThemeSwitch } from "#src/components/shared/theme-switch.tsx";
 import { t } from "#src/i18n.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
-import { layer, space } from "#src/tokens.stylex.ts";
+import { layer, layout, space } from "#src/tokens.stylex.ts";
 import type { SupportedLocale } from "#src/types.ts";
 
 interface HeaderProps {
@@ -53,7 +53,7 @@ const styles = stylex.create({
     paddingRight: "var(--removed-body-scroll-bar-size, 0px)",
   },
   nav: {
-    maxInlineSize: "1140px",
+    maxInlineSize: layout.maxInlineSize,
     marginBlock: 0,
     marginInline: "auto",
     paddingBlock: 0,

--- a/src/tokens.stylex.ts
+++ b/src/tokens.stylex.ts
@@ -85,6 +85,10 @@ export const constants = stylex.defineConsts({
   DARK: "@media (prefers-color-scheme: dark)",
 });
 
+export const layout = stylex.defineConsts({
+  maxInlineSize: "1140px",
+});
+
 export const color = stylex.defineVars({
   colorScheme: {
     default: light.colorScheme,


### PR DESCRIPTION
## Summary

Eliminates the magic-number `"1140px"` that was duplicated across 11 layout files and components by extracting it into a `layout` constant in `tokens.stylex.ts` using `stylex.defineConsts`. All call sites now import and reference `layout.maxInlineSize`, so the site's maximum content width can be changed in one place.

## Context

`stylex.defineConsts` was chosen over `defineVars` because this value is a static constant — it doesn't need theme-awareness or runtime CSS variable indirection.

Closes #1699