### PR TITLE
feat: convert playground to scrollable top-down path-traced scene

### DIFF
--- a/src/components/playground/loop.ts
+++ b/src/components/playground/loop.ts
@@ -150,6 +150,30 @@ export interface LoopControls {
   setIsDark: (next: boolean) => void;
 }
 
+type Vec3 = [number, number, number];
+
+interface CameraBasis {
+  camPos: Vec3;
+  fwd: Vec3;
+  right: Vec3;
+  up: Vec3;
+}
+
+// Camera basis must match the ray construction in pathtracer-fs.glsl exactly —
+// the shader does `rd = normalize(fwd + px*right + py*up)` using these vectors,
+// and reprojection assumes the same basis for the previous frame.
+// Pure top-down: fwd is straight down, so cross(fwd, worldUp) is degenerate.
+// The basis is hard-coded with world +z mapped to up-on-screen so scrolling
+// still pans along the z axis naturally.
+function computeCameraBasis(scrollOffset: number): CameraBasis {
+  return {
+    camPos: [0, 7, scrollOffset],
+    fwd: [0, -1, 0],
+    right: [-1, 0, 0],
+    up: [0, 0, 1],
+  };
+}
+
 export function start(
   { gl, pathtraceProgram, displayProgram, canvas, bufferInfo }: Context,
   { isDark: initialIsDark }: { isDark: boolean },
@@ -172,73 +196,44 @@ export function start(
   let readFBO = fbos.a;
   let writeFBO = fbos.b;
 
-  // Frame counter for accumulation
+  // RNG seed counter — monotonically increments so each frame gets a fresh
+  // random sequence. Never reset; temporal stability is tracked separately.
   let frameIndex = 0;
 
-  // Resize handling — recreate FBOs and reset accumulation
+  // Scroll offset — tied to window.scrollY so touch scroll on mobile and
+  // mouse wheel on desktop both drive the camera through the browser's
+  // native scroll. Scrolling down (scrollY increases) shifts the camera
+  // toward -z, revealing content below the visible area on screen.
+  const SCROLL_FACTOR = 0.005;
+  let scrollOffset = -window.scrollY * SCROLL_FACTOR;
+  let lastScrollOffset = scrollOffset;
+
+  // Stable-frame counter: frames since the camera last moved. Drives the
+  // accumulation weight so static images keep converging while scrolling
+  // falls back to an EMA floor.
+  let stableFrames = 0;
+
+  // Previous camera basis used for temporal reprojection. `hasPrevFrame`
+  // gates the first frame where there is nothing to reproject from.
+  let prevCam: CameraBasis = computeCameraBasis(scrollOffset);
+  let hasPrevFrame = false;
+
+  // Resize handling — recreate FBOs and cold-start accumulation.
   const observer = new ResizeObserver(() => {
     resizeCanvasToDisplaySize(canvas, dpr);
     gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
     const att = fbos.attachments;
     resizeFramebufferInfo(gl, fbos.a, att, gl.canvas.width, gl.canvas.height);
     resizeFramebufferInfo(gl, fbos.b, att, gl.canvas.width, gl.canvas.height);
-    frameIndex = 0;
+    hasPrevFrame = false;
+    stableFrames = 0;
   });
   observer.observe(canvas);
 
-  // Pointer tracking — drag-to-orbit camera with cumulative offset
-  // cameraOffset accumulates across drag gestures (in CSS pixels)
-  const cameraOffset: [number, number] = [0, 0];
-  let dragStart: [number, number] | null = null;
-  let dragStartOffset: [number, number] = [0, 0];
-
-  // Virtual pointer position sent to the shader — derived from cameraOffset
-  const pointerPosition: [number, number] = [0, 0];
-  let lastPointerX = 0;
-  let lastPointerY = 0;
-
-  function updatePointerPosition() {
-    // Shader does: mouse = u_mouse / u_resolution - 0.5
-    // So canvas center → mouse = [0, 0] → default camera
-    pointerPosition[0] = gl.canvas.width * 0.5 + cameraOffset[0] * dpr;
-    pointerPosition[1] = gl.canvas.height * 0.5 + cameraOffset[1] * dpr;
-  }
-
-  document.addEventListener(
-    "pointerdown",
-    (e) => {
-      if (e.pointerType === "mouse" && e.button !== 0) return;
-      dragStart = [e.clientX, e.clientY];
-      dragStartOffset = [cameraOffset[0], cameraOffset[1]];
-    },
-    { signal: abortController.signal, passive: true },
-  );
-
-  document.addEventListener(
-    "pointermove",
-    (e) => {
-      if (!dragStart) return;
-      const dx = e.clientX - dragStart[0];
-      const dy = e.clientY - dragStart[1];
-      cameraOffset[0] = dragStartOffset[0] + dx;
-      cameraOffset[1] = dragStartOffset[1] - dy; // flip y: drag up = camera up
-      updatePointerPosition();
-    },
-    { signal: abortController.signal, passive: true },
-  );
-
-  document.addEventListener(
-    "pointerup",
+  window.addEventListener(
+    "scroll",
     () => {
-      dragStart = null;
-    },
-    { signal: abortController.signal, passive: true },
-  );
-
-  document.addEventListener(
-    "pointercancel",
-    () => {
-      dragStart = null;
+      scrollOffset = -window.scrollY * SCROLL_FACTOR;
     },
     { signal: abortController.signal, passive: true },
   );
@@ -264,22 +259,25 @@ export function start(
       if (gpuResult !== null) lastGpuTime = gpuResult;
     }
 
-    // Reset accumulation on mouse move or debug option change
-    const curMouseX = Math.round(pointerPosition[0]);
-    const curMouseY = Math.round(pointerPosition[1]);
+    // Feature/theme changes invalidate shaded color entirely — drop history.
+    // Scroll changes preserve history (reprojection handles the camera move)
+    // but reset the stable-frame counter so blend weight re-floors at the
+    // EMA rate.
     const debugKey = JSON.stringify(debug);
-    if (
-      curMouseX !== lastPointerX ||
-      curMouseY !== lastPointerY ||
-      debugKey !== prevDebugKey ||
-      isDark !== prevIsDark
-    ) {
-      frameIndex = 0;
-      lastPointerX = curMouseX;
-      lastPointerY = curMouseY;
+    const featuresChanged = debugKey !== prevDebugKey || isDark !== prevIsDark;
+    if (featuresChanged) {
+      hasPrevFrame = false;
+      stableFrames = 0;
       prevDebugKey = debugKey;
       prevIsDark = isDark;
+    } else if (scrollOffset !== lastScrollOffset) {
+      stableFrames = 0;
+      lastScrollOffset = scrollOffset;
+    } else {
+      stableFrames++;
     }
+
+    const curCam = computeCameraBasis(scrollOffset);
 
     gpuTimer?.begin();
 
@@ -290,7 +288,16 @@ export function start(
 
     setUniforms(pathtraceProgram, {
       u_resolution: [gl.canvas.width, gl.canvas.height],
-      u_mouse: pointerPosition,
+      u_camPos: curCam.camPos,
+      u_camFwd: curCam.fwd,
+      u_camRight: curCam.right,
+      u_camUp: curCam.up,
+      u_prevCamPos: prevCam.camPos,
+      u_prevCamFwd: prevCam.fwd,
+      u_prevCamRight: prevCam.right,
+      u_prevCamUp: prevCam.up,
+      u_hasPrevFrame: hasPrevFrame ? 1 : 0,
+      u_stableFrames: stableFrames,
       u_dark: isDark ? 1.0 : 0.0,
       u_debugMode: DEBUG_MODE_MAP[debug.mode],
       u_enableShadows: debug.shadows ? 1 : 0,
@@ -322,6 +329,10 @@ export function start(
     writeFBO = temp;
     frameIndex++;
 
+    // Current camera becomes next frame's reprojection reference.
+    prevCam = curCam;
+    hasPrevFrame = true;
+
     lastCpuTime = performance.now() - cpuStart;
     fpsFrameCount++;
 
@@ -336,7 +347,7 @@ export function start(
         drawCalls: 2,
         resolution: [gl.canvas.width, gl.canvas.height],
         triangles: 2,
-        samplesPerPixel: frameIndex,
+        samplesPerPixel: stableFrames + 1,
       });
       fpsFrameCount = 0;
       lastStatsTime = now;

--- a/src/components/playground/playground-canvas.tsx
+++ b/src/components/playground/playground-canvas.tsx
@@ -226,6 +226,10 @@ export function PlaygroundCanvas() {
   return (
     <>
       <canvas ref={canvasRef} css={styles.canvas} />
+      {/* Spacer gives the page a real scroll range. The shader reads
+          window.scrollY to pan the camera, so this also defines the total
+          travel distance along the desk. */}
+      <div aria-hidden css={styles.scrollSpacer} />
       {stats && (
         <StatsOverlay
           stats={stats}
@@ -243,7 +247,12 @@ const styles = stylex.create({
     inset: 0,
     width: "100%",
     height: "100%",
-    touchAction: "none",
+    pointerEvents: "none",
+  },
+  scrollSpacer: {
+    width: "1px",
+    height: "4000px",
+    pointerEvents: "none",
   },
   overlay: {
     position: "fixed",

--- a/src/components/playground/shaders/pathtracer-fs.glsl
+++ b/src/components/playground/shaders/pathtracer-fs.glsl
@@ -3,7 +3,16 @@ precision highp float;
 precision highp int;
 
 uniform vec2 u_resolution;
-uniform vec2 u_mouse;
+uniform vec3 u_camPos;
+uniform vec3 u_camFwd;
+uniform vec3 u_camRight;
+uniform vec3 u_camUp;
+uniform vec3 u_prevCamPos;
+uniform vec3 u_prevCamFwd;
+uniform vec3 u_prevCamRight;
+uniform vec3 u_prevCamUp;
+uniform int u_hasPrevFrame;
+uniform float u_stableFrames;
 uniform float u_dark;
 uniform int u_debugMode;     // 0=normal, 1=noisy(single sample), 2=normals, 3=albedo
 uniform int u_enableShadows; // bounced indirect light
@@ -54,6 +63,36 @@ vec3 cosineDir(vec3 n) {
   return normalize(u * cos(phi) * sinTheta + v * sin(phi) * sinTheta + n * cosTheta);
 }
 
+// ---- Procedural noise (deterministic, used for concrete texturing) ----
+
+float hash21(vec2 p) {
+  p = fract(p * vec2(234.34f, 435.345f));
+  p += dot(p, p + 34.23f);
+  return fract(p.x * p.y);
+}
+
+float valueNoise(vec2 p) {
+  vec2 i = floor(p);
+  vec2 f = fract(p);
+  f = f * f * (3.0f - 2.0f * f);
+  float a = hash21(i);
+  float b = hash21(i + vec2(1.0f, 0.0f));
+  float c = hash21(i + vec2(0.0f, 1.0f));
+  float d = hash21(i + vec2(1.0f, 1.0f));
+  return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
+}
+
+float fbm(vec2 p) {
+  float v = 0.0f;
+  float amp = 0.5f;
+  for (int i = 0; i < 5; i++) {
+    v += amp * valueNoise(p);
+    p *= 2.0f;
+    amp *= 0.5f;
+  }
+  return v;
+}
+
 // ---- Ray-primitive intersections ----
 
 struct Hit {
@@ -91,16 +130,40 @@ bool traceScene(vec3 ro, vec3 rd, inout Hit hit) {
   float t;
   vec3 n;
 
-  // Ground plane
+  // Concrete floor
   if (u_enableAO == 1 && abs(rd.y) > 0.0001f) {
     float tPlane = -ro.y / rd.y;
     if (tPlane > 0.001f && tPlane < closest) {
       closest = tPlane;
       hit.t = tPlane;
-      hit.normal = vec3(0.0f, 1.0f, 0.0f);
       vec3 p = ro + rd * tPlane;
-      float check = mod(floor(p.x) + floor(p.z), 2.0f);
-      hit.albedo = mix(vec3(0.4f), vec3(0.8f), check);
+      vec2 q = p.xz;
+
+      // Height field — drives both large-scale tonal variation and a
+      // micro-relief normal so the surface catches light irregularly.
+      float eps = 0.04f;
+      float h = fbm(q * 0.8f);
+      float hx = fbm((q + vec2(eps, 0.0f)) * 0.8f);
+      float hz = fbm((q + vec2(0.0f, eps)) * 0.8f);
+      float bumpScale = 0.25f;
+      hit.normal = normalize(vec3(
+        (h - hx) / eps * bumpScale,
+        1.0f,
+        (h - hz) / eps * bumpScale
+      ));
+
+      // Albedo — warm neutral grey with layered noise and sparse aggregate.
+      float medium = valueNoise(q * 4.0f);
+      float specks = valueNoise(q * 45.0f);
+      vec3 baseColor = vec3(0.54f, 0.52f, 0.5f);
+      baseColor *= 0.72f + h * 0.56f;       // large weathering patches
+      baseColor *= 0.9f + medium * 0.2f;    // mid-scale grain
+      float dark = smoothstep(0.78f, 0.84f, specks);
+      baseColor = mix(baseColor, vec3(0.18f, 0.17f, 0.15f), dark * 0.55f);
+      float bright = smoothstep(0.94f, 0.97f, specks);
+      baseColor = mix(baseColor, vec3(0.85f, 0.83f, 0.8f), bright * 0.65f);
+
+      hit.albedo = baseColor;
       hit.metallic = 0.0f;
       hit.emission = vec3(0.0f);
       didHit = true;
@@ -182,10 +245,11 @@ vec3 skyColor(vec3 dir) {
 
 // ---- Path tracing ----
 
-vec3 pathTrace(vec3 ro, vec3 rd) {
+vec3 pathTrace(vec3 ro, vec3 rd, out float firstHitT) {
   vec3 throughput = vec3(1.0f);
   vec3 color = vec3(0.0f);
   int maxBounces = u_enableShadows == 1 ? 5 : 1;
+  firstHitT = -1.0f;
 
   for (int i = 0; i < 8; i++) {
     if (i >= maxBounces) break;
@@ -195,6 +259,8 @@ vec3 pathTrace(vec3 ro, vec3 rd) {
       color += throughput * skyColor(rd);
       break;
     }
+
+    if (i == 0) firstHitT = hit.t;
 
     color += throughput * hit.emission;
 
@@ -225,34 +291,22 @@ vec3 pathTrace(vec3 ro, vec3 rd) {
 void main() {
   rngSeed(uvec2(gl_FragCoord.xy), uint(u_frameIndex));
 
-  vec2 uv = gl_FragCoord.xy / u_resolution;
+  float minDim = min(u_resolution.x, u_resolution.y);
 
   // Jittered sub-pixel position for anti-aliasing
   vec2 jitter = vec2(rand(), rand()) - 0.5f;
-  vec2 pixelPos = (gl_FragCoord.xy + jitter - 0.5f * u_resolution) / min(u_resolution.x, u_resolution.y);
+  vec2 pixelPos = (gl_FragCoord.xy + jitter - 0.5f * u_resolution) / minDim;
 
-  // Camera — mouse-controlled, no auto-rotation (accumulation needs stable camera)
-  vec2 mouse = u_mouse / u_resolution - 0.5f;
-  if (u_mouse.x <= 0.0f && u_mouse.y <= 0.0f) {
-    mouse = vec2(0.0f);
-  }
-
-  float camAngle = mouse.x * 2.0f;
-  float camHeight = 2.5f + mouse.y * 2.0f;
-  vec3 ro = vec3(6.0f * cos(camAngle), camHeight, 6.0f * sin(camAngle));
-  vec3 target = vec3(0.0f, 0.8f, 0.0f);
-  vec3 fwd = normalize(target - ro);
-  vec3 right = normalize(cross(fwd, vec3(0.0f, 1.0f, 0.0f)));
-  vec3 up = cross(right, fwd);
-  vec3 rd = normalize(fwd + pixelPos.x * right + pixelPos.y * up);
+  vec3 ro = u_camPos;
+  vec3 rd = normalize(u_camFwd + pixelPos.x * u_camRight + pixelPos.y * u_camUp);
 
   // Debug: normals
   if (u_debugMode == 2) {
     Hit hit;
     if (traceScene(ro, rd, hit)) {
-      outColor = vec4(hit.normal * 0.5f + 0.5f, 1.0f);
+      outColor = vec4(hit.normal * 0.5f + 0.5f, hit.t);
     } else {
-      outColor = vec4(0.0f);
+      outColor = vec4(0.0f, 0.0f, 0.0f, -1.0f);
     }
     return;
   }
@@ -261,27 +315,78 @@ void main() {
   if (u_debugMode == 3) {
     Hit hit;
     if (traceScene(ro, rd, hit)) {
-      outColor = vec4(hit.albedo, 1.0f);
+      outColor = vec4(hit.albedo, hit.t);
     } else {
-      outColor = vec4(skyColor(rd), 1.0f);
+      outColor = vec4(skyColor(rd), -1.0f);
     }
     return;
   }
 
-  vec3 sampleColor = pathTrace(ro, rd);
+  float firstHitT;
+  vec3 sampleColor = pathTrace(ro, rd, firstHitT);
   sampleColor = min(sampleColor, vec3(10.0f)); // clamp fireflies
 
   // Debug: raw single noisy sample
   if (u_debugMode == 1) {
     vec3 col = sampleColor / (sampleColor + 1.0f);
-    outColor = vec4(pow(col, vec3(0.4545f)), 1.0f);
+    outColor = vec4(pow(col, vec3(0.4545f)), firstHitT);
     return;
   }
 
-  // Accumulate with previous frame in linear HDR space
-  vec3 prev = texture(u_prevFrame, uv).rgb;
-  float weight = 1.0f / (u_frameIndex + 1.0f);
-  vec3 accumulated = mix(prev, sampleColor, weight);
+  // --- Temporal accumulation ---
+  // Default: no history, use the raw sample.
+  vec3 finalColor = sampleColor;
 
-  outColor = vec4(accumulated, 1.0f);
+  if (u_hasPrevFrame == 1) {
+    // Weight sequence: EMA floor of 1/8 during motion / early rest to keep
+    // noise bounded, then 1/(stable+1) arithmetic mean for clean convergence.
+    float weight = min(1.0f / (u_stableFrames + 1.0f), 0.125f);
+
+    if (u_stableFrames > 0.5f) {
+      // Camera is static — same-pixel accumulation. Reprojection-with-
+      // validation would reject silhouette pixels (jitter makes them flip
+      // between sphere and ground), leaving edges permanently noisy. When
+      // nothing is moving we can trust this pixel's history represents the
+      // same sub-pixel neighborhood, and blending the jittered samples in
+      // place converges to the correctly anti-aliased color.
+      vec3 prevRgb = texture(u_prevFrame, gl_FragCoord.xy / u_resolution).rgb;
+      finalColor = mix(prevRgb, sampleColor, weight);
+    } else if (firstHitT > 0.0f) {
+      // Camera moved — reproject this pixel's world hit through the previous
+      // camera and validate via position match to reject disoccluded history.
+      vec3 worldHit = ro + rd * firstHitT;
+      vec3 delta = worldHit - u_prevCamPos;
+      float prevF = dot(delta, u_prevCamFwd);
+      if (prevF > 0.001f) {
+        vec2 prevPixelPos = vec2(
+          dot(delta, u_prevCamRight),
+          dot(delta, u_prevCamUp)
+        ) / prevF;
+        vec2 prevUV = prevPixelPos * (minDim / u_resolution) + 0.5f;
+
+        if (prevUV.x >= 0.0f && prevUV.x <= 1.0f && prevUV.y >= 0.0f && prevUV.y <= 1.0f) {
+          vec4 prev = texture(u_prevFrame, prevUV);
+          float prevT = prev.a;
+
+          if (prevT > 0.0f) {
+            // Reconstruct the world point the previous frame actually shaded
+            // at that UV and reject if it's a different surface.
+            vec3 prevRd = normalize(u_prevCamFwd
+              + prevPixelPos.x * u_prevCamRight
+              + prevPixelPos.y * u_prevCamUp);
+            vec3 prevWorld = u_prevCamPos + prevRd * prevT;
+            float d = length(prevWorld - worldHit);
+            float camDist = length(worldHit - u_camPos);
+            if (d < 0.05f * camDist) {
+              finalColor = mix(prev.rgb, sampleColor, weight);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Encode primary hit distance in alpha for next frame's reprojection.
+  // -1 means "miss" so downstream frames don't try to reproject from sky.
+  outColor = vec4(finalColor, firstHitT > 0.0f ? firstHitT : -1.0f);
 }


### PR DESCRIPTION
## Summary

Replaces the playground's drag-to-orbit camera with a fixed top-down camera whose z position is driven by `window.scrollY`, turning the canvas into a scrollable scene that works for both desktop wheel and mobile touch. A temporal reprojection accumulation pipeline replaces the previous per-pixel frame-count average: primary hit distance is encoded in the framebuffer's alpha channel so the next frame can reproject world hits through the prior camera and reuse history during camera motion, falling back to same-pixel accumulation at rest so silhouettes converge to clean anti-aliased edges rather than stalling at the EMA noise floor. The checker ground is replaced with a procedural concrete material using hash-based value noise and fBM for a bump-mapped normal, multi-scale albedo warmth, and speckle.

## Context

The top-down camera basis is hard-coded rather than computed from `cross(fwd, worldUp)` because that cross product is degenerate when `fwd` points straight down. The canvas uses `pointerEvents: none` so touch-scroll events propagate to the document body; the stats overlay remains interactive via its own fixed positioning and higher z-index. The accumulation weight formula `min(1/(stableFrames+1), 0.125)` acts as an EMA floor during motion and converges to an arithmetic mean at rest.