### PR TITLE
fix: add machine-readable dateTime to portfolio time elements

### DIFF
--- a/src/app/[locale]/(home)/(details)/education/altrincham-grammar-school-for-boys/page.tsx
+++ b/src/app/[locale]/(home)/(details)/education/altrincham-grammar-school-for-boys/page.tsx
@@ -75,6 +75,7 @@ export default function Page() {
           zh: "A-Levels（普通教育高级程度证书）",
         })}
         date={t({ en: "Sep 2011 - Jul 2013", zh: "2011年9月 - 2013年7月" })}
+        dateTime="2011-09"
       />
       <p>{t({ en: "Results: A*AAB", zh: "成绩: A*AAB" })}</p>
       <p>{t({ en: "Subjects:", zh: "科目：" })}</p>

--- a/src/app/[locale]/(home)/(details)/education/university-of-bristol/page.tsx
+++ b/src/app/[locale]/(home)/(details)/education/university-of-bristol/page.tsx
@@ -61,6 +61,7 @@ export default function Page() {
           zh: "理学硕士 - 高级计算机 创新技术",
         })}
         date={t({ en: "Sep 2016 - Jan 2018", zh: "2016年9月 - 2018年1月" })}
+        dateTime="2016-09"
       />
       <p>{t({ en: "Grade: Merit", zh: "学位等级：优等" })}</p>
       <p>{t({ en: "Core Courses:", zh: "核心科目：" })}</p>

--- a/src/app/[locale]/(home)/(details)/education/university-of-nottingham/page.tsx
+++ b/src/app/[locale]/(home)/(details)/education/university-of-nottingham/page.tsx
@@ -63,6 +63,7 @@ export default function Page() {
           zh: "荣誉理学学士 - 计算机科学",
         })}
         date={t({ en: "Sep 2013 - Jul 2016", zh: "2013年9月 - 2016年7月" })}
+        dateTime="2013-09"
       />
       <p>
         {t({ en: "Grade: First-class Honours", zh: "学位等级：一等荣誉学位" })}

