### PR TITLE
fix: remeasure scroll fades when children change

### DIFF
--- a/src/hooks/use-scroll-fades.test.ts
+++ b/src/hooks/use-scroll-fades.test.ts
@@ -164,4 +164,42 @@ describe("useScrollFades", () => {
 
     expect(removeSpy).toHaveBeenCalledWith("scroll", expect.any(Function));
   });
+
+  it("remeasures when children change content width without container resize", async () => {
+    class StubResizeObserver implements ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    const originalRO = window.ResizeObserver;
+    window.ResizeObserver = StubResizeObserver;
+
+    try {
+      // Start with content that fits — no fades.
+      const el = makeScrollable({
+        scrollLeft: 0,
+        scrollWidth: 200,
+        clientWidth: 200,
+      });
+      const ref = { current: el };
+      const { result } = renderHook(() => useScrollFades(ref));
+
+      expect(result.current.showLeftFade).toBe(false);
+      expect(result.current.showRightFade).toBe(false);
+
+      // Simulate a child being added: scrollWidth grows past clientWidth,
+      // but the container's own box size is unchanged.
+      redefineScroll(el, { scrollWidth: 500 });
+      const child = document.createElement("div");
+      await act(async () => {
+        el.appendChild(child);
+        // MutationObserver callbacks are microtasks; flush them.
+        await Promise.resolve();
+      });
+
+      expect(result.current.showRightFade).toBe(true);
+    } finally {
+      window.ResizeObserver = originalRO;
+    }
+  });
 });

--- a/src/hooks/use-scroll-fades.ts
+++ b/src/hooks/use-scroll-fades.ts
@@ -2,7 +2,9 @@ import { useEffect, useState } from "react";
 
 /**
  * Tracks horizontal scroll position to determine whether left/right
- * fade indicators should be visible. Listens to scroll and resize events.
+ * fade indicators should be visible. Listens to scroll events, container
+ * resizes, and child additions/removals/resizes so `scrollWidth` changes
+ * that leave the container's own box unchanged still trigger a remeasure.
  */
 export function useScrollFades(scrollRef: React.RefObject<HTMLElement | null>) {
   const [showLeftFade, setShowLeftFade] = useState(false);
@@ -23,17 +25,40 @@ export function useScrollFades(scrollRef: React.RefObject<HTMLElement | null>) {
     // ResizeObserver fires its callback asynchronously after observe(),
     // which handles initial state without a synchronous setState in the effect.
     // Falls back to a rAF-deferred call in environments without ResizeObserver (e.g. jsdom).
-    let observer: ResizeObserver | undefined;
+    let resizeObserver: ResizeObserver | undefined;
+    let mutationObserver: MutationObserver | undefined;
     if (typeof ResizeObserver !== "undefined") {
-      observer = new ResizeObserver(update);
-      observer.observe(el);
+      resizeObserver = new ResizeObserver(update);
+      resizeObserver.observe(el);
+      // Also observe each direct child so changes in content width
+      // (items streamed in, filmography resolving more credits, etc.)
+      // re-trigger the measurement even when the container's own box
+      // is unchanged.
+      for (const child of el.children) {
+        resizeObserver.observe(child);
+      }
+      if (typeof MutationObserver !== "undefined") {
+        mutationObserver = new MutationObserver((mutations) => {
+          for (const mutation of mutations) {
+            for (const node of mutation.addedNodes) {
+              if (node instanceof Element) resizeObserver?.observe(node);
+            }
+            for (const node of mutation.removedNodes) {
+              if (node instanceof Element) resizeObserver?.unobserve(node);
+            }
+          }
+          update();
+        });
+        mutationObserver.observe(el, { childList: true });
+      }
     } else {
       requestAnimationFrame(update);
     }
 
     return () => {
       el.removeEventListener("scroll", update);
-      observer?.disconnect();
+      resizeObserver?.disconnect();
+      mutationObserver?.disconnect();
     };
   }, [scrollRef]);
 


### PR DESCRIPTION
## Summary

`useScrollFades` now remeasures when children are added, removed, or resize — not only when the container itself resizes. The fade indicators previously went stale whenever `scrollWidth` changed without the container's own box resizing (e.g. items streaming in, filmography credits resolving after data fetch), leaving users with a scrollable row that looked non-scrollable. The hook now observes each direct child with the existing `ResizeObserver` and uses a `MutationObserver` to keep that set in sync as children come and go.