### PR TITLE
fix: include saved preference count in chat trigger aria-label

### DIFF
--- a/src/components/ai-chat/preference-panel.test.tsx
+++ b/src/components/ai-chat/preference-panel.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { PortalTargetProvider } from "#src/components/shared/fixed-element-portal-target.tsx";
 import type { StoredPreference } from "#src/preference-store/preference-store.ts";
 import { render, screen, userEvent } from "#src/test-utils.tsx";
-import { PreferencePanel } from "./preference-panel";
+import { PreferencePanel, PreferenceTrigger } from "./preference-panel";
 
 const samplePreferences: ReadonlyArray<StoredPreference> = [
   {
@@ -85,5 +85,33 @@ describe("PreferencePanel clear-all confirmation", () => {
     await vi.waitFor(() => {
       expect(screen.getByRole("button", { name: "Close" })).toHaveFocus();
     });
+  });
+});
+
+describe("PreferenceTrigger accessible name", () => {
+  it("uses the bare 'Preferences' label when no preferences are saved", () => {
+    render(<PreferenceTrigger count={0} onOpen={vi.fn()} />);
+
+    expect(
+      screen.getByRole("button", { name: "Preferences" }),
+    ).toBeInTheDocument();
+  });
+
+  it("includes the count in the accessible name when preferences are saved", () => {
+    render(<PreferenceTrigger count={5} onOpen={vi.fn()} />);
+
+    expect(
+      screen.getByRole("button", { name: "Preferences, 5 saved" }),
+    ).toBeInTheDocument();
+  });
+
+  it("invokes onOpen when the trigger is clicked", async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
+    render(<PreferenceTrigger count={2} onOpen={onOpen} />);
+
+    await user.click(screen.getByRole("button"));
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/ai-chat/preference-panel.tsx
+++ b/src/components/ai-chat/preference-panel.tsx
@@ -8,6 +8,7 @@ import { TrashIcon } from "@phosphor-icons/react/dist/ssr/Trash";
 import { XIcon } from "@phosphor-icons/react/dist/ssr/X";
 import * as stylex from "@stylexjs/stylex";
 import { useEffect, useRef, useState } from "react";
+import { useLocale } from "#src/hooks/use-locale.ts";
 import { t } from "#src/i18n.ts";
 import type { StoredPreference } from "#src/preference-store/preference-store.ts";
 import { usePreferences } from "#src/preference-store/use-preferences.ts";
@@ -36,19 +37,12 @@ export function PreferenceManager() {
 
   return (
     <>
-      <button
-        type="button"
-        css={[buttonReset.base, flex.inlineCenter, triggerStyles.button]}
-        onClick={() => {
+      <PreferenceTrigger
+        count={preferences.length}
+        onOpen={() => {
           setIsOpen(true);
         }}
-        aria-label={t({ en: "Preferences", zh: "偏好设置" })}
-      >
-        <SlidersHorizontalIcon size={16} role="presentation" />
-        {preferences.length > 0 && (
-          <span css={triggerStyles.dot} aria-hidden="true" />
-        )}
-      </button>
+      />
       <PreferencePanel
         isOpen={isOpen}
         onClose={() => {
@@ -59,6 +53,32 @@ export function PreferenceManager() {
         onClearAll={clearAll}
       />
     </>
+  );
+}
+
+export function PreferenceTrigger({
+  count,
+  onOpen,
+}: {
+  count: number;
+  onOpen: () => void;
+}) {
+  const locale = useLocale();
+  const label =
+    count > 0
+      ? `${t({ en: "Preferences,", zh: "偏好设置，" })} ${count.toLocaleString(locale)} ${t({ en: "saved", zh: "项已保存" })}`
+      : t({ en: "Preferences", zh: "偏好设置" });
+
+  return (
+    <button
+      type="button"
+      css={[buttonReset.base, flex.inlineCenter, triggerStyles.button]}
+      onClick={onOpen}
+      aria-label={label}
+    >
+      <SlidersHorizontalIcon size={16} role="presentation" />
+      {count > 0 && <span css={triggerStyles.dot} aria-hidden="true" />}
+    </button>
   );
 }
 


### PR DESCRIPTION
## Summary

The AI-chat preferences trigger button previously exposed only a static `aria-label="Preferences"` with a purely decorative dot indicator (`aria-hidden="true"`), so screen-reader users had no way to tell whether any preferences were saved without opening the panel. The trigger's accessible name now reflects the saved count — `"Preferences"` when empty, `"Preferences, N saved"` (localised, e.g. `偏好设置， 5 项已保存`) when populated — so assistive tech conveys the same state the dot communicates visually. The rendering is extracted into a small `PreferenceTrigger` component so the label logic is unit-testable without mocking IndexedDB; `PreferenceManager` keeps ownership of `usePreferences()` and panel state.