### PR TITLE
feat: add openGraph and twitter metadata to portfolio detail pages

### DIFF
--- a/src/app/[locale]/(home)/(details)/education/altrincham-grammar-school-for-boys/page.tsx
+++ b/src/app/[locale]/(home)/(details)/education/altrincham-grammar-school-for-boys/page.tsx
@@ -8,15 +8,27 @@ import { validateLocale } from "#src/utils/validate-locale.ts";
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const params = await props.params;
   validateLocale(params.locale);
+  const title = t({
+    en: "Education at Altrincham Grammar School for Boys",
+    zh: "奥尔特灵厄姆男子文法学校 教育",
+  });
+  const description = t({
+    en: "Qingqi graduated from Altrincham Grammar School for Boys, achieving A*AAB for his A-Levels.",
+    zh: "石清琪在奥尔特灵厄姆男子文法学校研读 A-Levels，取得了 A*AAB 的成绩。",
+  });
+  const url =
+    params.locale === "zh"
+      ? new URL(
+          "/zh/education/altrincham-grammar-school-for-boys",
+          BASE_URL,
+        ).toString()
+      : new URL(
+          "/education/altrincham-grammar-school-for-boys",
+          BASE_URL,
+        ).toString();
   return {
-    title: t({
-      en: "Education at Altrincham Grammar School for Boys",
-      zh: "奥尔特灵厄姆男子文法学校 教育",
-    }),
-    description: t({
-      en: "Qingqi graduated from Altrincham Grammar School for Boys, achieving A*AAB for his A-Levels.",
-      zh: "石清琪在奥尔特灵厄姆男子文法学校研读 A-Levels，取得了 A*AAB 的成绩。",
-    }),
+    title,
+    description,
     alternates: {
       canonical: new URL(
         "/education/altrincham-grammar-school-for-boys",
@@ -32,6 +44,19 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
           BASE_URL,
         ).toString(),
       },
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: t({ en: "Qingqi Shi", zh: "石清琪" }),
+      locale: params.locale === "zh" ? "zh_CN" : "en_US",
+      type: "profile",
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
     },
   } satisfies Metadata;
 }

--- a/src/app/[locale]/(home)/(details)/education/university-of-bristol/page.tsx
+++ b/src/app/[locale]/(home)/(details)/education/university-of-bristol/page.tsx
@@ -9,15 +9,21 @@ import { validateLocale } from "#src/utils/validate-locale.ts";
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const params = await props.params;
   validateLocale(params.locale);
+  const title = t({
+    en: "Education at University of Bristol",
+    zh: "布里斯托大学 教育",
+  });
+  const description = t({
+    en: "Qingqi graduated from the University of Bristol with a Merit in MSc Advanced Computing - Creative Technology.",
+    zh: "石清琪毕业于布里斯托大学，取得了《高级计算机 创新技术》理学硕士。",
+  });
+  const url =
+    params.locale === "zh"
+      ? new URL("/zh/education/university-of-bristol", BASE_URL).toString()
+      : new URL("/education/university-of-bristol", BASE_URL).toString();
   return {
-    title: t({
-      en: "Education at University of Bristol",
-      zh: "布里斯托大学 教育",
-    }),
-    description: t({
-      en: "Qingqi graduated from the University of Bristol with a Merit in MSc Advanced Computing - Creative Technology.",
-      zh: "石清琪毕业于布里斯托大学，取得了《高级计算机 创新技术》理学硕士。",
-    }),
+    title,
+    description,
     alternates: {
       canonical: new URL(
         "/education/university-of-bristol",
@@ -27,6 +33,19 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
         en: new URL("/education/university-of-bristol", BASE_URL).toString(),
         zh: new URL("/zh/education/university-of-bristol", BASE_URL).toString(),
       },
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: t({ en: "Qingqi Shi", zh: "石清琪" }),
+      locale: params.locale === "zh" ? "zh_CN" : "en_US",
+      type: "profile",
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
     },
   } satisfies Metadata;
 }

--- a/src/app/[locale]/(home)/(details)/education/university-of-nottingham/page.tsx
+++ b/src/app/[locale]/(home)/(details)/education/university-of-nottingham/page.tsx
@@ -8,15 +8,21 @@ import { validateLocale } from "#src/utils/validate-locale.ts";
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const params = await props.params;
   validateLocale(params.locale);
