### PR TITLE
fix: read copyright year from client clock instead of build timestamp

### DIFF
--- a/src/components/home/current-year.tsx
+++ b/src/components/home/current-year.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+function subscribe() {
+  return () => {};
+}
+
+function getSnapshot() {
+  return new Date().getFullYear();
+}
+
+export function CurrentYear({ initialYear }: { initialYear: number }) {
+  const year = useSyncExternalStore(subscribe, getSnapshot, () => initialYear);
+  return <>{year}</>;
+}

--- a/src/components/home/footer.test.tsx
+++ b/src/components/home/footer.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "#src/test-utils.tsx";
+import { CurrentYear } from "./current-year";
+import { Footer } from "./footer";
+
+describe("CurrentYear", () => {
+  it("renders the runtime year from the client clock", () => {
+    const { container } = render(<CurrentYear initialYear={1970} />);
+    expect(container.textContent).toBe(String(new Date().getFullYear()));
+  });
+});
+
+describe("Footer", () => {
+  it("displays the current copyright year", () => {
+    render(<Footer locale="en" />);
+    const year = String(new Date().getFullYear());
+    expect(screen.getByText(`© ${year}`)).toBeInTheDocument();
+  });
+});

--- a/src/components/home/footer.tsx
+++ b/src/components/home/footer.tsx
@@ -5,12 +5,13 @@ import { flex, justify } from "#src/primitives/flex.stylex.ts";
 import { font, space } from "#src/tokens.stylex.ts";
 import type { SupportedLocale } from "#src/types.ts";
 import { Anchor } from "../shared/anchor";
+import { CurrentYear } from "./current-year";
 
 interface FooterProps {
   locale: SupportedLocale;
 }
 
-const CURRENT_YEAR = new Date().getFullYear();
+const BUILD_YEAR = new Date().getFullYear();
 
 export function Footer({ locale }: FooterProps) {
   return (
@@ -40,7 +41,9 @@ export function Footer({ locale }: FooterProps) {
       <div css={[styles.section, styles.copyrightSection]}>
         <small>
           <span css={styles.name}>{t({ en: "Qingqi Shi", zh: "石清琪" })}</span>
-          <span css={styles.copyright}>© {CURRENT_YEAR}</span>
+          <span css={styles.copyright}>
+            © <CurrentYear initialYear={BUILD_YEAR} />
+          </span>
         </small>
       </div>
     </footer>


### PR DESCRIPTION
## Summary

The footer's copyright year had regressed to a module-level `const CURRENT_YEAR = new Date().getFullYear()` inside a server component — the original fix from #2080 was silently reverted by a merge conflict in #2077. Because the site is statically generated, that module-level value freezes at build time, so if the site isn't rebuilt after January 1st the year stays stale (e.g. "© 2025" in January 2026). This restores the client-side year readout, but uses `useSyncExternalStore` instead of the `useState` + `useEffect` pattern from #2080.

The footer itself stays a server component; only a tiny `<CurrentYear>` client island hydrates with the runtime year. `getServerSnapshot` returns the build-year prop so SSR/hydration content matches deterministically, then `getSnapshot` takes over with `new Date().getFullYear()` on the client. For ~364 days/year this is a no-op; during the January window it silently corrects itself.

## Context

Switching to `useSyncExternalStore` avoids both problems with the previous `useState` + `useEffect` shape: the repo's `react-hooks/set-state-in-effect` lint rule flagged the effect-based update, and a naive `useState(() => new Date().getFullYear())` with divergent server/client initial values can produce a hydration mismatch. `useSyncExternalStore` is React's purpose-built primitive for server/client snapshot transitions — the `subscribe` fn is a no-op since the year doesn't change within a session.

Two new tests cover the client override: one passes a deliberately-wrong `initialYear={1970}` and asserts the runtime year renders, the other verifies the rendered `Footer` shows `© <runtime year>`. No `Date` mocking — both assert against the live `new Date().getFullYear()`, stable within a vitest run.