### PR TITLE
fix: localise known_for_department labels in person cards

### DIFF
--- a/src/components/ai-chat/compact-person-card.test.tsx
+++ b/src/components/ai-chat/compact-person-card.test.tsx
@@ -33,6 +33,21 @@ describe("CompactPersonCard", () => {
     expect(screen.getByText("Acting")).toBeInTheDocument();
   });
 
+  it("falls back to raw department for unknown values", () => {
+    render(
+      <CompactPersonCard
+        person={{
+          id: 1,
+          name: "Tom Hanks",
+          profilePath: "/tom.jpg",
+          knownForDepartment: "Unknown Dept",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Unknown Dept")).toBeInTheDocument();
+  });
+
   it("omits department when knownForDepartment is null", () => {
     render(
       <CompactPersonCard

--- a/src/components/ai-chat/compact-person-card.tsx
+++ b/src/components/ai-chat/compact-person-card.tsx
@@ -10,6 +10,7 @@ import { border, color, font, space } from "#src/tokens.stylex.ts";
 import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
 import type { PersonListItem } from "#src/utils/types.ts";
 import { TmdbImage } from "../movie-database/tmdb-image";
+import { DepartmentLabel } from "./department-label";
 
 interface CompactPersonCardProps {
   person: PersonListItem;
@@ -64,7 +65,9 @@ export function CompactPersonCard({ person, onClick }: CompactPersonCardProps) {
       </div>
       <span css={styles.name}>{label}</span>
       {person.knownForDepartment && (
-        <span css={styles.department}>{person.knownForDepartment}</span>
+        <span css={styles.department}>
+          <DepartmentLabel department={person.knownForDepartment} />
+        </span>
       )}
     </>
   );

--- a/src/components/ai-chat/department-label.ts
+++ b/src/components/ai-chat/department-label.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { t } from "#src/i18n.ts";
+
+export function DepartmentLabel({ department }: { department: string }) {
+  switch (department) {
+    case "Acting":
+      return t({ en: "Acting", zh: "演员" });
+    case "Directing":
+      return t({ en: "Directing", zh: "导演" });
+    case "Writing":
+      return t({ en: "Writing", zh: "编剧" });
+    case "Production":
+      return t({ en: "Production", zh: "制片" });
+    case "Sound":
+      return t({ en: "Sound", zh: "音效" });
+    case "Camera":
+      return t({ en: "Camera", zh: "摄影" });
+    case "Editing":
+      return t({ en: "Editing", zh: "剪辑" });
+    case "Visual Effects":
+      return t({ en: "Visual Effects", zh: "视觉特效" });
+    case "Crew":
+      return t({ en: "Crew", zh: "剧组" });
+    case "Art":
+      return t({ en: "Art", zh: "美术" });
+    case "Costume & Make-Up":
+      return t({ en: "Costume & Make-Up", zh: "服装与化妆" });
+    case "Lighting":
+      return t({ en: "Lighting", zh: "灯光" });
+    default:
+      return department;
+  }
+}

--- a/src/components/ai-chat/person-detail-content.tsx
+++ b/src/components/ai-chat/person-detail-content.tsx
@@ -14,6 +14,7 @@ import type { MediaListItem } from "#src/utils/types.ts";
 import { TmdbImage } from "../movie-database/tmdb-image";
 import { Skeleton } from "../shared/skeleton";
 import { CompactMediaCard } from "./compact-media-card";
+import { DepartmentLabel } from "./department-label";
 import { HorizontalScrollRow } from "./horizontal-scroll-row";
 import { useMediaDetail, type FocusedPerson } from "./media-detail-context";
 
@@ -46,16 +47,11 @@ export function PersonDetailContent({
   // Build filmography from credits
   const filmography = buildFilmography(creditsQuery.data);
 
-  const metaParts = detail
-    ? [
-        detail.knownForDepartment,
-        detail.birthday
-          ? `${detail.birthday.split("-")[0]}${detail.deathday ? ` – ${detail.deathday.split("-")[0]}` : ""} (${t({ en: "age", zh: "年龄" })} ${String(calculateAge(detail.birthday, detail.deathday))})`
-          : null,
-      ]
-        .filter(Boolean)
-        .join(" · ")
+  const lifespan = detail?.birthday
+    ? `${detail.birthday.split("-")[0]}${detail.deathday ? ` – ${detail.deathday.split("-")[0]}` : ""} (${t({ en: "age", zh: "年龄" })} ${String(calculateAge(detail.birthday, detail.deathday))})`
     : null;
+  const hasDepartment = Boolean(detail?.knownForDepartment);
+  const hasMeta = detail && (hasDepartment || lifespan);
 
   if (detailQuery.isError) {
     return (
@@ -87,8 +83,14 @@ export function PersonDetailContent({
         ) : null}
         <div css={styles.headerInfo}>
           <h2 css={styles.name}>{displayName}</h2>
-          {metaParts ? (
-            <div css={styles.meta}>{metaParts}</div>
+          {hasMeta ? (
+            <div css={styles.meta}>
+              {detail.knownForDepartment && (
+                <DepartmentLabel department={detail.knownForDepartment} />
+              )}
+              {detail.knownForDepartment && lifespan ? " · " : null}
+              {lifespan}
+            </div>
           ) : (
             detailQuery.isPending && <Skeleton width={180} height={14} />
           )}


### PR DESCRIPTION
## Summary

`CompactPersonCard` and `PersonDetailContent` rendered TMDB's `known_for_department` value (e.g. "Acting", "Directing") directly to the UI, leaving English strings visible in the Chinese locale alongside otherwise-translated copy. This introduces a shared `DepartmentLabel` component that dispatches on the 12 TMDB-documented department values via the existing `t({en, zh})` pipeline — mirroring the `TypeLabel` pattern already used in `tool-watch-providers.tsx` — with a default case that returns the raw string so future TMDB additions degrade gracefully instead of blanking the field. The server-side tool callsites are intentionally left untouched so the LLM still sees the stable English vocabulary.

## Context

The fallback behaviour is load-bearing: TMDB's department list is not versioned in the API, so an unknown value (new department, typo, stale data) must keep rendering the raw string rather than fall through to an empty span — a regression test pins this.