### PR TITLE
fix: manage focus and announce the clear-all confirmation

### DIFF
--- a/src/components/ai-chat/preference-panel.test.tsx
+++ b/src/components/ai-chat/preference-panel.test.tsx
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { PortalTargetProvider } from "#src/components/shared/fixed-element-portal-target.tsx";
+import type { StoredPreference } from "#src/preference-store/preference-store.ts";
+import { render, screen, userEvent } from "#src/test-utils.tsx";
+import { PreferencePanel } from "./preference-panel";
+
+const samplePreferences: ReadonlyArray<StoredPreference> = [
+  {
+    id: "genre:action",
+    category: "genre",
+    value: "Action",
+    sentiment: "like",
+    updatedAt: 1,
+  },
+];
+
+function renderPanel(
+  overrides: Partial<React.ComponentProps<typeof PreferencePanel>> = {},
+) {
+  const props: React.ComponentProps<typeof PreferencePanel> = {
+    isOpen: true,
+    onClose: vi.fn(),
+    preferences: samplePreferences,
+    onRemove: vi.fn(),
+    onClearAll: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+  return render(
+    <PortalTargetProvider>
+      <PreferencePanel {...props} />
+    </PortalTargetProvider>,
+  );
+}
+
+describe("PreferencePanel clear-all confirmation", () => {
+  it("moves focus to Cancel when the confirmation row appears", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(
+      screen.getByRole("button", { name: "Clear all preferences" }),
+    );
+
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveFocus();
+  });
+
+  it("returns focus to the Clear trigger when the user cancels", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(
+      screen.getByRole("button", { name: "Clear all preferences" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(
+      screen.getByRole("button", { name: "Clear all preferences" }),
+    ).toHaveFocus();
+  });
+
+  it("announces the confirmation prompt via a live region", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(
+      screen.getByRole("button", { name: "Clear all preferences" }),
+    );
+
+    const status = screen.getByRole("status");
+    expect(status).toHaveTextContent("Clear all preferences?");
+  });
+
+  it("keeps the live region mounted and empty when not confirming", () => {
+    renderPanel();
+
+    const status = screen.getByRole("status");
+    expect(status).toHaveTextContent("");
+  });
+
+  it("does not steal focus from the close button on initial open", async () => {
+    renderPanel();
+
+    // DetailOverlay's useDialogFocus focuses initialFocusRef (close button)
+    // asynchronously; the clear-all effect must not override that.
+    await vi.waitFor(() => {
+      expect(screen.getByRole("button", { name: "Close" })).toHaveFocus();
+    });
+  });
+});

--- a/src/components/ai-chat/preference-panel.tsx
+++ b/src/components/ai-chat/preference-panel.tsx
@@ -7,7 +7,7 @@ import { ThumbsUpIcon } from "@phosphor-icons/react/dist/ssr/ThumbsUp";
 import { TrashIcon } from "@phosphor-icons/react/dist/ssr/Trash";
 import { XIcon } from "@phosphor-icons/react/dist/ssr/X";
 import * as stylex from "@stylexjs/stylex";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { t } from "#src/i18n.ts";
 import type { StoredPreference } from "#src/preference-store/preference-store.ts";
 import { usePreferences } from "#src/preference-store/use-preferences.ts";
@@ -96,7 +96,7 @@ interface PreferencePanelProps {
   onClearAll: () => Promise<void>;
 }
 
-function PreferencePanel({
+export function PreferencePanel({
   isOpen,
   onClose,
   preferences,
@@ -104,7 +104,27 @@ function PreferencePanel({
   onClearAll,
 }: PreferencePanelProps) {
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const clearTriggerRef = useRef<HTMLButtonElement>(null);
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
   const [confirmingClear, setConfirmingClear] = useState(false);
+  const didMountRef = useRef(false);
+
+  // When the confirmation row appears, move focus to Cancel (safer default for
+  // a destructive confirm). When it's dismissed by the user, return focus to
+  // the Clear trigger — but only if it's still in the DOM, which it isn't when
+  // the clear succeeded and the last preference was removed. Skip the initial
+  // render so we don't steal focus from DetailOverlay's initialFocusRef.
+  useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
+    if (confirmingClear) {
+      cancelButtonRef.current?.focus();
+    } else {
+      clearTriggerRef.current?.focus();
+    }
+  }, [confirmingClear]);
 
   const grouped = new Map<StoredPreference["category"], StoredPreference[]>();
   for (const pref of preferences) {
@@ -200,6 +220,7 @@ function PreferencePanel({
                 {t({ en: "Yes, clear", zh: "确认清除" })}
               </button>
               <button
+                ref={cancelButtonRef}
                 type="button"
                 css={[buttonReset.base, styles.cancelButton]}
                 onClick={() => {
@@ -211,6 +232,7 @@ function PreferencePanel({
             </div>
           ) : (
             <button
+              ref={clearTriggerRef}
               type="button"
               css={[buttonReset.base, flex.row, styles.clearButton]}
               onClick={() => {
@@ -224,6 +246,17 @@ function PreferencePanel({
               })}
             </button>
           )}
+          {/* Stable live region: mounted whenever the footer is, populated
+              only while confirming, so AT reliably detects the content
+              change and announces the prompt. */}
+          <div role="status" aria-live="polite" css={styles.srOnly}>
+            {confirmingClear
+              ? t({
+                  en: "Clear all preferences? Confirm or cancel.",
+                  zh: "清除所有偏好？请确认或取消。",
+                })
+              : ""}
+          </div>
         </div>
       )}
     </DetailOverlay>
@@ -478,5 +511,16 @@ const styles = stylex.create({
     color: color.textMuted,
     cursor: "pointer",
     transition: "background-color 0.15s ease",
+  },
+  srOnly: {
+    position: "absolute",
+    width: "1px",
+    height: "1px",
+    padding: 0,
+    margin: "-1px",
+    overflow: "hidden",
+    clipPath: "inset(50%)",
+    whiteSpace: "nowrap",
+    borderWidth: 0,
   },
 });


### PR DESCRIPTION
## Summary

The inline "Clear all preferences" confirmation in the preference panel had no focus management and no screen-reader announcement — keyboard users stayed on the now-hidden Clear trigger when the confirm row appeared, and AT users got no signal that the destructive prompt had rendered. This PR moves focus to Cancel when the confirm row mounts (the safer default for a destructive confirm), returns focus to the Clear trigger when the user cancels, and adds a stable `role="status"` live region that is mounted whenever the footer is but only populated with the prompt text while confirming — a content-change pattern that AT combinations detect more reliably than conditionally mounting a live region. A `didMountRef` guard stops the effect from stealing focus from `DetailOverlay`'s `initialFocusRef` (the close button) on initial open.

## Context

A few adjacent concerns were intentionally left out of scope: the Cancel/"Yes, clear" buttons remain interactive while `onClearAll()` is in flight, Escape inside the confirm row still closes the whole dialog via `useDialogFocus`, and `confirmingClear` is not reset when the panel closes (re-opening mid-confirm still shows the prompt). Each is a separate behavioural change with its own trade-offs; this PR deliberately sticks to the focus + AT gap.