+  const title = t({
+    en: "Education at University of Nottingham",
+    zh: "诺丁汉大学 教育",
+  });
+  const description = t({
+    en: "Qingqi graduated from the University of Nottingham with a First-class Honours degree in BSc Computer Science.",
+    zh: "石清琪毕业于诺丁汉大学，取得了《计算机科学》荣誉理学学士。",
+  });
+  const url =
+    params.locale === "zh"
+      ? new URL("/zh/education/university-of-nottingham", BASE_URL).toString()
+      : new URL("/education/university-of-nottingham", BASE_URL).toString();
   return {
-    title: t({
-      en: "Education at University of Nottingham",
-      zh: "诺丁汉大学 教育",
-    }),
-    description: t({
-      en: "Qingqi graduated from the University of Nottingham with a First-class Honours degree in BSc Computer Science.",
-      zh: "石清琪毕业于诺丁汉大学，取得了《计算机科学》荣誉理学学士。",
-    }),
+    title,
+    description,
     alternates: {
       canonical: new URL(
         "/education/university-of-nottingham",
@@ -29,6 +35,19 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
           BASE_URL,
         ).toString(),
       },
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: t({ en: "Qingqi Shi", zh: "石清琪" }),
+      locale: params.locale === "zh" ? "zh_CN" : "en_US",
+      type: "profile",
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
     },
   } satisfies Metadata;
 }

--- a/src/app/[locale]/(home)/(details)/experiences/citadel/page.tsx
+++ b/src/app/[locale]/(home)/(details)/experiences/citadel/page.tsx
@@ -8,21 +8,40 @@ import { validateLocale } from "#src/utils/validate-locale.ts";
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const params = await props.params;
   validateLocale(params.locale);
+  const title = t({
+    en: "Software Engineer at Citadel - Crafting Dashboard Web Apps for the Financial Sector",
+    zh: "Citadel 的软件工程师 - 为金融行业打造仪表盘Web应用",
+  });
+  const description = t({
+    en: "Discover how Qingqi Shi, a software engineer at Citadel, develops dashboard web applications for the financial sector using React, TypeScript, and AG Grid.",
+    zh: "了解石清琪在 Citadel 担任软件工程师的经历，他使用 React、TypeScript 和 AG Grid 为金融行业开发仪表盘 Web 应用。",
+  });
+  const url =
+    params.locale === "zh"
+      ? new URL("/zh/experiences/citadel", BASE_URL).toString()
+      : new URL("/experiences/citadel", BASE_URL).toString();
   return {
-    title: t({
-      en: "Software Engineer at Citadel - Crafting Dashboard Web Apps for the Financial Sector",
-      zh: "Citadel 的软件工程师 - 为金融行业打造仪表盘Web应用",
-    }),
-    description: t({
-      en: "Discover how Qingqi Shi, a software engineer at Citadel, develops dashboard web applications for the financial sector using React, TypeScript, and AG Grid.",
-      zh: "了解石清琪在 Citadel 担任软件工程师的经历，他使用 React、TypeScript 和 AG Grid 为金融行业开发仪表盘 Web 应用。",
-    }),
+    title,
+    description,
     alternates: {
       canonical: new URL("/experiences/citadel", BASE_URL).toString(),
       languages: {
         en: new URL("/experiences/citadel", BASE_URL).toString(),
         zh: new URL("/zh/experiences/citadel", BASE_URL).toString(),
       },
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: t({ en: "Qingqi Shi", zh: "石清琪" }),
+      locale: params.locale === "zh" ? "zh_CN" : "en_US",
+      type: "profile",
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
     },
   } satisfies Metadata;
 }

--- a/src/app/[locale]/(home)/(details)/experiences/spotify/page.tsx
+++ b/src/app/[locale]/(home)/(details)/experiences/spotify/page.tsx
@@ -8,21 +8,40 @@ import { validateLocale } from "#src/utils/validate-locale.ts";
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const params = await props.params;
   validateLocale(params.locale);
