### PR TITLE
fix: tie tool-activity disclosure to region via aria-controls

### DIFF
--- a/src/components/ai-chat/tool-activity-group.test.tsx
+++ b/src/components/ai-chat/tool-activity-group.test.tsx
@@ -57,10 +57,31 @@ describe("ToolActivityGroup", () => {
     expect(screen.getByText("3 tool calls")).toBeInTheDocument();
   });
 
+  it("ties the disclosure button to the expanded region via aria-controls", async () => {
+    const user = userEvent.setup();
+    render(<ToolActivityGroup toolParts={completeParts} />);
+
+    const button = screen.getByRole("button");
+    const controlsId = button.getAttribute("aria-controls") ?? "";
+    expect(controlsId).not.toBe("");
+
+    // Target element must exist in the DOM in both the collapsed and
+    // expanded states so assistive tech can resolve aria-controls.
+    const collapsedTarget = document.getElementById(controlsId);
+    expect(collapsedTarget).not.toBeNull();
+    expect(collapsedTarget).toHaveAttribute("hidden");
+
+    await user.click(button);
+
+    const expandedTarget = document.getElementById(controlsId);
+    expect(expandedTarget).not.toBeNull();
+    expect(expandedTarget).not.toHaveAttribute("hidden");
+  });
+
   it("hides activity lines by default when all complete", () => {
     render(<ToolActivityGroup toolParts={completeParts} />);
 
-    expect(screen.queryByText("TMDB Search")).not.toBeInTheDocument();
+    expect(screen.getByText("TMDB Search")).not.toBeVisible();
   });
 
   it("toggles expanded state on click", async () => {
@@ -71,13 +92,13 @@ describe("ToolActivityGroup", () => {
     await user.click(button);
 
     expect(button).toHaveAttribute("aria-expanded", "true");
-    expect(screen.getByText("TMDB Search")).toBeInTheDocument();
-    expect(screen.getByText("Semantic Search")).toBeInTheDocument();
-    expect(screen.getByText("Presenting Results")).toBeInTheDocument();
+    expect(screen.getByText("TMDB Search")).toBeVisible();
+    expect(screen.getByText("Semantic Search")).toBeVisible();
+    expect(screen.getByText("Presenting Results")).toBeVisible();
 
     await user.click(button);
     expect(button).toHaveAttribute("aria-expanded", "false");
-    expect(screen.queryByText("TMDB Search")).not.toBeInTheDocument();
+    expect(screen.getByText("TMDB Search")).not.toBeVisible();
   });
 
   it("shows correct count in summary", () => {

--- a/src/components/ai-chat/tool-activity-group.tsx
+++ b/src/components/ai-chat/tool-activity-group.tsx
@@ -2,7 +2,7 @@
 
 import { CaretRightIcon } from "@phosphor-icons/react/dist/ssr/CaretRight";
 import * as stylex from "@stylexjs/stylex";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { t } from "#src/i18n.ts";
 import { flex } from "#src/primitives/flex.stylex.ts";
 import { motionConstants } from "#src/primitives/motion.stylex.ts";
@@ -28,6 +28,7 @@ export function ToolActivityGroup({
   isStreaming = false,
 }: ToolActivityGroupProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const expandedId = useId();
 
   if (toolParts.length === 0) return null;
 
@@ -62,6 +63,7 @@ export function ToolActivityGroup({
         type="button"
         css={[buttonReset.base, flex.row, styles.disclosureButton]}
         aria-expanded={isOpen}
+        aria-controls={expandedId}
         onClick={() => {
           setIsOpen((prev) => !prev);
         }}
@@ -74,19 +76,17 @@ export function ToolActivityGroup({
         />
         <span>{summaryText}</span>
       </button>
-      {isOpen && (
-        <div css={styles.expandedContent}>
-          {toolParts.map((part) => (
-            <ToolActivityLine
-              key={part.toolCallId}
-              toolName={part.toolName}
-              state={part.state}
-              input={part.input}
-              output={part.output}
-            />
-          ))}
-        </div>
-      )}
+      <div id={expandedId} css={styles.expandedContent} hidden={!isOpen}>
+        {toolParts.map((part) => (
+          <ToolActivityLine
+            key={part.toolCallId}
+            toolName={part.toolName}
+            state={part.state}
+            input={part.input}
+            output={part.output}
+          />
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The "N tool calls" disclosure button had `aria-expanded` but no `aria-controls`, and the expanded region was only mounted while open — so assistive tech couldn't announce or navigate to the controlled region when collapsed. The region is now always mounted with a stable `useId()` id, visibility is expressed via the native `hidden` attribute, and the button gains `aria-controls` pointing at that id. This matches the codebase's existing `ExpandableBiography` disclosure pattern. The visible "N tool calls" label and i18n strings are unchanged.