### PR TITLE
chore: enable strict TypeScript and React Compiler lint rules

### DIFF
--- a/e2e/media-detail-pages.spec.ts
+++ b/e2e/media-detail-pages.spec.ts
@@ -108,7 +108,9 @@ test("should prevent body scroll when trailer overlay is open", async ({
   await page.goto(`/en/movie-database/movie/${FIGHT_CLUB_ID}`);
 
   // Scroll down a bit to have some scroll position
-  await page.evaluate(() => window.scrollTo(0, 200));
+  await page.evaluate(() => {
+    window.scrollTo(0, 200);
+  });
   await page.waitForFunction(() => window.scrollY === 200);
 
   const scrollYBeforeOverlay = await page.evaluate(() => window.scrollY);

--- a/e2e/movie-tv-browsing.spec.ts
+++ b/e2e/movie-tv-browsing.spec.ts
@@ -149,7 +149,9 @@ test.describe("Movie and TV Show Browsing", () => {
     const lastCardBeforeScroll = await cards.last().getAttribute("aria-label");
 
     // Scroll to bottom
-    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await page.evaluate(() => {
+      window.scrollTo(0, document.body.scrollHeight);
+    });
 
     // Wait for the last card to change (new content loaded)
     await expect(async () => {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,8 +1,9 @@
 import eslintReact from "@eslint-react/eslint-plugin";
 import js from "@eslint/js";
+import nextPlugin from "@next/eslint-plugin-next";
 import stylexjs from "@stylexjs/eslint-plugin";
-import nextConfig from "eslint-config-next";
 import importPlugin from "eslint-plugin-import-x";
+import reactHooks from "eslint-plugin-react-hooks";
 import eslintPluginUnicorn from "eslint-plugin-unicorn";
 import { defineConfig } from "eslint/config";
 import { createRequire } from "node:module";
@@ -26,14 +27,13 @@ export default defineConfig([
       "playwright-report/**/*",
     ],
   },
-  ...nextConfig,
+  reactHooks.configs.flat["recommended-latest"],
   js.configs.recommended,
-  ...tsEslint.configs.recommendedTypeChecked,
+  ...tsEslint.configs.strictTypeChecked,
   eslintReact.configs["recommended-typescript"],
-  eslintReact.configs["disable-conflict-eslint-plugin-react"],
-  eslintReact.configs["disable-conflict-eslint-plugin-react-hooks"],
   {
     plugins: {
+      "@next/next": nextPlugin,
       "import-x": importPlugin,
       "@stylexjs": stylexjs,
       unicorn: eslintPluginUnicorn,
@@ -48,38 +48,11 @@ export default defineConfig([
       },
     },
     rules: {
-      // --- eslint-plugin-react → @eslint-react/eslint-plugin ---
-      // eslint-plugin-react (via eslint-config-next) crashes on ESLint 10.
-      "react/display-name": "off",
-      "react/jsx-key": "off",
-      "react/jsx-no-comment-textnodes": "off",
-      "react/jsx-no-duplicate-props": "off",
-      "react/jsx-no-undef": "off",
-      "react/jsx-uses-react": "off",
-      "react/jsx-uses-vars": "off",
-      "react/no-children-prop": "off",
-      "react/no-danger-with-children": "off",
-      "react/no-deprecated": "off",
-      "react/no-direct-mutation-state": "off",
-      "react/no-find-dom-node": "off",
-      "react/no-is-mounted": "off",
-      "react/no-render-return-value": "off",
-      "react/no-string-refs": "off",
-      "react/no-unescaped-entities": "off",
-      "react/require-render-return": "off",
-      // --- end eslint-plugin-react → @eslint-react/eslint-plugin ---
+      ...nextPlugin.configs.recommended.rules,
+      ...nextPlugin.configs["core-web-vitals"].rules,
       "@stylexjs/valid-styles": "error",
       "@typescript-eslint/consistent-type-imports": "error",
       "@typescript-eslint/consistent-type-exports": "error",
-      "@typescript-eslint/no-misused-promises": [
-        "error",
-        {
-          checksVoidReturn: {
-            arguments: false,
-            attributes: false,
-          },
-        },
-      ],
       "import-x/order": [
         "error",
         {
@@ -126,6 +99,7 @@ export default defineConfig([
   // type-checked rules and configure for Node.js/CommonJS.
   {
     files: ["tooling/**/*.js"],
+    ignores: ["tooling/tmdb-codegen/generator.js"],
     ...tsEslint.configs.disableTypeChecked,
     languageOptions: {
       sourceType: "commonjs",
@@ -144,12 +118,16 @@ export default defineConfig([
       "@typescript-eslint/no-require-imports": "off",
     },
   },
-  // Tooling MJS files (ESM) — disable type-checked rules only.
+  // Tooling ESM files — disable type-checked rules and add Node globals.
   {
-    files: ["tooling/**/*.mjs"],
+    files: ["tooling/**/*.mjs", "tooling/tmdb-codegen/generator.js"],
     ...tsEslint.configs.disableTypeChecked,
     languageOptions: {
       parserOptions: { projectService: false },
+      globals: {
+        console: "readonly",
+        process: "readonly",
+      },
     },
   },
 ]);

--- a/src/ai-chat/eval/throttle.ts
+++ b/src/ai-chat/eval/throttle.ts
@@ -35,9 +35,8 @@ export function createThrottle(clock: Clock = defaultClock): TokenThrottle {
     let total = pruneWindow();
 
     while (total >= threshold) {
+      // total >= threshold guarantees entries is non-empty after pruneWindow
       const oldest = entries[0];
-      if (!oldest) break;
-
       const ageOutAt = oldest.timestamp + WINDOW_MS;
       const sleepMs = ageOutAt - clock.now();
       if (sleepMs > 0) {

--- a/src/ai-chat/session-schema.ts
+++ b/src/ai-chat/session-schema.ts
@@ -6,13 +6,13 @@ const localeField = { locale: z.enum(["en", "zh"]).default("en") };
 
 export const sessionChatInputSchema = z.discriminatedUnion("trigger", [
   z.object({
-    sessionId: z.string().uuid().optional(),
+    sessionId: z.uuid().optional(),
     ...localeField,
     trigger: z.literal("submit-message"),
     message: z.custom<UIMessage>(isUIMessage),
   }),
   z.object({
-    sessionId: z.string().uuid(),
+    sessionId: z.uuid(),
     ...localeField,
     trigger: z.literal("regenerate-message"),
   }),
@@ -20,4 +20,4 @@ export const sessionChatInputSchema = z.discriminatedUnion("trigger", [
 
 export type SessionChatInput = z.infer<typeof sessionChatInputSchema>;
 
-export const sessionIdSchema = z.string().uuid();
+export const sessionIdSchema = z.uuid();

--- a/src/ai-chat/tools/person-credits.ts
+++ b/src/ai-chat/tools/person-credits.ts
@@ -82,7 +82,7 @@ export function createPersonCreditsTool() {
         if (!isRecord(raw)) continue;
         if (typeof raw.id !== "number") continue;
         const mediaType = getMediaType(raw);
-        const key = `${mediaType}:${raw.id}`;
+        const key = `${String(mediaType)}:${String(raw.id)}`;
         if (seen.has(key)) continue;
         seen.add(key);
         results.push({
@@ -101,7 +101,7 @@ export function createPersonCreditsTool() {
         if (!isRecord(raw)) continue;
         if (typeof raw.id !== "number") continue;
         const mediaType = getMediaType(raw);
-        const key = `${mediaType}:${raw.id}`;
+        const key = `${String(mediaType)}:${String(raw.id)}`;
         if (seen.has(key)) continue;
         seen.add(key);
         results.push({

--- a/src/ai-chat/tools/present-media.test.ts
+++ b/src/ai-chat/tools/present-media.test.ts
@@ -56,7 +56,8 @@ describe("createPresentMediaTool", () => {
         { id: 2, media_type: "tv" as const },
       ],
     };
-    const result = await tool.execute!(input, {
+    if (!tool.execute) throw new Error("expected execute");
+    const result = await tool.execute(input, {
       toolCallId: "test",
       messages: [],
       abortSignal: AbortSignal.timeout(5000),

--- a/src/ai-chat/tools/review-summary.test.ts
+++ b/src/ai-chat/tools/review-summary.test.ts
@@ -38,7 +38,7 @@ function reviewsResponse(
       },
       content: r.content,
       created_at: "2024-01-01T00:00:00.000Z",
-      id: `review-${i}`,
+      id: `review-${String(i)}`,
       updated_at: "2024-01-01T00:00:00.000Z",
     })),
   };
@@ -80,7 +80,8 @@ async function executeTool(input: {
 }) {
   const tool = createReviewSummaryTool("en");
   const parsed = reviewSummaryInputSchema.parse(input);
-  const result = await tool.execute!(parsed, executeContext);
+  if (!tool.execute) throw new Error("expected execute");
+  const result = await tool.execute(parsed, executeContext);
   return JSON.parse(JSON.stringify(result)) as ReviewSummaryResult;
 }
 
@@ -348,7 +349,8 @@ describe("review summary error handling", () => {
       media_type: "movie",
       title: "Fight Club",
     });
-    const result = await tool.execute!(parsed, executeContext);
+    if (!tool.execute) throw new Error("expected execute");
+    const result = await tool.execute(parsed, executeContext);
 
     expect(isToolError(result)).toBe(true);
     if (isToolError(result)) {
@@ -382,7 +384,8 @@ describe("review summary error handling", () => {
       media_type: "movie",
       title: "Fight Club",
     });
-    const result = await tool.execute!(parsed, executeContext);
+    if (!tool.execute) throw new Error("expected execute");
+    const result = await tool.execute(parsed, executeContext);
 
     expect(isToolError(result)).toBe(true);
     if (isToolError(result)) {

--- a/src/ai-chat/tools/review-summary.ts
+++ b/src/ai-chat/tools/review-summary.ts
@@ -108,7 +108,7 @@ function buildSummarizationPrompt(
 ): string {
   const reviewBlock = reviews
     .map((r) => {
-      const ratingStr = r.rating !== null ? ` [${r.rating}/10]` : "";
+      const ratingStr = r.rating !== null ? ` [${String(r.rating)}/10]` : "";
       return `- ${r.author}${ratingStr}: ${r.content}`;
     })
     .join("\n");

--- a/src/ai-chat/tools/save-preference.test.ts
+++ b/src/ai-chat/tools/save-preference.test.ts
@@ -91,7 +91,8 @@ describe("createSavePreferenceTool", () => {
         },
       ],
     };
-    const result = await tool.execute!(input, {
+    if (!tool.execute) throw new Error("expected execute");
+    const result = await tool.execute(input, {
       toolCallId: "test",
       messages: [],
       abortSignal: AbortSignal.timeout(5000),

--- a/src/ai-chat/tools/semantic-search.test.ts
+++ b/src/ai-chat/tools/semantic-search.test.ts
@@ -118,7 +118,8 @@ describe("semantic search error handling", () => {
     // getVectorIndex() throws. The tool should convert that into a
     // structured error rather than propagating the exception.
     const tool = createSemanticSearchTool("en");
-    const result = await tool.execute!(
+    if (!tool.execute) throw new Error("expected execute");
+    const result = await tool.execute(
       { query: "mind-bending sci-fi" },
       {
         toolCallId: "test",

--- a/src/ai-chat/tools/tmdb-search.test.ts
+++ b/src/ai-chat/tools/tmdb-search.test.ts
@@ -111,7 +111,8 @@ describe("tmdb search execute", () => {
     );
 
     const tool = createTmdbSearchTool("en");
-    const results = await tool.execute!(
+    if (!tool.execute) throw new Error("expected execute");
+    const results = await tool.execute(
       { query: "Dune" },
       {
         toolCallId: "test",
@@ -144,7 +145,7 @@ describe("tmdb search execute", () => {
 
   it("caps results at 10", async () => {
     const results = Array.from({ length: 15 }, (_, i) =>
-      movieResult({ id: i + 1, title: `Movie ${i + 1}` }),
+      movieResult({ id: i + 1, title: `Movie ${String(i + 1)}` }),
     );
 
     server.use(
@@ -159,7 +160,8 @@ describe("tmdb search execute", () => {
     );
 
     const tool = createTmdbSearchTool("en");
-    const items = await tool.execute!(
+    if (!tool.execute) throw new Error("expected execute");
+    const items = await tool.execute(
       { query: "Movie" },
       {
         toolCallId: "test",
@@ -184,7 +186,8 @@ describe("tmdb search execute", () => {
     );
 
     const tool = createTmdbSearchTool("en");
-    const results = await tool.execute!(
+    if (!tool.execute) throw new Error("expected execute");
+    const results = await tool.execute(
       { query: "xyznonexistent" },
       {
         toolCallId: "test",
@@ -213,7 +216,8 @@ describe("tmdb search execute", () => {
     );
 
     const tool = createTmdbSearchTool("zh");
-    await tool.execute!(
+    if (!tool.execute) throw new Error("expected execute");
+    await tool.execute(
       { query: "Parasite" },
       {
         toolCallId: "test",
@@ -242,7 +246,8 @@ describe("tmdb search execute", () => {
     );
 
     const tool = createTmdbSearchTool("en");
-    await tool.execute!(
+    if (!tool.execute) throw new Error("expected execute");
+    await tool.execute(
       { query: "Breaking Bad" },
       {
         toolCallId: "test",
@@ -267,7 +272,8 @@ describe("tmdb search execute", () => {
     );
 
     const tool = createTmdbSearchTool("en");
-    const results = await tool.execute!(
+    if (!tool.execute) throw new Error("expected execute");
+    const results = await tool.execute(
       { query: "Inception" },
       {
         toolCallId: "test",
@@ -300,7 +306,8 @@ describe("tmdb search execute", () => {
     );
 
     const tool = createTmdbSearchTool("en");
-    const result = await tool.execute!(
+    if (!tool.execute) throw new Error("expected execute");
+    const result = await tool.execute(
       { query: "Dune" },
       {
         toolCallId: "test",
@@ -329,7 +336,8 @@ describe("tmdb search execute", () => {
     );
 
     const tool = createTmdbSearchTool("en");
-    const results = await tool.execute!(
+    if (!tool.execute) throw new Error("expected execute");
+    const results = await tool.execute(
       { query: "Breaking Bad" },
       {
         toolCallId: "test",

--- a/src/ai-chat/tools/watch-providers.test.ts
+++ b/src/ai-chat/tools/watch-providers.test.ts
@@ -20,7 +20,8 @@ function provider(overrides: {
   logo_path?: string;
 }) {
   return {
-    logo_path: overrides.logo_path ?? `/logo-${overrides.provider_id}.jpg`,
+    logo_path:
+      overrides.logo_path ?? `/logo-${String(overrides.provider_id)}.jpg`,
     provider_id: overrides.provider_id,
     provider_name: overrides.provider_name,
     display_priority: overrides.display_priority,
@@ -71,7 +72,8 @@ async function executeTool(input: {
   provider_name?: string;
 }) {
   const tool = createWatchProvidersTool();
-  const result = await tool.execute!(input, executeContext);
+  if (!tool.execute) throw new Error("expected execute");
+  const result = await tool.execute(input, executeContext);
   return JSON.parse(JSON.stringify(result)) as
     | RegionResult
     | ProviderSearchResultType;
@@ -374,8 +376,8 @@ describe("watch providers execute", () => {
       await executeTool({ id: 550, media_type: "movie", region: "US" }),
     );
 
-    expect(result.providers).not.toBeNull();
-    const names = result.providers!.flatrate.map((p) => p.name);
+    if (!result.providers) throw new Error("expected providers");
+    const names = result.providers.flatrate.map((p) => p.name);
     expect(names).toEqual(["Netflix", "Disney+", "Amazon Prime"]);
   });
 
@@ -405,8 +407,8 @@ describe("watch providers execute", () => {
       await executeTool({ id: 550, media_type: "movie", region: "US" }),
     );
 
-    expect(result.providers).not.toBeNull();
-    const firstProvider = result.providers!.flatrate[0];
+    if (!result.providers) throw new Error("expected providers");
+    const firstProvider = result.providers.flatrate[0];
     expect(firstProvider).toBeDefined();
     expect(Object.keys(firstProvider)).toEqual(["id", "name", "logoPath"]);
   });
@@ -424,7 +426,8 @@ describe("watch providers error handling", () => {
     );
 
     const tool = createWatchProvidersTool();
-    const result = await tool.execute!(
+    if (!tool.execute) throw new Error("expected execute");
+    const result = await tool.execute(
       { id: 550, media_type: "movie", region: "US" },
       executeContext,
     );

--- a/src/ai-chat/use-ai-chat.ts
+++ b/src/ai-chat/use-ai-chat.ts
@@ -3,7 +3,7 @@
 import { useChat } from "@ai-sdk/react";
 import type { UIMessage } from "ai";
 import { DefaultChatTransport } from "ai";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import { z } from "zod";
 import { isUIMessage } from "#src/ai-chat/is-ui-message.ts";
 import { accumulateToolOutputs } from "#src/components/ai-chat/map-tool-output.ts";
@@ -82,15 +82,36 @@ async function fetchSession(
   if (response.status === 404) {
     return null;
   }
-  throw new Error(`Failed to fetch session: ${response.status}`);
+  throw new Error(`Failed to fetch session: ${String(response.status)}`);
 }
+
+// localStorage doesn't fire storage events for same-tab changes and we only
+// need the value at mount time, so subscribe is a no-op. Module-level constant
+// ensures referential stability for useSyncExternalStore.
+const noopSubscribe = () => () => {};
 
 type ContinueSessionStatus = "idle" | "pending" | "error";
 
 export function useAIChat({ locale }: { locale: SupportedLocale }) {
-  const [previousSessionId, setPreviousSessionId] = useState<string | null>(
-    null,
+  // Read the stored session ID from localStorage via useSyncExternalStore.
+  // This avoids the hydration mismatch (getServerSnapshot returns null for SSR)
+  // without needing a useEffect + setState workaround.
+  const storedSessionId = useSyncExternalStore(
+    noopSubscribe,
+    () => getStoredSessionId(locale),
+    () => null,
   );
+
+  // Track whether the banner has been dismissed (user started chatting,
+  // continued, or explicitly dismissed). Resets when locale changes so a
+  // stored session for the new locale can surface.
+  const [dismissed, setDismissed] = useState(false);
+  const [dismissedForLocale, setDismissedForLocale] = useState(locale);
+  if (dismissedForLocale !== locale) {
+    setDismissedForLocale(locale);
+    setDismissed(false);
+  }
+
   const [continueSessionStatus, setContinueSessionStatus] =
     useState<ContinueSessionStatus>("idle");
 
@@ -104,7 +125,7 @@ export function useAIChat({ locale }: { locale: SupportedLocale }) {
         }
         const lastMessage = messages[messages.length - 1];
 
-        if (!sessionId && lastMessage) {
+        if (!sessionId && messages.length > 0) {
           const prefsCtx = getCachedPreferencesContext();
           if (prefsCtx) {
             const enrichedMessage = {
@@ -152,40 +173,31 @@ export function useAIChat({ locale }: { locale: SupportedLocale }) {
     return chatResult.sendMessage(...args);
   }
 
-  // Deferred to useEffect so the initial render matches the server (null),
-  // avoiding a hydration mismatch — localStorage is not available during SSR.
-  useEffect(() => {
-    const stored = getStoredSessionId(locale);
-    if (stored) {
-      setPreviousSessionId(stored);
-    }
-  }, [locale]);
-
-  // Dismiss banner when user starts a new conversation
-  if (previousSessionId && chatResult.messages.length > 0) {
-    setPreviousSessionId(null);
-  }
+  // Derive previousSessionId: show the stored session only when the user
+  // hasn't dismissed the banner and hasn't started a new conversation.
+  const previousSessionId =
+    dismissed || chatResult.messages.length > 0 ? null : storedSessionId;
 
   const continueSession = () => {
-    if (!previousSessionId) return;
+    if (!storedSessionId) return;
     // De-dupe rapid clicks — the previous in-flight fetch will resolve the
     // banner one way or another.
     if (continueSessionStatus === "pending") return;
     setContinueSessionStatus("pending");
-    fetchSession(previousSessionId)
+    fetchSession(storedSessionId)
       .then((result) => {
         if (!result) {
           // 404: session gone server-side. Forget it and start fresh.
           clearStoredSessionId(locale);
-          setPreviousSessionId(null);
+          setDismissed(true);
           setContinueSessionStatus("idle");
           return;
         }
         chatResult.setMessages(result.messages);
-        setPreviousSessionId(null);
+        setDismissed(true);
         setContinueSessionStatus("idle");
       })
-      .catch((error) => {
+      .catch((error: unknown) => {
         // Network / 5xx: surface to the user instead of silently freezing
         // the banner. The user can retry or dismiss.
         console.error("Failed to restore session", error);
@@ -195,7 +207,7 @@ export function useAIChat({ locale }: { locale: SupportedLocale }) {
 
   const dismissPreviousSession = () => {
     clearStoredSessionId(locale);
-    setPreviousSessionId(null);
+    setDismissed(true);
     setContinueSessionStatus("idle");
   };
 

--- a/src/app/[locale]/movie-database/(list)/layout.tsx
+++ b/src/app/[locale]/movie-database/(list)/layout.tsx
@@ -12,7 +12,7 @@ import type { SupportedLocale } from "#src/types.ts";
 import { validateLocale } from "#src/utils/validate-locale.ts";
 
 const SKELETON_ITEMS = Array.from({ length: 20 }, (_, i) => ({
-  key: `skeleton-${i}`,
+  key: `skeleton-${String(i)}`,
   delay: i * 100,
 }));
 

--- a/src/app/[locale]/movie-database/[type]/[id]/page.tsx
+++ b/src/app/[locale]/movie-database/[type]/[id]/page.tsx
@@ -92,7 +92,7 @@ export default async function Page({ params }: PageProps) {
 
     const meta = [
       tvShow.first_air_date?.split("-")[0],
-      `${tvShow.number_of_seasons} ${seasonLabel} • ${tvShow.number_of_episodes} ${episodeLabel}`,
+      `${String(tvShow.number_of_seasons)} ${seasonLabel} • ${String(tvShow.number_of_episodes)} ${episodeLabel}`,
       tvShow.genres
         ?.map((genre) => genre.name)
         .filter(Boolean)

--- a/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/ai-chat-view.tsx
@@ -69,7 +69,9 @@ export function AIChatView({
       setIsAtBottom(atBottom);
     };
     window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => window.removeEventListener("scroll", handleScroll);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
   }, []);
 
   const scrollToBottom = () => {
@@ -131,8 +133,12 @@ export function AIChatView({
             status={status}
             attachedMedia={attachedMedia}
             onSend={handleSend}
-            onStop={stop}
-            onClearAttachment={() => setAttachedMedia(null)}
+            onStop={() => {
+              void stop();
+            }}
+            onClearAttachment={() => {
+              setAttachedMedia(null);
+            }}
           />
         </div>
         <MediaDetailOverlay />

--- a/src/app/api/ai-chat/route.ts
+++ b/src/app/api/ai-chat/route.ts
@@ -81,10 +81,10 @@ export async function POST(request: NextRequest) {
 
         const reader = innerStream.getReader();
         try {
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            writer.write(value);
+          let chunk = await reader.read();
+          while (!chunk.done) {
+            writer.write(chunk.value);
+            chunk = await reader.read();
           }
         } catch (error) {
           console.error("AI Chat inner stream error:", error);

--- a/src/components/ai-chat/chat-input-bar.tsx
+++ b/src/components/ai-chat/chat-input-bar.tsx
@@ -8,7 +8,11 @@ import { flex } from "#src/primitives/flex.stylex.ts";
 import { truncate } from "#src/primitives/layout.stylex.ts";
 import { buttonReset } from "#src/primitives/reset.stylex.ts";
 import { border, color, font, space } from "#src/tokens.stylex.ts";
-import { ChatTextarea, chatTextareaStyles } from "../shared/chat-textarea";
+import {
+  ChatTextarea,
+  chatTextareaStyles,
+  useChatTextarea,
+} from "../shared/chat-textarea";
 import type { AttachedMedia } from "./chat-actions-context";
 
 interface ChatInputBarProps {
@@ -64,41 +68,65 @@ export function ChatInputBar({
           </div>
         )
       }
-      actionButton={({ trimmedText, focusTextarea }) =>
-        isLoading ? (
-          <button
-            type="button"
-            aria-label={stopLabel}
-            onClick={() => {
-              onStop();
-              focusTextarea();
-            }}
-            css={[
-              flex.inlineCenter,
-              buttonReset.base,
-              chatTextareaStyles.iconButton,
-              chatTextareaStyles.iconButtonActive,
-            ]}
-          >
-            <StopIcon weight="fill" role="presentation" />
-          </button>
-        ) : (
-          <button
-            type="submit"
-            aria-label={sendLabel}
-            disabled={!trimmedText}
-            css={[
-              flex.inlineCenter,
-              buttonReset.base,
-              chatTextareaStyles.iconButton,
-              !!trimmedText && chatTextareaStyles.iconButtonActive,
-            ]}
-          >
-            <ArrowUpIcon weight="bold" role="presentation" />
-          </button>
-        )
-      }
-    />
+    >
+      <ChatInputBarActions
+        isLoading={isLoading}
+        sendLabel={sendLabel}
+        stopLabel={stopLabel}
+        onStop={onStop}
+      />
+    </ChatTextarea>
+  );
+}
+
+function ChatInputBarActions({
+  isLoading,
+  sendLabel,
+  stopLabel,
+  onStop,
+}: {
+  isLoading: boolean;
+  sendLabel: string;
+  stopLabel: string;
+  onStop: () => void;
+}) {
+  const { trimmedText, focusTextarea } = useChatTextarea();
+
+  if (isLoading) {
+    return (
+      <button
+        type="button"
+        aria-label={stopLabel}
+        onClick={() => {
+          onStop();
+          focusTextarea();
+        }}
+        css={[
+          flex.inlineCenter,
+          buttonReset.base,
+          chatTextareaStyles.iconButton,
+          chatTextareaStyles.iconButtonActive,
+        ]}
+      >
+        <StopIcon weight="fill" role="presentation" />
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="submit"
+      aria-label={sendLabel}
+      disabled={!trimmedText}
+      css={[
+        flex.inlineCenter,
+        buttonReset.base,
+        chatTextareaStyles.iconButton,
+        !!trimmedText && chatTextareaStyles.iconButtonActive,
+      ]}
+    >
+      <ArrowUpIcon weight="bold" role="presentation" />
+    </button>
   );
 }
 

--- a/src/components/ai-chat/chat-message-list.tsx
+++ b/src/components/ai-chat/chat-message-list.tsx
@@ -36,7 +36,7 @@ function getLatestInputTokens(
 ): number {
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];
-    if (msg?.role === "assistant" && msg.metadata?.inputTokens != null) {
+    if (msg.role === "assistant" && msg.metadata?.inputTokens != null) {
       return msg.metadata.inputTokens;
     }
   }
@@ -92,7 +92,9 @@ export function ChatMessageList({
       scrollToBottomIfNeeded();
     });
     observer.observe(el);
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+    };
   }, [status]);
 
   const showTypingIndicator = status === "submitted" || status === "streaming";

--- a/src/components/ai-chat/chat-message.tsx
+++ b/src/components/ai-chat/chat-message.tsx
@@ -91,7 +91,9 @@ export function ChatMessage({
                 content={part.text}
                 onCaughtUp={
                   isActiveTextPart
-                    ? () => setReleasedTextParts((prev) => prev + 1)
+                    ? () => {
+                        setReleasedTextParts((prev) => prev + 1);
+                      }
                     : undefined
                 }
                 sealed={isSealed}
@@ -160,7 +162,7 @@ export function ChatMessage({
 }
 
 function isCompactionPart(part: TextUIPart): boolean {
-  return part.providerMetadata?.anthropic?.type === "compaction";
+  return part.providerMetadata?.anthropic.type === "compaction";
 }
 
 export function deriveMessageData(parts: UIMessage["parts"]) {
@@ -188,7 +190,7 @@ export function deriveMessageData(parts: UIMessage["parts"]) {
       const typeKey = part.type;
       const count = typeCounts.get(typeKey) ?? 0;
       typeCounts.set(typeKey, count + 1);
-      partKeys.push(`${typeKey}-${count}`);
+      partKeys.push(`${typeKey}-${String(count)}`);
     }
 
     if (isToolUIPart(part)) {

--- a/src/components/ai-chat/compact-person-card.tsx
+++ b/src/components/ai-chat/compact-person-card.tsx
@@ -28,7 +28,7 @@ function ProfilePhoto({
 }) {
   const { data: config } = useSuspenseQuery(tmdbQueries.configuration);
 
-  if (!config.images?.base_url || !config.images?.profile_sizes) {
+  if (!config.images?.base_url || !config.images.profile_sizes) {
     return <div css={[flex.center, styles.photoFallback]}>{alt.charAt(0)}</div>;
   }
 

--- a/src/components/ai-chat/detail-overlay.test.tsx
+++ b/src/components/ai-chat/detail-overlay.test.tsx
@@ -9,10 +9,18 @@ function TestHarness() {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <PortalTargetProvider>
-      <button onClick={() => setIsOpen(true)}>Open</button>
+      <button
+        onClick={() => {
+          setIsOpen(true);
+        }}
+      >
+        Open
+      </button>
       <DetailOverlay
         isOpen={isOpen}
-        onClose={() => setIsOpen(false)}
+        onClose={() => {
+          setIsOpen(false);
+        }}
         aria-label="Test dialog"
       >
         <p>Dialog content</p>

--- a/src/components/ai-chat/horizontal-scroll-buttons.tsx
+++ b/src/components/ai-chat/horizontal-scroll-buttons.tsx
@@ -42,7 +42,9 @@ export function HorizontalScrollButtons({
         aria-label={t({ en: "Scroll left", zh: "向左滚动" })}
         aria-hidden={!showLeft}
         tabIndex={showLeft ? 0 : -1}
-        onClick={() => scroll(-1)}
+        onClick={() => {
+          scroll(-1);
+        }}
         css={[
           buttonReset.base,
           styles.button,
@@ -57,7 +59,9 @@ export function HorizontalScrollButtons({
         aria-label={t({ en: "Scroll right", zh: "向右滚动" })}
         aria-hidden={!showRight}
         tabIndex={showRight ? 0 : -1}
-        onClick={() => scroll(1)}
+        onClick={() => {
+          scroll(1);
+        }}
         css={[
           buttonReset.base,
           styles.button,

--- a/src/components/ai-chat/map-tool-output.test.ts
+++ b/src/components/ai-chat/map-tool-output.test.ts
@@ -14,14 +14,14 @@ function msg(
   parts: UIMessage["parts"],
   role: "user" | "assistant" = "assistant",
 ): UIMessage {
-  return { id: `msg-${Math.random()}`, role, parts };
+  return { id: `msg-${String(Math.random())}`, role, parts };
 }
 
 function toolPart(toolName: string, output: unknown) {
   return {
     type: "dynamic-tool" as const,
     toolName,
-    toolCallId: `call-${Math.random()}`,
+    toolCallId: `call-${String(Math.random())}`,
     state: "output-available" as const,
     input: {},
     output,

--- a/src/components/ai-chat/map-tool-output.ts
+++ b/src/components/ai-chat/map-tool-output.ts
@@ -153,7 +153,7 @@ export function buildSearchResultsMap(
   const map = new Map<string, MediaListItem>();
   for (const item of items) {
     if (item.mediaType) {
-      map.set(`${item.mediaType}:${item.id}`, item);
+      map.set(`${item.mediaType}:${String(item.id)}`, item);
     }
   }
   return map;
@@ -168,7 +168,7 @@ export function resolveMediaItems(
 
   const items: MediaListItem[] = [];
   for (const entry of parsed.data.media) {
-    const key = `${entry.media_type}:${entry.id}`;
+    const key = `${entry.media_type}:${String(entry.id)}`;
     const found = searchResults.get(key);
     if (found) {
       items.push(found);
@@ -290,9 +290,9 @@ export function resolvePersonItems(
 
 function watchProvidersKey(data: WatchProviderOutput): string {
   if (data.type === "region") {
-    return `wp:region:${data.id}:${data.mediaType}:${data.region}`;
+    return `wp:region:${String(data.id)}:${data.mediaType}:${data.region}`;
   }
-  return `wp:provider:${data.id}:${data.mediaType}:${data.providerName.toLowerCase()}`;
+  return `wp:provider:${String(data.id)}:${data.mediaType}:${data.providerName.toLowerCase()}`;
 }
 
 export function buildWatchProvidersMap(
@@ -312,7 +312,7 @@ export function resolveWatchProviders(
 ): WatchProviderOutput | null {
   const parsed = presentWatchProvidersInputSchema.safeParse(input);
   if (!parsed.success) return null;
-  const key = `wp:region:${parsed.data.id}:${parsed.data.media_type}:${parsed.data.region.toUpperCase()}`;
+  const key = `wp:region:${String(parsed.data.id)}:${parsed.data.media_type}:${parsed.data.region.toUpperCase()}`;
   return watchProviders.get(key) ?? null;
 }
 
@@ -322,6 +322,6 @@ export function resolveProviderRegions(
 ): WatchProviderOutput | null {
   const parsed = presentProviderRegionsInputSchema.safeParse(input);
   if (!parsed.success) return null;
-  const key = `wp:provider:${parsed.data.id}:${parsed.data.media_type}:${parsed.data.provider_name.toLowerCase()}`;
+  const key = `wp:provider:${String(parsed.data.id)}:${parsed.data.media_type}:${parsed.data.provider_name.toLowerCase()}`;
   return watchProviders.get(key) ?? null;
 }

--- a/src/components/ai-chat/media-detail-content.tsx
+++ b/src/components/ai-chat/media-detail-content.tsx
@@ -68,10 +68,9 @@ export function MediaDetailContent({
         detail.releaseDate?.split("-")[0],
         mediaType === "tv"
           ? detail.numberOfSeasons
-            ? `${detail.numberOfSeasons} ${
-                new Intl.PluralRules(locale ?? "en").select(
-                  detail.numberOfSeasons,
-                ) === "one"
+            ? `${String(detail.numberOfSeasons)} ${
+                new Intl.PluralRules(locale).select(detail.numberOfSeasons) ===
+                "one"
                   ? t({ en: "season", zh: "季" })
                   : t({ en: "seasons", zh: "季" })
               }`

--- a/src/components/ai-chat/media-detail-overlay.tsx
+++ b/src/components/ai-chat/media-detail-overlay.tsx
@@ -15,7 +15,9 @@ function getDialogLabel(media: FocusedMedia): string {
 export function MediaDetailOverlay() {
   const { focusedMedia, setFocusedMedia } = useMediaDetail();
 
-  const handleClose = () => setFocusedMedia(null);
+  const handleClose = () => {
+    setFocusedMedia(null);
+  };
 
   return (
     <DetailOverlay

--- a/src/components/ai-chat/person-detail-content.tsx
+++ b/src/components/ai-chat/person-detail-content.tsx
@@ -50,7 +50,7 @@ export function PersonDetailContent({
     ? [
         detail.knownForDepartment,
         detail.birthday
-          ? `${detail.birthday.split("-")[0]}${detail.deathday ? ` – ${detail.deathday.split("-")[0]}` : ""} (${t({ en: "age", zh: "年龄" })} ${calculateAge(detail.birthday, detail.deathday)})`
+          ? `${detail.birthday.split("-")[0]}${detail.deathday ? ` – ${detail.deathday.split("-")[0]}` : ""} (${t({ en: "age", zh: "年龄" })} ${String(calculateAge(detail.birthday, detail.deathday))})`
           : null,
       ]
         .filter(Boolean)
@@ -160,7 +160,9 @@ function ExpandableBiography({ text }: { text: string }) {
 
     const observer = new ResizeObserver(measure);
     observer.observe(el);
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+    };
   }, []);
 
   return (
@@ -175,7 +177,9 @@ function ExpandableBiography({ text }: { text: string }) {
         <button
           type="button"
           css={[buttonReset.base, styles.readMoreButton]}
-          onClick={() => setExpanded((prev) => !prev)}
+          onClick={() => {
+            setExpanded((prev) => !prev);
+          }}
         >
           {expanded
             ? t({ en: "Read less", zh: "收起" })
@@ -226,7 +230,7 @@ function buildFilmography(
         ? entry.media_type
         : null;
     if (!mediaType) return;
-    const key = `${mediaType}:${entry.id}`;
+    const key = `${mediaType}:${String(entry.id)}`;
     if (seen.has(key)) return;
     seen.add(key);
     entries.push({
@@ -272,7 +276,7 @@ function FilmographyScroller({
         const { mediaType } = item;
         return (
           <div
-            key={`${mediaType}-${item.id}`}
+            key={`${String(mediaType)}-${String(item.id)}`}
             css={filmStyles.cardWrapper}
             role="listitem"
           >

--- a/src/components/ai-chat/person-detail-overlay.tsx
+++ b/src/components/ai-chat/person-detail-overlay.tsx
@@ -12,7 +12,9 @@ function getDialogLabel(person: FocusedPerson): string {
 export function PersonDetailOverlay() {
   const { focusedPerson, setFocusedPerson } = useMediaDetail();
 
-  const handleClose = () => setFocusedPerson(null);
+  const handleClose = () => {
+    setFocusedPerson(null);
+  };
 
   return (
     <DetailOverlay

--- a/src/components/ai-chat/preference-panel.tsx
+++ b/src/components/ai-chat/preference-panel.tsx
@@ -39,7 +39,9 @@ export function PreferenceManager() {
       <button
         type="button"
         css={[buttonReset.base, flex.inlineCenter, triggerStyles.button]}
-        onClick={() => setIsOpen(true)}
+        onClick={() => {
+          setIsOpen(true);
+        }}
         aria-label={t({ en: "Preferences", zh: "偏好设置" })}
       >
         <SlidersHorizontalIcon size={16} role="presentation" />
@@ -49,7 +51,9 @@ export function PreferenceManager() {
       </button>
       <PreferencePanel
         isOpen={isOpen}
-        onClose={() => setIsOpen(false)}
+        onClose={() => {
+          setIsOpen(false);
+        }}
         preferences={preferences}
         onRemove={(id) => void remove(id)}
         onClearAll={clearAll}
@@ -198,7 +202,9 @@ function PreferencePanel({
               <button
                 type="button"
                 css={[buttonReset.base, styles.cancelButton]}
-                onClick={() => setConfirmingClear(false)}
+                onClick={() => {
+                  setConfirmingClear(false);
+                }}
               >
                 {t({ en: "Cancel", zh: "取消" })}
               </button>
@@ -207,7 +213,9 @@ function PreferencePanel({
             <button
               type="button"
               css={[buttonReset.base, flex.row, styles.clearButton]}
-              onClick={() => setConfirmingClear(true)}
+              onClick={() => {
+                setConfirmingClear(true);
+              }}
             >
               <TrashIcon size={14} role="presentation" />
               {t({
@@ -248,7 +256,9 @@ function CategorySection({
           <PreferenceChip
             key={pref.id}
             preference={pref}
-            onRemove={() => onRemove(pref.id)}
+            onRemove={() => {
+              onRemove(pref.id);
+            }}
           />
         ))}
       </div>

--- a/src/components/ai-chat/recommended-media.tsx
+++ b/src/components/ai-chat/recommended-media.tsx
@@ -50,7 +50,7 @@ async function TrendingMoviesRow({
   const response = await getTrendingMovies({
     time_window: "week",
     language: locale,
-  }).catch((error) => {
+  }).catch((error: unknown) => {
     console.error("Failed to fetch trending movies:", error);
     return null;
   });
@@ -87,7 +87,7 @@ async function TrendingTvShowsRow({
   const response = await getTrendingTvShows({
     time_window: "week",
     language: locale,
-  }).catch((error) => {
+  }).catch((error: unknown) => {
     console.error("Failed to fetch trending TV shows:", error);
     return null;
   });

--- a/src/components/ai-chat/tool-activity-group.tsx
+++ b/src/components/ai-chat/tool-activity-group.tsx
@@ -62,7 +62,9 @@ export function ToolActivityGroup({
         type="button"
         css={[buttonReset.base, flex.row, styles.disclosureButton]}
         aria-expanded={isOpen}
-        onClick={() => setIsOpen((prev) => !prev)}
+        onClick={() => {
+          setIsOpen((prev) => !prev);
+        }}
       >
         <CaretRightIcon
           size={14}

--- a/src/components/ai-chat/tool-activity-line.tsx
+++ b/src/components/ai-chat/tool-activity-line.tsx
@@ -46,7 +46,7 @@ function getPersonCount(input: unknown): number | null {
 function getPersonIdSummary(input: unknown): string | null {
   if (!isRecord(input)) return null;
   if (typeof input.person_id === "number") {
-    return `ID ${input.person_id}`;
+    return `ID ${String(input.person_id)}`;
   }
   return null;
 }

--- a/src/components/ai-chat/tool-media-cards.tsx
+++ b/src/components/ai-chat/tool-media-cards.tsx
@@ -25,7 +25,7 @@ export function ToolMediaCards({ items }: ToolMediaCardsProps) {
         const { mediaType } = item;
         return (
           <div
-            key={`${item.mediaType ?? "unknown"}-${item.id}`}
+            key={`${item.mediaType ?? "unknown"}-${String(item.id)}`}
             css={styles.cardWrapper}
             role="listitem"
           >

--- a/src/components/ai-chat/tool-person-cards.tsx
+++ b/src/components/ai-chat/tool-person-cards.tsx
@@ -23,7 +23,7 @@ export function ToolPersonCards({ items }: ToolPersonCardsProps) {
     >
       {items.map((person) => (
         <div
-          key={`person-${person.id}`}
+          key={`person-${String(person.id)}`}
           css={styles.cardWrapper}
           role="listitem"
         >

--- a/src/components/ai-chat/tool-review-summary.tsx
+++ b/src/components/ai-chat/tool-review-summary.tsx
@@ -106,8 +106,8 @@ export function ToolReviewSummary({
       setSelectedLevel(null);
       const message =
         locale === "zh"
-          ? `用辣度 ${level} 重新总结"${data.title}"的评论`
-          : `Summarize reviews for "${data.title}" with spiciness level ${level}`;
+          ? `用辣度 ${String(level)} 重新总结"${data.title}"的评论`
+          : `Summarize reviews for "${data.title}" with spiciness level ${String(level)}`;
       sendMessage(message);
     } else {
       setSelectedLevel(level);
@@ -130,7 +130,7 @@ export function ToolReviewSummary({
           <span css={styles.countBadge}>
             {data.reviewCount === 1
               ? t({ en: "1 review", zh: "1 条评论" })
-              : `${data.reviewCount} ${t({ en: "reviews", zh: "条评论" })}`}
+              : `${String(data.reviewCount)} ${t({ en: "reviews", zh: "条评论" })}`}
           </span>
         </div>
       </div>
@@ -153,7 +153,9 @@ export function ToolReviewSummary({
                     isCurrent && styles.levelButtonCurrent,
                     isSelected && styles.levelButtonSelected,
                   ]}
-                  onClick={() => handleTap(level)}
+                  onClick={() => {
+                    handleTap(level);
+                  }}
                   aria-label={
                     isSelected ? confirmLabels[level] : spicinessLabels[level]
                   }

--- a/src/components/ai-chat/tool-watch-providers-skeleton.tsx
+++ b/src/components/ai-chat/tool-watch-providers-skeleton.tsx
@@ -33,7 +33,7 @@ export function ToolWatchProvidersSkeleton() {
           <div css={styles.logoRow}>
             {Array.from({ length: row.logoCount }, (_, i) => (
               <Skeleton
-                key={`${row.key}-${i}`}
+                key={`${row.key}-${String(i)}`}
                 width={36}
                 height={36}
                 delay={delayIndex++ * STAGGER_DELAY}

--- a/src/components/ai-chat/tool-watch-providers.tsx
+++ b/src/components/ai-chat/tool-watch-providers.tsx
@@ -212,7 +212,7 @@ function ProviderLogo({
       css={styles.logo}
       src={src}
       srcSet={srcSet}
-      sizes={`${size}px`}
+      sizes={`${String(size)}px`}
       alt={name}
       title={name}
       width={size}
@@ -362,10 +362,12 @@ function CountryList({ countries }: { countries: ReadonlyArray<string> }) {
           {" "}
           <button
             type="button"
-            onClick={() => setExpanded(true)}
+            onClick={() => {
+              setExpanded(true);
+            }}
             css={styles.showMoreButton}
           >
-            {`+${remaining} `}
+            {`+${String(remaining)} `}
             {t({ en: "more", zh: "更多" })}
           </button>
         </>
@@ -394,7 +396,7 @@ function ProviderSearchResults({ data }: { data: ProviderSearchData }) {
         <span css={styles.regionBadge}>
           {regions.length === 1
             ? t({ en: "1 region", zh: "1 个地区" })
-            : `${regions.length} ${t({ en: "regions", zh: "个地区" })}`}
+            : `${String(regions.length)} ${t({ en: "regions", zh: "个地区" })}`}
         </span>
       </div>
 

--- a/src/components/ai-chat/use-smoothed-text.test.ts
+++ b/src/components/ai-chat/use-smoothed-text.test.ts
@@ -170,6 +170,8 @@ describe("useSmoothedText", () => {
       });
     window.matchMedia = vi.fn().mockReturnValue({
       matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
     } as MediaQueryList);
   });
 
@@ -254,6 +256,8 @@ describe("useSmoothedText", () => {
   it("returns target text immediately when reduced motion is preferred", () => {
     window.matchMedia = vi.fn().mockReturnValue({
       matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
     } as MediaQueryList);
 
     const { result } = renderHook(() => useSmoothedText("Instant text"));
@@ -376,6 +380,8 @@ describe("useSmoothedText", () => {
   it("calls onCaughtUp with reduced motion", () => {
     window.matchMedia = vi.fn().mockReturnValue({
       matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
     } as MediaQueryList);
 
     const onCaughtUp = vi.fn();

--- a/src/components/ai-chat/use-smoothed-text.ts
+++ b/src/components/ai-chat/use-smoothed-text.ts
@@ -1,6 +1,12 @@
 "use client";
 
-import { useEffect, useEffectEvent, useRef, useState } from "react";
+import {
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
 /** Target reveal rate scales with buffer size (chars per 16.67ms at 60fps baseline) */
 const RATE_FACTOR = 0.08;
@@ -14,6 +20,38 @@ const MIN_RATE = 0.033;
 const FRAME_MS = 16.67;
 /** Maximum delta to prevent jumps after tab switches or long pauses */
 const MAX_DELTA_MS = 100;
+
+// Reduced-motion detection via useSyncExternalStore. Module-level functions
+// ensure stable references so useSyncExternalStore doesn't re-subscribe.
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+function subscribeReducedMotion(onChange: () => void) {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return () => {};
+  }
+  const mql = window.matchMedia(REDUCED_MOTION_QUERY);
+  mql.addEventListener("change", onChange);
+  return () => {
+    mql.removeEventListener("change", onChange);
+  };
+}
+
+function getReducedMotionSnapshot() {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return false;
+  }
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+function getReducedMotionServerSnapshot() {
+  return false;
+}
 
 const MARKER_CHARS = /[*`~]/;
 
@@ -355,16 +393,21 @@ export function useSmoothedText(
   // should not restart the animation loop when it changes.
   const getTrailingBufferHint = useEffectEvent(() => trailingBufferHint);
 
+  const prefersReducedMotion = useSyncExternalStore(
+    subscribeReducedMotion,
+    getReducedMotionSnapshot,
+    getReducedMotionServerSnapshot,
+  );
+
   useEffect(() => {
-    if (
-      typeof window !== "undefined" &&
-      typeof window.matchMedia === "function" &&
-      window.matchMedia("(prefers-reduced-motion: reduce)").matches
-    ) {
+    // Reduced-motion: skip the animation loop entirely. The hook returns
+    // targetText directly (below) so no setState is needed here.
+    if (prefersReducedMotion) {
       cancelAnimationFrame(rafRef.current);
       displayedLengthRef.current = targetText.length;
-      setDisplayedText(targetText);
-      onCaughtUp();
+      if (sealed) {
+        onCaughtUp();
+      }
       return;
     }
 
@@ -437,8 +480,10 @@ export function useSmoothedText(
 
     lastTimestampRef.current = 0;
     rafRef.current = requestAnimationFrame(animate);
-    return () => cancelAnimationFrame(rafRef.current);
-  }, [targetText, sealed]);
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, [targetText, sealed, prefersReducedMotion]);
 
-  return displayedText;
+  return prefersReducedMotion ? targetText : displayedText;
 }

--- a/src/components/calculator/calculator-display.tsx
+++ b/src/components/calculator/calculator-display.tsx
@@ -31,7 +31,7 @@ function updateFontSize(
   const availableWidth = container.clientWidth - paddingX;
 
   // Measure text width at max size to calculate scaling factor
-  text.style.fontSize = `${maxSize}px`;
+  text.style.fontSize = `${String(maxSize)}px`;
   const textWidthAtMax = text.scrollWidth;
 
   let finalSize: number;
@@ -44,7 +44,7 @@ function updateFontSize(
     finalSize = Math.max(maxSize * scaleFactor, minSize);
   }
 
-  text.style.fontSize = `${finalSize}px`;
+  text.style.fontSize = `${String(finalSize)}px`;
 
   // Content is scrollable when at minimum font size and still overflowing
   const textOverflows = text.scrollWidth > availableWidth;
@@ -76,7 +76,9 @@ export function CalculatorDisplay({
     });
     observer.observe(container);
 
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+    };
   }, []);
 
   // Recalculate font size when the display text changes.

--- a/src/components/calculator/calculator-logic.ts
+++ b/src/components/calculator/calculator-logic.ts
@@ -64,7 +64,7 @@ export function infixToRPN(tokens: Token[]): Token[] {
   for (const token of tokens) {
     if (token.type === "number") {
       output.push(token);
-    } else if (token.type === "binaryOperator") {
+    } else {
       while (operatorStack.length > 0) {
         const topOperator = operatorStack[operatorStack.length - 1];
         if (
@@ -99,7 +99,7 @@ export function evaluateRPN(tokens: Token[]): number {
   for (const token of tokens) {
     if (token.type === "number") {
       stack.push(token.value);
-    } else if (token.type === "binaryOperator") {
+    } else {
       const rhs = stack.pop();
       const lhs = stack.pop();
       if (rhs === undefined || lhs === undefined) {

--- a/src/components/calculator/calculator.tsx
+++ b/src/components/calculator/calculator.tsx
@@ -212,7 +212,9 @@ export function Calculator() {
                 label={label}
                 isZero={label === BUTTON_ZERO}
                 isRowEnd={label === row[row.length - 1]}
-                onClick={() => handleClick(label)}
+                onClick={() => {
+                  handleClick(label);
+                }}
               />
             ))}
           </Fragment>

--- a/src/components/movie-database/backdrop-image.tsx
+++ b/src/components/movie-database/backdrop-image.tsx
@@ -18,7 +18,7 @@ interface BackdropImageProps {
 export async function BackdropImage({ backdropPath, alt }: BackdropImageProps) {
   const config = await getConfiguration();
 
-  if (!config.images?.base_url || !config.images?.backdrop_sizes) {
+  if (!config.images?.base_url || !config.images.backdrop_sizes) {
     return null;
   }
 

--- a/src/components/movie-database/genre-filter-button.tsx
+++ b/src/components/movie-database/genre-filter-button.tsx
@@ -28,7 +28,7 @@ export function GenreFilterButton() {
       popupRole="group"
     >
       {t({ en: "Genre", zh: "类型" })}
-      {genres.size ? ` (${genres.size})` : null}
+      {genres.size ? ` (${String(genres.size)})` : null}
     </MenuButton>
   );
 }

--- a/src/components/movie-database/media-card.tsx
+++ b/src/components/movie-database/media-card.tsx
@@ -26,7 +26,7 @@ export function MediaCard({ media, allowFollow }: MediaCardProps) {
   const locale = useLocale();
 
   const href = getLocalePath(
-    `/movie-database/${media.mediaType}/${media.id.toString()}`,
+    `/movie-database/${String(media.mediaType)}/${media.id.toString()}`,
     locale,
   );
 

--- a/src/components/movie-database/media-type-toggle.test.tsx
+++ b/src/components/movie-database/media-type-toggle.test.tsx
@@ -10,18 +10,16 @@ import { MediaTypeToggle } from "./media-type-toggle";
 beforeAll(() => {
   HTMLElement.prototype.setPointerCapture = vi.fn();
   HTMLElement.prototype.releasePointerCapture = vi.fn();
-  if (!window.matchMedia) {
-    window.matchMedia = vi.fn().mockReturnValue({
-      matches: false,
-      media: "",
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    });
-  }
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    media: "",
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  });
 });
 
 function Harness({ children }: { children: ReactNode }) {

--- a/src/components/movie-database/media-virtuoso-grid.tsx
+++ b/src/components/movie-database/media-virtuoso-grid.tsx
@@ -6,9 +6,8 @@ import { useState } from "react";
 import { VirtuosoGrid } from "react-virtuoso";
 import { Grid } from "#src/components/movie-database/grid.tsx";
 import { useViewportHeight } from "#src/hooks/use-viewport-height.ts";
-import { color, layout, ratio, space } from "#src/tokens.stylex.ts";
+import { color, layout, space } from "#src/tokens.stylex.ts";
 import type { MediaListItem } from "#src/utils/types.ts";
-import { Skeleton } from "../shared/skeleton";
 import { MediaCard } from "./media-card";
 
 interface MediaVirtuosoGridProps {
@@ -35,13 +34,9 @@ export function MediaVirtuosoGrid({
       key={virtuosoKey}
       data={items}
       components={gridComponents}
-      itemContent={(index) => {
-        const item = items[index];
-        if (!item) {
-          return <Skeleton css={styles.skeleton} delay={index * 100} />;
-        }
-        return <MediaCard media={item} allowFollow={index < 20} />;
-      }}
+      itemContent={(index) => (
+        <MediaCard media={items[index]} allowFollow={index < 20} />
+      )}
       endReached={() => {
         if (hasNextPage && !isFetching) {
           void fetchNextPage();
@@ -59,11 +54,6 @@ const gridComponents = {
 };
 
 const styles = stylex.create({
-  skeleton: {
-    aspectRatio: ratio.poster,
-    width: "100%",
-    overflow: "hidden",
-  },
   notFound: {
     maxInlineSize: layout.maxInlineSize,
     marginBlock: 0,

--- a/src/components/movie-database/mobile-filters-button.tsx
+++ b/src/components/movie-database/mobile-filters-button.tsx
@@ -32,7 +32,7 @@ export function MobileFiltersButton({
       popupRole="group"
     >
       {children}
-      {genres.size ? ` (${genres.size})` : null}
+      {genres.size ? ` (${String(genres.size)})` : null}
     </MenuButton>
   );
 }

--- a/src/components/movie-database/poster-image.tsx
+++ b/src/components/movie-database/poster-image.tsx
@@ -22,7 +22,7 @@ interface PosterImageProps {
 export function PosterImage({ posterPath, alt }: PosterImageProps) {
   const { data: config } = useSuspenseQuery(tmdbQueries.configuration);
 
-  if (!config.images?.base_url || !config.images?.poster_sizes) {
+  if (!config.images?.base_url || !config.images.poster_sizes) {
     return (
       <div css={[imageCover.base, flex.center, styles.errored]}>
         <div>{alt}</div>

--- a/src/components/movie-database/similar-media.tsx
+++ b/src/components/movie-database/similar-media.tsx
@@ -16,7 +16,7 @@ import { Grid } from "./grid";
 import { SimilarMediaList } from "./similar-media-list";
 
 const SKELETON_ITEMS = Array.from({ length: 20 }, (_, i) => ({
-  key: `skeleton-${i}`,
+  key: `skeleton-${String(i)}`,
   delay: i * 100,
 }));
 

--- a/src/components/movie-database/tmdb-image.tsx
+++ b/src/components/movie-database/tmdb-image.tsx
@@ -55,8 +55,12 @@ export function TmdbImage({
         sizes={sizes}
         loading={loading}
         decoding="async"
-        onLoad={() => setLoaded(true)}
-        onError={() => setErrored(true)}
+        onLoad={() => {
+          setLoaded(true);
+        }}
+        onError={() => {
+          setErrored(true);
+        }}
         ref={(el) => {
           if (el?.complete && el.naturalWidth > 0) setLoaded(true);
         }}

--- a/src/components/movie-database/trailer-button.tsx
+++ b/src/components/movie-database/trailer-button.tsx
@@ -27,13 +27,17 @@ export function TrailerButton({
       <Button
         icon={<PlayIcon weight="fill" role="presentation" />}
         variant="primary"
-        onClick={() => setIsOpen(true)}
+        onClick={() => {
+          setIsOpen(true);
+        }}
       >
         {children}
       </Button>
       <Overlay
         isOpen={isOpen}
-        onClose={() => setIsOpen(false)}
+        onClose={() => {
+          setIsOpen(false);
+        }}
         aria-label={iframeTitle}
       >
         <iframe

--- a/src/components/playground/loop.ts
+++ b/src/components/playground/loop.ts
@@ -98,7 +98,6 @@ function setupGpuTimer(gl: WebGL2RenderingContext): GpuTimer | null {
       activeThisFrame = false;
       if (pendingQuery) return;
       const query = gl.createQuery();
-      if (!query) return;
       gl.beginQuery(TIME_ELAPSED_EXT, query);
       pendingQuery = query;
       activeThisFrame = true;

--- a/src/components/playground/playground-canvas.tsx
+++ b/src/components/playground/playground-canvas.tsx
@@ -14,12 +14,12 @@ function formatStats(stats: FrameStats) {
   const gpu =
     stats.frameGpu !== null ? `${stats.frameGpu.toFixed(2)} ms` : "n/a";
   return [
-    `FPS: ${stats.fps}`,
+    `FPS: ${String(stats.fps)}`,
     `CPU: ${stats.frameCpu.toFixed(2)} ms`,
     `GPU: ${gpu}`,
-    `Samples/px: ${stats.samplesPerPixel}`,
-    `Draw calls: ${stats.drawCalls}`,
-    `Resolution: ${stats.resolution[0]}×${stats.resolution[1]}`,
+    `Samples/px: ${String(stats.samplesPerPixel)}`,
+    `Draw calls: ${String(stats.drawCalls)}`,
+    `Resolution: ${String(stats.resolution[0])}×${String(stats.resolution[1])}`,
   ].join("\n");
 }
 
@@ -55,7 +55,9 @@ function StatsOverlay({
   const handleCopy = () => {
     void navigator.clipboard.writeText(formatStats(stats)).then(() => {
       setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
+      setTimeout(() => {
+        setCopied(false);
+      }, 1500);
     });
   };
 
@@ -63,14 +65,14 @@ function StatsOverlay({
     <div css={styles.overlay}>
       <table css={styles.table}>
         <tbody>
-          <Row label="FPS" value={`${stats.fps}`} />
+          <Row label="FPS" value={String(stats.fps)} />
           <Row label="CPU" value={`${stats.frameCpu.toFixed(2)} ms`} />
           <Row label="GPU" value={gpuLabel} />
-          <Row label="Samples/px" value={`${stats.samplesPerPixel}`} />
-          <Row label="Draw calls" value={`${stats.drawCalls}`} />
+          <Row label="Samples/px" value={String(stats.samplesPerPixel)} />
+          <Row label="Draw calls" value={String(stats.drawCalls)} />
           <Row
             label="Resolution"
-            value={`${stats.resolution[0]}×${stats.resolution[1]}`}
+            value={`${String(stats.resolution[0])}×${String(stats.resolution[1])}`}
           />
         </tbody>
       </table>
@@ -85,7 +87,9 @@ function StatsOverlay({
               key={key}
               label={label}
               active={debug[key]}
-              onToggle={() => onDebugChange({ ...debug, [key]: !debug[key] })}
+              onToggle={() => {
+                onDebugChange({ ...debug, [key]: !debug[key] });
+              }}
             />
           ))}
         </div>
@@ -100,7 +104,9 @@ function StatsOverlay({
             <button
               key={value}
               type="button"
-              onClick={() => onDebugChange({ ...debug, mode: value })}
+              onClick={() => {
+                onDebugChange({ ...debug, mode: value });
+              }}
               css={[
                 styles.modeButton,
                 debug.mode === value && styles.modeButtonActive,

--- a/src/components/shared/anchor.test.tsx
+++ b/src/components/shared/anchor.test.tsx
@@ -48,7 +48,8 @@ describe("Anchor", () => {
     );
 
     const link = screen.getByRole("link", { name: "External" });
-    const rel = link.getAttribute("rel")!;
+    const rel = link.getAttribute("rel");
+    if (!rel) throw new Error("expected rel attribute");
     const tokens = rel.split(/\s+/);
     expect(tokens.filter((t) => t === "noopener")).toHaveLength(1);
     expect(tokens.filter((t) => t === "noreferrer")).toHaveLength(1);

--- a/src/components/shared/animate-to-target.tsx
+++ b/src/components/shared/animate-to-target.tsx
@@ -112,7 +112,7 @@ export function AnimateToTarget({
         const currentScaleY =
           startScaleY + (endScaleY - startScaleY) * progress;
         return {
-          transform: `translate3d(${currentTranslateX}px, ${currentTranslateY}px, 0px) scale(${currentScaleX}, ${currentScaleY})`,
+          transform: `translate3d(${String(currentTranslateX)}px, ${String(currentTranslateY)}px, 0px) scale(${String(currentScaleX)}, ${String(currentScaleY)})`,
           opacity: animateToTarget
             ? progress > 0.7
               ? 1 - (progress - 0.7) / 0.3
@@ -132,7 +132,7 @@ export function AnimateToTarget({
         const currentScaleY =
           startScaleY + (endScaleY - startScaleY) * progress;
         return {
-          transform: `scale(${1 / currentScaleX}, ${1 / currentScaleY})`,
+          transform: `scale(${String(1 / currentScaleX)}, ${String(1 / currentScaleY)})`,
         };
       }),
       animationOptions,

--- a/src/components/shared/button-shared.stylex.ts
+++ b/src/components/shared/button-shared.stylex.ts
@@ -18,7 +18,7 @@ export const sharedStyles = stylex.create({
     borderRadius: buttonTokens.borderRadius,
     boxShadow: buttonTokens.boxShadow,
     transition: {
-      default: `background 0.2s ease, transform ${PRESS_ANIMATION_DURATION}ms ease-out, filter ${PRESS_ANIMATION_DURATION}ms ease-out`,
+      default: `background 0.2s ease, transform ${String(PRESS_ANIMATION_DURATION)}ms ease-out, filter ${String(PRESS_ANIMATION_DURATION)}ms ease-out`,
       [motionConstants.REDUCED_MOTION]: "background 0.2s ease",
     },
     backgroundColor: {
@@ -91,7 +91,7 @@ export const sharedStyles = stylex.create({
   },
   releasedOutside: {
     transition: {
-      default: `background 0.2s ease, transform ${RELEASE_OUTSIDE_ANIMATION_DURATION}ms ease-out, filter ${RELEASE_OUTSIDE_ANIMATION_DURATION}ms ease-out`,
+      default: `background 0.2s ease, transform ${String(RELEASE_OUTSIDE_ANIMATION_DURATION)}ms ease-out, filter ${String(RELEASE_OUTSIDE_ANIMATION_DURATION)}ms ease-out`,
       [motionConstants.REDUCED_MOTION]: "background 0.2s ease",
     },
   },

--- a/src/components/shared/chat-textarea.tsx
+++ b/src/components/shared/chat-textarea.tsx
@@ -2,14 +2,26 @@
 
 import { ArrowUpIcon } from "@phosphor-icons/react/dist/ssr/ArrowUp";
 import * as stylex from "@stylexjs/stylex";
-import { useRef, useState, type ReactNode } from "react";
+import { createContext, use, useRef, useState, type ReactNode } from "react";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { buttonReset } from "#src/primitives/reset.stylex.ts";
 import { border, color, font, space } from "#src/tokens.stylex.ts";
 
-interface ActionButtonContext {
+interface ChatTextareaContextValue {
   trimmedText: string;
   focusTextarea: () => void;
+}
+
+const ChatTextareaContext = createContext<ChatTextareaContextValue | null>(
+  null,
+);
+
+export function useChatTextarea() {
+  const ctx = use(ChatTextareaContext);
+  if (!ctx) {
+    throw new Error("useChatTextarea must be used within a ChatTextarea");
+  }
+  return ctx;
 }
 
 interface ChatTextareaProps {
@@ -20,11 +32,8 @@ interface ChatTextareaProps {
   autoGrow?: boolean;
   /** Content rendered before the textarea (e.g. attachment row). */
   beforeTextarea?: ReactNode;
-  /**
-   * Override the default send button. Receives context with the current trimmed
-   * text and a function to focus the textarea.
-   */
-  actionButton?: (context: ActionButtonContext) => ReactNode;
+  /** Override the default send button. Use `useChatTextarea()` inside children to access context. */
+  children?: ReactNode;
 }
 
 export function ChatTextarea({
@@ -34,10 +43,10 @@ export function ChatTextarea({
   disabled = false,
   autoGrow = false,
   beforeTextarea,
-  actionButton,
+  children,
 }: ChatTextareaProps) {
   const [text, setText] = useState("");
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const trimmed = text.trim();
 
   function resetHeight() {
@@ -63,11 +72,11 @@ export function ChatTextarea({
     if (autoGrow) {
       const textarea = event.target;
       textarea.style.height = "auto";
-      textarea.style.height = `${textarea.scrollHeight}px`;
+      textarea.style.height = `${String(textarea.scrollHeight)}px`;
     }
   }
 
-  function handleSubmit(event: React.FormEvent) {
+  function handleSubmit(event: React.SubmitEvent) {
     event.preventDefault();
     submit();
   }
@@ -84,39 +93,39 @@ export function ChatTextarea({
   }
 
   return (
-    <form onSubmit={handleSubmit} css={[flex.wrap, styles.container]}>
-      {beforeTextarea}
-      <textarea
-        ref={textareaRef}
-        value={text}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        placeholder={placeholder}
-        aria-label={placeholder}
-        rows={1}
-        disabled={disabled}
-        css={[styles.textarea, autoGrow && styles.textareaAutoGrow]}
-        autoComplete="off"
-        enterKeyHint="send"
-      />
-      {actionButton ? (
-        actionButton({ trimmedText: trimmed, focusTextarea })
-      ) : (
-        <button
-          type="submit"
-          aria-label={sendLabel}
-          disabled={!trimmed || disabled}
-          css={[
-            flex.inlineCenter,
-            buttonReset.base,
-            styles.iconButton,
-            !!trimmed && styles.iconButtonActive,
-          ]}
-        >
-          <ArrowUpIcon weight="bold" role="presentation" />
-        </button>
-      )}
-    </form>
+    <ChatTextareaContext value={{ trimmedText: trimmed, focusTextarea }}>
+      <form onSubmit={handleSubmit} css={[flex.wrap, styles.container]}>
+        {beforeTextarea}
+        <textarea
+          ref={textareaRef}
+          value={text}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          aria-label={placeholder}
+          rows={1}
+          disabled={disabled}
+          css={[styles.textarea, autoGrow && styles.textareaAutoGrow]}
+          autoComplete="off"
+          enterKeyHint="send"
+        />
+        {children ?? (
+          <button
+            type="submit"
+            aria-label={sendLabel}
+            disabled={!trimmed || disabled}
+            css={[
+              flex.inlineCenter,
+              buttonReset.base,
+              styles.iconButton,
+              !!trimmed && styles.iconButtonActive,
+            ]}
+          >
+            <ArrowUpIcon weight="bold" role="presentation" />
+          </button>
+        )}
+      </form>
+    </ChatTextareaContext>
   );
 }
 

--- a/src/components/shared/locale-selector.tsx
+++ b/src/components/shared/locale-selector.tsx
@@ -75,7 +75,7 @@ function setLocaleCookie(locale: SupportedLocale) {
   // set cookie for next-i18n-router
   const maxAge = 31536000; // 1 year in seconds
   const secure = window.location.protocol === "https:" ? ";Secure" : "";
-  document.cookie = `${LOCALE_COOKIE_NAME}=${locale};max-age=${maxAge};path=/;SameSite=Lax${secure}`;
+  document.cookie = `${LOCALE_COOKIE_NAME}=${locale};max-age=${String(maxAge)};path=/;SameSite=Lax${secure}`;
 }
 
 const styles = stylex.create({

--- a/src/components/shared/menu-button.test.tsx
+++ b/src/components/shared/menu-button.test.tsx
@@ -17,18 +17,16 @@ beforeAll(() => {
     onfinish: null,
     oncancel: null,
   });
-  if (!window.matchMedia) {
-    window.matchMedia = vi.fn().mockReturnValue({
-      matches: false,
-      media: "",
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    });
-  }
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    media: "",
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  });
 });
 
 // MenuItem calls useRouter() at render time, which requires the Next.js

--- a/src/components/shared/menu-button.tsx
+++ b/src/components/shared/menu-button.tsx
@@ -86,10 +86,8 @@ export function MenuButton({
           css={styles.backdrop}
           aria-hidden="true"
           onClick={() => {
-            if (isMenuShown) {
-              setIsMenuShown(false);
-              outsideClickedRef.current = true;
-            }
+            setIsMenuShown(false);
+            outsideClickedRef.current = true;
           }}
         />
       )}
@@ -134,17 +132,17 @@ export function MenuButton({
               currentIndex === -1
                 ? items[0]
                 : items[(currentIndex + 1) % items.length];
-            next?.focus();
+            next.focus();
           } else if (e.key === "ArrowUp") {
             const prev =
               currentIndex === -1
                 ? items[items.length - 1]
                 : items[(currentIndex - 1 + items.length) % items.length];
-            prev?.focus();
+            prev.focus();
           } else if (e.key === "Home") {
-            items[0]?.focus();
-          } else if (e.key === "End") {
-            items[items.length - 1]?.focus();
+            items[0].focus();
+          } else {
+            items[items.length - 1].focus();
           }
         }}
         onBlur={(e) => {
@@ -162,7 +160,9 @@ export function MenuButton({
             {...buttonProps}
             aria-expanded={isMenuShown}
             aria-haspopup={popupRole === "menu" ? "menu" : "true"}
-            onClick={() => setIsMenuShown(true)}
+            onClick={() => {
+              setIsMenuShown(true);
+            }}
             disabled={disabled}
             id={targetId}
             labelId={`${targetId}-label`}
@@ -185,7 +185,7 @@ export function MenuButton({
             <div
               ref={popupRef}
               role={popupRole}
-              aria-labelledby={popupRole ? `${targetId}-label` : undefined}
+              aria-labelledby={`${targetId}-label`}
             >
               {children && <div css={styles.menuTitle}>{children}</div>}
               {menuContent}

--- a/src/components/shared/skeleton.tsx
+++ b/src/components/shared/skeleton.tsx
@@ -68,12 +68,12 @@ const styles = stylex.create({
     [skeletonTokens.height]: "100%",
   },
   width: (width: number) => ({
-    [skeletonTokens.width]: `${width}px`,
+    [skeletonTokens.width]: `${String(width)}px`,
   }),
   height: (height: number) => ({
-    [skeletonTokens.height]: `${height}px`,
+    [skeletonTokens.height]: `${String(height)}px`,
   }),
   delay: (delay: number) => ({
-    [skeletonTokens.delay]: `${delay}ms`,
+    [skeletonTokens.delay]: `${String(delay)}ms`,
   }),
 });

--- a/src/components/shared/switch.test.tsx
+++ b/src/components/shared/switch.test.tsx
@@ -10,11 +10,27 @@ function ThreeStateTestComponent() {
   return (
     <>
       <Switch value={state} onChange={setState} />
-      <button onClick={() => setState("on")}>Set On</button>
-      <button onClick={() => setState("indeterminate")}>
+      <button
+        onClick={() => {
+          setState("on");
+        }}
+      >
+        Set On
+      </button>
+      <button
+        onClick={() => {
+          setState("indeterminate");
+        }}
+      >
         Set Indeterminate
       </button>
-      <button onClick={() => setState("off")}>Set Off</button>
+      <button
+        onClick={() => {
+          setState("off");
+        }}
+      >
+        Set Off
+      </button>
     </>
   );
 }

--- a/src/components/shared/switch.tsx
+++ b/src/components/shared/switch.tsx
@@ -164,8 +164,12 @@ export function Switch({
           setControlledValue(value === "on" ? "off" : "on");
         }
       }}
-      onChange={(e) => e.preventDefault()}
-      onClick={(e) => e.preventDefault()}
+      onChange={(e) => {
+        e.preventDefault();
+      }}
+      onClick={(e) => {
+        e.preventDefault();
+      }}
     />
   );
 }
@@ -226,8 +230,8 @@ const styles = stylex.create({
       },
     },
   },
-  dragging: (position) => ({
-    [switchTokens.thumbPosition]: `${position}px`,
+  dragging: (position: number | null) => ({
+    [switchTokens.thumbPosition]: `${String(position)}px`,
     "::before": {
       transition: null,
     },

--- a/src/components/shared/theme-switch.test.tsx
+++ b/src/components/shared/theme-switch.test.tsx
@@ -13,18 +13,16 @@ const LABELS: [string, string, string] = [
 beforeAll(() => {
   HTMLElement.prototype.setPointerCapture = vi.fn();
   HTMLElement.prototype.releasePointerCapture = vi.fn();
-  if (!window.matchMedia) {
-    window.matchMedia = vi.fn().mockReturnValue({
-      matches: false,
-      media: "",
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    });
-  }
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    media: "",
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  });
 });
 
 beforeEach(() => {

--- a/src/components/shared/theme-switch.tsx
+++ b/src/components/shared/theme-switch.tsx
@@ -43,7 +43,7 @@ export function ThemeSwitch({ labels }: ThemeSwitchProps) {
 
     metaTag.setAttribute(
       "content",
-      !theme || theme === "system"
+      theme === "system"
         ? preferDark
           ? "#000000"
           : "#ffffff"
@@ -82,9 +82,11 @@ export function ThemeSwitch({ labels }: ThemeSwitchProps) {
         <Button
           role="radio"
           aria-label={labels[2]}
-          aria-checked={!theme || theme === "system"}
-          onClick={() => setTheme("system")}
-          disabled={!theme || theme === "system"}
+          aria-checked={theme === "system"}
+          onClick={() => {
+            setTheme("system");
+          }}
+          disabled={theme === "system"}
           title={labels[2]}
         >
           <div css={styles.systemIcon}>
@@ -101,20 +103,16 @@ export function ThemeSwitch({ labels }: ThemeSwitchProps) {
         id="theme-switch"
         css={styles.switch}
         value={
-          !theme || theme === "system"
+          theme === "system"
             ? themeMap[preferDark ? "dark" : "light"]
             : themeMap[theme]
         }
-        onChange={(state) => setTheme(state === "on" ? "dark" : "light")}
+        onChange={(state) => {
+          setTheme(state === "on" ? "dark" : "light");
+        }}
         aria-label={
           labels[
-            !theme || theme === "system"
-              ? preferDark
-                ? 0
-                : 1
-              : theme === "dark"
-                ? 0
-                : 1
+            theme === "system" ? (preferDark ? 0 : 1) : theme === "dark" ? 0 : 1
           ]
         }
       />

--- a/src/hooks/use-controlled.ts
+++ b/src/hooks/use-controlled.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useState } from "react";
 
 /**
  * Hook for optionally controlled state. When `controlled` is provided,
@@ -18,17 +18,17 @@ export function useControlled<T>({
   controlled: T | undefined;
   defaultValue: T;
 }): [T, (next: T) => void] {
-  const isControlledRef = useRef(controlled !== undefined);
+  // Captured once on mount — the controlled/uncontrolled decision is
+  // fixed for the component's lifetime (same semantics as the old ref).
+  const [isControlled] = useState(() => controlled !== undefined);
   const [internalValue, setInternalValue] = useState(defaultValue);
 
   // When controlled, use the provided value (falling back to
   // defaultValue for the impossible case where controlled becomes
   // undefined after initialisation).
-  const value = isControlledRef.current
-    ? (controlled ?? defaultValue)
-    : internalValue;
+  const value = isControlled ? (controlled ?? defaultValue) : internalValue;
 
-  const setter = isControlledRef.current ? noop : setInternalValue;
+  const setter = isControlled ? noop : setInternalValue;
 
   return [value, setter];
 }

--- a/src/hooks/use-dialog-focus.test.ts
+++ b/src/hooks/use-dialog-focus.test.ts
@@ -39,7 +39,9 @@ describe("useDialogFocus", () => {
     const dialogRef = { current: dialog };
     const onClose = vi.fn();
 
-    renderHook(() => useDialogFocus({ isOpen: true, dialogRef, onClose }));
+    renderHook(() => {
+      useDialogFocus({ isOpen: true, dialogRef, onClose });
+    });
 
     expect(button1).toHaveFocus();
   });
@@ -50,14 +52,14 @@ describe("useDialogFocus", () => {
     const initialFocusRef = { current: button2 };
     const onClose = vi.fn();
 
-    renderHook(() =>
+    renderHook(() => {
       useDialogFocus({
         isOpen: true,
         dialogRef,
         onClose,
         initialFocusRef,
-      }),
-    );
+      });
+    });
 
     expect(button2).toHaveFocus();
   });
@@ -67,7 +69,9 @@ describe("useDialogFocus", () => {
     const dialogRef = { current: dialog };
     const onClose = vi.fn();
 
-    renderHook(() => useDialogFocus({ isOpen: false, dialogRef, onClose }));
+    renderHook(() => {
+      useDialogFocus({ isOpen: false, dialogRef, onClose });
+    });
 
     expect(button1).not.toHaveFocus();
   });
@@ -77,7 +81,9 @@ describe("useDialogFocus", () => {
     const dialogRef = { current: dialog };
     const onClose = vi.fn();
 
-    renderHook(() => useDialogFocus({ isOpen: true, dialogRef, onClose }));
+    renderHook(() => {
+      useDialogFocus({ isOpen: true, dialogRef, onClose });
+    });
 
     fireEvent.keyDown(document, { key: "Escape" });
 
@@ -89,7 +95,9 @@ describe("useDialogFocus", () => {
     const dialogRef = { current: dialog };
     const onClose = vi.fn();
 
-    renderHook(() => useDialogFocus({ isOpen: false, dialogRef, onClose }));
+    renderHook(() => {
+      useDialogFocus({ isOpen: false, dialogRef, onClose });
+    });
 
     fireEvent.keyDown(document, { key: "Escape" });
 
@@ -101,7 +109,9 @@ describe("useDialogFocus", () => {
     const dialogRef = { current: dialog };
     const onClose = vi.fn();
 
-    renderHook(() => useDialogFocus({ isOpen: true, dialogRef, onClose }));
+    renderHook(() => {
+      useDialogFocus({ isOpen: true, dialogRef, onClose });
+    });
 
     button3.focus();
     expect(button3).toHaveFocus();
@@ -116,7 +126,9 @@ describe("useDialogFocus", () => {
     const dialogRef = { current: dialog };
     const onClose = vi.fn();
 
-    renderHook(() => useDialogFocus({ isOpen: true, dialogRef, onClose }));
+    renderHook(() => {
+      useDialogFocus({ isOpen: true, dialogRef, onClose });
+    });
 
     button1.focus();
     expect(button1).toHaveFocus();
@@ -131,7 +143,9 @@ describe("useDialogFocus", () => {
     const dialogRef = { current: dialog };
     const onClose = vi.fn();
 
-    renderHook(() => useDialogFocus({ isOpen: true, dialogRef, onClose }));
+    renderHook(() => {
+      useDialogFocus({ isOpen: true, dialogRef, onClose });
+    });
 
     button2.focus();
     expect(button2).toHaveFocus();
@@ -157,9 +171,9 @@ describe("useDialogFocus", () => {
     const dialogRef = { current: dialog };
     const onClose = vi.fn();
 
-    const { unmount } = renderHook(() =>
-      useDialogFocus({ isOpen: true, dialogRef, onClose }),
-    );
+    const { unmount } = renderHook(() => {
+      useDialogFocus({ isOpen: true, dialogRef, onClose });
+    });
 
     // Focus moved into dialog
     expect(trigger).not.toHaveFocus();

--- a/src/hooks/use-press-animation.ts
+++ b/src/hooks/use-press-animation.ts
@@ -221,7 +221,9 @@ export function usePressAnimation<T extends HTMLElement>({
       }
     };
     window.addEventListener("blur", handleWindowBlur);
-    return () => window.removeEventListener("blur", handleWindowBlur);
+    return () => {
+      window.removeEventListener("blur", handleWindowBlur);
+    };
   }, []);
 
   return {

--- a/src/hooks/use-press-handlers.ts
+++ b/src/hooks/use-press-handlers.ts
@@ -99,8 +99,8 @@ export function usePressHandlers<T extends HTMLElement>({
   const pressedStyle =
     isPressed && !disabled
       ? {
-          "--button-nudge-x": `${nudgeOffset.x}px`,
-          "--button-nudge-y": `${nudgeOffset.y}px`,
+          "--button-nudge-x": `${String(nudgeOffset.x)}px`,
+          "--button-nudge-y": `${String(nudgeOffset.y)}px`,
         }
       : undefined;
 

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -13,7 +13,9 @@ let themeSingleton: string | null = null;
 function setTheme(newTheme: SupportedTheme) {
   themeSingleton = newTheme;
   localStorage.setItem(STORAGE_KEY, newTheme);
-  listeners.forEach((listener) => listener());
+  listeners.forEach((listener) => {
+    listener();
+  });
 }
 
 function getSupportedTheme(theme: string | null): SupportedTheme {

--- a/src/hooks/use-viewport-height.ts
+++ b/src/hooks/use-viewport-height.ts
@@ -2,7 +2,9 @@ import { useSyncExternalStore } from "react";
 
 function subscribe(onChange: () => void) {
   window.addEventListener("resize", onChange);
-  return () => window.removeEventListener("resize", onChange);
+  return () => {
+    window.removeEventListener("resize", onChange);
+  };
 }
 
 function getSnapshot() {

--- a/src/i18n/client-runtime.ts
+++ b/src/i18n/client-runtime.ts
@@ -9,18 +9,16 @@ import { parseMessage } from "#src/utils/parse-message.tsx";
 // within component render, so the rules-of-hooks are satisfied.
 export function useI18nLookup(key: string): string {
   const { translations } = use(I18nContext);
-  const value = translations[key];
-  if (process.env.NODE_ENV !== "production" && value === undefined) {
+  if (process.env.NODE_ENV !== "production" && !(key in translations)) {
     throw new Error(`[i18n] Missing translation key: ${key}`);
   }
-  return value;
+  return translations[key];
 }
 
 export function useI18nLookupParse(key: string): ReactNode {
   const { translations } = use(I18nContext);
-  const value = translations[key];
-  if (process.env.NODE_ENV !== "production" && value === undefined) {
+  if (process.env.NODE_ENV !== "production" && !(key in translations)) {
     throw new Error(`[i18n] Missing translation key: ${key}`);
   }
-  return parseMessage(value);
+  return parseMessage(translations[key]);
 }

--- a/src/i18n/server-runtime.ts
+++ b/src/i18n/server-runtime.ts
@@ -14,17 +14,17 @@ const bundles: Record<SupportedLocale, Record<string, string>> = {
 };
 
 export function __i18n_lookup(key: string): string {
-  const value = bundles[getLocale()][key];
-  if (process.env.NODE_ENV !== "production" && value === undefined) {
+  const bundle = bundles[getLocale()];
+  if (process.env.NODE_ENV !== "production" && !(key in bundle)) {
     throw new Error(`[i18n] Missing translation key: ${key}`);
   }
-  return value;
+  return bundle[key];
 }
 
 export function __i18n_lookupParse(key: string): ReactNode {
-  const value = bundles[getLocale()][key];
-  if (process.env.NODE_ENV !== "production" && value === undefined) {
+  const bundle = bundles[getLocale()];
+  if (process.env.NODE_ENV !== "production" && !(key in bundle)) {
     throw new Error(`[i18n] Missing translation key: ${key}`);
   }
-  return parseMessage(value);
+  return parseMessage(bundle[key]);
 }

--- a/src/preference-store/preference-store.ts
+++ b/src/preference-store/preference-store.ts
@@ -67,9 +67,12 @@ function openDB(): Promise<IDBDatabase> {
       }
     };
 
-    request.onsuccess = () => resolve(request.result);
-    request.onerror = () =>
+    request.onsuccess = () => {
+      resolve(request.result);
+    };
+    request.onerror = () => {
       reject(request.error ?? new Error("Failed to open IndexedDB"));
+    };
   });
 }
 
@@ -83,10 +86,15 @@ export async function getAllPreferences(): Promise<StoredPreference[]> {
       const raw: unknown[] = request.result;
       resolve(raw.filter(isStoredPreference));
     };
-    request.onerror = () =>
+    request.onerror = () => {
       reject(request.error ?? new Error("Failed to read preferences"));
-    tx.oncomplete = () => db.close();
-    tx.onerror = () => db.close();
+    };
+    tx.oncomplete = () => {
+      db.close();
+    };
+    tx.onerror = () => {
+      db.close();
+    };
   });
 }
 

--- a/src/preference-store/use-preferences.ts
+++ b/src/preference-store/use-preferences.ts
@@ -28,7 +28,14 @@ export function usePreferences() {
   }
 
   useEffect(() => {
-    void reload();
+    void (async () => {
+      try {
+        const all = await getAllPreferences();
+        setPreferences(all);
+      } catch {
+        setPreferences([]);
+      }
+    })();
   }, []);
 
   async function remove(id: string) {

--- a/src/test-msw.ts
+++ b/src/test-msw.ts
@@ -3,6 +3,12 @@ import { afterAll, afterEach, beforeAll } from "vitest";
 
 export const server = setupServer();
 
-beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: "error" });
+});
+afterEach(() => {
+  server.resetHandlers();
+});
+afterAll(() => {
+  server.close();
+});

--- a/src/utils/api-request-wrapper.ts
+++ b/src/utils/api-request-wrapper.ts
@@ -16,14 +16,14 @@ export async function apiRequestWrapper<
 
     if (Array.isArray(value)) {
       for (const item of value) {
-        url.searchParams.append(key, `${item}`);
+        url.searchParams.append(key, String(item));
       }
     } else if (
       typeof value === "string" ||
       typeof value === "number" ||
       typeof value === "boolean"
     ) {
-      url.searchParams.set(key, `${value}`);
+      url.searchParams.set(key, String(value));
     }
   }
   const response = await fetch(url.toString(), {

--- a/src/utils/get-query-client.ts
+++ b/src/utils/get-query-client.ts
@@ -1,6 +1,6 @@
 import {
   defaultShouldDehydrateQuery,
-  isServer,
+  environmentManager,
   QueryClient,
 } from "@tanstack/react-query";
 
@@ -25,7 +25,7 @@ function makeQueryClient() {
 let browserQueryClient: QueryClient | undefined = undefined;
 
 export function getQueryClient() {
-  if (isServer) {
+  if (environmentManager.isServer()) {
     // Server: always make a new query client
     return makeQueryClient();
   } else {

--- a/src/utils/parse-message.test.tsx
+++ b/src/utils/parse-message.test.tsx
@@ -203,8 +203,8 @@ describe("parseMessage", () => {
       expect(container.querySelectorAll("p")).toHaveLength(2);
       expect(container.querySelector("p strong")).toBeTruthy();
       const paragraphs = container.querySelectorAll("p");
-      expect(paragraphs[0]?.textContent).toBe("First paragraph with bold");
-      expect(paragraphs[1]?.textContent).toBe("Second paragraph with emphasis");
+      expect(paragraphs[0].textContent).toBe("First paragraph with bold");
+      expect(paragraphs[1].textContent).toBe("Second paragraph with emphasis");
     });
   });
 });

--- a/src/utils/tmdb-client.ts
+++ b/src/utils/tmdb-client.ts
@@ -67,7 +67,7 @@ async function tmdbFetch<T>(url: string, errorMessage: string): Promise<T> {
 
   if (!response.ok) {
     throw new Error(
-      `${errorMessage} (${response.status}:${response.statusText})`,
+      `${errorMessage} (${String(response.status)}:${response.statusText})`,
     );
   }
 
@@ -88,7 +88,7 @@ export async function tmdbGet<TPath extends keyof paths>(
   pathParams?: PathParams<TPath>,
 ) {
   // Replace path parameters with sanitized values
-  let resolvedPath = `${path}`;
+  let resolvedPath: string = path;
   if (pathParams) {
     for (const [key, value] of Object.entries(pathParams)) {
       const sanitizedValue = sanitizePathParam(value);

--- a/src/utils/tmdb-image.ts
+++ b/src/utils/tmdb-image.ts
@@ -17,8 +17,10 @@ export function buildSrcSet(
     return { src: `${baseUrl}original${path}`, srcSet: "" };
   }
 
-  const src = `${baseUrl}w${widths[widths.length - 1]}${path}`;
-  const srcSet = widths.map((w) => `${baseUrl}w${w}${path} ${w}w`).join(", ");
+  const src = `${baseUrl}w${String(widths[widths.length - 1])}${path}`;
+  const srcSet = widths
+    .map((w) => `${baseUrl}w${String(w)}${path} ${String(w)}w`)
+    .join(", ");
 
   return { src, srcSet };
 }

--- a/src/utils/tmdb-queries.test.ts
+++ b/src/utils/tmdb-queries.test.ts
@@ -94,7 +94,8 @@ describe("mediaDetail", () => {
       );
 
       const options = mediaDetail({ type: "movie", id: "550" });
-      const result = await options.queryFn!({} as never);
+      if (!options.queryFn) throw new Error("expected queryFn");
+      const result = await options.queryFn({} as never);
 
       expect(result).toEqual({
         title: "Fight Club",
@@ -121,7 +122,8 @@ describe("mediaDetail", () => {
       );
 
       const options = mediaDetail({ type: "movie", id: "550" });
-      const result = await options.queryFn!({} as never);
+      if (!options.queryFn) throw new Error("expected queryFn");
+      const result = await options.queryFn({} as never);
 
       expect(result.title).toBe("FC");
     });
@@ -134,7 +136,8 @@ describe("mediaDetail", () => {
       );
 
       const options = mediaDetail({ type: "movie", id: "550" });
-      const result = await options.queryFn!({} as never);
+      if (!options.queryFn) throw new Error("expected queryFn");
+      const result = await options.queryFn({} as never);
 
       expect(result.runtime).toBe(0);
     });
@@ -154,7 +157,8 @@ describe("mediaDetail", () => {
       );
 
       const options = mediaDetail({ type: "movie", id: "550" });
-      const result = await options.queryFn!({} as never);
+      if (!options.queryFn) throw new Error("expected queryFn");
+      const result = await options.queryFn({} as never);
 
       expect(result.genres).toEqual(["Drama", "Thriller"]);
     });
@@ -173,7 +177,8 @@ describe("mediaDetail", () => {
         id: "550",
         language: "zh",
       });
-      await options.queryFn!({} as never);
+      if (!options.queryFn) throw new Error("expected queryFn");
+      await options.queryFn({} as never);
 
       const url = new URL(requestUrl);
       expect(url.searchParams.get("movie_id")).toBe("550");
@@ -190,7 +195,8 @@ describe("mediaDetail", () => {
       );
 
       const options = mediaDetail({ type: "tv", id: "1399" });
-      const result = await options.queryFn!({} as never);
+      if (!options.queryFn) throw new Error("expected queryFn");
+      const result = await options.queryFn({} as never);
 
       expect(result).toEqual({
         title: "Game of Thrones",
@@ -217,7 +223,8 @@ describe("mediaDetail", () => {
       );
 
       const options = mediaDetail({ type: "tv", id: "1399" });
-      const result = await options.queryFn!({} as never);
+      if (!options.queryFn) throw new Error("expected queryFn");
+      const result = await options.queryFn({} as never);
 
       expect(result.title).toBe("GoT");
     });
@@ -230,7 +237,8 @@ describe("mediaDetail", () => {
       );
 
       const options = mediaDetail({ type: "tv", id: "1399" });
-      const result = await options.queryFn!({} as never);
+      if (!options.queryFn) throw new Error("expected queryFn");
+      const result = await options.queryFn({} as never);
 
       expect(result.numberOfSeasons).toBe(0);
     });
@@ -250,7 +258,8 @@ describe("mediaDetail", () => {
       );
 
       const options = mediaDetail({ type: "tv", id: "1399" });
-      const result = await options.queryFn!({} as never);
+      if (!options.queryFn) throw new Error("expected queryFn");
+      const result = await options.queryFn({} as never);
 
       expect(result.genres).toEqual(["科幻", "剧情"]);
     });
@@ -265,7 +274,8 @@ describe("mediaDetail", () => {
       );
 
       const options = mediaDetail({ type: "tv", id: "1399", language: "en" });
-      await options.queryFn!({} as never);
+      if (!options.queryFn) throw new Error("expected queryFn");
+      await options.queryFn({} as never);
 
       const url = new URL(requestUrl);
       expect(url.searchParams.get("series_id")).toBe("1399");
@@ -291,7 +301,8 @@ describe("mediaVideos", () => {
       id: "550",
       language: "en",
     });
-    const result = await options.queryFn!({} as never);
+    if (!options.queryFn) throw new Error("expected queryFn");
+    const result = await options.queryFn({} as never);
 
     const url = new URL(requestUrl);
     expect(url.searchParams.get("movie_id")).toBe("550");
@@ -309,7 +320,8 @@ describe("mediaVideos", () => {
     );
 
     const options = mediaVideos({ type: "tv", id: "1399", language: "en" });
-    const result = await options.queryFn!({} as never);
+    if (!options.queryFn) throw new Error("expected queryFn");
+    const result = await options.queryFn({} as never);
 
     const url = new URL(requestUrl);
     expect(url.searchParams.get("series_id")).toBe("1399");
@@ -355,7 +367,8 @@ describe("personDetail", () => {
     );
 
     const options = personDetail({ id: "31" });
-    const result = await options.queryFn!({} as never);
+    if (!options.queryFn) throw new Error("expected queryFn");
+    const result = await options.queryFn({} as never);
 
     expect(result).toEqual({
       name: "Tom Hanks",
@@ -375,7 +388,8 @@ describe("personDetail", () => {
     );
 
     const options = personDetail({ id: "31" });
-    const result = await options.queryFn!({} as never);
+    if (!options.queryFn) throw new Error("expected queryFn");
+    const result = await options.queryFn({} as never);
 
     expect(result.deathday).toBe("2014-08-11");
   });
@@ -388,7 +402,8 @@ describe("personDetail", () => {
     );
 
     const options = personDetail({ id: "31" });
-    const result = await options.queryFn!({} as never);
+    if (!options.queryFn) throw new Error("expected queryFn");
+    const result = await options.queryFn({} as never);
 
     expect(result.deathday).toBeNull();
   });
@@ -401,7 +416,8 @@ describe("personDetail", () => {
     );
 
     const options = personDetail({ id: "31" });
-    const result = await options.queryFn!({} as never);
+    if (!options.queryFn) throw new Error("expected queryFn");
+    const result = await options.queryFn({} as never);
 
     expect(result.name).toBe("");
   });
@@ -421,7 +437,8 @@ describe("personDetail", () => {
     );
 
     const options = personDetail({ id: "31" });
-    const result = await options.queryFn!({} as never);
+    if (!options.queryFn) throw new Error("expected queryFn");
+    const result = await options.queryFn({} as never);
 
     expect(result.profilePath).toBeNull();
     expect(result.biography).toBeNull();
@@ -439,7 +456,8 @@ describe("personDetail", () => {
     );
 
     const options = personDetail({ id: "31", language: "zh" });
-    await options.queryFn!({} as never);
+    if (!options.queryFn) throw new Error("expected queryFn");
+    await options.queryFn({} as never);
 
     const url = new URL(requestUrl);
     expect(url.searchParams.get("person_id")).toBe("31");

--- a/src/vector-db/search.ts
+++ b/src/vector-db/search.ts
@@ -22,20 +22,20 @@ export function buildFilterString(
 
   if (filters.genreIds) {
     for (const id of filters.genreIds) {
-      conditions.push(`genreIds CONTAINS ${id}`);
+      conditions.push(`genreIds CONTAINS ${String(id)}`);
     }
   }
 
   if (filters.releaseYearMin !== undefined) {
-    conditions.push(`releaseYear >= ${filters.releaseYearMin}`);
+    conditions.push(`releaseYear >= ${String(filters.releaseYearMin)}`);
   }
 
   if (filters.releaseYearMax !== undefined) {
-    conditions.push(`releaseYear <= ${filters.releaseYearMax}`);
+    conditions.push(`releaseYear <= ${String(filters.releaseYearMax)}`);
   }
 
   if (filters.voteAverageMin !== undefined) {
-    conditions.push(`voteAverage >= ${filters.voteAverageMin}`);
+    conditions.push(`voteAverage >= ${String(filters.voteAverageMin)}`);
   }
 
   if (filters.originalLanguage) {
@@ -46,13 +46,13 @@ export function buildFilterString(
 
   if (filters.directorIds) {
     for (const id of filters.directorIds) {
-      conditions.push(`directorIds CONTAINS ${id}`);
+      conditions.push(`directorIds CONTAINS ${String(id)}`);
     }
   }
 
   if (filters.castIds) {
     for (const id of filters.castIds) {
-      conditions.push(`castIds CONTAINS ${id}`);
+      conditions.push(`castIds CONTAINS ${String(id)}`);
     }
   }
 

--- a/tooling/i18n-codegen/import-graph.ts
+++ b/tooling/i18n-codegen/import-graph.ts
@@ -113,7 +113,7 @@ function getImportSources(ast: BabelFile): string[] {
       node.exportKind !== "type"
     ) {
       sources.push(node.source.value);
-    } else if (node.type === "ExportAllDeclaration" && node.source) {
+    } else if (node.type === "ExportAllDeclaration") {
       sources.push(node.source.value);
     }
   }

--- a/tooling/tmdb-codegen/generate-selective-zod.test.ts
+++ b/tooling/tmdb-codegen/generate-selective-zod.test.ts
@@ -561,7 +561,7 @@ describe("generateSchemasFromSource - Robustness & Performance", () => {
     // Generate a large interface with 50 fields
     const largeQueryFields = Array.from(
       { length: 50 },
-      (_, i) => `"field_${i}": string${i % 3 === 0 ? "?" : ""};`,
+      (_, i) => `"field_${String(i)}": string${i % 3 === 0 ? "?" : ""};`,
     ).join("\n              ");
 
     const largeTypeScript = `

--- a/tooling/tmdb-codegen/generate-selective-zod.ts
+++ b/tooling/tmdb-codegen/generate-selective-zod.ts
@@ -101,8 +101,9 @@ function convertTypeToZod(type: ts.Type, typeChecker: ts.TypeChecker): string {
     return `z.union([${uniqueSchemas.join(", ")}])`;
   }
 
-  // Handle arrays - check symbol name first, then use isArrayType
-  if (type.symbol && type.symbol.name === "Array") {
+  // Handle arrays - guard against missing symbol (runtime possibility for
+  // primitives/void/never despite TS types claiming it's always present).
+  if ("symbol" in type && type.symbol.name === "Array") {
     const typeReference = type as ts.TypeReference;
     if (typeReference.typeArguments && typeReference.typeArguments.length > 0) {
       const elementType = typeReference.typeArguments[0];
@@ -113,7 +114,7 @@ function convertTypeToZod(type: ts.Type, typeChecker: ts.TypeChecker): string {
   }
 
   // Handle arrays using TypeChecker method
-  if (typeChecker.isArrayType && typeChecker.isArrayType(type)) {
+  if (typeChecker.isArrayType(type)) {
     // For newer TypeScript versions, use getTypeArguments
     const typeReference = type as ts.TypeReference;
     if (typeReference.typeArguments && typeReference.typeArguments.length > 0) {
@@ -142,9 +143,12 @@ function convertTypeToZod(type: ts.Type, typeChecker: ts.TypeChecker): string {
       const propertySchemas: string[] = [];
 
       for (const prop of properties) {
+        if (!prop.declarations || prop.declarations.length === 0) {
+          continue;
+        }
         const propType = typeChecker.getTypeOfSymbolAtLocation(
           prop,
-          prop.declarations![0],
+          prop.declarations[0],
         );
         const propName = prop.name;
         const isPropOptional = (prop.flags & ts.SymbolFlags.Optional) !== 0;
@@ -164,7 +168,9 @@ function convertTypeToZod(type: ts.Type, typeChecker: ts.TypeChecker): string {
   }
 
   // Fallback for unknown types
-  console.warn(`   ⚠️  Unknown type flags: ${type.flags}, using z.unknown()`);
+  console.warn(
+    `   ⚠️  Unknown type flags: ${String(type.flags)}, using z.unknown()`,
+  );
   return "z.unknown()";
 }
 
@@ -197,7 +203,7 @@ function extractOperationType(
   typeChecker: ts.TypeChecker,
 ): ts.Type | null {
   for (const member of operationsInterface.members) {
-    if (ts.isPropertySignature(member) && member.name) {
+    if (ts.isPropertySignature(member)) {
       // Handle both identifier and string literal property names
       let memberName = "";
       if (ts.isIdentifier(member.name)) {
@@ -315,10 +321,10 @@ ${operationsZodEntries}});
 
   console.log("✅ Selective Zod schema generation completed!");
   console.log(
-    `   📄 Generated ${generatedCount}/${REQUIRED_OPERATIONS.length} operation schemas`,
+    `   📄 Generated ${String(generatedCount)}/${String(REQUIRED_OPERATIONS.length)} operation schemas`,
   );
   console.log(`   📦 File size: ${(stats.size / 1024).toFixed(1)}KB`);
-  console.log(`   📝 Line count: ${lineCount} lines`);
+  console.log(`   📝 Line count: ${String(lineCount)} lines`);
   console.log(`   💾 Saved to: ${outputPath}`);
 }
 
@@ -460,38 +466,41 @@ function parseOperationFromTsProgram(
   }
 
   // Navigate to parameters.query
-  const operationSymbol = operationType.symbol;
-  if (!operationSymbol) {
-    return null;
-  }
-
   // Get parameters property
-  const parametersProperty = operationSymbol.members?.get(
+  const parametersProperty = operationType.symbol.members?.get(
     "parameters" as ts.__String,
   );
   if (!parametersProperty) {
     return null;
   }
 
-  const parametersType = typeChecker.getTypeOfSymbolAtLocation(
-    parametersProperty,
-    parametersProperty.declarations![0],
-  );
-
-  // Get query property from parameters
-  const parametersSymbol = parametersType.symbol;
-  if (!parametersSymbol) {
+  if (
+    !parametersProperty.declarations ||
+    parametersProperty.declarations.length === 0
+  ) {
     return null;
   }
 
-  const queryProperty = parametersSymbol.members?.get("query" as ts.__String);
+  const parametersType = typeChecker.getTypeOfSymbolAtLocation(
+    parametersProperty,
+    parametersProperty.declarations[0],
+  );
+
+  // Get query property from parameters
+  const queryProperty = parametersType.symbol.members?.get(
+    "query" as ts.__String,
+  );
   if (!queryProperty) {
+    return null;
+  }
+
+  if (!queryProperty.declarations || queryProperty.declarations.length === 0) {
     return null;
   }
 
   const queryType = typeChecker.getTypeOfSymbolAtLocation(
     queryProperty,
-    queryProperty.declarations![0],
+    queryProperty.declarations[0],
   );
 
   // Check if query is optional

--- a/tooling/vector-ingest/ingest.test.ts
+++ b/tooling/vector-ingest/ingest.test.ts
@@ -54,7 +54,9 @@ function makeFakeIndex() {
       if (!namespaces.has(locale)) {
         namespaces.set(locale, makeFakeNamespace());
       }
-      return namespaces.get(locale)!;
+      const ns = namespaces.get(locale);
+      if (!ns) throw new Error(`expected namespace for locale ${locale}`);
+      return ns;
     },
     namespaces,
   };

--- a/tooling/vector-ingest/ingest.ts
+++ b/tooling/vector-ingest/ingest.ts
@@ -80,16 +80,16 @@ async function main() {
     strict: true,
   });
 
-  const dryRun = values["dry-run"] ?? false;
-  const incremental = values.incremental ?? false;
-  const days = parseInt(values.days ?? "1", 10);
+  const dryRun = values["dry-run"];
+  const incremental = values.incremental;
+  const days = parseInt(values.days, 10);
   const limit = values.limit ? parseInt(values.limit, 10) : undefined;
 
   if (Number.isNaN(days) || days < 1) {
     throw new Error(`Invalid --days value: ${values.days}`);
   }
   if (limit !== undefined && (Number.isNaN(limit) || limit < 1)) {
-    throw new Error(`Invalid --limit value: ${values.limit}`);
+    throw new Error(`Invalid --limit value: ${String(values.limit)}`);
   }
 
   const apiToken = getRequiredEnv("TMDB_API_TOKEN");
@@ -155,12 +155,14 @@ export async function runFull(
 
   console.log(`\nExport stats:`);
   console.log(
-    `  Movies: ${movieEntries.length} total, ${filteredMovies.length} after popularity >= ${MIN_POPULARITY_MOVIE} filter`,
+    `  Movies: ${String(movieEntries.length)} total, ${String(filteredMovies.length)} after popularity >= ${String(MIN_POPULARITY_MOVIE)} filter`,
   );
   console.log(
-    `  TV: ${tvEntries.length} total, ${filteredTv.length} after popularity >= ${MIN_POPULARITY_TV} filter`,
+    `  TV: ${String(tvEntries.length)} total, ${String(filteredTv.length)} after popularity >= ${String(MIN_POPULARITY_TV)} filter`,
   );
-  console.log(`  Total to fetch: ${filteredMovies.length + filteredTv.length}`);
+  console.log(
+    `  Total to fetch: ${String(filteredMovies.length + filteredTv.length)}`,
+  );
 
   if (dryRun) {
     console.log("\n[DRY RUN] Stopping before API calls and upserts.");
@@ -173,7 +175,7 @@ export async function runFull(
   let tvIds = filteredTv.map((e) => e.id);
 
   if (limit !== undefined) {
-    console.log(`\n  Limiting to ${limit} per media type`);
+    console.log(`\n  Limiting to ${String(limit)} per media type`);
     movieIds = movieIds.slice(0, limit);
     tvIds = tvIds.slice(0, limit);
   }
@@ -202,7 +204,9 @@ export async function runIncremental(
   dryRun: boolean,
   limit?: number,
 ): Promise<IngestStats[]> {
-  console.log(`Starting incremental ingestion (last ${days} day(s))...`);
+  console.log(
+    `Starting incremental ingestion (last ${String(days)} day(s))...`,
+  );
 
   const endDate = new Date();
   const startDate = new Date(endDate);
@@ -227,10 +231,10 @@ export async function runIncremental(
   const changesOnlyTvIds = changedTvIds.filter((id) => !trendingTvSet.has(id));
 
   console.log(
-    `Changes: ${changedMovieIds.length} movies, ${changedTvIds.length} TV shows`,
+    `Changes: ${String(changedMovieIds.length)} movies, ${String(changedTvIds.length)} TV shows`,
   );
   console.log(
-    `Trending: ${trendingMovieIds.length} movies, ${trendingTvIds.length} TV shows`,
+    `Trending: ${String(trendingMovieIds.length)} movies, ${String(trendingTvIds.length)} TV shows`,
   );
 
   if (dryRun) {
@@ -268,7 +272,7 @@ export async function runIncremental(
   ];
 
   if (limit !== undefined) {
-    console.log(`  Limiting to ${limit} per media type`);
+    console.log(`  Limiting to ${String(limit)} per media type`);
     for (const batch of batches) {
       batch.ids = batch.ids.slice(0, limit);
     }
@@ -285,7 +289,7 @@ export async function runIncremental(
       if (batch.ids.length > 0) {
         const label = batch.mediaType === "tv" ? "TV shows" : "movies";
         console.log(
-          `  Fetching and upserting ${batch.ids.length} ${batch.label} ${label}...`,
+          `  Fetching and upserting ${String(batch.ids.length)} ${batch.label} ${label}...`,
         );
         allStats.push(
           await fetchAndUpsert(
@@ -320,7 +324,7 @@ async function upsertWithRetry(
       return records.length;
     } catch (retryError) {
       console.error(
-        `    Upsert retry failed, skipping batch of ${records.length}: ${String(retryError)}`,
+        `    Upsert retry failed, skipping batch of ${String(records.length)}: ${String(retryError)}`,
       );
       return 0;
     }
@@ -368,7 +372,7 @@ export async function fetchAndUpsert(
           result.reason.statusCode === 404
         ) {
           notFoundErrors++;
-          toDelete.push(`${mediaType}-${id}`);
+          toDelete.push(`${mediaType}-${String(id)}`);
         } else {
           otherErrors++;
           if (otherErrors <= 10) {
@@ -401,7 +405,7 @@ export async function fetchAndUpsert(
     // Progress logging
     if (processed % 500 === 0 || processed === ids.length) {
       console.log(
-        `    Progress: ${processed}/${ids.length} processed, ${upserted + batch.length} upserted, ${notFoundErrors} deleted, ${skippedVoteCount} skipped (low votes), ${otherErrors} errors`,
+        `    Progress: ${String(processed)}/${String(ids.length)} processed, ${String(upserted + batch.length)} upserted, ${String(notFoundErrors)} deleted, ${String(skippedVoteCount)} skipped (low votes), ${String(otherErrors)} errors`,
       );
     }
   }
@@ -420,7 +424,7 @@ export async function fetchAndUpsert(
   }
 
   console.log(
-    `    Done: ${upserted} upserted, ${notFoundErrors} deleted, ${skippedVoteCount} skipped, ${otherErrors} errors`,
+    `    Done: ${String(upserted)} upserted, ${String(notFoundErrors)} deleted, ${String(skippedVoteCount)} skipped, ${String(otherErrors)} errors`,
   );
 
   return {
@@ -457,16 +461,16 @@ export function writeSummary(allStats: IngestStats[]) {
     );
     if (s.deleted > 0) {
       console.log(
-        `::notice::${s.locale}/${s.mediaType}: deleted ${s.deleted} stale vectors (TMDB 404)`,
+        `::notice::${s.locale}/${s.mediaType}: deleted ${String(s.deleted)} stale vectors (TMDB 404)`,
       );
     }
     if (s.otherErrors > 0) {
       console.log(
-        `::warning::${s.locale}/${s.mediaType}: ${s.otherErrors} unexpected errors`,
+        `::warning::${s.locale}/${s.mediaType}: ${String(s.otherErrors)} unexpected errors`,
       );
     }
     mdLines?.push(
-      `| ${s.locale} | ${s.mediaType} | ${s.total} | ${s.upserted} | ${s.deleted} | ${s.skippedVoteCount} | ${s.otherErrors} |`,
+      `| ${s.locale} | ${s.mediaType} | ${String(s.total)} | ${String(s.upserted)} | ${String(s.deleted)} | ${String(s.skippedVoteCount)} | ${String(s.otherErrors)} |`,
     );
   }
 

--- a/tooling/vector-ingest/tmdb-client.ts
+++ b/tooling/vector-ingest/tmdb-client.ts
@@ -18,7 +18,7 @@ export class TmdbApiError extends Error {
   readonly statusCode: number;
 
   constructor(statusCode: number, path: string, statusText: string) {
-    super(`TMDB API error: ${statusCode} ${statusText} (${path})`);
+    super(`TMDB API error: ${String(statusCode)} ${statusText} (${path})`);
     this.statusCode = statusCode;
   }
 }
@@ -44,7 +44,7 @@ export class TmdbClient {
     const month = String(date.getMonth() + 1).padStart(2, "0");
     const day = String(date.getDate()).padStart(2, "0");
     const year = date.getFullYear();
-    const dateStr = `${month}_${day}_${year}`;
+    const dateStr = `${month}_${day}_${String(year)}`;
 
     const exportType = type === "movie" ? "movie_ids" : "tv_series_ids";
     const url = `${TMDB_EXPORT_BASE}/${exportType}_${dateStr}.json.gz`;
@@ -52,7 +52,7 @@ export class TmdbClient {
     const response = await fetch(url);
     if (!response.ok) {
       throw new Error(
-        `Failed to download daily export: ${response.status} ${response.statusText} (${url})`,
+        `Failed to download daily export: ${String(response.status)} ${response.statusText} (${url})`,
       );
     }
 
@@ -82,14 +82,14 @@ export class TmdbClient {
   ): Promise<TmdbMovieDetail> {
     await this.rateLimiter.acquire();
     return this.apiFetch<TmdbMovieDetail>(
-      `/3/movie/${movieId}?append_to_response=credits,keywords,watch/providers&language=${language}`,
+      `/3/movie/${String(movieId)}?append_to_response=credits,keywords,watch/providers&language=${language}`,
     );
   }
 
   async fetchTvDetail(tvId: number, language: string): Promise<TmdbTvDetail> {
     await this.rateLimiter.acquire();
     return this.apiFetch<TmdbTvDetail>(
-      `/3/tv/${tvId}?append_to_response=credits,keywords,watch/providers&language=${language}`,
+      `/3/tv/${String(tvId)}?append_to_response=credits,keywords,watch/providers&language=${language}`,
     );
   }
 
@@ -109,7 +109,7 @@ export class TmdbClient {
     while (page <= totalPages) {
       await this.rateLimiter.acquire();
       const response = await this.apiFetch<TmdbChangesResponse>(
-        `/3/${type}/changes?start_date=${startDate}&end_date=${endDate}&page=${page}`,
+        `/3/${type}/changes?start_date=${startDate}&end_date=${endDate}&page=${String(page)}`,
       );
       for (const result of response.results ?? []) {
         ids.add(result.id);
@@ -133,7 +133,7 @@ export class TmdbClient {
     while (ids.length < limit) {
       await this.rateLimiter.acquire();
       const response = await this.apiFetch<TmdbTrendingResponse>(
-        `/3/trending/${path}/day?page=${page}`,
+        `/3/trending/${path}/day?page=${String(page)}`,
       );
       for (const result of response.results ?? []) {
         ids.push(result.id);
@@ -162,7 +162,7 @@ export class TmdbClient {
     if (response.status === 429) {
       if (retries >= MAX_RETRIES) {
         throw new Error(
-          `TMDB rate limit exceeded after ${MAX_RETRIES} retries (${path})`,
+          `TMDB rate limit exceeded after ${String(MAX_RETRIES)} retries (${path})`,
         );
       }
       this.rateLimiter.onRateLimited();

--- a/tooling/vector-ingest/transform.ts
+++ b/tooling/vector-ingest/transform.ts
@@ -25,13 +25,13 @@ export function transformMovie(detail: TmdbMovieDetail): VectorRecord {
   const directors = extractDirectors(detail.credits.crew ?? [], "movie");
   const cast = extractCast(detail.credits.cast ?? []);
   const platforms = extractStreamingPlatforms(
-    detail["watch/providers"]?.results,
+    detail["watch/providers"].results,
   );
   const keywords = extractKeywordsFromMovie(detail);
   const genres = (detail.genres ?? []).flatMap((g) => (g.name ? [g.name] : []));
 
   return {
-    id: `movie-${detail.id}`,
+    id: `movie-${String(detail.id)}`,
     data: composeEmbeddingText({
       title: detail.title ?? "",
       originalTitle: detail.original_title ?? "",
@@ -65,13 +65,13 @@ export function transformTv(detail: TmdbTvDetail): VectorRecord {
   const directors = extractDirectors(detail.credits.crew ?? [], "tv");
   const cast = extractCast(detail.credits.cast ?? []);
   const platforms = extractStreamingPlatforms(
-    detail["watch/providers"]?.results,
+    detail["watch/providers"].results,
   );
   const keywords = extractKeywordsFromTv(detail);
   const genres = (detail.genres ?? []).flatMap((g) => (g.name ? [g.name] : []));
 
   return {
-    id: `tv-${detail.id}`,
+    id: `tv-${String(detail.id)}`,
     data: composeEmbeddingText({
       title: detail.name ?? "",
       originalTitle: detail.original_name ?? "",

--- a/tooling/vector-ingest/verify.ts
+++ b/tooling/vector-ingest/verify.ts
@@ -50,7 +50,7 @@ async function main() {
         const meta = result.metadata;
         if (!meta) continue;
         console.log(
-          `  [${result.score.toFixed(3)}] ${meta.title} (${meta.releaseYear}) - ${meta.mediaType}`,
+          `  [${result.score.toFixed(3)}] ${meta.title} (${String(meta.releaseYear)}) - ${meta.mediaType}`,
         );
       }
     }


### PR DESCRIPTION
## Summary

- Replace `eslint-config-next` with direct `@next/eslint-plugin-next` and `eslint-plugin-react-hooks` — eliminates `eslint-plugin-react` (crashes on ESLint 10) and the blanket `disable-conflict-eslint-plugin-react-hooks` config that was silently disabling all React Compiler rules (`refs`, `purity`, `immutability`, `set-state-in-effect`, etc.).
- Upgrade from `recommendedTypeChecked` to `strictTypeChecked` for typescript-eslint, with default strict settings for `restrict-template-expressions` and `no-misused-promises`.
- Remove `jsx-a11y` (warn-only rules were noise).
- Fix all resulting lint errors across 94 files, including:
  - Refactor `ChatTextarea` from render-prop to Context + composition (`react-hooks/refs`)
  - Use `useSyncExternalStore` for localStorage and reduced-motion reads (`react-hooks/set-state-in-effect`)
  - Wrap non-string template literal expressions with `String()`
  - Remove non-null assertions, dead code branches, unnecessary conditions
  - Replace deprecated APIs (`z.uuid()`, `environmentManager.isServer()`, `SubmitEvent`)

Zero `eslint-disable` suppressions for React Compiler rules.