### PR TITLE
fix: match watch-provider names exactly after normalisation

### DIFF
--- a/src/ai-chat/tools/watch-providers.test.ts
+++ b/src/ai-chat/tools/watch-providers.test.ts
@@ -562,4 +562,213 @@ describe("watch providers provider search", () => {
     expect(result.regions).toHaveLength(1);
     expect(result.regions[0].country).toBe("US");
   });
+
+  it('matches "Disney Plus" against the canonical "Disney+" name', async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/watch/providers`, () =>
+        HttpResponse.json(
+          watchProvidersResponse(550, {
+            US: {
+              link: "https://example.com/US",
+              flatrate: [
+                provider({
+                  provider_id: 337,
+                  provider_name: "Disney+",
+                  display_priority: 1,
+                }),
+              ],
+            },
+          }),
+        ),
+      ),
+    );
+
+    const result = asSearchResult(
+      await executeTool({
+        id: 550,
+        media_type: "movie",
+        provider_name: "Disney Plus",
+      }),
+    );
+
+    expect(result.regions).toHaveLength(1);
+    expect(result.regions[0].country).toBe("US");
+    expect(result.providerLogoPath).toBe("/logo-337.jpg");
+  });
+
+  it('does not match "Disney+" against the unrelated "Disney+ Hotstar" service', async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/watch/providers`, () =>
+        HttpResponse.json(
+          watchProvidersResponse(550, {
+            IN: {
+              link: "https://example.com/IN",
+              flatrate: [
+                provider({
+                  provider_id: 122,
+                  provider_name: "Disney+ Hotstar",
+                  display_priority: 1,
+                }),
+              ],
+            },
+          }),
+        ),
+      ),
+    );
+
+    const result = asSearchResult(
+      await executeTool({
+        id: 550,
+        media_type: "movie",
+        provider_name: "Disney+",
+      }),
+    );
+
+    expect(result.regions).toEqual([]);
+    expect(result.providerLogoPath).toBeNull();
+  });
+
+  it('does not match "HBO" against the unrelated "Amazon Channel - HBO" addon', async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/watch/providers`, () =>
+        HttpResponse.json(
+          watchProvidersResponse(550, {
+            US: {
+              link: "https://example.com/US",
+              flatrate: [
+                provider({
+                  provider_id: 999,
+                  provider_name: "Amazon Channel - HBO",
+                  display_priority: 1,
+                }),
+              ],
+            },
+          }),
+        ),
+      ),
+    );
+
+    const result = asSearchResult(
+      await executeTool({
+        id: 550,
+        media_type: "movie",
+        provider_name: "HBO",
+      }),
+    );
+
+    expect(result.regions).toEqual([]);
+  });
+
+  it('does not match "Apple" against unrelated Apple-branded services', async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/watch/providers`, () =>
+        HttpResponse.json(
+          watchProvidersResponse(550, {
+            US: {
+              link: "https://example.com/US",
+              flatrate: [
+                provider({
+                  provider_id: 350,
+                  provider_name: "Apple TV+",
+                  display_priority: 1,
+                }),
+              ],
+              rent: [
+                provider({
+                  provider_id: 2,
+                  provider_name: "Apple TV Channel",
+                  display_priority: 2,
+                }),
+              ],
+            },
+          }),
+        ),
+      ),
+    );
+
+    const result = asSearchResult(
+      await executeTool({
+        id: 550,
+        media_type: "movie",
+        provider_name: "Apple",
+      }),
+    );
+
+    expect(result.regions).toEqual([]);
+  });
+
+  it('matches "Apple TV+" exactly without picking up "Apple TV Channel"', async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/watch/providers`, () =>
+        HttpResponse.json(
+          watchProvidersResponse(550, {
+            US: {
+              link: "https://example.com/US",
+              flatrate: [
+                provider({
+                  provider_id: 350,
+                  provider_name: "Apple TV+",
+                  display_priority: 1,
+                }),
+              ],
+              rent: [
+                provider({
+                  provider_id: 2,
+                  provider_name: "Apple TV Channel",
+                  display_priority: 2,
+                }),
+              ],
+            },
+          }),
+        ),
+      ),
+    );
+
+    const result = asSearchResult(
+      await executeTool({
+        id: 550,
+        media_type: "movie",
+        provider_name: "Apple TV+",
+      }),
+    );
+
+    expect(result.regions).toEqual([{ country: "US", types: ["flatrate"] }]);
+    expect(result.providerLogoPath).toBe("/logo-350.jpg");
+  });
+
+  it('does not match "Prime" against "Amazon Prime Video" or addon channels', async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/watch/providers`, () =>
+        HttpResponse.json(
+          watchProvidersResponse(550, {
+            US: {
+              link: "https://example.com/US",
+              flatrate: [
+                provider({
+                  provider_id: 9,
+                  provider_name: "Amazon Prime Video",
+                  display_priority: 1,
+                }),
+                provider({
+                  provider_id: 10,
+                  provider_name: "Amazon Prime Video with Ads",
+                  display_priority: 2,
+                }),
+              ],
+            },
+          }),
+        ),
+      ),
+    );
+
+    const result = asSearchResult(
+      await executeTool({
+        id: 550,
+        media_type: "movie",
+        provider_name: "Prime",
+      }),
+    );
+
+    expect(result.regions).toEqual([]);
+  });
 });

