### PR TITLE
fix: mark language on bilingual 404 page for screen readers

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -13,16 +13,18 @@ export const metadata: Metadata = {
 
 export default function NotFound() {
   return (
-    <html suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning>
       <body css={[globalStyles.body, styles.body]}>
         {/* eslint-disable-next-line @eslint-react/dom-no-dangerously-set-innerhtml -- Theme initialization before hydration */}
         <script dangerouslySetInnerHTML={{ __html: themeHack }} />
         <div css={styles.container}>
           <h1 css={styles.heading}>404</h1>
           <p css={styles.description}>Page not found</p>
-          <p css={styles.description}>页面未找到</p>
+          <p css={styles.description} lang="zh">
+            页面未找到
+          </p>
           <Link href="/" css={styles.link}>
-            Go home / 返回首页
+            <span>Go home</span> / <span lang="zh">返回首页</span>
           </Link>
         </div>
       </body>


### PR DESCRIPTION
## Summary

The bilingual 404 page rendered `<html>` without a `lang` attribute and mixed English and Chinese text inside the same elements, so screen readers announced both halves in a single voice (WCAG 3.1.1 and 3.1.2). This PR adds `lang="en"` to the root `<html>` (matching `global-error.tsx` and the `validateLocale` default), wraps the standalone Chinese paragraph `页面未找到` with `lang="zh"`, and splits the "Go home / 返回首页" link into two spans so the Chinese half gets `lang="zh"` while the English half inherits from the root. `suppressHydrationWarning` is preserved because the `themeHack` inline script still mutates `<html>` before hydration.

## Context

No visible text, layout, or CSS change — the new `<span>` wrappers have no styles and the slash literal and whitespace survive the split, so the link's accessible name is still "Go home / 返回首页". The existing language-toggle e2e test keys off `getByRole("heading", { name: "404" })` and is unaffected.