### PR TITLE
feat: add external link indicator to AI chat markdown links

### DIFF
--- a/src/components/ai-chat/markdown-content.test.tsx
+++ b/src/components/ai-chat/markdown-content.test.tsx
@@ -74,7 +74,9 @@ describe("MarkdownContent", () => {
 
   it("renders links with correct attributes", () => {
     render(<MarkdownContent content="Visit [Example](https://example.com)" />);
-    const link = screen.getByRole("link", { name: "Example" });
+    const link = screen.getByRole("link", {
+      name: "Example(opens in new tab)",
+    });
     expect(link).toHaveAttribute("href", "https://example.com");
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noopener noreferrer");

--- a/src/components/ai-chat/markdown-content.tsx
+++ b/src/components/ai-chat/markdown-content.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import { ArrowSquareOutIcon } from "@phosphor-icons/react/dist/ssr/ArrowSquareOut";
 import * as stylex from "@stylexjs/stylex";
 import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { t } from "#src/i18n.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { border, color, font, space } from "#src/tokens.stylex.ts";
 
@@ -32,6 +34,24 @@ const styles = stylex.create({
   a: {
     color: color.controlActive,
     textDecoration: "underline",
+  },
+  externalIcon: {
+    verticalAlign: "baseline",
+    position: "relative",
+    top: "0.1em",
+    marginInlineStart: "0.1em",
+    opacity: 0.7,
+  },
+  srOnly: {
+    position: "absolute",
+    width: "1px",
+    height: "1px",
+    padding: 0,
+    margin: "-1px",
+    overflow: "hidden",
+    clipPath: "inset(50%)",
+    whiteSpace: "nowrap",
+    borderWidth: 0,
   },
   ul: {
     paddingLeft: space._4,
@@ -115,13 +135,31 @@ const styles = stylex.create({
   },
 });
 
+function ExternalLinkIndicator() {
+  return (
+    <>
+      <ArrowSquareOutIcon
+        size="0.85em"
+        css={styles.externalIcon}
+        aria-hidden="true"
+      />
+      <span css={styles.srOnly}>
+        {t({ en: "(opens in new tab)", zh: "(在新标签页中打开)" })}
+      </span>
+    </>
+  );
+}
+
 const components: Components = {
   h1: ({ node, ...props }) => <h1 css={styles.h1} {...props} />,
   h2: ({ node, ...props }) => <h2 css={styles.h2} {...props} />,
   h3: ({ node, ...props }) => <h3 css={styles.h3} {...props} />,
   p: ({ node, ...props }) => <p css={styles.p} {...props} />,
-  a: ({ node, ...props }) => (
-    <a target="_blank" rel="noopener noreferrer" css={styles.a} {...props} />
+  a: ({ node, children, ...props }) => (
+    <a target="_blank" rel="noopener noreferrer" css={styles.a} {...props}>
+      {children}
+      <ExternalLinkIndicator />
+    </a>
   ),
   ul: ({ node, ...props }) => <ul css={styles.ul} {...props} />,
   ol: ({ node, ...props }) => <ol css={styles.ol} {...props} />,


### PR DESCRIPTION
## Summary

Links rendered in AI chat responses open in new tabs (`target="_blank"`) but previously gave no visual or accessible indication of this behavior. Adds a subtle ArrowSquareOut icon and screen-reader-only "(opens in new tab)" text to every markdown link in `MarkdownContent`, improving discoverability and meeting WCAG guidance on advance warning for new-window links.