### PR TITLE
fix: format review-summary rating with locale and a11y label

### DIFF
--- a/src/components/ai-chat/tool-review-summary.test.tsx
+++ b/src/components/ai-chat/tool-review-summary.test.tsx
@@ -74,6 +74,31 @@ describe("ToolReviewSummary", () => {
     expect(screen.getByText(/8\.2/)).toBeInTheDocument();
   });
 
+  it("rounds fractional ratings to one decimal", () => {
+    renderWithActions(
+      <ToolReviewSummary
+        data={makeReviewData({ averageRating: 7.4234 })}
+        isInteractive
+      />,
+    );
+
+    expect(screen.getByText("★ 7.4")).toBeInTheDocument();
+    expect(screen.queryByText(/7\.4234/)).not.toBeInTheDocument();
+  });
+
+  it("exposes an accessible rating label", () => {
+    renderWithActions(
+      <ToolReviewSummary
+        data={makeReviewData({ averageRating: 7.4234 })}
+        isInteractive
+      />,
+    );
+
+    expect(
+      screen.getByRole("img", { name: "Average rating: 7.4 out of 10" }),
+    ).toBeInTheDocument();
+  });
+
   it("omits average rating when null", () => {
     renderWithActions(
       <ToolReviewSummary

--- a/src/components/ai-chat/tool-review-summary.tsx
+++ b/src/components/ai-chat/tool-review-summary.tsx
@@ -84,6 +84,14 @@ export function ToolReviewSummary({
   const locale = useLocale();
   const [selectedLevel, setSelectedLevel] = useState<number | null>(null);
 
+  const ratingFormatter = new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 1,
+  });
+  const formattedRating =
+    data.averageRating !== null
+      ? ratingFormatter.format(data.averageRating)
+      : null;
+
   const spicinessLabels: Record<number, string> = {
     1: t({ en: "Mild", zh: "温和" }),
     2: t({ en: "Chill", zh: "平淡" }),
@@ -121,10 +129,13 @@ export function ToolReviewSummary({
           {t({ en: "Review Summary", zh: "评论摘要" })}
         </span>
         <div css={[flex.row, styles.badges]}>
-          {data.averageRating !== null && (
-            <span css={styles.ratingBadge}>
-              {"★ "}
-              {data.averageRating}
+          {formattedRating !== null && (
+            <span
+              css={styles.ratingBadge}
+              role="img"
+              aria-label={`${t({ en: "Average rating", zh: "平均评分" })}: ${formattedRating}${t({ en: " out of 10", zh: "/10" })}`}
+            >
+              <span aria-hidden="true">{`★ ${formattedRating}`}</span>
             </span>
           )}
           <span css={styles.countBadge}>


### PR DESCRIPTION
## Summary

`ToolReviewSummary` rendered `data.averageRating` as the raw numeric value, so a TMDB rating like `7.4234` surfaced as "★ 7.4234" instead of "★ 7.4" — breaking parity with every other rating display in the app (`media-poster.tsx`, `media-detail-hero.tsx`, `media-detail-content.tsx`), which all use `Intl.NumberFormat(locale, { maximumFractionDigits: 1 })`. The badge also had no accessible label, so screen readers announced "star 7.4" literally. This runs the rating through the same locale formatter and wraps the visible glyph+number in an `aria-hidden` span, with `role="img"` + `aria-label="Average rating: 7.4 out of 10"` on the badge — matching the shape already used by `media-detail-content.tsx:143` for the same rating-badge pattern.

## Context

The server-side contract is deliberately untouched — `averageRating: number | null` still flows to the LLM as a raw numeric value, and the null sentinel still omits the badge entirely. Only the UI formatting and the accessible name change.