### PR TITLE
feat: keep ai chat accessible while scrolling the movie list

### DIFF
--- a/src/ai-chat/use-ai-chat-send.ts
+++ b/src/ai-chat/use-ai-chat-send.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useAIChatContext } from "#src/ai-chat/ai-chat-context.tsx";
+
+export function useAIChatSend(aiModeHref: string) {
+  const router = useRouter();
+  const { sendMessage, status } = useAIChatContext();
+  const isLoading = status === "submitted" || status === "streaming";
+
+  function send(message: string) {
+    if (isLoading) return;
+    void sendMessage({ text: message });
+    router.push(aiModeHref);
+  }
+
+  return { send, isLoading };
+}

--- a/src/app/[locale]/movie-database/(list)/layout.tsx
+++ b/src/app/[locale]/movie-database/(list)/layout.tsx
@@ -4,6 +4,7 @@ import { DotGridBackground } from "#src/components/ai-chat/dot-grid-background.t
 import { FiltersSkeleton } from "#src/components/movie-database/filters-skeleton.tsx";
 import { Grid } from "#src/components/movie-database/grid.tsx";
 import { HeroSection } from "#src/components/movie-database/hero-section.tsx";
+import { HeroVisibilityProvider } from "#src/components/movie-database/hero-visibility-provider.tsx";
 import { RetryableErrorBoundary } from "#src/components/shared/retryable-error-boundary.tsx";
 import { Skeleton } from "#src/components/shared/skeleton.tsx";
 import { t } from "#src/i18n.ts";
@@ -33,27 +34,29 @@ export default async function Layout({
       })}
     >
       <DotGridBackground />
-      <main>
-        <HeroSection />
-        <Suspense
-          fallback={
-            <>
-              <FiltersSkeleton locale={validatedLocale} />
-              <Grid>
-                {SKELETON_ITEMS.map((item) => (
-                  <Skeleton
-                    key={item.key}
-                    css={styles.skeleton}
-                    delay={item.delay}
-                  />
-                ))}
-              </Grid>
-            </>
-          }
-        >
-          {children}
-        </Suspense>
-      </main>
+      <HeroVisibilityProvider>
+        <main>
+          <HeroSection />
+          <Suspense
+            fallback={
+              <>
+                <FiltersSkeleton locale={validatedLocale} />
+                <Grid>
+                  {SKELETON_ITEMS.map((item) => (
+                    <Skeleton
+                      key={item.key}
+                      css={styles.skeleton}
+                      delay={item.delay}
+                    />
+                  ))}
+                </Grid>
+              </>
+            }
+          >
+            {children}
+          </Suspense>
+        </main>
+      </HeroVisibilityProvider>
     </RetryableErrorBoundary>
   );
 }

--- a/src/app/[locale]/movie-database/(list)/page.tsx
+++ b/src/app/[locale]/movie-database/(list)/page.tsx
@@ -16,6 +16,7 @@ import { t } from "#src/i18n.ts";
 import type { PageProps } from "#src/types.ts";
 import { getQueryClient } from "#src/utils/get-query-client.ts";
 import { isGenreFilterType, isSort } from "#src/utils/media-filter-types.ts";
+import { getLocalePath } from "#src/utils/pathname.ts";
 import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
 
 export default async function Page(
@@ -104,7 +105,10 @@ export default async function Page(
         }}
       >
         <Suspense fallback={<FiltersSkeleton locale={params.locale} />}>
-          <Filters mobileButtonLabel={t({ en: "Refine", zh: "筛选" })} />
+          <Filters
+            mobileButtonLabel={t({ en: "Refine", zh: "筛选" })}
+            aiModeHref={getLocalePath("/movie-database/ai-mode", params.locale)}
+          />
         </Suspense>
         <MediaList initialPage={1} />
       </MediaFiltersProvider>

