### PR TITLE
fix: keep dialog focus stable across caller re-renders

### DIFF
--- a/src/hooks/use-dialog-focus.test.ts
+++ b/src/hooks/use-dialog-focus.test.ts
@@ -298,4 +298,64 @@ describe("useDialogFocus", () => {
     // Focus restored to trigger
     expect(trigger).toHaveFocus();
   });
+
+  it("does not steal focus or overwrite triggerRef when the caller re-renders with a new onClose identity", () => {
+    const trigger = document.createElement("button");
+    trigger.textContent = "Trigger";
+    document.body.append(trigger);
+    trigger.focus();
+
+    const { dialog, button1, button2 } = createFocusableDialog();
+    const dialogRef = { current: dialog };
+
+    const { rerender, unmount } = renderHook(
+      ({ onClose }: { onClose: () => void }) => {
+        useDialogFocus({ isOpen: true, dialogRef, onClose });
+      },
+      { initialProps: { onClose: vi.fn() } },
+    );
+
+    // Hook moved focus to first focusable on mount.
+    expect(button1).toHaveFocus();
+
+    // Simulate the user tabbing within the dialog.
+    button2.focus();
+    expect(button2).toHaveFocus();
+
+    // Parent re-renders and passes a brand-new inline onClose — this is
+    // what happens on every AI-chat streaming chunk. The dialog stays open.
+    rerender({ onClose: vi.fn() });
+
+    // Focus must stay where the user put it, not snap back to button1.
+    expect(button2).toHaveFocus();
+
+    // And on unmount, the trigger saved on the original open should still
+    // be restored — proving triggerRef wasn't overwritten with a dialog-
+    // internal element during the re-render.
+    unmount();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("invokes the latest onClose after the caller re-renders with a new identity", () => {
+    const { dialog } = createFocusableDialog();
+    const dialogRef = { current: dialog };
+    const firstOnClose = vi.fn();
+    const secondOnClose = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ onClose }: { onClose: () => void }) => {
+        useDialogFocus({ isOpen: true, dialogRef, onClose });
+      },
+      { initialProps: { onClose: firstOnClose } },
+    );
+
+    rerender({ onClose: secondOnClose });
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    // The Escape handler reads the latest onClose, not the one captured
+    // when the effect first ran.
+    expect(firstOnClose).not.toHaveBeenCalled();
+    expect(secondOnClose).toHaveBeenCalledOnce();
+  });
 });

--- a/src/hooks/use-dialog-focus.ts
+++ b/src/hooks/use-dialog-focus.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type RefObject } from "react";
+import { useEffect, useEffectEvent, useRef, type RefObject } from "react";
 
 const FOCUSABLE_SELECTOR = [
   'a[href]:not([tabindex="-1"])',
@@ -43,6 +43,25 @@ export function useDialogFocus({
 }) {
   const triggerRef = useRef<HTMLElement | null>(null);
 
+  // Read the latest `onClose` / `initialFocusRef` without putting them in
+  // the effect dep array. Parent re-renders (e.g. per AI-chat streaming
+  // chunk) hand us fresh inline closures and freshly-derived refs; without
+  // this indirection the effect tears down and restarts on every render,
+  // which silently yanks focus back to the initial target, overwrites
+  // `triggerRef` with a dialog-internal element, and re-binds the keydown
+  // handler. See cycle 5 brief.
+  const handleEscape = useEffectEvent(() => {
+    onClose();
+  });
+  const resolveInitialFocus = useEffectEvent(() => {
+    if (initialFocusRef?.current) return initialFocusRef.current;
+    if (dialogRef.current) {
+      const focusable = getFocusableElements(dialogRef.current);
+      if (focusable.length > 0) return focusable[0];
+    }
+    return null;
+  });
+
   useEffect(() => {
     if (!isOpen) return;
 
@@ -54,17 +73,12 @@ export function useDialogFocus({
 
     // Move focus into the dialog once the portal renders
     requestAnimationFrame(() => {
-      if (initialFocusRef?.current) {
-        initialFocusRef.current.focus();
-      } else if (dialogRef.current) {
-        const focusable = getFocusableElements(dialogRef.current);
-        if (focusable.length > 0) focusable[0].focus();
-      }
+      resolveInitialFocus()?.focus();
     });
 
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
-        onClose();
+        handleEscape();
         return;
       }
 
@@ -92,5 +106,5 @@ export function useDialogFocus({
       // Restore focus to the element that opened the dialog
       triggerRef.current?.focus();
     };
-  }, [isOpen, onClose, dialogRef, initialFocusRef]);
+  }, [isOpen, dialogRef]);
 }


### PR DESCRIPTION
## Summary

`useDialogFocus` previously listed `onClose` and `initialFocusRef` in its effect dep array, so every parent re-render that passed a fresh inline `onClose` or a newly-derived ref tore the effect down and rebuilt it — yanking focus back to the initial target mid-interaction, overwriting the saved trigger with a dialog-internal element, and re-binding the global keydown handler. This was particularly visible while the AI chat streamed and any open dialog lost the user's current focus position once per chunk. The hook now reads `onClose` and `initialFocusRef` through `useEffectEvent` and trims the dep array to `[isOpen, dialogRef]`, matching the `useEffectEvent` pattern the codebase already uses elsewhere.