### PR TITLE
fix: strip attached media prefix from user chat bubble

### DIFF
--- a/src/components/ai-chat/chat-message.tsx
+++ b/src/components/ai-chat/chat-message.tsx
@@ -64,7 +64,7 @@ export function ChatMessage({
           if (isUser) {
             return (
               <p key={key} css={[styles.partBase, styles.text]}>
-                {part.text}
+                {stripAttachedMediaPrefix(part.text)}
               </p>
             );
           }
@@ -159,6 +159,12 @@ export function ChatMessage({
       })}
     </div>
   );
+}
+
+const ATTACHED_MEDIA_PREFIX = /^\[About: .+ \((?:movie|tv)\)] /;
+
+function stripAttachedMediaPrefix(text: string): string {
+  return text.replace(ATTACHED_MEDIA_PREFIX, "");
 }
 
 function isCompactionPart(part: TextUIPart): boolean {

--- a/src/components/ai-chat/tool-activity-line.tsx
+++ b/src/components/ai-chat/tool-activity-line.tsx
@@ -170,9 +170,15 @@ export function ToolActivityLine({
     }
   }
 
+  const statusText = isComplete
+    ? t({ en: "Complete", zh: "完成" })
+    : isError
+      ? t({ en: "Error", zh: "错误" })
+      : t({ en: "In progress", zh: "进行中" });
+
   return (
     <div css={[flex.row, styles.line]}>
-      <span css={[flex.center, styles.icon]}>
+      <span css={[flex.center, styles.icon]} role="status">
         {isInProgress && <span css={styles.pulsingDot} />}
         {isComplete && (
           <CheckIcon size={ICON_SIZE} weight="bold" aria-hidden="true" />
@@ -184,6 +190,7 @@ export function ToolActivityLine({
             aria-hidden="true"
           />
         )}
+        <span css={styles.srOnly}>{statusText}</span>
       </span>
       <span css={styles.label}>{label}</span>
       {summary != null && (
@@ -240,5 +247,16 @@ const styles = stylex.create({
   },
   separator: {
     opacity: 0.5,
+  },
+  srOnly: {
+    position: "absolute",
+    width: "1px",
+    height: "1px",
+    padding: 0,
+    margin: "-1px",
+    overflow: "hidden",
+    clipPath: "inset(50%)",
+    whiteSpace: "nowrap",
+    borderWidth: 0,
   },
 });


### PR DESCRIPTION
## Summary

When a user sends a message with attached media context, the raw bracket prefix (`[About: Inception (movie)]`) meant for the LLM was shown verbatim in the user's chat bubble. Strips this internal prefix at render time so users see only the question they typed, while the full prefixed text remains in the API conversation for the LLM.