--- a/src/components/movie-database/collapsed-chat-button.test.tsx
+++ b/src/components/movie-database/collapsed-chat-button.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "#src/test-utils.tsx";
+import { CollapsedChatButton } from "./collapsed-chat-button";
+import { HeroVisibilityContext } from "./hero-visibility-context";
+
+function renderButton({ isHeroInputVisible }: { isHeroInputVisible: boolean }) {
+  return render(
+    <HeroVisibilityContext
+      value={{
+        isHeroInputVisible,
+        heroInputRef: { current: null },
+      }}
+    >
+      <CollapsedChatButton
+        aiModeHref="/en/movie-database/ai-mode"
+        label="AI"
+        ariaLabel="Ask AI about movies and TV shows"
+      />
+    </HeroVisibilityContext>,
+  );
+}
+
+describe("CollapsedChatButton", () => {
+  it("renders the link as aria-hidden and inert when hero input is visible", () => {
+    renderButton({ isHeroInputVisible: true });
+    const link = screen.getByRole("link", {
+      name: "Ask AI about movies and TV shows",
+      hidden: true,
+    });
+    expect(link).toHaveAttribute("tabindex", "-1");
+    expect(link.closest("[aria-hidden='true']")).not.toBeNull();
+  });
+
+  it("renders a reachable link when hero input is not visible", () => {
+    renderButton({ isHeroInputVisible: false });
+    const link = screen.getByRole("link", {
+      name: "Ask AI about movies and TV shows",
+    });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/en/movie-database/ai-mode");
+    expect(link).not.toHaveAttribute("tabindex", "-1");
+  });
+
+  it("shows the label text", () => {
+    renderButton({ isHeroInputVisible: false });
+    expect(screen.getByText("AI")).toBeInTheDocument();
+  });
+});

--- a/src/components/movie-database/collapsed-chat-button.tsx
+++ b/src/components/movie-database/collapsed-chat-button.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { SparkleIcon } from "@phosphor-icons/react/dist/ssr/Sparkle";
+import * as stylex from "@stylexjs/stylex";
+import { breakpoints } from "#src/breakpoints.stylex.ts";
+import { flex } from "#src/primitives/flex.stylex.ts";
+import { color, space } from "#src/tokens.stylex.ts";
+import { AnchorButton } from "../shared/anchor-button";
+import {
+  DATA_HERO_COLLAPSED_BUTTON,
+  useHeroVisibility,
+} from "./hero-visibility-context";
+
+interface CollapsedChatButtonProps {
+  aiModeHref: string;
+  label: string;
+  ariaLabel: string;
+}
+
+export function CollapsedChatButton({
+  aiModeHref,
+  label,
+  ariaLabel,
+}: CollapsedChatButtonProps) {
+  const { isHeroInputVisible } = useHeroVisibility();
+
+  return (
+    <div
+      css={[
+        styles.container,
+        isHeroInputVisible ? styles.hidden : styles.visible,
+      ]}
+      aria-hidden={isHeroInputVisible || undefined}
+      {...{ [DATA_HERO_COLLAPSED_BUTTON]: "" }}
+    >
+      <AnchorButton
+        href={aiModeHref}
+        aria-label={ariaLabel}
+        tabIndex={isHeroInputVisible ? -1 : undefined}
+        icon={
+          <span css={[flex.inlineCenter, styles.icon]}>
+            <SparkleIcon weight="fill" role="presentation" />
+          </span>
+        }
+      >
+        {label}
+      </AnchorButton>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  container: {
+    display: { default: "flex", [breakpoints.md]: "none" },
+    willChange: "transform, opacity",
+    position: "absolute",
+    insetBlockStart: 0,
+    insetBlockEnd: 0,
+    insetInlineEnd: `calc(${space._3} + env(safe-area-inset-right, 0px) + var(--removed-body-scroll-bar-size, 0px))`,
+    alignItems: "center",
+  },
+  visible: {
+    opacity: 1,
+    pointerEvents: "auto",
+  },
+  hidden: {
+    opacity: 0,
+    pointerEvents: "none",
+  },
+  icon: {
+    color: color.controlActive,
+  },
+});

