### PR TITLE
fix: detect cached image errors in TmdbImage ref callback

### DIFF
--- a/src/components/movie-database/tmdb-image.test.tsx
+++ b/src/components/movie-database/tmdb-image.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { render, screen } from "#src/test-utils.tsx";
+import { TmdbImage } from "./tmdb-image";
+
+const COMMON_PROPS = {
+  baseUrl: "https://image.tmdb.org/t/p/",
+  sizeConfig: ["w200", "w400"] as const,
+  path: "/poster.jpg",
+  alt: "Test poster",
+  sizes: "100vw",
+};
+
+function stubImageElement(values: { complete: boolean; naturalWidth: number }) {
+  const completeSpy = Object.getOwnPropertyDescriptor(
+    HTMLImageElement.prototype,
+    "complete",
+  );
+  const widthSpy = Object.getOwnPropertyDescriptor(
+    HTMLImageElement.prototype,
+    "naturalWidth",
+  );
+  Object.defineProperty(HTMLImageElement.prototype, "complete", {
+    configurable: true,
+    get() {
+      return values.complete;
+    },
+  });
+  Object.defineProperty(HTMLImageElement.prototype, "naturalWidth", {
+    configurable: true,
+    get() {
+      return values.naturalWidth;
+    },
+  });
+  return () => {
+    if (completeSpy) {
+      Object.defineProperty(
+        HTMLImageElement.prototype,
+        "complete",
+        completeSpy,
+      );
+    } else {
+      Reflect.deleteProperty(HTMLImageElement.prototype, "complete");
+    }
+    if (widthSpy) {
+      Object.defineProperty(
+        HTMLImageElement.prototype,
+        "naturalWidth",
+        widthSpy,
+      );
+    } else {
+      Reflect.deleteProperty(HTMLImageElement.prototype, "naturalWidth");
+    }
+  };
+}
+
+describe("TmdbImage", () => {
+  let restore: (() => void) | undefined;
+
+  afterEach(() => {
+    restore?.();
+    restore = undefined;
+  });
+
+  it("renders the image and a sibling skeleton while loading", () => {
+    restore = stubImageElement({ complete: false, naturalWidth: 0 });
+    const { container } = render(<TmdbImage {...COMMON_PROPS} />);
+
+    expect(screen.getByRole("img")).toBeInTheDocument();
+    // Skeleton sibling = an extra div before the img
+    expect(container.querySelectorAll("div, img")).toHaveLength(2);
+  });
+
+  it("removes the skeleton once onLoad fires", () => {
+    restore = stubImageElement({ complete: false, naturalWidth: 0 });
+    const { container } = render(<TmdbImage {...COMMON_PROPS} />);
+
+    fireEvent.load(screen.getByRole("img"));
+
+    expect(container.querySelectorAll("div, img")).toHaveLength(1);
+    expect(screen.getByRole("img")).toBeInTheDocument();
+  });
+
+  it("renders the errorFallback when onError fires", () => {
+    restore = stubImageElement({ complete: false, naturalWidth: 0 });
+    render(
+      <TmdbImage {...COMMON_PROPS} errorFallback={<span>fallback ui</span>} />,
+    );
+
+    fireEvent.error(screen.getByRole("img"));
+
+    expect(screen.getByText("fallback ui")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("detects cached successes via the ref callback (complete + naturalWidth > 0)", () => {
+    restore = stubImageElement({ complete: true, naturalWidth: 200 });
+    const { container } = render(<TmdbImage {...COMMON_PROPS} />);
+
+    // Image present, no skeleton sibling
+    expect(screen.getByRole("img")).toBeInTheDocument();
+    expect(container.querySelectorAll("div, img")).toHaveLength(1);
+  });
+
+  it("detects cached errors via the ref callback (complete + naturalWidth === 0) and shows the fallback", () => {
+    restore = stubImageElement({ complete: true, naturalWidth: 0 });
+    render(
+      <TmdbImage {...COMMON_PROPS} errorFallback={<span>fallback ui</span>} />,
+    );
+
+    expect(screen.getByText("fallback ui")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/movie-database/tmdb-image.tsx
+++ b/src/components/movie-database/tmdb-image.tsx
@@ -62,7 +62,16 @@ export function TmdbImage({
           setErrored(true);
         }}
         ref={(el) => {
-          if (el?.complete && el.naturalWidth > 0) setLoaded(true);
+          if (!el?.complete) return;
+          // Browsers short-circuit cached responses without firing onLoad/onError,
+          // so probe the element directly. naturalWidth > 0 means a decoded image
+          // is in memory; naturalWidth === 0 on a complete image means the fetch
+          // failed (404, network error, etc.) and the response was cached.
+          if (el.naturalWidth > 0) {
+            setLoaded(true);
+          } else {
+            setErrored(true);
+          }
         }}
       />
     </>


### PR DESCRIPTION
## Summary

`TmdbImage`'s ref-callback probe handled cached *successes* (`complete && naturalWidth > 0` → `setLoaded(true)`) but ignored cached *errors*. Browsers short-circuit cached responses without firing `onLoad` or `onError`, so the ref callback is the only signal available — and previously, cached-error images sat on the loading skeleton forever, never falling through to the `errorFallback` that consumers like `PosterImage` and `CompactPersonCard` already supply.

This PR makes the probe symmetric: an early-return when the element isn't yet `complete`, then `naturalWidth > 0` → `setLoaded(true)` and `naturalWidth === 0` → `setErrored(true)`. `naturalWidth === 0` on a `complete` image is the cross-browser "decode failed" signal per MDN. The in-flight (`complete === false`) path and the `onLoad` / `onError` handlers are unchanged.

## Context

A legitimate 0×0 image (200 OK with empty body) would now also trigger the fallback, which is consistent with the bug report — a 0px image isn't useful to render, and TMDB image paths never produce zero-width images in practice. Five new tests cover in-flight, `onLoad`, `onError`, cached success, and cached error. The cached-state tests stub `HTMLImageElement.prototype` `complete` and `naturalWidth` getters via `Object.defineProperty` (jsdom doesn't fetch images, so prototype probing is the standard pattern for this kind of code path) and restore the original descriptors in `afterEach`, matching the per-instance pattern in `use-scroll-fades.test.ts`.