### PR TITLE
fix: run pnpm install on session start in worktrees

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,17 @@
     "deny": ["Read(./.env)", "Read(./.env.*)"]
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c '[[ \"$CLAUDE_PROJECT_DIR\" == *\".claude/worktrees/\"* ]] || exit 0; [ -L \"$CLAUDE_PROJECT_DIR/node_modules/typescript\" ] && exit 0; cd \"$CLAUDE_PROJECT_DIR\" && pnpm install --prefer-offline'"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,3 +1,2 @@
 .claude/settings.local.json
 .env.local
-node_modules


### PR DESCRIPTION
## Summary

Worktrees created from this repo were broken because `.worktreeinclude` copies the `node_modules/` directory tree but drops symlinks, and pnpm's `node_modules/` is almost entirely symlinks into `.pnpm/` — so the copied scaffold left `node_modules/typescript`, `next`, etc. missing and `pnpm build:tsc` failed at startup. This removes `node_modules` from `.worktreeinclude` and adds a `SessionStart` hook to `.claude/settings.json` that runs `pnpm install --prefer-offline` whenever Claude Code starts in a worktree path and `node_modules/typescript` is not yet a valid symlink. The symlink check makes the hook idempotent and cheap (~1ms when deps are already wired up); the path gate prevents it from firing in the main checkout.

## Context

`worktree.symlinkDirectories: ["node_modules"]` was ruled out because symlinking the entire directory makes it shared mutable state across worktrees, which breaks any worktree on a branch with a different lockfile (e.g. Dependabot branches). A `WorktreeCreate` hook was ruled out because it replaces the default git worktree creation entirely and would also disable the auto-cleanup behavior of `WorktreeRemove`. There is no official Claude Code "post-worktree-create" hook event, so `SessionStart` is the correct insertion point. The hook does not fire for `Agent({ isolation: "worktree" })` subagents, but a `PreToolUse` Bash backstop wasn't worth the per-call overhead.