### PR TITLE
fix: pass locale to person_credits TMDB request

### DIFF
--- a/src/ai-chat/chat.ts
+++ b/src/ai-chat/chat.ts
@@ -44,7 +44,7 @@ export async function chat({
       present_watch_providers: createPresentWatchProvidersTool(),
       present_provider_regions: createPresentProviderRegionsTool(),
       media_credits: createMediaCreditsTool(),
-      person_credits: createPersonCreditsTool(),
+      person_credits: createPersonCreditsTool(locale),
       present_person: createPresentPersonTool(),
       review_summary: createReviewSummaryTool(locale),
       save_preference: createSavePreferenceTool(),

--- a/src/ai-chat/tools/person-credits.test.ts
+++ b/src/ai-chat/tools/person-credits.test.ts
@@ -30,8 +30,11 @@ interface CreditEntry {
   department: string | undefined;
 }
 
-async function executeTool(input: { person_id: number }) {
-  const tool = createPersonCreditsTool();
+async function executeTool(
+  input: { person_id: number },
+  locale: "en" | "zh" = "en",
+) {
+  const tool = createPersonCreditsTool(locale);
   if (!tool.execute) throw new Error("expected execute");
   const result = await tool.execute(input, executeContext);
   return JSON.parse(JSON.stringify(result)) as CreditEntry[];
@@ -69,7 +72,7 @@ describe("personCreditsInputSchema", () => {
 
 describe("createPersonCreditsTool", () => {
   it("returns a tool with description and inputSchema", () => {
-    const tool = createPersonCreditsTool();
+    const tool = createPersonCreditsTool("en");
     expect(tool.description).toBeDefined();
     expect(tool.description).toContain("filmography");
     expect(tool.inputSchema).toBeDefined();
@@ -166,7 +169,7 @@ describe("person credits execute", () => {
       ),
     );
 
-    const tool = createPersonCreditsTool();
+    const tool = createPersonCreditsTool("en");
     if (!tool.execute) throw new Error("expected execute");
     const result = await tool.execute({ person_id: 287 }, executeContext);
 
@@ -174,5 +177,25 @@ describe("person credits execute", () => {
     if (isToolError(result)) {
       expect(result.reason).toBe("tmdb_unavailable");
     }
+  });
+
+  it("passes locale as the language parameter to TMDB", async () => {
+    let capturedLanguage: string | null = null;
+
+    server.use(
+      http.get(`${TMDB_BASE}/3/person/287/combined_credits`, ({ request }) => {
+        const url = new URL(request.url);
+        capturedLanguage = url.searchParams.get("language");
+        return HttpResponse.json({
+          id: 287,
+          cast: [castEntry({ id: 1, title: "绿里奇迹", vote_average: 8 })],
+          crew: [],
+        });
+      }),
+    );
+
+    await executeTool({ person_id: 287 }, "zh");
+
+    expect(capturedLanguage).toBe("zh");
   });
 });

--- a/src/ai-chat/tools/person-credits.ts
+++ b/src/ai-chat/tools/person-credits.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { getPersonCombinedCredits } from "#src/_generated/tmdb-server-functions.ts";
+import type { SupportedLocale } from "#src/types.ts";
 import { isRecord } from "#src/utils/type-guards.ts";
 import { toolError } from "./tool-error";
 
@@ -62,7 +63,7 @@ interface CreditResult {
 // Trimming after sort preserves the highest-rated entries.
 const MAX_RESULTS = 30;
 
-export function createPersonCreditsTool() {
+export function createPersonCreditsTool(locale: SupportedLocale) {
   return tool({
     description: TOOL_DESCRIPTION,
     inputSchema: personCreditsInputSchema,
@@ -71,6 +72,7 @@ export function createPersonCreditsTool() {
       try {
         credits = await getPersonCombinedCredits({
           person_id: person_id.toString(),
+          language: locale,
         });
       } catch (error) {
         console.error("person_credits failed", error);


### PR DESCRIPTION
## Summary

The `person_credits` AI-chat tool called TMDB's `combined_credits` endpoint without a `language` parameter, so Chinese-locale users saw English film/TV titles in the filmography cards the assistant renders — breaking parity with the sibling `tmdb_search`, `semantic_search`, and `review_summary` tool factories, which all already thread `locale` into their TMDB requests. This updates `createPersonCreditsTool` to take a required `locale` argument and forwards it as the `language` query param. The required-arg shape forces TypeScript to validate the single call site in `chat.ts`.

## Context

The `media_credits` tool was reviewed and deliberately left out of scope — its cast/crew `name` fields are proper nouns that TMDB doesn't translate, so the payoff is much smaller than for `person_credits`, which carries localisable film/TV titles. It can be picked up separately if the smaller surface (character/department strings) turns out to matter.