### PR TITLE
fix: announce conversation-length warning via role=status

### DIFF
--- a/src/components/ai-chat/chat-message-list.test.tsx
+++ b/src/components/ai-chat/chat-message-list.test.tsx
@@ -1,4 +1,8 @@
 import { describe, expect, it } from "vitest";
+import {
+  COMPACTION_TRIGGER_TOKENS,
+  USAGE_WARNING_RATIO,
+} from "#src/ai-chat/context-management-shared.ts";
 import type { ChatUIMessage } from "#src/ai-chat/use-ai-chat.ts";
 import { render, screen } from "#src/test-utils.tsx";
 import { ChatMessageList } from "./chat-message-list";
@@ -195,5 +199,54 @@ describe("ChatMessageList", () => {
       />,
     );
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("announces the usage warning via role='status' when token threshold is crossed", () => {
+    const overWarningThreshold =
+      COMPACTION_TRIGGER_TOKENS * USAGE_WARNING_RATIO + 1;
+    const messages = [
+      createMessage({
+        id: "1",
+        role: "user",
+        parts: [{ type: "text", text: "Hello" }],
+      }),
+      createMessage({
+        id: "2",
+        role: "assistant",
+        parts: [{ type: "text", text: "Lengthy response" }],
+        metadata: { inputTokens: overWarningThreshold },
+      }),
+    ];
+
+    render(
+      <ChatMessageList {...defaultProps} messages={messages} status="ready" />,
+    );
+
+    const statusEl = screen.getByRole("status");
+    expect(statusEl).toHaveTextContent("The conversation is getting lengthy");
+  });
+
+  it("omits the usage warning when token count is below threshold", () => {
+    const messages = [
+      createMessage({
+        id: "1",
+        role: "user",
+        parts: [{ type: "text", text: "Hello" }],
+      }),
+      createMessage({
+        id: "2",
+        role: "assistant",
+        parts: [{ type: "text", text: "Short response" }],
+        metadata: { inputTokens: 1000 },
+      }),
+    ];
+
+    render(
+      <ChatMessageList {...defaultProps} messages={messages} status="ready" />,
+    );
+
+    expect(
+      screen.queryByText("The conversation is getting lengthy"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/ai-chat/chat-message-list.tsx
+++ b/src/components/ai-chat/chat-message-list.tsx
@@ -144,7 +144,7 @@ export function ChatMessageList({
         </div>
       )}
       {showUsageWarning && (
-        <p css={styles.usageWarning}>
+        <p css={styles.usageWarning} role="status">
           {t({
             en: "The conversation is getting lengthy",
             zh: "对话越来越长",


### PR DESCRIPTION
## Summary

The "conversation is getting lengthy" warning in `ChatMessageList` mounted with no live-region role, so assistive tech never announced it when the input-token count crossed 60% of the compaction threshold. Adds `role="status"` to the warning `<p>` — the same pattern already used by `CompactionNotice` in the same folder — so the message is announced politely on mount. The warning stays outside the `role="log"` messages container to avoid double announcement via the list's existing `aria-live` surface.