### PR TITLE
fix: exclude tabindex=-1 and inert elements from dialog focus trap

### DIFF
--- a/src/hooks/use-dialog-focus.test.ts
+++ b/src/hooks/use-dialog-focus.test.ts
@@ -160,6 +160,121 @@ describe("useDialogFocus", () => {
     expect(prevented).toBe(false);
   });
 
+  it("skips buttons with tabindex=-1 when finding initial focus", () => {
+    const dialog = document.createElement("div");
+    const hiddenButton = document.createElement("button");
+    hiddenButton.textContent = "Hidden";
+    hiddenButton.tabIndex = -1;
+    const visibleButton = document.createElement("button");
+    visibleButton.textContent = "Visible";
+    dialog.append(hiddenButton, visibleButton);
+    document.body.append(dialog);
+
+    const dialogRef = { current: dialog };
+    const onClose = vi.fn();
+
+    renderHook(() => {
+      useDialogFocus({ isOpen: true, dialogRef, onClose });
+    });
+
+    expect(visibleButton).toHaveFocus();
+    expect(hiddenButton).not.toHaveFocus();
+  });
+
+  it("skips tabindex=-1 elements when wrapping focus on Tab", () => {
+    const dialog = document.createElement("div");
+    const first = document.createElement("button");
+    first.textContent = "First";
+    const middleHidden = document.createElement("button");
+    middleHidden.textContent = "Hidden";
+    middleHidden.tabIndex = -1;
+    const last = document.createElement("button");
+    last.textContent = "Last";
+    dialog.append(first, middleHidden, last);
+    document.body.append(dialog);
+
+    const dialogRef = { current: dialog };
+    const onClose = vi.fn();
+
+    renderHook(() => {
+      useDialogFocus({ isOpen: true, dialogRef, onClose });
+    });
+
+    last.focus();
+    fireEvent.keyDown(document, { key: "Tab" });
+
+    // Wraps to first (not to the tabindex=-1 element)
+    expect(first).toHaveFocus();
+  });
+
+  it("skips tabindex=-1 elements when wrapping focus on Shift+Tab", () => {
+    const dialog = document.createElement("div");
+    const first = document.createElement("button");
+    first.textContent = "First";
+    const lastHidden = document.createElement("button");
+    lastHidden.textContent = "Hidden";
+    lastHidden.tabIndex = -1;
+    const last = document.createElement("button");
+    last.textContent = "Last";
+    dialog.append(first, lastHidden, last);
+    document.body.append(dialog);
+
+    const dialogRef = { current: dialog };
+    const onClose = vi.fn();
+
+    renderHook(() => {
+      useDialogFocus({ isOpen: true, dialogRef, onClose });
+    });
+
+    first.focus();
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+
+    // Wraps to the last real focusable, not the tabindex=-1 element
+    expect(last).toHaveFocus();
+  });
+
+  it("includes elements with tabindex=0 on non-standard tags", () => {
+    const dialog = document.createElement("div");
+    const customFocusable = document.createElement("div");
+    customFocusable.setAttribute("role", "application");
+    customFocusable.tabIndex = 0;
+    const button = document.createElement("button");
+    button.textContent = "Button";
+    dialog.append(customFocusable, button);
+    document.body.append(dialog);
+
+    const dialogRef = { current: dialog };
+    const onClose = vi.fn();
+
+    renderHook(() => {
+      useDialogFocus({ isOpen: true, dialogRef, onClose });
+    });
+
+    expect(customFocusable).toHaveFocus();
+  });
+
+  it("skips elements inside an inert subtree", () => {
+    const dialog = document.createElement("div");
+    const inertSection = document.createElement("div");
+    inertSection.setAttribute("inert", "");
+    const inertButton = document.createElement("button");
+    inertButton.textContent = "Inert";
+    inertSection.append(inertButton);
+    const activeButton = document.createElement("button");
+    activeButton.textContent = "Active";
+    dialog.append(inertSection, activeButton);
+    document.body.append(dialog);
+
+    const dialogRef = { current: dialog };
+    const onClose = vi.fn();
+
+    renderHook(() => {
+      useDialogFocus({ isOpen: true, dialogRef, onClose });
+    });
+
+    expect(activeButton).toHaveFocus();
+  });
+
   it("saves and restores trigger focus on cleanup", () => {
     const trigger = document.createElement("button");
     trigger.textContent = "Trigger";

--- a/src/hooks/use-dialog-focus.ts
+++ b/src/hooks/use-dialog-focus.ts
@@ -1,7 +1,20 @@
 import { useEffect, useRef, type RefObject } from "react";
 
-const FOCUSABLE_SELECTOR =
-  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), iframe, [tabindex]:not([tabindex="-1"])';
+const FOCUSABLE_SELECTOR = [
+  'a[href]:not([tabindex="-1"])',
+  'button:not([disabled]):not([tabindex="-1"])',
+  'textarea:not([disabled]):not([tabindex="-1"])',
+  'input:not([disabled]):not([tabindex="-1"])',
+  'select:not([disabled]):not([tabindex="-1"])',
+  'iframe:not([tabindex="-1"])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
+function getFocusableElements(container: HTMLElement) {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+  ).filter((element) => !element.closest("[inert]"));
+}
 
 /**
  * Manages focus lifecycle for modal dialogs:
@@ -43,10 +56,9 @@ export function useDialogFocus({
     requestAnimationFrame(() => {
       if (initialFocusRef?.current) {
         initialFocusRef.current.focus();
-      } else {
-        const firstFocusable =
-          dialogRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
-        firstFocusable?.focus();
+      } else if (dialogRef.current) {
+        const focusable = getFocusableElements(dialogRef.current);
+        if (focusable.length > 0) focusable[0].focus();
       }
     });
 
@@ -58,8 +70,7 @@ export function useDialogFocus({
 
       // Trap focus within the dialog
       if (event.key === "Tab" && dialogRef.current) {
-        const focusableElements =
-          dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+        const focusableElements = getFocusableElements(dialogRef.current);
         if (focusableElements.length === 0) return;
 
         const first = focusableElements[0];


### PR DESCRIPTION
## Summary

`useDialogFocus` was treating `<button tabindex="-1">` as focusable because the `:not([tabindex="-1"])` filter was only applied to the generic `[tabindex]` clause — the `button:not([disabled])` clause still matched hidden buttons. Inside `DetailOverlay` this meant Tab/Shift+Tab wraparound and initial focus could land on the horizontal-scroll arrows or the scroll-to-bottom button while they were hidden (`tabIndex={-1}`). This PR applies `:not([tabindex="-1"])` to every clause of the selector and introduces a small `getFocusableElements` helper that additionally filters out descendants of any `[inert]` subtree, used by both the initial-focus path and the Tab trap. The public hook signature is unchanged, so no consumer updates are needed.

## Context

The fix stays inside the hook rather than changing the `tabIndex={-1}` controls themselves — the controls are correct (they remove themselves from the tab order while hidden); the trap was the side that ignored them. The `[inert]` filter mirrors browser behavior for inert subtrees and guards future consumers that nest inert regions inside a dialog.