### PR TITLE
fix: indicate external links on Card and hide internal details affordance

### DIFF
--- a/src/components/shared/card.test.tsx
+++ b/src/components/shared/card.test.tsx
@@ -13,6 +13,8 @@ function hashKey(en: string, zh: string) {
 
 const translations = {
   [hashKey("Details", "详情")]: "Details",
+  [hashKey("Visit", "访问")]: "Visit",
+  [hashKey("(opens in new tab)", "(在新标签页中打开)")]: "(opens in new tab)",
 };
 
 function renderCard(ui: React.ReactElement) {
@@ -60,5 +62,20 @@ describe("Card", () => {
 
     const link = screen.getByRole("link");
     expect(link).toHaveAttribute("aria-label", "Custom Card");
+  });
+
+  it("shows a Visit affordance and announces external links", () => {
+    renderCard(
+      <Card href="https://example.com/" target="_blank">
+        <div>External Content</div>
+      </Card>,
+    );
+
+    expect(screen.queryByText("Details")).not.toBeInTheDocument();
+    expect(screen.getByText("Visit")).toBeInTheDocument();
+    expect(screen.getByText("(opens in new tab)")).toBeInTheDocument();
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noreferrer"));
   });
 });

--- a/src/components/shared/card.tsx
+++ b/src/components/shared/card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ArrowRightIcon } from "@phosphor-icons/react/dist/ssr/ArrowRight";
+import { ArrowSquareOutIcon } from "@phosphor-icons/react/dist/ssr/ArrowSquareOut";
 import * as stylex from "@stylexjs/stylex";
 import { t } from "#src/i18n.ts";
 import { motionConstants } from "#src/primitives/motion.stylex.ts";
@@ -18,6 +19,7 @@ import { cardTokens } from "./card.stylex";
 type CardProps = React.ComponentProps<typeof Anchor>;
 
 export function Card({ children, className, style, ...rest }: CardProps) {
+  const isExternal = rest.target === "_blank";
   return (
     <Anchor
       {...rest}
@@ -29,8 +31,24 @@ export function Card({ children, className, style, ...rest }: CardProps) {
       {children}
       <div css={styles.detailsBackdrop} />
       <div css={styles.detailsIndicator}>
-        <span css={styles.detailsText}>{t({ en: "Details", zh: "详情" })}</span>
-        <ArrowRightIcon aria-hidden="true" />
+        <span css={styles.detailsText}>
+          {isExternal
+            ? t({ en: "Visit", zh: "访问" })
+            : t({ en: "Details", zh: "详情" })}
+        </span>
+        {isExternal ? (
+          <ArrowSquareOutIcon aria-hidden="true" />
+        ) : (
+          <ArrowRightIcon aria-hidden="true" />
+        )}
+        {isExternal && (
+          <span css={styles.srOnly}>
+            {t({
+              en: "(opens in new tab)",
+              zh: "(在新标签页中打开)",
+            })}
+          </span>
+        )}
       </div>
     </Anchor>
   );
@@ -138,5 +156,16 @@ const styles = stylex.create({
   },
   detailsText: {
     fontWeight: font.weight_6,
+  },
+  srOnly: {
+    position: "absolute",
+    width: "1px",
+    height: "1px",
+    padding: 0,
+    margin: "-1px",
+    overflow: "hidden",
+    clipPath: "inset(50%)",
+    whiteSpace: "nowrap",
+    borderWidth: 0,
   },
 });


### PR DESCRIPTION
## Summary

The `Card` component unconditionally hid the external-link indicator added in #2145 and always rendered its internal "Details →" hover affordance, so external cards (currently the Student Loan Calculator on the home page) gave assistive tech no "opens in new tab" cue and misled sighted users into expecting an in-app detail page. `Card` now detects `target="_blank"`, forwards `indicateExternal` through to `Anchor` so the same icon, localised sr-only "(opens in new tab)" label, and `rel="noopener noreferrer"` wiring from #2145 applies, and skips the "Details →" indicator + backdrop for external destinations.