### PR TITLE
fix: expose biography read-more as an ARIA disclosure

### DIFF
--- a/src/components/ai-chat/person-detail-content.test.tsx
+++ b/src/components/ai-chat/person-detail-content.test.tsx
@@ -1,0 +1,84 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { render, screen, userEvent } from "#src/test-utils.tsx";
+import { ExpandableBiography } from "./person-detail-content";
+
+// jsdom does not compute layout, so scrollHeight/clientHeight default to 0 and
+// the biography never registers as "clamped". Stub the Element prototype so
+// ExpandableBiography's ResizeObserver callback computes scrollHeight > clientHeight.
+// ResizeObserver is also absent in jsdom — provide a no-op to avoid
+// constructor errors.
+const originalScrollHeight = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  "scrollHeight",
+);
+const originalClientHeight = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  "clientHeight",
+);
+const originalResizeObserver = globalThis.ResizeObserver;
+
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+    configurable: true,
+    get: () => 200,
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get: () => 100,
+  });
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+afterAll(() => {
+  if (originalScrollHeight) {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      "scrollHeight",
+      originalScrollHeight,
+    );
+  }
+  if (originalClientHeight) {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      "clientHeight",
+      originalClientHeight,
+    );
+  }
+  globalThis.ResizeObserver = originalResizeObserver;
+});
+
+const LONG_BIO =
+  "Tom Hanks is an American actor and filmmaker known for both his comedic and dramatic roles.";
+
+describe("ExpandableBiography disclosure semantics", () => {
+  it("exposes aria-expanded='false' when collapsed", () => {
+    render(<ExpandableBiography text={LONG_BIO} />);
+
+    const button = screen.getByRole("button", { name: "Read more" });
+    expect(button).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("flips aria-expanded to 'true' after clicking Read more", async () => {
+    const user = userEvent.setup();
+    render(<ExpandableBiography text={LONG_BIO} />);
+
+    await user.click(screen.getByRole("button", { name: "Read more" }));
+
+    const button = screen.getByRole("button", { name: "Read less" });
+    expect(button).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("points aria-controls at the biography paragraph", () => {
+    render(<ExpandableBiography text={LONG_BIO} />);
+
+    const button = screen.getByRole("button", { name: "Read more" });
+    const controlsId = button.getAttribute("aria-controls");
+    expect(controlsId).toBeTruthy();
+    const paragraph = document.getElementById(controlsId ?? "");
+    expect(paragraph).toHaveTextContent(LONG_BIO);
+  });
+});

--- a/src/components/ai-chat/person-detail-content.tsx
+++ b/src/components/ai-chat/person-detail-content.tsx
@@ -2,7 +2,7 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { useQueries } from "@tanstack/react-query";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { breakpoints } from "#src/breakpoints.stylex.ts";
 import { useLocale } from "#src/hooks/use-locale.ts";
 import { t } from "#src/i18n.ts";
@@ -138,10 +138,11 @@ function ProfileImage({
 
 const LINE_CLAMP = 6;
 
-function ExpandableBiography({ text }: { text: string }) {
+export function ExpandableBiography({ text }: { text: string }) {
   const [expanded, setExpanded] = useState(false);
   const [isClamped, setIsClamped] = useState(false);
   const paragraphRef = useRef<HTMLParagraphElement>(null);
+  const biographyId = useId();
 
   // Observe layout changes on the paragraph itself. `measure` reads live
   // DOM (scrollHeight vs clientHeight) rather than closing over `expanded`,
@@ -168,6 +169,7 @@ function ExpandableBiography({ text }: { text: string }) {
   return (
     <div>
       <p
+        id={biographyId}
         ref={paragraphRef}
         css={[styles.biography, !expanded && styles.biographyClamped]}
       >
@@ -177,6 +179,8 @@ function ExpandableBiography({ text }: { text: string }) {
         <button
           type="button"
           css={[buttonReset.base, styles.readMoreButton]}
+          aria-expanded={expanded}
+          aria-controls={biographyId}
           onClick={() => {
             setExpanded((prev) => !prev);
           }}


### PR DESCRIPTION
## Summary

The "Read more" / "Read less" toggle in `ExpandableBiography` had no ARIA state, so screen-reader users had no way to know the button toggled hidden content or that the state had flipped. This wires it up as a standard disclosure: the button carries `aria-expanded={expanded}` (mirroring the `ToolActivityGroup` precedent) and `aria-controls` pointing at the biography paragraph, whose id is generated via `useId()` — the same primitive already used in `menu-button.tsx` and `genre-filter.tsx`. The paragraph remains mounted at all times (only CSS-clamped), which is what makes pairing `aria-controls` appropriate here.

## Context

The test file shims `scrollHeight`, `clientHeight`, and `ResizeObserver` at the jsdom level because those APIs are absent in jsdom and the existing clamp-measurement code relies on them — the pattern matches `calculator-display.test.tsx` (ResizeObserver shim) and `anchor-button.test.tsx` (setPointerCapture shim), so no `vi.mock` of application modules was introduced.