### PR TITLE
fix: only apply negative margin overlap when backdrop is present

### DIFF
--- a/src/components/ai-chat/media-detail-content.tsx
+++ b/src/components/ai-chat/media-detail-content.tsx
@@ -88,6 +88,8 @@ export function MediaDetailContent({
     (video) => video.type === "Trailer" && video.official,
   );
 
+  const hasBackdrop = Boolean(detail?.backdropPath && imageBaseUrl);
+
   if (detailQuery.isError) {
     return (
       <div css={styles.body}>
@@ -117,7 +119,7 @@ export function MediaDetailContent({
       ) : (
         detailQuery.isPending && <Skeleton css={skeletonStyles.backdrop} />
       )}
-      <div css={styles.body}>
+      <div css={[styles.body, hasBackdrop && styles.bodyWithBackdrop]}>
         <div css={styles.header}>
           {posterPath && imageBaseUrl ? (
             <div css={styles.posterWrapper}>
@@ -295,6 +297,8 @@ const styles = stylex.create({
     flexDirection: "column",
     gap: space._3,
     padding: space._4,
+  },
+  bodyWithBackdrop: {
     marginTop: `calc(-1 * ${space._10})`,
   },
   header: {


### PR DESCRIPTION
## Summary

The media detail overlay's body content used an unconditional negative margin to overlap onto the backdrop gradient. When no backdrop image was present (missing `backdropPath` or `imageBaseUrl`), this pulled content up into the dialog's close button area. Conditionally applies the negative margin only when a backdrop actually renders.

## Visual verification

Reproduced locally via `pnpm dev` → `http://localhost:3000/en/movie-database/ai-mode`, driving the page with Playwright. The AI chat was prompted to `Search TMDB for 'The Deluge Postscriptum' - a Polish documentary` (TMDB movie [1356423](https://www.themoviedb.org/movie/1356423) — a real film with `backdrop_path: null`). Clicking the returned search-result card opens the `MediaDetailOverlay`. Screenshots were taken on `master` (before) and with the PR's patch applied (after), at mobile (400×800) and desktop (1280×800) viewports.

Note: the overlay is React state inside the AI chat, so there's no stable URL for the "no-backdrop" state — the reproduction is "search the movie, click the card." Screenshots are the concrete artifact; the Vercel preview deployment requires auth and cannot be linked publicly.

### Mobile — before (master)
On master, the rating row (`6 (1)`) is hidden behind the close button area, and "The Deluge:" runs up against the X.

![mobile before](https://raw.githubusercontent.com/QingqiShi/shiqingqi.com/f3f93fe40108ec2049b53617e4260b2ca1283e82/before-mobile.png)

### Mobile — after (this PR)
Rating row is visible; title has proper vertical spacing from the close button.

![mobile after](https://raw.githubusercontent.com/QingqiShi/shiqingqi.com/f3f93fe40108ec2049b53617e4260b2ca1283e82/after-mobile.png)

### Desktop — before (master)
Poster + title pulled up above the normal header position; rating hidden.

![desktop before](https://raw.githubusercontent.com/QingqiShi/shiqingqi.com/f3f93fe40108ec2049b53617e4260b2ca1283e82/before-desktop.png)

### Desktop — after (this PR)
Poster, rating, and title sit cleanly within the card.

![desktop after](https://raw.githubusercontent.com/QingqiShi/shiqingqi.com/f3f93fe40108ec2049b53617e4260b2ca1283e82/after-desktop.png)

### Regression check — with-backdrop case
Verified Inception (TMDB 27205, backdrop present) separately at both viewports. Layout matches master — the poster and title still overlap the backdrop gradient as intended.