### PR TITLE
feat: add consistent focus-visible outline to shared primitives

### DIFF
--- a/src/components/shared/anchor.tsx
+++ b/src/components/shared/anchor.tsx
@@ -3,7 +3,7 @@
 import * as stylex from "@stylexjs/stylex";
 import Link from "next/link";
 import { useState } from "react";
-import { border } from "#src/tokens.stylex.ts";
+import { border, color } from "#src/tokens.stylex.ts";
 import { anchorTokens } from "./anchor.stylex";
 
 export function Anchor({
@@ -57,5 +57,10 @@ const styles = stylex.create({
     color: anchorTokens.color,
     fontWeight: anchorTokens.fontWeight,
     textDecorationThickness: { default: null, ":hover": border.size_2 },
+    outline: {
+      default: "none",
+      ":focus-visible": `2px solid ${color.controlActive}`,
+    },
+    outlineOffset: { default: null, ":focus-visible": "2px" },
   },
 });

--- a/src/components/shared/button-shared.stylex.ts
+++ b/src/components/shared/button-shared.stylex.ts
@@ -30,6 +30,13 @@ export const sharedStyles = stylex.create({
     filter: "brightness(1)",
     // Touch action to prevent browser gestures from interfering
     touchAction: "manipulation",
+    // Focus ring for keyboard users (WCAG 2.4.7). Replaces the browser
+    // default so the indicator stays consistent across browsers.
+    outline: {
+      default: "none",
+      ":focus-visible": `2px solid ${color.controlActive}`,
+    },
+    outlineOffset: { default: null, ":focus-visible": "2px" },
   },
   hasIcon: {
     paddingLeft: controlSize._2,

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -61,6 +61,12 @@ const styles = stylex.create({
       ":hover": "scale(1.05) translate3d(0, -0.2rem, 0)",
     },
     backdropFilter: { default: null, ":hover": "blur(2rem)" },
+    outline: {
+      default: "none",
+      ":focus-visible": `2px solid ${color.controlActive}`,
+    },
+    // Draw the ring inside the box so `overflow: hidden` doesn't clip it.
+    outlineOffset: { default: null, ":focus-visible": "-2px" },
 
     [cardTokens.detailsIndicatorOpacity]: {
       default: 0,

--- a/src/components/shared/menu-item.tsx
+++ b/src/components/shared/menu-item.tsx
@@ -62,6 +62,11 @@ const styles = stylex.create({
     padding: controlSize._3,
     textDecoration: "none",
     transition: "background-color 0.2s",
+    outline: {
+      default: "none",
+      ":focus-visible": `2px solid ${color.controlActive}`,
+    },
+    outlineOffset: { default: null, ":focus-visible": "2px" },
   },
   itemActive: {
     color: color.textOnActive,


### PR DESCRIPTION
## Summary

Four shared primitives — the button base styles (`button-shared.stylex.ts`), the `Anchor` link, the `Card`, and `MenuItem` — shipped without a `:focus-visible` outline, so keyboard users on `Button`, `AnchorButton`, `MenuButton`, detail-overlay close buttons, `ThemeSwitch`, `LocaleSelector`, cards, and menu rows relied on whatever the browser default happened to be. This PR adds a consistent 2px outline per primitive, reusing the exact convention already established in `compact-media-card.tsx`, `compact-person-card.tsx`, and `calculator-button.tsx` (`outline: 2px solid ${color.controlActive}` + `outlineOffset: 2px`, with `outline: none` as the default to replace the browser ring).

`Card` uses `outlineOffset: -2px` so the ring draws inside the box — the card sets `overflow: hidden`, which would clip a positive-offset outline on some browsers. The inline comment in the diff captures this constraint. The active-state background fill and the focus outline coexist visually since they target different properties.

## Context

`:focus-visible` is a CSS pseudo-class and can't be meaningfully asserted in JSDOM; the repo's Playwright e2e suite continues to exercise these surfaces unchanged. `AnchorButton` composes `Anchor` plus the button base, so both now carry an identical focus-visible rule — StyleX picks one deterministically per-property, and the values match, so there's no visible conflict.