### PR TITLE
feat: indicate external links across the app

### DIFF
--- a/src/components/ai-chat/markdown-content.tsx
+++ b/src/components/ai-chat/markdown-content.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { ArrowSquareOutIcon } from "@phosphor-icons/react/dist/ssr/ArrowSquareOut";
 import * as stylex from "@stylexjs/stylex";
 import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { t } from "#src/i18n.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { border, color, font, space } from "#src/tokens.stylex.ts";
+import { ExternalLinkIndicator } from "../shared/external-link-indicator";
 
 const styles = stylex.create({
   h1: {
@@ -34,24 +33,6 @@ const styles = stylex.create({
   a: {
     color: color.controlActive,
     textDecoration: "underline",
-  },
-  externalIcon: {
-    verticalAlign: "baseline",
-    position: "relative",
-    top: "0.1em",
-    marginInlineStart: "0.1em",
-    opacity: 0.7,
-  },
-  srOnly: {
-    position: "absolute",
-    width: "1px",
-    height: "1px",
-    padding: 0,
-    margin: "-1px",
-    overflow: "hidden",
-    clipPath: "inset(50%)",
-    whiteSpace: "nowrap",
-    borderWidth: 0,
   },
   ul: {
     paddingLeft: space._4,
@@ -134,21 +115,6 @@ const styles = stylex.create({
     gap: space._2,
   },
 });
-
-function ExternalLinkIndicator() {
-  return (
-    <>
-      <ArrowSquareOutIcon
-        size="0.85em"
-        css={styles.externalIcon}
-        aria-hidden="true"
-      />
-      <span css={styles.srOnly}>
-        {t({ en: "(opens in new tab)", zh: "(在新标签页中打开)" })}
-      </span>
-    </>
-  );
-}
 
 const components: Components = {
   h1: ({ node, ...props }) => <h1 css={styles.h1} {...props} />,

--- a/src/components/ai-chat/media-detail-content.tsx
+++ b/src/components/ai-chat/media-detail-content.tsx
@@ -20,6 +20,7 @@ import { formatRuntime } from "#src/utils/format-runtime.ts";
 import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
 import { TmdbImage } from "../movie-database/tmdb-image";
 import { Button } from "../shared/button";
+import { ExternalLinkIndicator } from "../shared/external-link-indicator";
 import { Skeleton } from "../shared/skeleton";
 import { useChatActions } from "./chat-actions-context";
 import { useMediaDetail, type FocusedMedia } from "./media-detail-context";
@@ -172,12 +173,13 @@ export function MediaDetailContent({
               rel="noopener noreferrer"
               aria-label={
                 locale === "zh"
-                  ? `观看${displayTitle}的预告`
-                  : `Watch trailer for ${displayTitle}`
+                  ? `观看${displayTitle}的预告 (在新标签页中打开)`
+                  : `Watch trailer for ${displayTitle} (opens in new tab)`
               }
             >
               <PlayIcon weight="fill" size={14} aria-hidden="true" />
               {t({ en: "Trailer", zh: "预告" })}
+              <ExternalLinkIndicator />
             </a>
           )}
           <AddToChatButton id={id} mediaType={mediaType} title={displayTitle} />

--- a/src/components/ai-chat/tool-watch-providers.tsx
+++ b/src/components/ai-chat/tool-watch-providers.tsx
@@ -10,6 +10,7 @@ import { border, color, font, space } from "#src/tokens.stylex.ts";
 import { buildSrcSet } from "#src/utils/tmdb-image.ts";
 import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
 import { isRecord } from "#src/utils/type-guards.ts";
+import { ExternalLinkIndicator } from "../shared/external-link-indicator";
 
 interface ProviderEntry {
   id: number;
@@ -298,6 +299,7 @@ function RegionWatchProviders({ data }: { data: WatchProviderData }) {
               en: "Data provided by JustWatch",
               zh: "数据由 JustWatch 提供",
             })}
+            <ExternalLinkIndicator />
           </a>
         ) : (
           <span>

--- a/src/components/shared/anchor-button.tsx
+++ b/src/components/shared/anchor-button.tsx
@@ -38,6 +38,7 @@ export function AnchorButton({
     <Anchor
       aria-current={isActive ? "true" : undefined}
       {...restProps}
+      indicateExternal={false}
       ref={anchorRef}
       className={className}
       style={{ ...style, ...pressedStyle }}

--- a/src/components/shared/anchor.test.tsx
+++ b/src/components/shared/anchor.test.tsx
@@ -17,7 +17,9 @@ describe("Anchor", () => {
       </Anchor>,
     );
 
-    const link = screen.getByRole("link", { name: "External" });
+    const link = screen.getByRole("link", {
+      name: "External(opens in new tab)",
+    });
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });
 
@@ -28,7 +30,9 @@ describe("Anchor", () => {
       </Anchor>,
     );
 
-    const link = screen.getByRole("link", { name: "External" });
+    const link = screen.getByRole("link", {
+      name: "External(opens in new tab)",
+    });
     const rel = link.getAttribute("rel");
     expect(rel).toContain("nofollow");
     expect(rel).toContain("me");
@@ -47,12 +51,14 @@ describe("Anchor", () => {
       </Anchor>,
     );
 
-    const link = screen.getByRole("link", { name: "External" });
+    const link = screen.getByRole("link", {
+      name: "External(opens in new tab)",
+    });
     const rel = link.getAttribute("rel");
     if (!rel) throw new Error("expected rel attribute");
     const tokens = rel.split(/\s+/);
-    expect(tokens.filter((t) => t === "noopener")).toHaveLength(1);
-    expect(tokens.filter((t) => t === "noreferrer")).toHaveLength(1);
+    expect(tokens.filter((token) => token === "noopener")).toHaveLength(1);
+    expect(tokens.filter((token) => token === "noreferrer")).toHaveLength(1);
   });
 
   it("does not add rel when target is not _blank", () => {
@@ -60,5 +66,39 @@ describe("Anchor", () => {
 
     const link = screen.getByRole("link", { name: "Local" });
     expect(link).not.toHaveAttribute("rel");
+  });
+
+  it("announces 'opens in new tab' for _blank links", () => {
+    render(
+      <Anchor href="https://example.com" target="_blank">
+        External
+      </Anchor>,
+    );
+
+    expect(
+      screen.getByRole("link", { name: "External(opens in new tab)" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the external indicator for internal links", () => {
+    render(<Anchor href="/local">Local</Anchor>);
+
+    const link = screen.getByRole("link", { name: "Local" });
+    expect(link).toHaveAccessibleName("Local");
+  });
+
+  it("suppresses the external indicator when indicateExternal is false", () => {
+    render(
+      <Anchor
+        href="https://example.com"
+        target="_blank"
+        indicateExternal={false}
+      >
+        External
+      </Anchor>,
+    );
+
+    const link = screen.getByRole("link", { name: "External" });
+    expect(link).toHaveAccessibleName("External");
   });
 });

--- a/src/components/shared/anchor.tsx
+++ b/src/components/shared/anchor.tsx
@@ -5,6 +5,17 @@ import Link from "next/link";
 import { useState } from "react";
 import { border, color } from "#src/tokens.stylex.ts";
 import { anchorTokens } from "./anchor.stylex";
+import { ExternalLinkIndicator } from "./external-link-indicator";
+
+interface AnchorExtraProps {
+  /**
+   * Show the external-link icon and screen-reader "opens in new tab" label
+   * when `target="_blank"`. Defaults to true. Opt out for wrappers that
+   * already render their own external-link affordance (e.g. `Card`, or
+   * icon-slot-driven buttons).
+   */
+  indicateExternal?: boolean;
+}
 
 export function Anchor({
   className,
@@ -14,13 +25,17 @@ export function Anchor({
   rel,
   target,
   ref,
+  children,
+  indicateExternal = true,
   ...props
-}: React.ComponentProps<typeof Link>) {
+}: React.ComponentProps<typeof Link> & AnchorExtraProps) {
   const [hovered, setHovered] = useState(false);
 
   // Automatically ensure noopener and noreferrer are present for _blank links
   const resolvedRel =
     target === "_blank" ? mergeRel(rel, "noopener noreferrer") : rel;
+
+  const showIndicator = indicateExternal && target === "_blank";
 
   return (
     <Link
@@ -36,7 +51,10 @@ export function Anchor({
       className={className}
       style={style}
       css={styles.a}
-    />
+    >
+      {children}
+      {showIndicator && <ExternalLinkIndicator />}
+    </Link>
   );
 }
 

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -19,7 +19,13 @@ type CardProps = React.ComponentProps<typeof Anchor>;
 
 export function Card({ children, className, style, ...rest }: CardProps) {
   return (
-    <Anchor {...rest} className={className} style={style} css={styles.card}>
+    <Anchor
+      {...rest}
+      indicateExternal={false}
+      className={className}
+      style={style}
+      css={styles.card}
+    >
       {children}
       <div css={styles.detailsBackdrop} />
       <div css={styles.detailsIndicator}>

--- a/src/components/shared/external-link-indicator.tsx
+++ b/src/components/shared/external-link-indicator.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { ArrowSquareOutIcon } from "@phosphor-icons/react/dist/ssr/ArrowSquareOut";
+import * as stylex from "@stylexjs/stylex";
+import { t } from "#src/i18n.ts";
+
+export function ExternalLinkIndicator() {
+  return (
+    <>
+      <ArrowSquareOutIcon size="0.85em" css={styles.icon} aria-hidden="true" />
+      <span css={styles.srOnly}>
+        {t({ en: "(opens in new tab)", zh: "(在新标签页中打开)" })}
+      </span>
+    </>
+  );
+}
+
+const styles = stylex.create({
+  icon: {
+    verticalAlign: "baseline",
+    position: "relative",
+    top: "0.1em",
+    marginInlineStart: "0.1em",
+    opacity: 0.7,
+  },
+  srOnly: {
+    position: "absolute",
+    width: "1px",
+    height: "1px",
+    padding: 0,
+    margin: "-1px",
+    overflow: "hidden",
+    clipPath: "inset(50%)",
+    whiteSpace: "nowrap",
+    borderWidth: 0,
+  },
+});


### PR DESCRIPTION
## Summary

Extracts the AI-chat markdown "external link" affordance (arrow icon + sr-only "opens in new tab" / "在新标签页中打开") into a shared `ExternalLinkIndicator` primitive, and wires it into the `Anchor` component so every `target="_blank"` link automatically gains a visual and screen-reader hint. Wrappers that already own their own external-facing affordance opt out via a new `indicateExternal` prop: `Card` (its "Details →" hover indicator would collide) and `AnchorButton` (its icon slot drives layout). Two plain `<a>` call sites — the JustWatch attribution and the YouTube trailer link — render the indicator manually; the trailer's `aria-label` is extended with the localised new-tab hint so the announcement survives the `aria-label`-overrides-children rule.

## Context

Centralising on `Anchor` makes the invariant load-bearing: future external links get the affordance by default rather than silently missing it. The opt-out defaults to `indicateExternal={true}` precisely so a forgetful author still gets correct behaviour; the two opt-out sites are wrappers that render their own indicator, not individual link call sites.