### PR TITLE
perf: cache tool output maps during text streaming

### DIFF
--- a/src/ai-chat/use-ai-chat.ts
+++ b/src/ai-chat/use-ai-chat.ts
@@ -6,14 +6,15 @@ import { DefaultChatTransport } from "ai";
 import { useEffect, useState, useSyncExternalStore } from "react";
 import { z } from "zod";
 import { isUIMessage } from "#src/ai-chat/is-ui-message.ts";
-import { createToolOutputAccumulator } from "#src/components/ai-chat/map-tool-output.ts";
+import {
+  accumulateToolOutputs,
+  toolOutputsFingerprint,
+} from "#src/components/ai-chat/map-tool-output.ts";
 import {
   getCachedPreferencesContext,
   getPreferencesContextReady,
 } from "#src/preference-store/preference-store.ts";
 import type { SupportedLocale } from "#src/types.ts";
-
-const accumulateToolOutputs = createToolOutputAccumulator();
 
 export interface ChatMessageMetadata {
   inputTokens?: number;
@@ -213,10 +214,29 @@ export function useAIChat({ locale }: { locale: SupportedLocale }) {
     setContinueSessionStatus("idle");
   };
 
+  // `chatResult.messages` changes reference on every streaming chunk, but the
+  // set of resolved tool outputs only changes when a tool call completes. Cache
+  // the derived maps keyed on a fingerprint of tool call IDs, using React's
+  // "store info from previous renders" pattern, so downstream components
+  // receive stable map references during text streaming. React Compiler cannot
+  // memoize this automatically — `messages` is a new array every chunk, so it
+  // has no referential equality signal to cache on.
+  const fingerprint = toolOutputsFingerprint(chatResult.messages);
+  const [cachedToolOutputs, setCachedToolOutputs] = useState(() => ({
+    fingerprint,
+    maps: accumulateToolOutputs(chatResult.messages),
+  }));
+  if (cachedToolOutputs.fingerprint !== fingerprint) {
+    setCachedToolOutputs({
+      fingerprint,
+      maps: accumulateToolOutputs(chatResult.messages),
+    });
+  }
+
   return {
     ...chatResult,
     sendMessage,
-    toolOutputs: accumulateToolOutputs(chatResult.messages),
+    toolOutputs: cachedToolOutputs.maps,
     previousSessionId,
     continueSession,
     continueSessionStatus,

--- a/src/ai-chat/use-ai-chat.ts
+++ b/src/ai-chat/use-ai-chat.ts
@@ -6,12 +6,14 @@ import { DefaultChatTransport } from "ai";
 import { useEffect, useState, useSyncExternalStore } from "react";
 import { z } from "zod";
 import { isUIMessage } from "#src/ai-chat/is-ui-message.ts";
-import { accumulateToolOutputs } from "#src/components/ai-chat/map-tool-output.ts";
+import { createToolOutputAccumulator } from "#src/components/ai-chat/map-tool-output.ts";
 import {
   getCachedPreferencesContext,
   getPreferencesContextReady,
 } from "#src/preference-store/preference-store.ts";
 import type { SupportedLocale } from "#src/types.ts";
+
+const accumulateToolOutputs = createToolOutputAccumulator();
 
 export interface ChatMessageMetadata {
   inputTokens?: number;

--- a/src/components/ai-chat/map-tool-output.test.ts
+++ b/src/components/ai-chat/map-tool-output.test.ts
@@ -8,6 +8,7 @@ import {
   mapToolOutputToMediaItems,
   resolveMediaItems,
   resolvePersonItems,
+  toolOutputsFingerprint,
 } from "./map-tool-output";
 
 function msg(
@@ -752,5 +753,76 @@ describe("buildPersonResultsMap for media_credits", () => {
     const output = { cast: [], crew: [] };
     const map = buildPersonResultsMap("media_credits", output);
     expect(map.size).toBe(0);
+  });
+});
+
+describe("toolOutputsFingerprint", () => {
+  function partWithId(
+    toolCallId: string,
+    state: "output-available" | "input-streaming" | "input-available",
+  ) {
+    return {
+      type: "dynamic-tool" as const,
+      toolName: "tmdb_search",
+      toolCallId,
+      state,
+      input: {},
+      ...(state === "output-available" ? { output: [] } : {}),
+    };
+  }
+
+  it("returns empty string for no messages", () => {
+    expect(toolOutputsFingerprint([])).toBe("");
+  });
+
+  it("ignores parts that are not resolved tool outputs", () => {
+    const messages = [
+      msg([
+        { type: "text", text: "hello" },
+        partWithId("a", "input-streaming"),
+        partWithId("b", "input-available"),
+      ]),
+    ];
+    expect(toolOutputsFingerprint(messages)).toBe("");
+  });
+
+  it("stays stable when only non-tool parts change (streaming text chunks)", () => {
+    const toolParts = [partWithId("call-1", "output-available")];
+    const before = [msg([...toolParts, { type: "text", text: "partial" }])];
+    const after = [
+      msg([...toolParts, { type: "text", text: "partial growing" }]),
+    ];
+    expect(toolOutputsFingerprint(before)).toBe(toolOutputsFingerprint(after));
+  });
+
+  it("changes when a new tool output is appended", () => {
+    const first = [msg([partWithId("call-1", "output-available")])];
+    const second = [
+      msg([
+        partWithId("call-1", "output-available"),
+        partWithId("call-2", "output-available"),
+      ]),
+    ];
+    expect(toolOutputsFingerprint(first)).not.toBe(
+      toolOutputsFingerprint(second),
+    );
+  });
+
+  it("differs between two conversations with the same output count (session switch)", () => {
+    const sessionA = [
+      msg([
+        partWithId("a-1", "output-available"),
+        partWithId("a-2", "output-available"),
+      ]),
+    ];
+    const sessionB = [
+      msg([
+        partWithId("b-1", "output-available"),
+        partWithId("b-2", "output-available"),
+      ]),
+    ];
+    expect(toolOutputsFingerprint(sessionA)).not.toBe(
+      toolOutputsFingerprint(sessionB),
+    );
   });
 });

--- a/src/components/ai-chat/map-tool-output.ts
+++ b/src/components/ai-chat/map-tool-output.ts
@@ -14,68 +14,54 @@ export interface ToolOutputMaps {
   watchProvidersMap: ReadonlyMap<string, WatchProviderOutput>;
 }
 
-export function createToolOutputAccumulator(): (
-  messages: ReadonlyArray<UIMessage>,
-) => ToolOutputMaps {
-  let cachedResult: ToolOutputMaps | null = null;
-  let cachedOutputCount = -1;
-
-  return (messages) => {
-    let outputCount = 0;
-    for (const message of messages) {
-      for (const part of message.parts) {
-        if (isToolUIPart(part) && part.state === "output-available") {
-          outputCount++;
-        }
-      }
-    }
-
-    if (cachedResult && outputCount === cachedOutputCount) {
-      return cachedResult;
-    }
-
-    return recompute(messages, outputCount);
-  };
-
-  function recompute(
-    messages: ReadonlyArray<UIMessage>,
-    outputCount: number,
-  ): ToolOutputMaps {
-    const searchResultsMap = new Map<string, MediaListItem>();
-    const personResultsMap = new Map<number, PersonListItem>();
-    const watchProvidersMap = new Map<string, WatchProviderOutput>();
-
-    for (const message of messages) {
-      for (const part of message.parts) {
-        if (!isToolUIPart(part)) continue;
-        if (part.state !== "output-available" || !("output" in part)) continue;
-
-        const name = getToolName(part);
-
-        for (const [k, v] of buildSearchResultsMap(name, part.output)) {
-          searchResultsMap.set(k, v);
-        }
-        for (const [k, v] of buildPersonResultsMap(name, part.output)) {
-          personResultsMap.set(k, v);
-        }
-        if (name === "watch_providers") {
-          for (const [k, v] of buildWatchProvidersMap(part.output)) {
-            watchProvidersMap.set(k, v);
-          }
-        }
-      }
-    }
-
-    cachedOutputCount = outputCount;
-    cachedResult = { searchResultsMap, personResultsMap, watchProvidersMap };
-    return cachedResult;
-  }
-}
-
 export function accumulateToolOutputs(
   messages: ReadonlyArray<UIMessage>,
 ): ToolOutputMaps {
-  return createToolOutputAccumulator()(messages);
+  const searchResultsMap = new Map<string, MediaListItem>();
+  const personResultsMap = new Map<number, PersonListItem>();
+  const watchProvidersMap = new Map<string, WatchProviderOutput>();
+
+  for (const message of messages) {
+    for (const part of message.parts) {
+      if (!isToolUIPart(part)) continue;
+      if (part.state !== "output-available" || !("output" in part)) continue;
+
+      const name = getToolName(part);
+
+      for (const [k, v] of buildSearchResultsMap(name, part.output)) {
+        searchResultsMap.set(k, v);
+      }
+      for (const [k, v] of buildPersonResultsMap(name, part.output)) {
+        personResultsMap.set(k, v);
+      }
+      if (name === "watch_providers") {
+        for (const [k, v] of buildWatchProvidersMap(part.output)) {
+          watchProvidersMap.set(k, v);
+        }
+      }
+    }
+  }
+
+  return { searchResultsMap, personResultsMap, watchProvidersMap };
+}
+
+// Fingerprint identifying the set of resolved tool outputs across a conversation.
+// Stable across text-streaming chunks (new message/array refs don't change it),
+// but changes when a tool output is added OR when messages are replaced with a
+// different set (e.g. continueSession / regenerate). Used to key a memoization
+// cache without deep-comparing tool outputs.
+export function toolOutputsFingerprint(
+  messages: ReadonlyArray<UIMessage>,
+): string {
+  let fingerprint = "";
+  for (const message of messages) {
+    for (const part of message.parts) {
+      if (!isToolUIPart(part)) continue;
+      if (part.state !== "output-available") continue;
+      fingerprint += `${part.toolCallId}|`;
+    }
+  }
+  return fingerprint;
 }
 
 function mapTmdbSearchOutput(output: unknown): ReadonlyArray<MediaListItem> {

--- a/src/components/ai-chat/map-tool-output.ts
+++ b/src/components/ai-chat/map-tool-output.ts
@@ -14,35 +14,68 @@ export interface ToolOutputMaps {
   watchProvidersMap: ReadonlyMap<string, WatchProviderOutput>;
 }
 
-export function accumulateToolOutputs(
+export function createToolOutputAccumulator(): (
   messages: ReadonlyArray<UIMessage>,
-): ToolOutputMaps {
-  const searchResultsMap = new Map<string, MediaListItem>();
-  const personResultsMap = new Map<number, PersonListItem>();
-  const watchProvidersMap = new Map<string, WatchProviderOutput>();
+) => ToolOutputMaps {
+  let cachedResult: ToolOutputMaps | null = null;
+  let cachedOutputCount = -1;
 
-  for (const message of messages) {
-    for (const part of message.parts) {
-      if (!isToolUIPart(part)) continue;
-      if (part.state !== "output-available" || !("output" in part)) continue;
-
-      const name = getToolName(part);
-
-      for (const [k, v] of buildSearchResultsMap(name, part.output)) {
-        searchResultsMap.set(k, v);
-      }
-      for (const [k, v] of buildPersonResultsMap(name, part.output)) {
-        personResultsMap.set(k, v);
-      }
-      if (name === "watch_providers") {
-        for (const [k, v] of buildWatchProvidersMap(part.output)) {
-          watchProvidersMap.set(k, v);
+  return (messages) => {
+    let outputCount = 0;
+    for (const message of messages) {
+      for (const part of message.parts) {
+        if (isToolUIPart(part) && part.state === "output-available") {
+          outputCount++;
         }
       }
     }
-  }
 
-  return { searchResultsMap, personResultsMap, watchProvidersMap };
+    if (cachedResult && outputCount === cachedOutputCount) {
+      return cachedResult;
+    }
+
+    return recompute(messages, outputCount);
+  };
+
+  function recompute(
+    messages: ReadonlyArray<UIMessage>,
+    outputCount: number,
+  ): ToolOutputMaps {
+    const searchResultsMap = new Map<string, MediaListItem>();
+    const personResultsMap = new Map<number, PersonListItem>();
+    const watchProvidersMap = new Map<string, WatchProviderOutput>();
+
+    for (const message of messages) {
+      for (const part of message.parts) {
+        if (!isToolUIPart(part)) continue;
+        if (part.state !== "output-available" || !("output" in part)) continue;
+
+        const name = getToolName(part);
+
+        for (const [k, v] of buildSearchResultsMap(name, part.output)) {
+          searchResultsMap.set(k, v);
+        }
+        for (const [k, v] of buildPersonResultsMap(name, part.output)) {
+          personResultsMap.set(k, v);
+        }
+        if (name === "watch_providers") {
+          for (const [k, v] of buildWatchProvidersMap(part.output)) {
+            watchProvidersMap.set(k, v);
+          }
+        }
+      }
+    }
+
+    cachedOutputCount = outputCount;
+    cachedResult = { searchResultsMap, personResultsMap, watchProvidersMap };
+    return cachedResult;
+  }
+}
+
+export function accumulateToolOutputs(
+  messages: ReadonlyArray<UIMessage>,
+): ToolOutputMaps {
+  return createToolOutputAccumulator()(messages);
 }
 
 function mapTmdbSearchOutput(output: unknown): ReadonlyArray<MediaListItem> {


### PR DESCRIPTION
## Summary

During text streaming, `useChat` returns a new `messages` array reference on every chunk, causing `accumulateToolOutputs` to rebuild three Maps on every render even though tool outputs haven't changed. This introduced referential instability — downstream components like `ToolVisualOutput` and `ToolMediaCards` re-rendered unnecessarily because they received new Map references each time.

## Approach

Caches the derived maps in `useAIChat` using React's ["store info from previous renders"](https://react.dev/reference/react/useState#storing-information-from-previous-renders) setState-during-render pattern, keyed on a fingerprint of resolved tool call IDs.

- `accumulateToolOutputs` stays pure — no external state, no side effects during render.
- Cache is per-hook instance (not module-level), so it doesn't leak across mounts or future consumers.
- Cache key is a concatenation of `toolCallId` strings, which is sound across session switches (`continueSession` replaces messages entirely) and message regeneration. A count-based key would false-positive if two different conversations happened to have the same number of tool outputs.

Manual memoization was considered (`useMemo`) but the project's React Compiler linter forbids it; the setState-during-render pattern is the pure equivalent and doesn't violate the Rules of React.

## Tests

Added unit tests for `toolOutputsFingerprint` covering:
- stability across text-streaming chunks (tool parts unchanged, text growing),
- invalidation when a new tool output is appended,
- different fingerprints for two conversations with the same output count (session switch).