### PR TITLE
chore: remove react-scan devtool script from root layout

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -63,10 +63,6 @@ export default async function RootLayout({
           }}
         />
         {/* eslint-enable @eslint-react/dom-no-dangerously-set-innerhtml */}
-        {process.env.NODE_ENV === "development" && (
-          // eslint-disable-next-line @next/next/no-sync-scripts
-          <script src="https://unpkg.com/react-scan/dist/auto.global.js" />
-        )}
         {locale === "en" && (
           <link
             rel="preload"


### PR DESCRIPTION
## Summary

Removes the react-scan browser devtool that was being injected via a CDN `<script>` tag in the root layout during development. AI models taking screenshots for debugging would capture the blue React Scan overlays, which made the screenshots harder to use.