### PR TITLE
fix: announce sort direction and next action to assistive tech

### DIFF
--- a/e2e/movie-tv-browsing.spec.ts
+++ b/e2e/movie-tv-browsing.spec.ts
@@ -26,8 +26,12 @@ test.describe("Movie and TV Show Browsing", () => {
     await expect(page.getByRole("button", { name: /^genre/i })).toBeVisible();
 
     // Verify sort links (Popularity and Rating)
-    await expect(page.getByRole("link", { name: /popularity/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /rating/i })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /sort by popularity/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /sort by rating/i }),
+    ).toBeVisible();
   });
 
   test("should toggle between movies and TV shows", async ({ page }) => {
@@ -93,17 +97,19 @@ test.describe("Movie and TV Show Browsing", () => {
 
   test("should toggle between popularity and rating sort", async ({ page }) => {
     // Click the Rating sort link
-    await page.getByRole("link", { name: /^rating/i }).click();
+    await page.getByRole("link", { name: /sort by rating/i }).click();
 
-    // Verify rating link is now active
-    await expect(page.getByRole("link", { name: /rating.*↓/i })).toBeVisible();
+    // Verify rating link is now active (descending)
+    await expect(
+      page.getByRole("link", { name: /sort by rating, descending/i }),
+    ).toBeVisible();
 
     // Click popularity to switch back
-    await page.getByRole("link", { name: /^popularity/i }).click();
+    await page.getByRole("link", { name: /sort by popularity/i }).click();
 
-    // Verify popularity is now active
+    // Verify popularity is now active (descending)
     await expect(
-      page.getByRole("link", { name: /popularity.*↓/i }),
+      page.getByRole("link", { name: /sort by popularity, descending/i }),
     ).toBeVisible();
   });
 
@@ -123,10 +129,12 @@ test.describe("Movie and TV Show Browsing", () => {
     await page.locator("main").click({ position: { x: 10, y: 10 } });
 
     // Change sort to rating
-    await page.getByRole("link", { name: /^rating/i }).click();
+    await page.getByRole("link", { name: /sort by rating/i }).click();
 
-    // Verify rating is active
-    await expect(page.getByRole("link", { name: /rating.*↓/i })).toBeVisible();
+    // Verify rating is active (descending)
+    await expect(
+      page.getByRole("link", { name: /sort by rating, descending/i }),
+    ).toBeVisible();
 
     // Verify reset button is visible
     await expect(page.getByRole("link", { name: /reset/i })).toBeVisible();
@@ -137,7 +145,7 @@ test.describe("Movie and TV Show Browsing", () => {
     // Verify filters are cleared (genre button back to no count, popularity active)
     await expect(page.getByRole("button", { name: /^genre$/i })).toBeVisible();
     await expect(
-      page.getByRole("link", { name: /popularity.*↓/i }),
+      page.getByRole("link", { name: /sort by popularity, descending/i }),
     ).toBeVisible();
   });
 
@@ -185,13 +193,15 @@ test.describe("Movie and TV Show Browsing", () => {
     await page.locator("main").click({ position: { x: 10, y: 10 } });
 
     // Change sort
-    await page.getByRole("link", { name: /^rating/i }).click();
+    await page.getByRole("link", { name: /sort by rating/i }).click();
 
     // Verify both filters are visible in UI (persisted)
     await expect(
       page.getByRole("button", { name: /genre.*\(1\)/i }),
     ).toBeVisible();
-    await expect(page.getByRole("link", { name: /rating.*↓/i })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /sort by rating, descending/i }),
+    ).toBeVisible();
 
     // Reload page to test persistence
     await page.reload();
@@ -200,7 +210,9 @@ test.describe("Movie and TV Show Browsing", () => {
     await expect(
       page.getByRole("button", { name: /genre.*\(1\)/i }),
     ).toBeVisible();
-    await expect(page.getByRole("link", { name: /rating.*↓/i })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /sort by rating, descending/i }),
+    ).toBeVisible();
   });
 
   test("should load page with filters from URL parameters", async ({
@@ -217,7 +229,9 @@ test.describe("Movie and TV Show Browsing", () => {
     await expect(
       page.getByRole("button", { name: /genre.*\(1\)/i }),
     ).toBeVisible();
-    await expect(page.getByRole("link", { name: /rating.*↓/i })).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /sort by rating, descending/i }),
+    ).toBeVisible();
   });
 
   test("should navigate to movie and TV show detail pages from cards", async ({

--- a/src/components/movie-database/sort-filter.test.tsx
+++ b/src/components/movie-database/sort-filter.test.tsx
@@ -1,0 +1,116 @@
+import { PathnameContext } from "next/dist/shared/lib/hooks-client-context.shared-runtime";
+import type { ReactNode } from "react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent } from "#src/test-utils.tsx";
+import { MediaFiltersProvider } from "./media-filters-provider";
+import { SortFilter } from "./sort-filter";
+
+beforeAll(() => {
+  HTMLElement.prototype.setPointerCapture = vi.fn();
+  HTMLElement.prototype.releasePointerCapture = vi.fn();
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    media: "",
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  });
+});
+
+function Harness({ children }: { children: ReactNode }) {
+  return (
+    <PathnameContext value="/movie-database">
+      <MediaFiltersProvider>{children}</MediaFiltersProvider>
+    </PathnameContext>
+  );
+}
+
+function getPopularityButton() {
+  return screen.getByRole("link", {
+    name: /Sort by Popularity/,
+  });
+}
+
+function getRatingButton() {
+  return screen.getByRole("link", {
+    name: /Sort by Rating/,
+  });
+}
+
+describe("SortFilter aria-label direction semantics", () => {
+  it("labels the default active Popularity button as descending with a prompt to flip", () => {
+    render(
+      <Harness>
+        <SortFilter />
+      </Harness>,
+    );
+
+    expect(getPopularityButton()).toHaveAttribute(
+      "aria-label",
+      "Sort by Popularity, descending. Activate to sort ascending.",
+    );
+  });
+
+  it("labels the inactive Rating button without a direction", () => {
+    render(
+      <Harness>
+        <SortFilter />
+      </Harness>,
+    );
+
+    expect(getRatingButton()).toHaveAttribute("aria-label", "Sort by Rating.");
+  });
+
+  it("flips to ascending aria-label after clicking the active Popularity button", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness>
+        <SortFilter />
+      </Harness>,
+    );
+
+    await user.click(getPopularityButton());
+
+    expect(getPopularityButton()).toHaveAttribute(
+      "aria-label",
+      "Sort by Popularity, ascending. Activate to sort descending.",
+    );
+  });
+
+  it("activates Rating in descending mode when switching sort fields", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness>
+        <SortFilter />
+      </Harness>,
+    );
+
+    await user.click(getRatingButton());
+
+    expect(getRatingButton()).toHaveAttribute(
+      "aria-label",
+      "Sort by Rating, descending. Activate to sort ascending.",
+    );
+    // Popularity reverts to inactive copy once Rating takes over.
+    expect(getPopularityButton()).toHaveAttribute(
+      "aria-label",
+      "Sort by Popularity.",
+    );
+  });
+
+  it("hides the visual arrow from assistive technology", () => {
+    render(
+      <Harness>
+        <SortFilter />
+      </Harness>,
+    );
+
+    const popularity = getPopularityButton();
+    const arrowSpan = popularity.querySelector("span[aria-hidden='true']");
+    expect(arrowSpan).toBeInTheDocument();
+    expect(arrowSpan?.textContent).toContain("↓");
+  });
+});

--- a/src/components/movie-database/sort-filter.tsx
+++ b/src/components/movie-database/sort-filter.tsx
@@ -11,8 +11,47 @@ interface SortFilterProps {
   hideLabel?: boolean;
 }
 
+type SortDirection = "asc" | "desc" | null;
+
 export function SortFilter({ bright, hideLabel }: SortFilterProps) {
   const { sort, setSort, setSortUrl } = useMediaFilters();
+
+  const popularityDirection: SortDirection =
+    sort === "popularity.asc"
+      ? "asc"
+      : sort === "popularity.desc"
+        ? "desc"
+        : null;
+  const ratingDirection: SortDirection =
+    sort === "vote_average.asc"
+      ? "asc"
+      : sort === "vote_average.desc"
+        ? "desc"
+        : null;
+
+  const popularityLabel = t({ en: "Popularity", zh: "热度" });
+  const ratingLabel = t({ en: "Rating", zh: "评分" });
+
+  const sortByPrefix = t({ en: "Sort by ", zh: "按 " });
+  const descendingClause = t({
+    en: ", descending. Activate to sort ascending.",
+    zh: " 排序，降序。点击切换为升序。",
+  });
+  const ascendingClause = t({
+    en: ", ascending. Activate to sort descending.",
+    zh: " 排序，升序。点击切换为降序。",
+  });
+  const inactiveClause = t({ en: ".", zh: " 排序。" });
+
+  function buildAriaLabel(fieldLabel: string, direction: SortDirection) {
+    const suffix =
+      direction === "asc"
+        ? ascendingClause
+        : direction === "desc"
+          ? descendingClause
+          : inactiveClause;
+    return `${sortByPrefix}${fieldLabel}${suffix}`;
+  }
 
   return (
     <div>
@@ -24,20 +63,25 @@ export function SortFilter({ bright, hideLabel }: SortFilterProps) {
               ? setSortUrl("popularity.asc")
               : setSortUrl("popularity.desc")
           }
-          isActive={sort === "popularity.asc" || sort === "popularity.desc"}
+          isActive={popularityDirection !== null}
           onClick={(e) => {
             e.preventDefault();
             setSort(
               sort === "popularity.desc" ? "popularity.asc" : "popularity.desc",
             );
           }}
+          aria-label={buildAriaLabel(popularityLabel, popularityDirection)}
           bright={bright}
           rel="nofollow"
           prefetch={false}
         >
-          {t({ en: "Popularity", zh: "热度" })}
-          {sort === "popularity.asc" && " ↑"}
-          {sort === "popularity.desc" && " ↓"}
+          {popularityLabel}
+          {popularityDirection === "asc" && (
+            <span aria-hidden="true">{" ↑"}</span>
+          )}
+          {popularityDirection === "desc" && (
+            <span aria-hidden="true">{" ↓"}</span>
+          )}
         </AnchorButton>
         <AnchorButton
           href={
@@ -45,7 +89,7 @@ export function SortFilter({ bright, hideLabel }: SortFilterProps) {
               ? setSortUrl("vote_average.asc")
               : setSortUrl("vote_average.desc")
           }
-          isActive={sort === "vote_average.asc" || sort === "vote_average.desc"}
+          isActive={ratingDirection !== null}
           onClick={(e) => {
             e.preventDefault();
             setSort(
@@ -54,13 +98,14 @@ export function SortFilter({ bright, hideLabel }: SortFilterProps) {
                 : "vote_average.desc",
             );
           }}
+          aria-label={buildAriaLabel(ratingLabel, ratingDirection)}
           bright={bright}
           rel="nofollow"
           prefetch={false}
         >
-          {t({ en: "Rating", zh: "评分" })}
-          {sort === "vote_average.asc" && " ↑"}
-          {sort === "vote_average.desc" && " ↓"}
+          {ratingLabel}
+          {ratingDirection === "asc" && <span aria-hidden="true">{" ↑"}</span>}
+          {ratingDirection === "desc" && <span aria-hidden="true">{" ↓"}</span>}
         </AnchorButton>
       </AnchorButtonGroup>
     </div>


### PR DESCRIPTION
## Summary

The Popularity and Rating sort toggles in the movie-database filter bar rendered direction via raw `↑` / `↓` glyphs with no aria-label, so screen readers literally announced "up arrow" / "down arrow" and never communicated which direction was active or what a click would do. This wraps the glyphs in `aria-hidden` spans and builds an `aria-label` for each toggle that covers three states: active descending ("Sort by $, descending. Activate to sort ascending."), active ascending ("Sort by $, ascending. Activate to sort descending."), and inactive ("Sort by $."). Direction semantics live at the sort-filter call site rather than in `AnchorButton`, which keeps the toggle-specific copy out of the shared primitive. `aria-current="true"` already emitted by `AnchorButton` when `isActive` is preserved.

## Context

`aria-sort` was deliberately not used — these are toggle buttons, not table header cells, so the column-sort role doesn't fit. The new copy is constructed from pre-computed `t()` values at the top of the component body (not inside the `buildAriaLabel` helper), which keeps the `i18n/no-t-outside-render` ESLint rule happy without needing a lint-disable.