+  const title = t({
+    en: "Software Engineer II at Spotify - Developing Innovative Campaign Management Solutions",
+    zh: "Spotify 的软件工程师 II - 开发创新的广告活动管理解决方案",
+  });
+  const description = t({
+    en: "Learn about Qingqi Shi's experience as a Software Engineer II at Spotify, where he built a campaign management platform and contributed to company-wide initiatives.",
+    zh: "了解石清琪在 Spotify 担任软件工程师 II 的经验，他构建了一个广告活动管理平台，并为公司范围内的一些项目做出了贡献。",
+  });
+  const url =
+    params.locale === "zh"
+      ? new URL("/zh/experiences/spotify", BASE_URL).toString()
+      : new URL("/experiences/spotify", BASE_URL).toString();
   return {
-    title: t({
-      en: "Software Engineer II at Spotify - Developing Innovative Campaign Management Solutions",
-      zh: "Spotify 的软件工程师 II - 开发创新的广告活动管理解决方案",
-    }),
-    description: t({
-      en: "Learn about Qingqi Shi's experience as a Software Engineer II at Spotify, where he built a campaign management platform and contributed to company-wide initiatives.",
-      zh: "了解石清琪在 Spotify 担任软件工程师 II 的经验，他构建了一个广告活动管理平台，并为公司范围内的一些项目做出了贡献。",
-    }),
+    title,
+    description,
     alternates: {
       canonical: new URL("/experiences/spotify", BASE_URL).toString(),
       languages: {
         en: new URL("/experiences/spotify", BASE_URL).toString(),
         zh: new URL("/zh/experiences/spotify", BASE_URL).toString(),
       },
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: t({ en: "Qingqi Shi", zh: "石清琪" }),
+      locale: params.locale === "zh" ? "zh_CN" : "en_US",
+      type: "profile",
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
     },
   } satisfies Metadata;
 }

--- a/src/app/[locale]/(home)/(details)/experiences/wunderman-thompson-commerce/page.tsx
+++ b/src/app/[locale]/(home)/(details)/experiences/wunderman-thompson-commerce/page.tsx
@@ -8,15 +8,27 @@ import { validateLocale } from "#src/utils/validate-locale.ts";
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const params = await props.params;
   validateLocale(params.locale);
+  const title = t({
+    en: "Front-End Developer at Wunderman Thompson Commerce - Enhancing E-commerce Websites",
+    zh: "Wunderman Thompson Commerce 的前端开发人员 - 提升电子商务网站体验",
+  });
+  const description = t({
+    en: "Explore Qingqi Shi's role as a front-end developer at Wunderman Thompson Commerce, where he enhanced e-commerce websites and took on tech lead responsibilities.",
+    zh: "探讨石清琪在 Wunderman Thompson Commerce 担任前端开发人员的角色，他在提升电子商务网站体验和承担技术负责人职责方面发挥了关键作用。",
+  });
+  const url =
+    params.locale === "zh"
+      ? new URL(
+          "/zh/experiences/wunderman-thompson-commerce",
+          BASE_URL,
+        ).toString()
+      : new URL(
+          "/experiences/wunderman-thompson-commerce",
+          BASE_URL,
+        ).toString();
   return {
-    title: t({
-      en: "Front-End Developer at Wunderman Thompson Commerce - Enhancing E-commerce Websites",
-      zh: "Wunderman Thompson Commerce 的前端开发人员 - 提升电子商务网站体验",
-    }),
-    description: t({
-      en: "Explore Qingqi Shi's role as a front-end developer at Wunderman Thompson Commerce, where he enhanced e-commerce websites and took on tech lead responsibilities.",
-      zh: "探讨石清琪在 Wunderman Thompson Commerce 担任前端开发人员的角色，他在提升电子商务网站体验和承担技术负责人职责方面发挥了关键作用。",
-    }),
+    title,
+    description,
     alternates: {
       canonical: new URL(
         "/experiences/wunderman-thompson-commerce",
@@ -32,6 +44,19 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
           BASE_URL,
         ).toString(),
       },
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: t({ en: "Qingqi Shi", zh: "石清琪" }),
+      locale: params.locale === "zh" ? "zh_CN" : "en_US",
+      type: "profile",
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
     },
   } satisfies Metadata;
 }


### PR DESCRIPTION
## Summary

The six portfolio-detail pages under `/experiences/*` and `/education/*` shipped only `title`, `description`, and `alternates` from their own `generateMetadata` — so when shared to LinkedIn, Slack, Twitter, etc. they fell back to the generic site-wide card from the `(home)` layout, regardless of which role or school the URL pointed to. This PR adds per-page `openGraph` and `twitter` blocks so each detail URL now previews with its own title and description.

Each page hoists its existing `title` and `description` `t({...})` calls into local consts so the new blocks reuse them without duplicating translations, adds a locale-aware canonical `url`, and follows the shape established by `src/app/[locale]/movie-database/[type]/[id]/layout.tsx` (minus the backdrop image — portfolio entries have no cover image). `openGraph.type` is `"profile"` since each page is a recruiter-facing profile of a role or education entry. `twitter.card` is `"summary"` and neither `openGraph.images` nor `twitter.images` is set — deliberately omitted rather than pointing at a phantom URL.

## Context

Locale codes (`zh_CN` / `en_US`) and the `siteName` translation match the movie-database detail layout, keeping a single convention for all detail-type metadata. The existing `satisfies Metadata` type guard accepts the new fields without changes.