### PR TITLE
fix: tie MenuButton trigger to its popup via aria-controls

### DIFF
--- a/src/components/shared/menu-button.test.tsx
+++ b/src/components/shared/menu-button.test.tsx
@@ -200,6 +200,71 @@ describe("MenuButton keyboard navigation", () => {
     expect(container.querySelector("[inert]")).toBeNull();
   });
 
+  it("ties the trigger to the popup via aria-controls while closed", () => {
+    render(
+      <RouterProvider>
+        <TestMenu />
+      </RouterProvider>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Open menu" });
+    const controlsId = trigger.getAttribute("aria-controls") ?? "";
+    expect(controlsId).not.toBe("");
+
+    // Popup is always mounted (hidden via inert), so the referenced element
+    // must exist in the DOM even before the menu is opened.
+    const popup = document.getElementById(controlsId);
+    expect(popup).not.toBeNull();
+    expect(popup).toHaveAttribute("role", "menu");
+  });
+
+  it("keeps aria-controls pointing at the popup after opening", async () => {
+    const user = userEvent.setup();
+    render(
+      <RouterProvider>
+        <TestMenu />
+      </RouterProvider>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Open menu" });
+    const controlsIdBefore = trigger.getAttribute("aria-controls") ?? "";
+
+    await user.click(trigger);
+
+    // Same relationship holds open — same id, same popup element.
+    const controlsIdAfter = trigger.getAttribute("aria-controls") ?? "";
+    expect(controlsIdAfter).toBe(controlsIdBefore);
+
+    const popup = document.getElementById(controlsIdAfter);
+    expect(popup).not.toBeNull();
+    // Popup is the element carrying role=menu and the menu items.
+    expect(popup).toHaveAttribute("role", "menu");
+    expect(popup?.querySelectorAll('[role="menuitem"]')).toHaveLength(3);
+  });
+
+  it("ties the trigger to the popup via aria-controls for non-menu popups too", () => {
+    render(
+      <MenuButton
+        buttonProps={{ type: "button", "aria-label": "Open filters" }}
+        popupRole="group"
+        menuContent={
+          <div>
+            <button type="button">Filter A</button>
+            <button type="button">Filter B</button>
+          </div>
+        }
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Open filters" });
+    const controlsId = trigger.getAttribute("aria-controls") ?? "";
+    expect(controlsId).not.toBe("");
+
+    const popup = document.getElementById(controlsId);
+    expect(popup).not.toBeNull();
+    expect(popup).toHaveAttribute("role", "group");
+  });
+
   it("does not intercept arrow keys when popupRole is not 'menu'", async () => {
     const user = userEvent.setup();
 

--- a/src/components/shared/menu-button.tsx
+++ b/src/components/shared/menu-button.tsx
@@ -78,6 +78,7 @@ export function MenuButton({
   }, [isMenuShown, popupRole]);
 
   const targetId = useId();
+  const popupId = `${targetId}-popup`;
 
   return (
     <>
@@ -160,6 +161,7 @@ export function MenuButton({
             {...buttonProps}
             aria-expanded={isMenuShown}
             aria-haspopup={popupRole === "menu" ? "menu" : "true"}
+            aria-controls={popupId}
             onClick={() => {
               setIsMenuShown(true);
             }}
@@ -184,6 +186,7 @@ export function MenuButton({
             targetId={targetId}
           >
             <div
+              id={popupId}
               ref={popupRef}
               role={popupRole}
               aria-labelledby={`${targetId}-label`}


### PR DESCRIPTION
## Summary

`MenuButton`'s trigger had `aria-expanded` and `aria-haspopup` but no `aria-controls`, so assistive tech couldn't navigate from the trigger to the popup it reveals — missing half of the WAI-ARIA "Menu Button" relationship. The trigger now carries `aria-controls` pointing at a stable id derived from the existing `useId()`, and the popup `<div>` that already carries `role={popupRole}` + `aria-labelledby` now has the matching `id`. The popup is always mounted (hidden via `inert`), so `aria-controls` resolves in both open and closed states. The fix lands at the primitive so `LocaleSelector` and `MobileFiltersButton` benefit without caller changes.