### PR TITLE
fix: clean up copy timeout in StatsOverlay on unmount

### DIFF
--- a/src/components/playground/playground-canvas.tsx
+++ b/src/components/playground/playground-canvas.tsx
@@ -49,14 +49,28 @@ function StatsOverlay({
   onDebugChange: (next: DebugOptions) => void;
 }) {
   const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current !== null) {
+        clearTimeout(copyTimeoutRef.current);
+      }
+    };
+  }, []);
+
   const gpuLabel =
     stats.frameGpu !== null ? `${stats.frameGpu.toFixed(2)} ms` : "n/a";
 
   const handleCopy = () => {
     void navigator.clipboard.writeText(formatStats(stats)).then(() => {
       setCopied(true);
-      setTimeout(() => {
+      if (copyTimeoutRef.current !== null) {
+        clearTimeout(copyTimeoutRef.current);
+      }
+      copyTimeoutRef.current = setTimeout(() => {
         setCopied(false);
+        copyTimeoutRef.current = null;
       }, 1500);
     });
   };


### PR DESCRIPTION
## Summary

Adds proper cleanup for the "Copied!" feedback timeout in the playground's `StatsOverlay` component. The 1500ms `setTimeout` that resets the copied state was previously never cleared — if the component unmounted before the timer fired, `setCopied` would be called on a stale component, and rapid clicks would stack multiple timers. The timer ID is now tracked in a ref with cleanup on unmount and deduplication on repeated clicks, matching the existing pattern in `use-press-animation.ts`.