### PR TITLE
fix: make hero chat input inert when hidden

### DIFF
--- a/src/components/movie-database/hero-chat-input.tsx
+++ b/src/components/movie-database/hero-chat-input.tsx
@@ -32,6 +32,8 @@ export function HeroChatInput({
       <div
         ref={heroInputRef}
         css={isHeroInputVisible ? styles.visible : styles.hidden}
+        aria-hidden={!isHeroInputVisible || undefined}
+        inert={!isHeroInputVisible || undefined}
       >
         <ChatTextarea
           placeholder={placeholder}
@@ -60,9 +62,11 @@ export function HeroChatInput({
 const styles = stylex.create({
   visible: {
     opacity: 1,
+    pointerEvents: "auto",
   },
   hidden: {
     opacity: 0,
+    pointerEvents: "none",
   },
   icon: {
     color: color.controlActive,


### PR DESCRIPTION
## Summary

The hero chat input kept focus order and accessibility-tree presence when it faded out during the morph into the collapsed chat input, which meant keyboard users could tab into an invisible textarea and screen readers announced two "Ask AI" inputs at once. This mirrors the already-shipped `aria-hidden` + `inert` + `pointer-events: none` pattern on the sibling `CollapsedChatInput`, applied with the inverse `isHeroInputVisible` condition so the two sides of the morph are symmetric. Opacity-only transition and the IntersectionObserver driving visibility are untouched, so the morph animation is preserved.