### PR TITLE
fix: add inert attribute to MenuButton popup when closed

### DIFF
--- a/e2e/movie-tv-browsing.spec.ts
+++ b/e2e/movie-tv-browsing.spec.ts
@@ -66,23 +66,27 @@ test.describe("Movie and TV Show Browsing", () => {
       page.getByRole("button", { name: /genre.*\(1\)/i }),
     ).toBeVisible();
 
+    // Dismiss menu before reopening to let the layout settle after scroll
+    await page.keyboard.press("Escape");
+
     // Open genre menu again and click "Adventure" for multiple genres
-    await page
-      .getByRole("button", { name: /genre.*\(1\)/i })
-      .click({ force: true });
+    const genreButton1 = page.getByRole("button", { name: /genre.*\(1\)/i });
+    await genreButton1.click();
     const adventureLink = page.getByRole("link", { name: /^adventure$/i });
     await expect(adventureLink).toBeVisible();
-    await adventureLink.click({ force: true });
+    await adventureLink.click();
 
     // Verify genre count shows 2 genres selected
     await expect(
       page.getByRole("button", { name: /genre.*\(2\)/i }),
     ).toBeVisible();
 
+    // Dismiss menu before reopening
+    await page.keyboard.press("Escape");
+
     // Open genre menu and verify "Any selected" option appears (ALL/ANY toggle)
-    await page
-      .getByRole("button", { name: /genre.*\(2\)/i })
-      .click({ force: true });
+    const genreButton2 = page.getByRole("button", { name: /genre.*\(2\)/i });
+    await genreButton2.click();
     const anyButton = page.getByRole("link", { name: /any selected/i });
     await expect(anyButton).toBeVisible();
   });

--- a/e2e/movie-tv-browsing.spec.ts
+++ b/e2e/movie-tv-browsing.spec.ts
@@ -70,7 +70,9 @@ test.describe("Movie and TV Show Browsing", () => {
     await page
       .getByRole("button", { name: /genre.*\(1\)/i })
       .click({ force: true });
-    await page.getByRole("link", { name: /^adventure$/i }).click();
+    const adventureLink = page.getByRole("link", { name: /^adventure$/i });
+    await expect(adventureLink).toBeVisible();
+    await adventureLink.click({ force: true });
 
     // Verify genre count shows 2 genres selected
     await expect(

--- a/src/components/shared/menu-button.test.tsx
+++ b/src/components/shared/menu-button.test.tsx
@@ -182,6 +182,24 @@ describe("MenuButton keyboard navigation", () => {
     expect(trigger).toHaveFocus();
   });
 
+  it("marks the popup as inert when the menu is closed", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <RouterProvider>
+        <TestMenu />
+      </RouterProvider>,
+    );
+
+    // Before opening, the popup container should be inert so keyboard
+    // users cannot tab into invisible menu items.
+    const inertEl = container.querySelector("[inert]");
+    expect(inertEl).not.toBeNull();
+
+    // After opening, the popup should no longer be inert.
+    await user.click(screen.getByRole("button", { name: "Open menu" }));
+    expect(container.querySelector("[inert]")).toBeNull();
+  });
+
   it("does not intercept arrow keys when popupRole is not 'menu'", async () => {
     const user = userEvent.setup();
 

--- a/src/components/shared/menu-button.tsx
+++ b/src/components/shared/menu-button.tsx
@@ -176,6 +176,7 @@ export function MenuButton({
             !isMenuShown && styles.hidden,
             styles[position],
           ]}
+          inert={!isMenuShown}
         >
           <AnimateToTarget
             css={[styles.menu]}


### PR DESCRIPTION
## Summary

Prevents keyboard users from tabbing into invisible menu items when the MenuButton popup is closed. The popup container stays in the DOM for animation purposes but had no mechanism to exclude it from the tab order or accessibility tree when hidden — the existing `pointerEvents: "none"` style only blocked mouse interaction. Adding the `inert` HTML attribute to the popup container when the menu is not shown removes it from keyboard navigation and the accessibility tree entirely.