### PR TITLE
fix: handle nested HTML tags correctly in parseMessage

### DIFF
--- a/src/utils/parse-message.test.tsx
+++ b/src/utils/parse-message.test.tsx
@@ -73,6 +73,18 @@ describe("parseMessage", () => {
       expect(container.textContent).toBe("Bold with emphasis");
     });
 
+    it("preserves text after inner closing tag within outer element", () => {
+      const result = parseMessage(
+        "<strong>bold <em>italic</em> still bold</strong>",
+      );
+      const { container } = render(<>{result}</>);
+      expect(container.querySelector("strong")).toBeTruthy();
+      expect(container.querySelector("strong em")).toBeTruthy();
+      expect(container.querySelector("strong")?.textContent).toBe(
+        "bold italic still bold",
+      );
+    });
+
     it("parses deeply nested tags", () => {
       const result = parseMessage(
         "<p>Paragraph with <strong>bold and <em>italic and <b>more bold</b></em></strong></p>",

--- a/src/utils/parse-message.tsx
+++ b/src/utils/parse-message.tsx
@@ -49,12 +49,14 @@ function parseTokens(tokens: string[], componentMap: typeof defaultComponents) {
       }
 
       let endIndex = i + 1;
-      while (
-        endIndex < tokens.length &&
-        !isTagEnd(tokens[endIndex]) &&
-        !getTagEndName(tokens[endIndex])
-      ) {
-        endIndex++;
+      let depth = 1;
+      while (endIndex < tokens.length && depth > 0) {
+        if (getTagBeginName(tokens[endIndex]) === tagName) {
+          depth++;
+        } else if (getTagEndName(tokens[endIndex]) === tagName) {
+          depth--;
+        }
+        if (depth > 0) endIndex++;
       }
 
       const children = tokens.slice(i + 1, endIndex);


### PR DESCRIPTION
## Summary

Fixes the `parseMessage` parser to correctly handle nested HTML tags. The closing-tag search loop previously stopped at any `</tag>` regardless of tag name, so input like `<strong>bold <em>italic</em> still bold</strong>` would terminate the `<strong>` scan at `</em>`, ejecting " still bold" outside the element. The loop now tracks nesting depth by tag name — it increments on same-name open tags, decrements on same-name close tags, and only stops when depth reaches zero.