### PR TITLE
fix: localise region name in watch providers card

### DIFF
--- a/src/components/ai-chat/tool-watch-providers.test.tsx
+++ b/src/components/ai-chat/tool-watch-providers.test.tsx
@@ -88,7 +88,9 @@ describe("ToolWatchProviders", () => {
     const data = makeRegionProviderData({ providers: null });
     render(<ToolWatchProviders data={data} />);
 
-    expect(screen.getByText("Not available in US")).toBeInTheDocument();
+    expect(
+      screen.getByText("Not available in United States"),
+    ).toBeInTheDocument();
   });
 
   it("shows JustWatch attribution text", () => {
@@ -102,7 +104,7 @@ describe("ToolWatchProviders", () => {
       <ToolWatchProviders data={makeRegionProviderData({ region: "GB" })} />,
     );
 
-    expect(screen.getByText("GB")).toBeInTheDocument();
+    expect(screen.getByText("United Kingdom")).toBeInTheDocument();
     expect(screen.getByText("Where to Watch")).toBeInTheDocument();
   });
 

--- a/src/components/ai-chat/tool-watch-providers.tsx
+++ b/src/components/ai-chat/tool-watch-providers.tsx
@@ -262,6 +262,9 @@ function ProviderSection({
 
 function RegionWatchProviders({ data }: { data: WatchProviderData }) {
   const { region, providers } = data;
+  const locale = useLocale();
+  const displayNames = getRegionDisplayNames(locale);
+  const regionDisplay = displayNames?.of(region) ?? region;
 
   return (
     <div css={styles.card}>
@@ -269,13 +272,13 @@ function RegionWatchProviders({ data }: { data: WatchProviderData }) {
         <span css={styles.title}>
           {t({ en: "Where to Watch", zh: "在哪里看" })}
         </span>
-        <span css={styles.regionBadge}>{region}</span>
+        <span css={styles.regionBadge}>{regionDisplay}</span>
       </div>
 
       {providers === null ? (
         <p css={styles.emptyText}>
           {t({ en: "Not available in ", zh: "在" })}
-          {region}
+          {regionDisplay}
           {t({ en: "", zh: "不可用" })}
         </p>
       ) : (


### PR DESCRIPTION
## Summary

`RegionWatchProviders` rendered the raw 2-letter ISO region code ("US", "GB") in both the region badge and the "Not available in …" empty-state message, while the sibling `CountryList` in the same file already localised codes to full country names. This fix resolves that inconsistency by reusing the existing `getRegionDisplayNames(locale)` helper so the badge and empty-state read "United States" / "United Kingdom" in English (and the corresponding `Intl.DisplayNames` output in other locales). The helper's try/catch fallback to the raw code is preserved, so unknown or malformed region codes still degrade gracefully.