### PR TITLE
chore: remove defaultMode bypass from project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,5 @@
 {
   "permissions": {
-    "defaultMode": "bypassPermissions",
     "deny": ["Read(./.env)", "Read(./.env.*)"]
   },
   "hooks": {


### PR DESCRIPTION
## Summary

Removes the `defaultMode: "bypassPermissions"` override from the project's `.claude/settings.json`. This setting is now configured at the user-level Claude Code settings globally, making the project-level override redundant. The `.env` deny rules and all hooks are preserved.