### PR TITLE
perf: preload Inter font on all locales, not just en

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -63,15 +63,21 @@ export default async function RootLayout({
           }}
         />
         {/* eslint-enable @eslint-react/dom-no-dangerously-set-innerhtml */}
-        {locale === "en" && (
-          <link
-            rel="preload"
-            href="/InterVariableOptimized.woff2"
-            as="font"
-            type="font/woff2"
-            crossOrigin="anonymous"
-          />
-        )}
+        {/*
+          Both locales render Latin text in Inter (names, dates, brand
+          wordmarks, numbers), so both locales benefit from preloading it.
+          The `@font-face` `unicode-range` limits Inter to Latin glyphs, so
+          CJK-only text still falls through to system fonts — the preload
+          warms the cache for the mixed-content case without wasting bytes
+          on pure-CJK runs.
+        */}
+        <link
+          rel="preload"
+          href="/InterVariableOptimized.woff2"
+          as="font"
+          type="font/woff2"
+          crossOrigin="anonymous"
+        />
       </head>
       <body css={globalStyles.body}>
         <I18nProvider locale={locale}>


### PR DESCRIPTION
## Summary

The Inter font preload was gated on `locale === "en"`, but the body font stack (`Inter, Inter-fallback, sans-serif`) is the same on both locales, and the `@font-face` `unicode-range` already limits Inter to Latin glyphs — so Chinese pages still render names, dates, numbers, and brand words in Inter once it downloads. The gate just delayed that first Latin request on `/zh`. The preload is now emitted unconditionally, with a comment explaining why so a future editor doesn't re-introduce the gate.