### PR TITLE
fix: cap initialItemCount to current items length in VirtuosoGrid

### DIFF
--- a/src/components/movie-database/media-virtuoso-grid.test.tsx
+++ b/src/components/movie-database/media-virtuoso-grid.test.tsx
@@ -1,0 +1,80 @@
+import type { UseSuspenseInfiniteQueryResult } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+import { render } from "#src/test-utils.tsx";
+import type { MediaListItem } from "#src/utils/types.ts";
+import { MediaVirtuosoGrid } from "./media-virtuoso-grid";
+
+function makeItems(count: number): MediaListItem[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    title: `Movie ${(i + 1).toString()}`,
+    posterPath: null,
+    rating: 7,
+    mediaType: "movie" as const,
+  }));
+}
+
+function makeQueryResult(
+  items: MediaListItem[],
+): UseSuspenseInfiniteQueryResult<MediaListItem[]> {
+  return {
+    data: items,
+    fetchNextPage: () => Promise.resolve({}) as never,
+    hasNextPage: false,
+    isFetching: false,
+    isFetchingNextPage: false,
+    isFetchingPreviousPage: false,
+    fetchPreviousPage: () => Promise.resolve({}) as never,
+    hasPreviousPage: false,
+    // remaining required fields from UseSuspenseInfiniteQueryResult
+    dataUpdatedAt: Date.now(),
+    error: null,
+    errorUpdateCount: 0,
+    errorUpdatedAt: 0,
+    failureCount: 0,
+    failureReason: null,
+    isError: false as const,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isLoading: false as const,
+    isLoadingError: false as const,
+    isPaused: false,
+    isPending: false as const,
+    isPlaceholderData: false,
+    isRefetchError: false as const,
+    isRefetching: false,
+    isStale: false,
+    isSuccess: true as const,
+    promise: Promise.resolve(items),
+    refetch: () => Promise.resolve({}) as never,
+    status: "success" as const,
+    fetchStatus: "idle" as const,
+  };
+}
+
+describe("MediaVirtuosoGrid", () => {
+  it("does not crash when data shrinks below the initial item count", () => {
+    const fiveItems = makeItems(5);
+    const twoItems = makeItems(2);
+
+    const { rerender } = render(
+      <MediaVirtuosoGrid
+        queryResult={makeQueryResult(fiveItems)}
+        virtuosoKey="test-key"
+        notFoundLabel="No items"
+      />,
+    );
+
+    // Simulate navigation back: component re-renders with fewer items
+    // but React state (initialItemCount) is preserved from the first render.
+    expect(() => {
+      rerender(
+        <MediaVirtuosoGrid
+          queryResult={makeQueryResult(twoItems)}
+          virtuosoKey="test-key"
+          notFoundLabel="No items"
+        />,
+      );
+    }).not.toThrow();
+  });
+});

--- a/src/components/movie-database/media-virtuoso-grid.tsx
+++ b/src/components/movie-database/media-virtuoso-grid.tsx
@@ -23,7 +23,8 @@ export function MediaVirtuosoGrid({
 }: MediaVirtuosoGridProps) {
   const { data: items, fetchNextPage, hasNextPage, isFetching } = queryResult;
   const height = useViewportHeight();
-  const [initialItemCount] = useState(items.length);
+  const [storedInitialItemCount] = useState(items.length);
+  const initialItemCount = Math.min(storedInitialItemCount, items.length);
 
   if (!items.length) {
     return <div css={styles.notFound}>🙉 {notFoundLabel}</div>;


### PR DESCRIPTION
## Summary

Fixes a production crash ("Cannot read properties of undefined (reading 'mediaType')") that occurred when navigating back from a media detail page to the movie database home page. `VirtuosoGrid`'s `initialItemCount` was locked to `items.length` at first mount via `useState`; when Next.js's router cache restored the component with fewer items than the stored count — because TanStack Query had garbage-collected pages the user had scrolled to — `VirtuosoGrid` called `itemContent` with out-of-bounds indices, making `items[index]` undefined and crashing on `media.mediaType`. The fix caps `initialItemCount` to `Math.min(storedInitialItemCount, items.length)` so it never exceeds the current data length.

## Context

Developed using TDD — the regression test was written first and confirmed to reproduce the exact production crash before the fix was applied. The "Try again" button worked in production because it remounted the component fresh, resetting `useState` and avoiding the stale count.