--- a/src/components/movie-database/collapsed-chat-input.tsx
+++ b/src/components/movie-database/collapsed-chat-input.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { SparkleIcon } from "@phosphor-icons/react/dist/ssr/Sparkle";
+import * as stylex from "@stylexjs/stylex";
+import { useAIChatSend } from "#src/ai-chat/use-ai-chat-send.ts";
+import { breakpoints } from "#src/breakpoints.stylex.ts";
+import { flex } from "#src/primitives/flex.stylex.ts";
+import { color } from "#src/tokens.stylex.ts";
+import { ChatTextarea } from "../shared/chat-textarea";
+import {
+  DATA_HERO_COLLAPSED_BUTTON,
+  useHeroVisibility,
+} from "./hero-visibility-context";
+
+interface CollapsedChatInputProps {
+  placeholder: string;
+  sendLabel: string;
+  aiModeHref: string;
+}
+
+export function CollapsedChatInput({
+  placeholder,
+  sendLabel,
+  aiModeHref,
+}: CollapsedChatInputProps) {
+  const { send, isLoading } = useAIChatSend(aiModeHref);
+  const { isHeroInputVisible } = useHeroVisibility();
+
+  return (
+    <div
+      css={[
+        styles.container,
+        isHeroInputVisible ? styles.hidden : styles.visible,
+      ]}
+      aria-hidden={isHeroInputVisible || undefined}
+      inert={isHeroInputVisible || undefined}
+      {...{ [DATA_HERO_COLLAPSED_BUTTON]: "" }}
+    >
+      <ChatTextarea
+        placeholder={placeholder}
+        sendLabel={sendLabel}
+        onSubmit={send}
+        disabled={isLoading}
+        compact
+        beforeTextarea={
+          <span css={[flex.inlineCenter, styles.icon]}>
+            <SparkleIcon weight="fill" role="presentation" />
+          </span>
+        }
+      />
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  container: {
+    display: { default: "none", [breakpoints.md]: "flex" },
+    willChange: "transform, opacity",
+    width: "min(22rem, 100%)",
+  },
+  visible: {
+    opacity: 1,
+    pointerEvents: "auto",
+  },
+  hidden: {
+    opacity: 0,
+    pointerEvents: "none",
+  },
+  icon: {
+    color: color.controlActive,
+    fontSize: "1.125em",
+  },
+});