--- a/src/app/[locale]/(home)/(details)/experiences/citadel/page.tsx
+++ b/src/app/[locale]/(home)/(details)/experiences/citadel/page.tsx
@@ -54,6 +54,7 @@ export default function Page() {
         title="Citadel"
         role={t({ en: "Software Engineer", zh: "软件工程师" })}
         date={t({ en: "Aug 2021 - Now", zh: "2021年8月 至今" })}
+        dateTime="2021-08"
       />
       <p>
         {t({

--- a/src/app/[locale]/(home)/(details)/experiences/spotify/page.tsx
+++ b/src/app/[locale]/(home)/(details)/experiences/spotify/page.tsx
@@ -54,6 +54,7 @@ export default function Page() {
         title="Spotify"
         role={t({ en: "Software Engineer II", zh: "软件工程师 II" })}
         date={t({ en: "Jul 2019 - Aug 2021", zh: "2019年7月 - 2021年8月" })}
+        dateTime="2019-07"
       />
       <p>
         {t({

--- a/src/app/[locale]/(home)/(details)/experiences/wunderman-thompson-commerce/page.tsx
+++ b/src/app/[locale]/(home)/(details)/experiences/wunderman-thompson-commerce/page.tsx
@@ -69,6 +69,7 @@ export default function Page() {
         title="Wunderman Thompson Commerce"
         role={t({ en: "Front End Developer", zh: "前端开发员" })}
         date={t({ en: "Sep 2017 - Jul 2019", zh: "2017年9月 - 2019年7月" })}
+        dateTime="2017-09"
       />
       <p>
         {t({

--- a/src/app/[locale]/(home)/page.tsx
+++ b/src/app/[locale]/(home)/page.tsx
@@ -103,6 +103,7 @@ export default async function Home(props: PageProps) {
           <ExperienceCard
             logo={<CitadelLogo />}
             dates={t({ en: "Aug 2021 - Now", zh: "2021年8月 至今" })}
+            dateTime="2021-08"
             href={getLocalePath("/experiences/citadel", locale)}
             css={styles.card}
             aria-label={t({
@@ -117,6 +118,7 @@ export default async function Home(props: PageProps) {
               en: "Jul 2019 - Aug 2021",
               zh: "2019年7月 - 2021年8月",
             })}
+            dateTime="2019-07"
             href={getLocalePath("/experiences/spotify", locale)}
             css={styles.card}
             aria-label={t({
@@ -130,6 +132,7 @@ export default async function Home(props: PageProps) {
               en: "Sep 2017 - Jul 2019",
               zh: "2017年9月 - 2019年7月",
             })}
+            dateTime="2017-09"
             href={getLocalePath(
               "/experiences/wunderman-thompson-commerce",
               locale,
@@ -156,6 +159,7 @@ export default async function Home(props: PageProps) {
               en: "Sep 2016 - Jan 2018",
               zh: "2016年9月 - 2018年1月",
             })}
+            dateTime="2016-09"
             href={getLocalePath("/education/university-of-bristol", locale)}
             css={styles.card}
           />
@@ -173,6 +177,7 @@ export default async function Home(props: PageProps) {
               en: "Sep 2013 - Jul 2016",
               zh: "2013年9月 - 2016年7月",
             })}
+            dateTime="2013-09"
             href={getLocalePath("/education/university-of-nottingham", locale)}
             css={styles.card}
           />
@@ -190,6 +195,7 @@ export default async function Home(props: PageProps) {
               en: "Sep 2011 - Jul 2013",
               zh: "2011年9月 - 2013年7月",
             })}
+            dateTime="2011-09"
             href={getLocalePath(
               "/education/altrincham-grammar-school-for-boys",
               locale,

--- a/src/components/home/detail-page-title.test.tsx
+++ b/src/components/home/detail-page-title.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { render } from "#src/test-utils.tsx";
+import { DetailPageTitle } from "./detail-page-title";
+
+describe("DetailPageTitle", () => {
+  it("emits a machine-readable dateTime attribute alongside the visible string", () => {
+    const { container } = render(
+      <DetailPageTitle
+        type="experience"
+        title="Citadel"
+        role="Software Engineer"
+        date="Aug 2021 - Now"
+        dateTime="2021-08"
+      />,
+    );
+
+    const timeEl = container.querySelector("time");
+    expect(timeEl).not.toBeNull();
+    expect(timeEl).toHaveAttribute("datetime", "2021-08");
+    expect(timeEl).toHaveTextContent("Aug 2021 - Now");
+  });
+
+  it("preserves the visible string exactly as passed", () => {
+    const { container } = render(
+      <DetailPageTitle
+        type="education"
+        title="University of Bristol"
+        role="MSc Advanced Computing"
+        date="Sep 2016 - Jan 2018"
+        dateTime="2016-09"
+      />,
+    );
+
+    const timeEl = container.querySelector("time");
+    expect(timeEl?.textContent).toBe("Sep 2016 - Jan 2018");
+    expect(timeEl).toHaveAttribute("datetime", "2016-09");
+  });
+});

--- a/src/components/home/detail-page-title.tsx
+++ b/src/components/home/detail-page-title.tsx
@@ -8,9 +8,17 @@ interface PageTitleProps {
   title: string;
   role: string;
   date: string;
+  /** ISO start date for the `<time dateTime>` attribute (e.g. "2021-08"). */
+  dateTime: string;
 }
 
-export function DetailPageTitle({ date, role, title, type }: PageTitleProps) {
+export function DetailPageTitle({
+  date,
+  dateTime,
+  role,
+  title,
+  type,
+}: PageTitleProps) {
   const typeLabel =
     type === "experience"
       ? t({ en: "Experience", zh: "工作" })
@@ -22,7 +30,9 @@ export function DetailPageTitle({ date, role, title, type }: PageTitleProps) {
         {typeLabel} - {title}
       </h2>
       <h1 css={styles.title}>{role}</h1>
-      <time css={styles.date}>{date}</time>
+      <time dateTime={dateTime} css={styles.date}>
+        {date}
+      </time>
     </header>
   );
 }

--- a/src/components/home/education-card.test.tsx
+++ b/src/components/home/education-card.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { render } from "#src/test-utils.tsx";
+import { EducationCard } from "./education-card";
+
+describe("EducationCard", () => {
+  it("emits dateTime on the <time> element for machine-readability", () => {
+    const { container } = render(
+      <EducationCard
+        logo={<span data-testid="logo" />}
+        name="University of Bristol"
+        dates="Sep 2016 - Jan 2018"
+        dateTime="2016-09"
+        href="/education/university-of-bristol"
+      />,
+    );
+
+    const timeEl = container.querySelector("time");
+    expect(timeEl).not.toBeNull();
+    expect(timeEl).toHaveAttribute("datetime", "2016-09");
+    expect(timeEl).toHaveTextContent("Sep 2016 - Jan 2018");
+  });
+});

--- a/src/components/home/education-card.tsx
+++ b/src/components/home/education-card.tsx
@@ -13,6 +13,8 @@ interface EducationCardProps extends React.ComponentProps<typeof Card> {
   name: string;
   nameSubText?: string;
   dates: string;
+  /** ISO start date for the `<time dateTime>` attribute (e.g. "2016-09"). */
+  dateTime: string;
 }
 
 export function EducationCard({
@@ -20,6 +22,7 @@ export function EducationCard({
   name,
   nameSubText,
   dates,
+  dateTime,
   className,
   style,
   ...rest
@@ -44,7 +47,9 @@ export function EducationCard({
           {nameSubText && <span css={styles.subText}> {nameSubText}</span>}
         </div>
       </div>
-      <time css={styles.dates}>{dates}</time>
+      <time dateTime={dateTime} css={styles.dates}>
+        {dates}
+      </time>
     </Card>
   );
 }

--- a/src/components/home/experience-card.test.tsx
+++ b/src/components/home/experience-card.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { render } from "#src/test-utils.tsx";
+import { ExperienceCard } from "./experience-card";
+
+describe("ExperienceCard", () => {
+  it("emits dateTime on the <time> element for machine-readability", () => {
+    const { container } = render(
+      <ExperienceCard
+        logo={<span data-testid="logo" />}
+        dates="Aug 2021 - Now"
+        dateTime="2021-08"
+        href="/experiences/citadel"
+      />,
+    );
+
+    const timeEl = container.querySelector("time");
+    expect(timeEl).not.toBeNull();
+    expect(timeEl).toHaveAttribute("datetime", "2021-08");
+    expect(timeEl).toHaveTextContent("Aug 2021 - Now");
+  });
+});

--- a/src/components/home/experience-card.tsx
+++ b/src/components/home/experience-card.tsx
@@ -8,11 +8,14 @@ import { color, font, ratio, space } from "#src/tokens.stylex.ts";
 interface ExperienceCardProps extends React.ComponentProps<typeof Card> {
   logo: React.ReactNode;
   dates: string;
+  /** ISO start date for the `<time dateTime>` attribute (e.g. "2021-08"). */
+  dateTime: string;
 }
 
 export function ExperienceCard({
   logo,
   dates,
+  dateTime,
   className,
   style,
   ...rest
@@ -22,7 +25,9 @@ export function ExperienceCard({
       <Suspense fallback={<Skeleton />}>
         <div css={styles.logo}>{logo}</div>
       </Suspense>
-      <time css={styles.dates}>{dates}</time>
+      <time dateTime={dateTime} css={styles.dates}>
+        {dates}
+      </time>
     </Card>
   );
 }


### PR DESCRIPTION
## Summary

The `<time>` elements on the homepage experience/education cards and the portfolio detail-page headers rendered localised strings like "Aug 2021 - Now" / "2021年8月 至今" with no `dateTime` attribute, which makes them semantically inert — crawlers and assistive tech cannot parse the localised text as a date. This adds a required `dateTime` prop to `ExperienceCard`, `EducationCard`, and `DetailPageTitle` and threads an ISO year-month value (e.g. `"2021-08"`) through all nine call sites. Ongoing ranges carry only the start date, per the MDN spec. Visible text is unchanged in both locales.

## Context

Making the prop required rather than optional means TypeScript enforces coverage at every call site, so a future card added without a `dateTime` won't silently regress to the semantically-inert state the fix is meant to remove.