--- a/src/ai-chat/tools/watch-providers.ts
+++ b/src/ai-chat/tools/watch-providers.ts
@@ -119,17 +119,30 @@ const AVAILABILITY_TYPES: AvailabilityType[] = [
   "free",
 ];
 
+/**
+ * Normalise a provider name for matching: lowercase, treat "+" as "plus",
+ * and strip everything else that isn't a letter or digit. So "Disney+",
+ * "disney plus", and "DISNEY+" all collapse to "disneyplus".
+ */
+function normaliseProviderName(name: string): string {
+  return name
+    .toLowerCase()
+    .replaceAll("+", "plus")
+    .replace(/[^a-z0-9]/g, "");
+}
+
 function findProvider(
   items: unknown,
   name: string,
 ): { found: boolean; logoPath: string | null } {
   if (!Array.isArray(items)) return { found: false, logoPath: null };
-  const lower = name.toLowerCase();
+  const target = normaliseProviderName(name);
+  if (target === "") return { found: false, logoPath: null };
   for (const item of items) {
     if (
       isRecord(item) &&
       typeof item.provider_name === "string" &&
-      item.provider_name.toLowerCase().includes(lower)
+      normaliseProviderName(item.provider_name) === target
     ) {
       return {
         found: true,


### PR DESCRIPTION
## Summary

`findProvider` — the matcher behind the AI-chat `watch_providers` tool's cross-region "Is X on Netflix?" path — used `.toLowerCase().includes()`. That happily reported `"Apple"` as found inside `"Apple TV+"`, `"Apple TV Channel"`, and `"Apple Music"` simultaneously, and `"HBO"` as found inside `"Amazon Channel - HBO"`. So the LLM could confidently answer "yes, available on HBO" when the underlying TMDB record was a different service entirely.

This PR replaces the substring check with a normalised exact match. A small `normaliseProviderName` helper lowercases, replaces `+` with `plus`, and strips remaining non-alphanumerics — so `"Disney+"`, `"disney plus"`, and `"DISNEY+"` all collapse to `"disneyplus"`. The matcher then requires `===` against the normalised provider name, with an early return for empty targets to defend against pure-punctuation queries.

## Context

Word-boundary matching was rejected here because `"Apple TV+"` and `"Apple TV Channel"` share boundaries on both `Apple` and `TV` — only full-string equality reliably distinguishes them. The trade-off is that vague queries like a bare `"Prime"` against `"Amazon Prime Video"` will return no match instead of a (previously) confident wrong answer; the brief explicitly preferred that outcome — the matcher's job is to be strict, not loose. The tool's input schema and `provider_name` describe text are deliberately unchanged.

Six new tests cover the legitimate `Disney Plus` → `Disney+` variant, the `Disney+` vs `Disney+ Hotstar` rejection, the `HBO` substring-pollution rejection, the `Apple` over-broad rejection, the positive-and-negative case where `Apple TV+` matches `Apple TV+` but doesn't pull in `Apple TV Channel` from the same payload, and the `Prime` vs `Amazon Prime Video` rejection. Existing happy-path tests for `Netflix` still pass.