### PR TITLE
fix: mark posters and backdrops decorative inside labelled containers

### DIFF
--- a/src/components/ai-chat/chat-message.test.tsx
+++ b/src/components/ai-chat/chat-message.test.tsx
@@ -176,12 +176,16 @@ describe("ChatMessage", () => {
 
     expect(screen.getByText("Here are some results:")).toBeInTheDocument();
     expect(screen.getByText("Hope that helps!")).toBeInTheDocument();
-    // Only the presented item renders as a card, not all search results
-    expect(screen.getByAltText("Inception")).toBeInTheDocument();
+    // Only the presented item renders as a card, not all search results.
+    // The button carries the title via aria-label; the img inside has
+    // empty alt to avoid duplicate announcements.
+    const inceptionButton = screen.getByRole("button", { name: "Inception" });
+    expect(inceptionButton).toBeInTheDocument();
+    expect(inceptionButton.querySelector("img")).toHaveAttribute("alt", "");
     expect(screen.queryByAltText("Other Movie")).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Inception" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: "Other Movie" }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders present_watch_providers card from watch_providers map", () => {
@@ -314,8 +318,10 @@ describe("ChatMessage", () => {
       </MediaDetailProvider>,
     );
 
-    // The poster image should render using data from the cumulative map
-    expect(screen.getByAltText("Inception")).toBeInTheDocument();
+    // The poster image should render using data from the cumulative map.
+    // Button label carries the title; img has empty alt (decorative).
+    const inceptionButton = screen.getByRole("button", { name: "Inception" });
+    expect(inceptionButton.querySelector("img")).toHaveAttribute("alt", "");
     expect(screen.getByText("Here it is again!")).toBeInTheDocument();
   });
 

--- a/src/components/ai-chat/compact-media-card.test.tsx
+++ b/src/components/ai-chat/compact-media-card.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from "#src/test-utils.tsx";
 import { CompactMediaCard } from "./compact-media-card";
 
 describe("CompactMediaCard", () => {
-  it("renders poster image when posterPath is provided", () => {
+  it("renders the poster image when posterPath is provided (non-interactive: alt names the image)", () => {
     render(
       <CompactMediaCard
         media={{
@@ -17,7 +17,31 @@ describe("CompactMediaCard", () => {
       />,
     );
 
+    // Without onClick the card is an unlabelled <div>, so the img's alt is
+    // still the title — it's the only accessible name for the image.
     expect(screen.getByAltText("Inception")).toBeInTheDocument();
+  });
+
+  it("renders the poster image with empty alt when wrapped in a labelled button", () => {
+    render(
+      <CompactMediaCard
+        media={{
+          id: 1,
+          title: "Inception",
+          posterPath: "/inception.jpg",
+          rating: 8.4,
+          mediaType: "movie",
+        }}
+        onClick={vi.fn()}
+      />,
+    );
+
+    // Title is already on the button's aria-label; repeating it via the img
+    // alt would cause duplicate announcements.
+    const img = screen.getByRole("button").querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute("alt", "");
+    expect(screen.queryByAltText("Inception")).not.toBeInTheDocument();
   });
 
   it("renders no-poster fallback when posterPath is null", () => {

--- a/src/components/ai-chat/compact-media-card.tsx
+++ b/src/components/ai-chat/compact-media-card.tsx
@@ -21,8 +21,6 @@ function getMediaLabel(media: MediaListItem): string {
 }
 
 export function CompactMediaCard({ media, onClick }: CompactMediaCardProps) {
-  const content = <MediaPoster media={media} compact />;
-
   if (onClick) {
     return (
       <button
@@ -31,12 +29,16 @@ export function CompactMediaCard({ media, onClick }: CompactMediaCardProps) {
         onClick={onClick}
         aria-label={getMediaLabel(media)}
       >
-        {content}
+        <MediaPoster media={media} compact decorative />
       </button>
     );
   }
 
-  return <div css={styles.compactCard}>{content}</div>;
+  return (
+    <div css={styles.compactCard}>
+      <MediaPoster media={media} compact />
+    </div>
+  );
 }
 
 const styles = stylex.create({

--- a/src/components/ai-chat/compact-person-card.test.tsx
+++ b/src/components/ai-chat/compact-person-card.test.tsx
@@ -63,7 +63,7 @@ describe("CompactPersonCard", () => {
     expect(screen.queryByText("Acting")).not.toBeInTheDocument();
   });
 
-  it("renders profile photo when profilePath is provided", () => {
+  it("renders profile photo when profilePath is provided (non-interactive: alt names the image)", () => {
     render(
       <CompactPersonCard
         person={{
@@ -79,6 +79,27 @@ describe("CompactPersonCard", () => {
     expect(img).toBeInTheDocument();
     expect(img.getAttribute("src")).toContain("/tom.jpg");
     expect(img.getAttribute("srcset")).toBeTruthy();
+  });
+
+  it("renders profile photo with empty alt when wrapped in a labelled button", () => {
+    render(
+      <CompactPersonCard
+        person={{
+          id: 1,
+          name: "Tom Hanks",
+          profilePath: "/tom.jpg",
+          knownForDepartment: "Acting",
+        }}
+        onClick={vi.fn()}
+      />,
+    );
+
+    // Name is already on the button's aria-label and in the visible <span>;
+    // repeating it via the img alt would cause duplicate announcements.
+    const img = screen.getByRole("button").querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute("alt", "");
+    expect(screen.queryByAltText("Tom Hanks")).not.toBeInTheDocument();
   });
 
   it("renders initial fallback when profilePath is null", () => {

--- a/src/components/ai-chat/compact-person-card.tsx
+++ b/src/components/ai-chat/compact-person-card.tsx
@@ -24,14 +24,18 @@ function getPersonLabel(person: PersonListItem): string {
 function ProfilePhoto({
   profilePath,
   alt,
+  fallbackInitial,
 }: {
   profilePath: string;
   alt: string;
+  fallbackInitial: string;
 }) {
   const { data: config } = useSuspenseQuery(tmdbQueries.configuration);
 
   if (!config.images?.base_url || !config.images.profile_sizes) {
-    return <div css={[flex.center, styles.photoFallback]}>{alt.charAt(0)}</div>;
+    return (
+      <div css={[flex.center, styles.photoFallback]}>{fallbackInitial}</div>
+    );
   }
 
   return (
@@ -44,7 +48,7 @@ function ProfilePhoto({
       imgCss={styles.photo}
       skeletonCss={styles.photoSkeleton}
       errorFallback={
-        <div css={[flex.center, styles.photoFallback]}>{alt.charAt(0)}</div>
+        <div css={[flex.center, styles.photoFallback]}>{fallbackInitial}</div>
       }
       loading="lazy"
     />
@@ -53,12 +57,21 @@ function ProfilePhoto({
 
 export function CompactPersonCard({ person, onClick }: CompactPersonCardProps) {
   const label = getPersonLabel(person);
+  // When wrapped in the labelled button below, the name is already announced
+  // via both the button's `aria-label` and the visible `<span>` below the
+  // photo, so the photo's `alt` is decorative. In the non-interactive `<div>`
+  // branch the image alt is the only name, so keep the label.
+  const photoAlt = onClick ? "" : label;
 
   const content = (
     <>
       <div css={styles.photoWrapper}>
         {person.profilePath ? (
-          <ProfilePhoto profilePath={person.profilePath} alt={label} />
+          <ProfilePhoto
+            profilePath={person.profilePath}
+            alt={photoAlt}
+            fallbackInitial={label.charAt(0)}
+          />
         ) : (
           <div css={[flex.center, styles.photoFallback]}>{label.charAt(0)}</div>
         )}

--- a/src/components/ai-chat/media-detail-content.tsx
+++ b/src/components/ai-chat/media-detail-content.tsx
@@ -115,7 +115,6 @@ export function MediaDetailContent({
           baseUrl={imageBaseUrl}
           sizes={config.images?.backdrop_sizes ?? []}
           path={detail.backdropPath}
-          alt={displayTitle}
         />
       ) : (
         detailQuery.isPending && <Skeleton css={skeletonStyles.backdrop} />
@@ -128,7 +127,7 @@ export function MediaDetailContent({
                 baseUrl={imageBaseUrl}
                 sizes={config.images?.poster_sizes ?? []}
                 path={posterPath}
-                alt={displayTitle}
+                fallbackInitial={displayTitle.charAt(0)}
               />
             </div>
           ) : posterPath ? (
@@ -221,24 +220,28 @@ function PosterImage({
   baseUrl,
   sizes,
   path,
-  alt,
+  fallbackInitial,
 }: {
   baseUrl: string;
   sizes: ReadonlyArray<string>;
   path: string;
-  alt: string;
+  fallbackInitial: string;
 }) {
+  // The surrounding overlay renders the media title in an adjacent <h2>,
+  // so the poster is decorative (WAI-ARIA 1.2 decorative-image pattern).
   return (
     <TmdbImage
       baseUrl={baseUrl}
       sizeConfig={sizes}
       path={path}
-      alt={alt}
+      alt=""
       sizes="90px"
       imgCss={imageCover.base}
       skeletonCss={skeletonStyles.poster}
       errorFallback={
-        <div css={[imageCover.base, styles.imageFallback]}>{alt.charAt(0)}</div>
+        <div css={[imageCover.base, styles.imageFallback]}>
+          {fallbackInitial}
+        </div>
       }
     />
   );
@@ -248,20 +251,20 @@ function BackdropImage({
   baseUrl,
   sizes,
   path,
-  alt,
 }: {
   baseUrl: string;
   sizes: ReadonlyArray<string>;
   path: string;
-  alt: string;
 }) {
+  // The surrounding overlay renders the media title in an adjacent <h2>,
+  // so the backdrop is decorative (WAI-ARIA 1.2 decorative-image pattern).
   return (
     <div css={styles.backdropContainer}>
       <TmdbImage
         baseUrl={baseUrl}
         sizeConfig={sizes}
         path={path}
-        alt={alt}
+        alt=""
         sizes="600px"
         imgCss={styles.backdropImage}
         skeletonCss={skeletonStyles.backdropOverlay}

--- a/src/components/ai-chat/recommended-media-row.test.tsx
+++ b/src/components/ai-chat/recommended-media-row.test.tsx
@@ -33,14 +33,22 @@ describe("RecommendedMediaRow", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders poster images for each item", () => {
+  it("renders poster images for each item with empty alt (title is on the button label)", () => {
     render(
       <MediaDetailProvider>
         <RecommendedMediaRow title="Trending Movies" items={mockItems} />
       </MediaDetailProvider>,
     );
-    expect(screen.getByAltText("Movie One")).toBeInTheDocument();
-    expect(screen.getByAltText("Movie Two")).toBeInTheDocument();
+    const oneImg = screen
+      .getByRole("button", { name: "Movie One" })
+      .querySelector("img");
+    const twoImg = screen
+      .getByRole("button", { name: "Movie Two" })
+      .querySelector("img");
+    expect(oneImg).not.toBeNull();
+    expect(oneImg).toHaveAttribute("alt", "");
+    expect(twoImg).not.toBeNull();
+    expect(twoImg).toHaveAttribute("alt", "");
   });
 
   it("renders rating badges", () => {

--- a/src/components/ai-chat/tool-media-cards.test.tsx
+++ b/src/components/ai-chat/tool-media-cards.test.tsx
@@ -44,15 +44,23 @@ describe("ToolMediaCards", () => {
     expect(buttons).toHaveLength(2);
   });
 
-  it("renders poster images", () => {
+  it("renders poster images with empty alt so the button's label is not duplicated", () => {
     render(
       <MediaDetailProvider>
         <ToolMediaCards items={mockItems} />
       </MediaDetailProvider>,
     );
 
-    expect(screen.getByAltText("Inception")).toBeInTheDocument();
-    expect(screen.getByAltText("Breaking Bad")).toBeInTheDocument();
+    const inceptionButton = screen.getByRole("button", { name: "Inception" });
+    const inceptionImg = inceptionButton.querySelector("img");
+    expect(inceptionImg).not.toBeNull();
+    expect(inceptionImg?.getAttribute("src")).toContain("/inception.jpg");
+    expect(inceptionImg).toHaveAttribute("alt", "");
+
+    const bbButton = screen.getByRole("button", { name: "Breaking Bad" });
+    const bbImg = bbButton.querySelector("img");
+    expect(bbImg).not.toBeNull();
+    expect(bbImg).toHaveAttribute("alt", "");
   });
 
   it("returns null when items array is empty", () => {

--- a/src/components/ai-chat/tool-visual-output.test.tsx
+++ b/src/components/ai-chat/tool-visual-output.test.tsx
@@ -66,8 +66,11 @@ describe("ToolVisualOutput", () => {
         </MediaDetailProvider>,
       );
 
-      expect(screen.getByAltText("Inception")).toBeInTheDocument();
-      expect(screen.getByRole("button")).toBeInTheDocument();
+      // Button carries the title via aria-label; the img inside has empty
+      // alt to avoid duplicate announcements.
+      const button = screen.getByRole("button", { name: "Inception" });
+      expect(button).toBeInTheDocument();
+      expect(button.querySelector("img")).toHaveAttribute("alt", "");
     });
 
     it("renders cards for output-available", () => {

--- a/src/components/movie-database/backdrop-image.tsx
+++ b/src/components/movie-database/backdrop-image.tsx
@@ -7,15 +7,17 @@ import { buildSrcSet } from "#src/utils/tmdb-image.ts";
 
 interface BackdropImageProps {
   backdropPath: string;
-  alt: string;
 }
 
 /**
  * A component that renders a backdrop image with responsive sizing.
  * If the required configuration is unavailable, nothing is rendered.
  * The component generates `srcSet` for responsive image handling.
+ *
+ * The backdrop is purely decorative reinforcement of the adjacent heading,
+ * so the `<img>` carries `alt=""` (WAI-ARIA 1.2 decorative-image pattern).
  */
-export async function BackdropImage({ backdropPath, alt }: BackdropImageProps) {
+export async function BackdropImage({ backdropPath }: BackdropImageProps) {
   const config = await getConfiguration();
 
   if (!config.images?.base_url || !config.images.backdrop_sizes) {
@@ -35,7 +37,7 @@ export async function BackdropImage({ backdropPath, alt }: BackdropImageProps) {
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         css={styles.image}
-        alt={alt}
+        alt=""
         src={src}
         srcSet={srcSet}
         sizes="100vw"

--- a/src/components/movie-database/media-card.tsx
+++ b/src/components/movie-database/media-card.tsx
@@ -39,7 +39,7 @@ export function MediaCard({ media, allowFollow }: MediaCardProps) {
       rel={allowFollow ? undefined : "nofollow"}
     >
       <div css={[absoluteFill.all, styles.posterContainer]}>
-        <MediaPoster media={media} />
+        <MediaPoster media={media} decorative />
       </div>
     </Card>
   );

--- a/src/components/movie-database/media-detail-hero.tsx
+++ b/src/components/movie-database/media-detail-hero.tsx
@@ -40,9 +40,7 @@ export function MediaDetailHero({
 
   return (
     <div css={styles.container}>
-      {backdropPath && (
-        <BackdropImage backdropPath={backdropPath} alt={title} />
-      )}
+      {backdropPath && <BackdropImage backdropPath={backdropPath} />}
       <div css={styles.hero}>
         <div
           css={styles.ratingContainer}

--- a/src/components/movie-database/media-poster.tsx
+++ b/src/components/movie-database/media-poster.tsx
@@ -11,6 +11,11 @@ import { PosterImage } from "./poster-image";
 interface MediaPosterProps {
   media: MediaListItem;
   compact?: boolean;
+  // When the poster is rendered inside a container that already carries the
+  // media title as its accessible name (e.g. `MediaCard`'s `aria-label`),
+  // set `decorative` so the `<img>` gets `alt=""` and screen readers stop
+  // announcing the title twice. The visible fallback still shows the title.
+  decorative?: boolean;
 }
 
 function getPosterAlt(media: MediaListItem): string {
@@ -22,14 +27,20 @@ function getPosterAlt(media: MediaListItem): string {
   return t({ en: "Media poster", zh: "媒体海报" });
 }
 
-export function MediaPoster({ media, compact }: MediaPosterProps) {
+export function MediaPoster({ media, compact, decorative }: MediaPosterProps) {
   const locale = useLocale();
   const formatter = new Intl.NumberFormat(locale, { maximumFractionDigits: 1 });
+  const alt = decorative ? "" : getPosterAlt(media);
+  const fallbackLabel = getPosterAlt(media);
 
   return (
     <>
       {media.posterPath ? (
-        <PosterImage posterPath={media.posterPath} alt={getPosterAlt(media)} />
+        <PosterImage
+          posterPath={media.posterPath}
+          alt={alt}
+          fallbackLabel={fallbackLabel}
+        />
       ) : (
         <div
           css={[

--- a/src/components/movie-database/poster-image.tsx
+++ b/src/components/movie-database/poster-image.tsx
@@ -12,6 +12,11 @@ import { TmdbImage } from "./tmdb-image.tsx";
 interface PosterImageProps {
   posterPath: string;
   alt: string;
+  // Visible text rendered inside the fallback/error UI. Separate from `alt`
+  // so callers can use `alt=""` for decorative images (e.g. inside a labelled
+  // card) while still showing the media title to sighted users when the
+  // poster is unavailable.
+  fallbackLabel?: string;
 }
 
 /**
@@ -19,13 +24,18 @@ interface PosterImageProps {
  * If the required configuration is unavailable or the image fails to load, a fallback UI is displayed.
  * The component supports lazy loading and generates `srcSet` for responsive image handling.
  */
-export function PosterImage({ posterPath, alt }: PosterImageProps) {
+export function PosterImage({
+  posterPath,
+  alt,
+  fallbackLabel,
+}: PosterImageProps) {
   const { data: config } = useSuspenseQuery(tmdbQueries.configuration);
+  const visibleLabel = fallbackLabel ?? alt;
 
   if (!config.images?.base_url || !config.images.poster_sizes) {
     return (
       <div css={[imageCover.base, flex.center, styles.errored]}>
-        <div>{alt}</div>
+        <div>{visibleLabel}</div>
         <div css={styles.errorText}>{t({ en: "No Poster", zh: "无海报" })}</div>
       </div>
     );
@@ -43,7 +53,7 @@ export function PosterImage({ posterPath, alt }: PosterImageProps) {
       skeletonCss={[flex.center, styles.errored]}
       errorFallback={
         <div css={[imageCover.base, flex.center, styles.errored]}>
-          <div>{alt}</div>
+          <div>{visibleLabel}</div>
           <div css={styles.errorText}>
             {t({ en: "No Poster", zh: "无海报" })}
           </div>


### PR DESCRIPTION
## Summary

Posters and backdrops rendered inside containers that already carry the media/person title as their accessible name (`<Card aria-label>`, labelled `<button aria-label>`, or adjacent `<h1>`/`<h2>`) now use `alt=""` so assistive tech stops announcing the title twice per card. Introduces an opt-in `decorative` prop on `MediaPoster` and a separate `fallbackLabel`/`fallbackInitial` prop so the visible "No Poster" / initial-letter affordances for sighted users are preserved even though the image alt is empty. The standalone and non-interactive branches of `CompactMediaCard` / `CompactPersonCard` keep their original alt, since there the image is the image's only accessible name.