--- a/src/components/movie-database/filters-container.tsx
+++ b/src/components/movie-database/filters-container.tsx
@@ -7,21 +7,29 @@ import { layer, layout, space } from "#src/tokens.stylex.ts";
 interface FiltersContainerProps {
   desktopChildren?: ReactNode;
   mobileChildren?: ReactNode;
+  trailingContent?: ReactNode;
 }
 
 export function FiltersContainer({
   desktopChildren,
   mobileChildren,
+  trailingContent,
 }: FiltersContainerProps) {
   return (
     <>
       <div css={[styles.desktopContainer, styles.desktopVisible]}>
         <div css={styles.desktopInnerContainer}>
-          <div css={[flex.row, styles.desktopContent]}>{desktopChildren}</div>
+          <div css={[flex.row, styles.desktopContent]}>
+            {desktopChildren}
+            {trailingContent && (
+              <div css={styles.trailingContent}>{trailingContent}</div>
+            )}
+          </div>
         </div>
       </div>
       <div css={[styles.mobileContainer, styles.mobileVisible]}>
         {mobileChildren}
+        {trailingContent}
       </div>
     </>
   );
@@ -51,6 +59,7 @@ const styles = stylex.create({
     display: "flex",
   },
   desktopContent: {
+    flexGrow: 1,
     gap: space._1,
   },
 
@@ -58,9 +67,14 @@ const styles = stylex.create({
     position: "sticky",
     top: `calc(${space._10} + env(safe-area-inset-top))`,
     zIndex: layer.overlay,
-    justifyContent: "space-between",
+    alignItems: "center",
+    gap: space._1,
     paddingLeft: `calc(${space._3} + env(safe-area-inset-left))`,
     paddingRight: `calc(${space._3} + env(safe-area-inset-right, 0px) + var(--removed-body-scroll-bar-size, 0px))`,
     marginBottom: space._3,
+  },
+
+  trailingContent: {
+    marginInlineStart: "auto",
   },
 });

--- a/src/components/movie-database/filters.tsx
+++ b/src/components/movie-database/filters.tsx
@@ -1,7 +1,10 @@
 import * as stylex from "@stylexjs/stylex";
+import { t } from "#src/i18n.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { controlSize, space } from "#src/tokens.stylex.ts";
 import { FixedContainerContent } from "../shared/fixed-container-content";
+import { CollapsedChatButton } from "./collapsed-chat-button";
+import { CollapsedChatInput } from "./collapsed-chat-input";
 import { FiltersContainer } from "./filters-container";
 import { GenreFilter } from "./genre-filter";
 import { GenreFilterButton } from "./genre-filter-button";
@@ -13,11 +16,32 @@ import { TmdbCredit, TmdbCreditInline } from "./tmdb-credit";
 
 interface FiltersProps {
   mobileButtonLabel: string;
+  aiModeHref: string;
 }
 
-export function Filters({ mobileButtonLabel }: FiltersProps) {
+export function Filters({ mobileButtonLabel, aiModeHref }: FiltersProps) {
   return (
     <FiltersContainer
+      trailingContent={
+        <>
+          <CollapsedChatInput
+            aiModeHref={aiModeHref}
+            placeholder={t({
+              en: "Ask about movies and TV shows...",
+              zh: "询问关于电影和电视剧的问题...",
+            })}
+            sendLabel={t({ en: "Send message", zh: "发送消息" })}
+          />
+          <CollapsedChatButton
+            aiModeHref={aiModeHref}
+            label={t({ en: "AI", zh: "AI" })}
+            ariaLabel={t({
+              en: "Ask AI about movies and TV shows",
+              zh: "向AI询问电影和电视剧",
+            })}
+          />
+        </>
+      }
       desktopChildren={
         <>
           <FixedContainerContent>

--- a/src/components/movie-database/hero-chat-input.tsx
+++ b/src/components/movie-database/hero-chat-input.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { SparkleIcon } from "@phosphor-icons/react/dist/ssr/Sparkle";
 import * as stylex from "@stylexjs/stylex";
-import { useRouter } from "next/navigation";
-import { useAIChatContext } from "#src/ai-chat/ai-chat-context.tsx";
-import { space } from "#src/tokens.stylex.ts";
+import { useAIChatSend } from "#src/ai-chat/use-ai-chat-send.ts";
+import { flex } from "#src/primitives/flex.stylex.ts";
+import { color, space } from "#src/tokens.stylex.ts";
 import { SuggestionChips } from "../ai-chat/suggestion-chips";
 import { ChatTextarea } from "../shared/chat-textarea";
+import { useHeroVisibility } from "./hero-visibility-context";
 
 interface HeroChatInputProps {
   placeholder: string;
@@ -22,24 +24,27 @@ export function HeroChatInput({
   suggestions,
   suggestionsGroupLabel,
 }: HeroChatInputProps) {
-  const router = useRouter();
-  const { sendMessage, status } = useAIChatContext();
-  const isLoading = status === "submitted" || status === "streaming";
-
-  function send(message: string) {
-    if (isLoading) return;
-    void sendMessage({ text: message });
-    router.push(aiModeHref);
-  }
+  const { send, isLoading } = useAIChatSend(aiModeHref);
+  const { heroInputRef, isHeroInputVisible } = useHeroVisibility();
 
   return (
     <>
-      <ChatTextarea
-        placeholder={placeholder}
-        sendLabel={sendLabel}
-        onSubmit={send}
-        disabled={isLoading}
-      />
+      <div
+        ref={heroInputRef}
+        css={isHeroInputVisible ? styles.visible : styles.hidden}
+      >
+        <ChatTextarea
+          placeholder={placeholder}
+          sendLabel={sendLabel}
+          onSubmit={send}
+          disabled={isLoading}
+          beforeTextarea={
+            <span css={[flex.inlineCenter, styles.icon]}>
+              <SparkleIcon weight="fill" role="presentation" />
+            </span>
+          }
+        />
+      </div>
       <div css={styles.suggestions}>
         <SuggestionChips
           suggestions={suggestions}
@@ -53,6 +58,16 @@ export function HeroChatInput({
 }
 
 const styles = stylex.create({
+  visible: {
+    opacity: 1,
+  },
+  hidden: {
+    opacity: 0,
+  },
+  icon: {
+    color: color.controlActive,
+    fontSize: "1.25em",
+  },
   suggestions: {
     marginTop: space._3,
   },

--- a/src/components/movie-database/hero-visibility-context.ts
+++ b/src/components/movie-database/hero-visibility-context.ts
@@ -1,0 +1,18 @@
+import { createContext, use, type RefObject } from "react";
+
+interface HeroVisibilityState {
+  isHeroInputVisible: boolean;
+  heroInputRef: RefObject<HTMLDivElement | null>;
+}
+
+export const HeroVisibilityContext = createContext<HeroVisibilityState>({
+  isHeroInputVisible: true,
+  heroInputRef: { current: null },
+});
+
+export function useHeroVisibility() {
+  return use(HeroVisibilityContext);
+}
+
+export const DATA_HERO_COLLAPSED_BUTTON = "data-hero-collapsed-button";
+export const DATA_HERO_REFINE_BUTTON = "data-hero-refine-button";

--- a/src/components/movie-database/hero-visibility-provider.tsx
+++ b/src/components/movie-database/hero-visibility-provider.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useLayoutEffect, useRef, type ReactNode } from "react";
+import { useIsElementVisible } from "#src/hooks/use-is-element-visible.ts";
+import { easing } from "#src/primitives/motion.stylex.ts";
+import {
+  DATA_HERO_COLLAPSED_BUTTON,
+  DATA_HERO_REFINE_BUTTON,
+  HeroVisibilityContext,
+} from "./hero-visibility-context";
+
+const MORPH_DURATION = 400;
+
+function hasLayout(rect: DOMRect) {
+  return rect.width > 0 && rect.height > 0;
+}
+
+function findVisibleElement(selector: string) {
+  for (const el of document.querySelectorAll<HTMLElement>(selector)) {
+    const rect = el.getBoundingClientRect();
+    if (hasLayout(rect)) return { el, rect };
+  }
+  return null;
+}
+
+export function HeroVisibilityProvider({ children }: { children: ReactNode }) {
+  const heroInputRef = useRef<HTMLDivElement>(null);
+  const isHeroInputVisible = useIsElementVisible(heroInputRef);
+  const isFirstRenderRef = useRef(true);
+  const morphAnimationsRef = useRef<Animation[]>([]);
+  const refineAnimationRef = useRef<Animation | null>(null);
+  const refinePrevRectRef = useRef<DOMRect | null>(null);
+
+  useLayoutEffect(() => {
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+
+    const refineFound = findVisibleElement(`[${DATA_HERO_REFINE_BUTTON}]`);
+    if (refineFound) {
+      const { el: refine, rect } = refineFound;
+      const prev = refinePrevRectRef.current;
+      if (
+        prev &&
+        !isFirstRenderRef.current &&
+        !prefersReducedMotion &&
+        (Math.abs(prev.left - rect.left) > 0.5 ||
+          Math.abs(prev.top - rect.top) > 0.5)
+      ) {
+        refineAnimationRef.current?.cancel();
+        refineAnimationRef.current = refine.animate(
+          [
+            {
+              transform: `translate(${String(prev.left - rect.left)}px, ${String(prev.top - rect.top)}px)`,
+            },
+            { transform: "translate(0, 0)" },
+          ],
+          { duration: MORPH_DURATION, easing: easing.entrance },
+        );
+      }
+      refinePrevRectRef.current = rect;
+    } else {
+      refinePrevRectRef.current = null;
+    }
+
+    if (isFirstRenderRef.current) {
+      isFirstRenderRef.current = false;
+      return;
+    }
+
+    const hero = heroInputRef.current;
+    if (!hero) return;
+
+    const collapsedFound = findVisibleElement(
+      `[${DATA_HERO_COLLAPSED_BUTTON}]`,
+    );
+    if (!collapsedFound) return;
+
+    for (const animation of morphAnimationsRef.current) {
+      animation.cancel();
+    }
+    morphAnimationsRef.current = [];
+
+    if (prefersReducedMotion) return;
+
+    const heroRect = hero.getBoundingClientRect();
+    if (!hasLayout(heroRect)) return;
+
+    const incoming = isHeroInputVisible ? hero : collapsedFound.el;
+    const outgoing = isHeroInputVisible ? collapsedFound.el : hero;
+    const fromRect = isHeroInputVisible ? collapsedFound.rect : heroRect;
+    const toRect = isHeroInputVisible ? heroRect : collapsedFound.rect;
+
+    const deltaX = fromRect.left - toRect.left;
+    const deltaY = fromRect.top - toRect.top;
+    const scaleX = fromRect.width / toRect.width;
+    const scaleY = fromRect.height / toRect.height;
+
+    const incomingAnimation = incoming.animate(
+      [
+        {
+          transformOrigin: "top left",
+          transform: `translate(${String(deltaX)}px, ${String(deltaY)}px) scale(${String(scaleX)}, ${String(scaleY)})`,
+          opacity: 0,
+          filter: "blur(3px)",
+        },
+        {
+          offset: 0.3,
+          filter: "blur(3px)",
+        },
+        {
+          transformOrigin: "top left",
+          transform: "translate(0, 0) scale(1, 1)",
+          opacity: 1,
+          filter: "blur(0)",
+        },
+      ],
+      { duration: MORPH_DURATION, easing: easing.entrance },
+    );
+
+    const outgoingAnimation = outgoing.animate(
+      [
+        { opacity: 1, filter: "blur(0)" },
+        { offset: 0.3, opacity: 0, filter: "blur(3px)" },
+        { opacity: 0, filter: "blur(3px)" },
+      ],
+      { duration: MORPH_DURATION, easing: easing.entrance },
+    );
+
+    morphAnimationsRef.current = [incomingAnimation, outgoingAnimation];
+  }, [isHeroInputVisible]);
+
+  useLayoutEffect(() => {
+    return () => {
+      for (const animation of morphAnimationsRef.current) {
+        animation.cancel();
+      }
+      refineAnimationRef.current?.cancel();
+    };
+  }, []);
+
+  return (
+    <HeroVisibilityContext value={{ isHeroInputVisible, heroInputRef }}>
+      {children}
+    </HeroVisibilityContext>
+  );
+}

--- a/src/components/movie-database/mobile-filters-button.tsx
+++ b/src/components/movie-database/mobile-filters-button.tsx
@@ -1,10 +1,16 @@
 "use client";
 
 import { FunnelIcon } from "@phosphor-icons/react/dist/ssr/Funnel";
+import * as stylex from "@stylexjs/stylex";
 import type { PropsWithChildren, ReactNode } from "react";
+import { breakpoints } from "#src/breakpoints.stylex.ts";
 import { useMediaFilters } from "#src/hooks/use-media-filters.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { MenuButton } from "../shared/menu-button";
+import {
+  DATA_HERO_REFINE_BUTTON,
+  useHeroVisibility,
+} from "./hero-visibility-context";
 
 interface MobileFiltersButtonProps {
   menuContent?: ReactNode;
@@ -15,24 +21,40 @@ export function MobileFiltersButton({
   children,
 }: PropsWithChildren<MobileFiltersButtonProps>) {
   const { canReset, genres } = useMediaFilters();
+  const { isHeroInputVisible } = useHeroVisibility();
 
   return (
-    <MenuButton
-      menuContent={menuContent}
-      buttonProps={{
-        icon: (
-          <span css={flex.center}>
-            <FunnelIcon weight="bold" role="presentation" />
-          </span>
-        ),
-        type: "button",
-        isActive: canReset,
-      }}
-      position="topRight"
-      popupRole="group"
+    <div
+      css={[styles.wrapper, isHeroInputVisible && styles.pushedRight]}
+      {...{ [DATA_HERO_REFINE_BUTTON]: "" }}
     >
-      {children}
-      {genres.size ? ` (${String(genres.size)})` : null}
-    </MenuButton>
+      <MenuButton
+        menuContent={menuContent}
+        buttonProps={{
+          icon: (
+            <span css={flex.center}>
+              <FunnelIcon weight="bold" role="presentation" />
+            </span>
+          ),
+          type: "button",
+          isActive: canReset,
+        }}
+        position="topRight"
+        popupRole="group"
+      >
+        {children}
+        {genres.size ? ` (${String(genres.size)})` : null}
+      </MenuButton>
+    </div>
   );
 }
+
+const styles = stylex.create({
+  wrapper: {
+    display: "flex",
+    willChange: "transform",
+  },
+  pushedRight: {
+    marginInlineStart: { default: "auto", [breakpoints.md]: "unset" },
+  },
+});

--- a/src/components/shared/chat-textarea.tsx
+++ b/src/components/shared/chat-textarea.tsx
@@ -30,6 +30,8 @@ interface ChatTextareaProps {
   onSubmit: (text: string) => void;
   disabled?: boolean;
   autoGrow?: boolean;
+  /** Reduced vertical padding for use inside sticky toolbars. */
+  compact?: boolean;
   /** Content rendered before the textarea (e.g. attachment row). */
   beforeTextarea?: ReactNode;
   /** Override the default send button. Use `useChatTextarea()` inside children to access context. */
@@ -42,6 +44,7 @@ export function ChatTextarea({
   onSubmit,
   disabled = false,
   autoGrow = false,
+  compact = false,
   beforeTextarea,
   children,
 }: ChatTextareaProps) {
@@ -94,7 +97,10 @@ export function ChatTextarea({
 
   return (
     <ChatTextareaContext value={{ trimmedText: trimmed, focusTextarea }}>
-      <form onSubmit={handleSubmit} css={[flex.wrap, styles.container]}>
+      <form
+        onSubmit={handleSubmit}
+        css={[flex.wrap, styles.container, compact && styles.containerCompact]}
+      >
         {beforeTextarea}
         <textarea
           ref={textareaRef}
@@ -157,6 +163,10 @@ const styles = stylex.create({
     paddingBlock: space._2,
     paddingLeft: space._3,
     paddingRight: space._2,
+  },
+  containerCompact: {
+    paddingBlock: space._1,
+    paddingLeft: space._2,
   },
   textarea: {
     flexGrow: 1,

--- a/src/hooks/use-is-element-visible.test.ts
+++ b/src/hooks/use-is-element-visible.test.ts
@@ -1,0 +1,92 @@
+import { renderHook, act } from "@testing-library/react";
+import { useRef } from "react";
+import {
+  describe,
+  expect,
+  it,
+  vi,
+  beforeEach,
+  afterEach,
+  type MockInstance,
+} from "vitest";
+import { useIsElementVisible } from "./use-is-element-visible";
+
+type ObserverCallback = (entries: Array<{ isIntersecting: boolean }>) => void;
+
+let observerCallback: ObserverCallback | null = null;
+let observeSpy: MockInstance;
+let disconnectSpy: MockInstance;
+
+beforeEach(() => {
+  observeSpy = vi.fn();
+  disconnectSpy = vi.fn();
+
+  vi.stubGlobal(
+    "IntersectionObserver",
+    vi.fn(function (this: unknown, callback: ObserverCallback) {
+      observerCallback = callback;
+      return { observe: observeSpy, disconnect: disconnectSpy };
+    }),
+  );
+});
+
+afterEach(() => {
+  observerCallback = null;
+  vi.restoreAllMocks();
+});
+
+describe("useIsElementVisible", () => {
+  it("returns true by default when ref is null", () => {
+    const { result } = renderHook(() => {
+      const ref = useRef<HTMLDivElement>(null);
+      return useIsElementVisible(ref);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("observes the element when ref is set", () => {
+    const el = document.createElement("div");
+    const ref = { current: el };
+    renderHook(() => useIsElementVisible(ref));
+
+    expect(observeSpy).toHaveBeenCalledWith(el);
+  });
+
+  it("returns false when observer reports not intersecting", () => {
+    const el = document.createElement("div");
+    const ref = { current: el };
+    const { result } = renderHook(() => useIsElementVisible(ref));
+
+    act(() => {
+      observerCallback?.([{ isIntersecting: false }]);
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true when observer reports intersecting", () => {
+    const el = document.createElement("div");
+    const ref = { current: el };
+    const { result } = renderHook(() => useIsElementVisible(ref));
+
+    act(() => {
+      observerCallback?.([{ isIntersecting: false }]);
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      observerCallback?.([{ isIntersecting: true }]);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("disconnects observer on unmount", () => {
+    const el = document.createElement("div");
+    const ref = { current: el };
+    const { unmount } = renderHook(() => useIsElementVisible(ref));
+
+    unmount();
+
+    expect(disconnectSpy).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/use-is-element-visible.ts
+++ b/src/hooks/use-is-element-visible.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState, type RefObject } from "react";
+
+/**
+ * Tracks whether a referenced element is visible in the viewport using
+ * IntersectionObserver.
+ */
+export function useIsElementVisible(
+  ref: RefObject<HTMLElement | null>,
+): boolean {
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsVisible(entry.isIntersecting);
+      },
+      { threshold: 0 },
+    );
+
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+    };
+  }, [ref]);
+
+  return isVisible;
+}


### PR DESCRIPTION
## Summary

Keeps the AI chat reachable while the user scrolls the movie list. The hero chat input morphs into a compact version anchored to the sticky filter toolbar; on mobile the Refine button slides out of the way to make room.

**Desktop**

```
hero chat input  ─────►  compact chat input (right of toolbar)
```

**Mobile**

```
┌─ before scroll ─────────────────────────┐   ┌─ after scroll ──────────────────────────┐
│ [Type] ······························[Refine]│   │ [Type][Refine] ···················[✨ AI]│
└─────────────────────────────────────────┘   └─────────────────────────────────────────┘
         (hero chat input above)                      (hero chat input scrolled away)
```

## Context

The first attempt used the native **View Transition API** with a shared `view-transition-name`. It looked right in isolation but felt laggy in practice:

- The transition fires mid-scroll
- The API pins a snapshot of the page for the animation's duration
- The real scroll keeps happening underneath, so the page visibly \"freezes\" under the user's finger

Switched to a **FLIP-style morph** driven by the Web Animations API:

- **CSS owns the steady states** — `opacity`, `pointer-events`, margins, and layout mode are driven off an `isHeroInputVisible` boolean from an `IntersectionObserver`.
- **A single `useLayoutEffect`** in the provider measures the old and new rects at commit time, then runs a transform + opacity + blur keyframe animation from the source rect to the incoming element's natural position.
- **Scroll keeps compositing normally** throughout the 400ms animation because transforms live in each element's own coordinate space — no snapshot, no freeze.

The Refine button uses the same FLIP pattern (rolling previous-rect ref) to slide sideways when the collapsed AI element appears. Mobile and desktop each render their own collapsed variant; the provider picks whichever has layout at transition time, so one orchestrator handles both breakpoints.

Closes #2025