### PR TITLE
fix: allow vercel branch url in referer validation

### DIFF
--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -54,7 +54,7 @@ describe("proxy referer validation for API routes", () => {
     expect(await response.json()).toEqual({ error: "Unauthorized" });
   });
 
-  it("allows requests from the current Vercel deployment", () => {
+  it("allows requests from the current Vercel deployment URL", () => {
     process.env.VERCEL_URL = "my-app-abc123.vercel.app";
     const response = proxy(
       apiRequest("/api/ai-chat", "https://my-app-abc123.vercel.app/search"),
@@ -64,8 +64,24 @@ describe("proxy referer validation for API routes", () => {
     delete process.env.VERCEL_URL;
   });
 
+  it("allows requests from the Vercel branch URL", () => {
+    process.env.VERCEL_BRANCH_URL =
+      "my-app-git-feature-qingqishis-projects.vercel.app";
+    const response = proxy(
+      apiRequest(
+        "/api/ai-chat",
+        "https://my-app-git-feature-qingqishis-projects.vercel.app/search",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    delete process.env.VERCEL_BRANCH_URL;
+  });
+
   it("rejects requests from other Vercel deployments", async () => {
     process.env.VERCEL_URL = "my-app-abc123.vercel.app";
+    process.env.VERCEL_BRANCH_URL =
+      "my-app-git-feature-qingqishis-projects.vercel.app";
     const response = proxy(
       apiRequest(
         "/api/ai-chat",
@@ -76,5 +92,6 @@ describe("proxy referer validation for API routes", () => {
     expect(response.status).toBe(403);
     expect(await response.json()).toEqual({ error: "Unauthorized" });
     delete process.env.VERCEL_URL;
+    delete process.env.VERCEL_BRANCH_URL;
   });
 });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -14,7 +14,7 @@ function validateReferer(request: NextRequest): NextResponse | null {
     const isLocalhost =
       refererUrl.hostname === "localhost" && refererUrl.protocol === "http:";
     const vercelUrls = [process.env.VERCEL_URL, process.env.VERCEL_BRANCH_URL]
-      .filter(Boolean)
+      .filter((url): url is string => Boolean(url))
       .map((url) => `https://${url}`);
     const allowedOrigins = [...ALLOWED_REFERER, ...vercelUrls];
     const isAllowedReferer = allowedOrigins.some(

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -13,12 +13,10 @@ function validateReferer(request: NextRequest): NextResponse | null {
     const refererUrl = new URL(referer);
     const isLocalhost =
       refererUrl.hostname === "localhost" && refererUrl.protocol === "http:";
-    const vercelUrl = process.env.VERCEL_URL
-      ? `https://${process.env.VERCEL_URL}`
-      : null;
-    const allowedOrigins = vercelUrl
-      ? [...ALLOWED_REFERER, vercelUrl]
-      : ALLOWED_REFERER;
+    const vercelUrls = [process.env.VERCEL_URL, process.env.VERCEL_BRANCH_URL]
+      .filter(Boolean)
+      .map((url) => `https://${url}`);
+    const allowedOrigins = [...ALLOWED_REFERER, ...vercelUrls];
     const isAllowedReferer = allowedOrigins.some(
       (allowed) => refererUrl.origin === allowed,
     );


### PR DESCRIPTION
## Summary

Fixes a regression from #2090 where AI chat requests from Vercel preview deployments were rejected with 403. The referer validation was only allowing `VERCEL_URL` (the unique per-deployment URL), but users visiting preview builds land on `VERCEL_BRANCH_URL` (the stable branch alias URL), which is a different hostname. The fix includes both env vars in the allowed-origins list when present, using a filter-map pattern that's cleaner than conditional spreading.

## Context

`VERCEL_URL` and `VERCEL_BRANCH_URL` serve different purposes: `VERCEL_URL` is unique to each deployment build (e.g. `my-app-abc123.vercel.app`), while `VERCEL_BRANCH_URL` is a stable alias tied to the branch (e.g. `my-app-git-feature-branch.vercel.app`). Both URLs legitimately represent the same deployed app, so both must be allowed. The security invariant from #2090 — rejecting other projects' Vercel URLs — is preserved: the test verifies that an unrelated referer is still blocked even when both env vars are set.