### PR TITLE
fix: correct ARIA roles in RecommendedMediaRow

### DIFF
--- a/src/components/ai-chat/recommended-media-row.tsx
+++ b/src/components/ai-chat/recommended-media-row.tsx
@@ -27,7 +27,6 @@ export function RecommendedMediaRow({
       <h2 css={styles.title}>{title}</h2>
       <HorizontalScrollRow
         ariaLabel={title}
-        role="region"
         wrapperCss={styles.scrollWrapper}
         containerCss={styles.scrollContainer}
         fadeLeftCss={styles.fadeLeft}
@@ -38,7 +37,7 @@ export function RecommendedMediaRow({
         {items.map((item) => {
           const { mediaType } = item;
           return (
-            <div key={item.id} css={styles.cardWrapper}>
+            <div key={item.id} role="listitem" css={styles.cardWrapper}>
               <CompactMediaCard
                 media={item}
                 onClick={


### PR DESCRIPTION
## Summary

`RecommendedMediaRow` overrode `HorizontalScrollRow` with `role="region"` while its card wrapper children had no ARIA role, breaking the ownership chain that screen readers rely on to announce list context (e.g., "item 1 of 10"). Removes the override so the default `role="list"` applies and adds `role="listitem"` to card wrappers, matching the pattern every other `HorizontalScrollRow` consumer already follows. The wrapping `<section>` element already provides region/landmark semantics.