### PR TITLE
fix: add h1 to movie-database, ai-mode, and calculator routes

### DIFF
--- a/src/app/[locale]/calculator/page.tsx
+++ b/src/app/[locale]/calculator/page.tsx
@@ -1,5 +1,26 @@
+import * as stylex from "@stylexjs/stylex";
 import { Calculator } from "#src/components/calculator/calculator.tsx";
+import { t } from "#src/i18n.ts";
 
 export default function Page() {
-  return <Calculator />;
+  return (
+    <>
+      <h1 css={styles.srOnly}>{t({ en: "Calculator", zh: "计算器" })}</h1>
+      <Calculator />
+    </>
+  );
 }
+
+const styles = stylex.create({
+  srOnly: {
+    position: "absolute",
+    width: "1px",
+    height: "1px",
+    padding: 0,
+    margin: "-1px",
+    overflow: "hidden",
+    clipPath: "inset(50%)",
+    whiteSpace: "nowrap",
+    borderWidth: 0,
+  },
+});

--- a/src/app/[locale]/movie-database/ai-mode/page.tsx
+++ b/src/app/[locale]/movie-database/ai-mode/page.tsx
@@ -35,43 +35,46 @@ export default async function Page({
   ];
 
   return (
-    <AIChatView
-      emptyState={
-        <div css={styles.welcomeContainer}>
-          <SuggestionChips
-            groupLabel={t({
-              en: "Suggested prompts",
-              zh: "推荐提问",
-            })}
-            suggestions={suggestions}
-          />
-          <RecommendedMedia locale={validatedLocale} />
-        </div>
-      }
-      messagesLabel={t({
-        en: "Chat messages",
-        zh: "聊天消息",
-      })}
-      typingIndicatorLabel={t({
-        en: "AI is thinking…",
-        zh: "AI 正在思考…",
-      })}
-      scrollToBottomLabel={t({
-        en: "Scroll to bottom",
-        zh: "滚动到底部",
-      })}
-      errorLabel={t({
-        en: "Something went wrong. Please try again.",
-        zh: "出了点问题，请重试。",
-      })}
-      placeholder={t({
-        en: "Ask about movies and TV shows...",
-        zh: "询问关于电影和电视剧的问题...",
-      })}
-      sendLabel={t({ en: "Send message", zh: "发送消息" })}
-      stopLabel={t({ en: "Stop generating", zh: "停止生成" })}
-      removeAttachmentLabel={t({ en: "Remove attachment", zh: "移除附件" })}
-    />
+    <>
+      <h1 css={styles.srOnly}>{t({ en: "AI Mode", zh: "AI 模式" })}</h1>
+      <AIChatView
+        emptyState={
+          <div css={styles.welcomeContainer}>
+            <SuggestionChips
+              groupLabel={t({
+                en: "Suggested prompts",
+                zh: "推荐提问",
+              })}
+              suggestions={suggestions}
+            />
+            <RecommendedMedia locale={validatedLocale} />
+          </div>
+        }
+        messagesLabel={t({
+          en: "Chat messages",
+          zh: "聊天消息",
+        })}
+        typingIndicatorLabel={t({
+          en: "AI is thinking…",
+          zh: "AI 正在思考…",
+        })}
+        scrollToBottomLabel={t({
+          en: "Scroll to bottom",
+          zh: "滚动到底部",
+        })}
+        errorLabel={t({
+          en: "Something went wrong. Please try again.",
+          zh: "出了点问题，请重试。",
+        })}
+        placeholder={t({
+          en: "Ask about movies and TV shows...",
+          zh: "询问关于电影和电视剧的问题...",
+        })}
+        sendLabel={t({ en: "Send message", zh: "发送消息" })}
+        stopLabel={t({ en: "Stop generating", zh: "停止生成" })}
+        removeAttachmentLabel={t({ en: "Remove attachment", zh: "移除附件" })}
+      />
+    </>
   );
 }
 
@@ -81,5 +84,16 @@ const styles = stylex.create({
     flexDirection: "column",
     gap: space._5,
     width: "100%",
+  },
+  srOnly: {
+    position: "absolute",
+    width: "1px",
+    height: "1px",
+    padding: 0,
+    margin: "-1px",
+    overflow: "hidden",
+    clipPath: "inset(50%)",
+    whiteSpace: "nowrap",
+    borderWidth: 0,
   },
 });

--- a/src/components/movie-database/hero-section.tsx
+++ b/src/components/movie-database/hero-section.tsx
@@ -27,12 +27,12 @@ export function HeroSection() {
 
   return (
     <section css={styles.section}>
-      <h2 css={styles.heading}>
+      <h1 css={styles.heading}>
         {t({
           en: "What do you want to watch?",
           zh: "你想看什么？",
         })}
-      </h2>
+      </h1>
       <div css={styles.inputWrapper}>
         <HeroChatInput
           placeholder={t({


### PR DESCRIPTION
## Summary

Three indexable routes previously shipped without a top-level `<h1>`: `/movie-database`, `/movie-database/ai-mode`, and `/calculator`. This left screen-reader "jump to h1" broken and gave Google/Bing no on-page topic signal matching each page's metadata title. This PR adds one `<h1>` per route, using a visible or visually-hidden element based on whether the page has a natural heading slot.

- **`/movie-database`** — promotes the existing hero heading in `hero-section.tsx` from `<h2>` to `<h1>`. The text was already the topmost heading and already styled as the page's dominant display heading, so visual weight is unchanged.
- **`/movie-database/ai-mode`** — adds a visually-hidden `<h1>AI Mode</h1>`. The page is a full-bleed chat surface with no natural visible title slot; a visible heading would fight the existing chat UX.
- **`/calculator`** — adds a visually-hidden `<h1>Calculator</h1>`. The calculator is a boxed widget centered by its layout's grid; a visible heading would break that centering and the fixed aspect box.

All new strings use `t({ en, zh })` per project i18n rules. The visually-hidden style reuses the existing in-repo `srOnly` block (same shape as `typing-indicator.tsx`, `tool-activity-line.tsx`, and `markdown-content.tsx`).

## Context

The two srOnly copies added here continue the existing in-repo pattern rather than introducing a new shared primitive — extracting the 3-to-5 call sites into a shared component would be a broader refactor outside this fix's scope.