### PR TITLE
fix: use inert on auxiliary chat buttons instead of aria-hidden + tabIndex

### DIFF
--- a/src/components/ai-chat/horizontal-scroll-buttons.tsx
+++ b/src/components/ai-chat/horizontal-scroll-buttons.tsx
@@ -40,8 +40,7 @@ export function HorizontalScrollButtons({
       <button
         type="button"
         aria-label={t({ en: "Scroll left", zh: "向左滚动" })}
-        aria-hidden={!showLeft}
-        tabIndex={showLeft ? 0 : -1}
+        inert={!showLeft}
         onClick={() => {
           scroll(-1);
         }}
@@ -57,8 +56,7 @@ export function HorizontalScrollButtons({
       <button
         type="button"
         aria-label={t({ en: "Scroll right", zh: "向右滚动" })}
-        aria-hidden={!showRight}
-        tabIndex={showRight ? 0 : -1}
+        inert={!showRight}
         onClick={() => {
           scroll(1);
         }}

--- a/src/components/ai-chat/recommended-media-row.test.tsx
+++ b/src/components/ai-chat/recommended-media-row.test.tsx
@@ -59,7 +59,13 @@ describe("RecommendedMediaRow", () => {
         <RecommendedMediaRow title="Trending Movies" items={mockItems} />
       </MediaDetailProvider>,
     );
-    expect(screen.queryAllByRole("button")).toHaveLength(2);
+    // One button per card, labelled with the media title.
+    expect(
+      screen.getByRole("button", { name: "Movie One" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Movie Two" }),
+    ).toBeInTheDocument();
   });
 
   it("renders no-poster fallback when posterPath is null", () => {

--- a/src/components/ai-chat/scroll-to-bottom-button.test.tsx
+++ b/src/components/ai-chat/scroll-to-bottom-button.test.tsx
@@ -33,22 +33,7 @@ describe("ScrollToBottomButton", () => {
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
 
-  it("is hidden from accessibility tree when not visible", () => {
-    render(
-      <ScrollToBottomButton
-        visible={false}
-        label="Scroll to bottom"
-        onClick={() => {}}
-      />,
-    );
-
-    // aria-hidden removes it from the accessible role query
-    expect(
-      screen.queryByRole("button", { name: "Scroll to bottom" }),
-    ).not.toBeInTheDocument();
-  });
-
-  it("is removed from tab order when not visible", () => {
+  it("is inert (hidden from AT, removed from tab order, non-clickable) when not visible", () => {
     const { container } = render(
       <ScrollToBottomButton
         visible={false}
@@ -58,10 +43,18 @@ describe("ScrollToBottomButton", () => {
     );
 
     const button = container.querySelector("button");
-    expect(button).toHaveAttribute("tabindex", "-1");
+    // The native `inert` attribute is the single declarative switch that
+    // covers all three concerns: removes the button from the a11y tree,
+    // skips it in the tab order, and blocks pointer events.
+    expect(button).toHaveAttribute("inert");
+    // And we no longer stack aria-hidden/tabIndex on top of inert — those
+    // would be redundant, and the aria-hidden + focusable combo is a WCAG
+    // 4.1.2 anti-pattern.
+    expect(button).not.toHaveAttribute("aria-hidden");
+    expect(button).not.toHaveAttribute("tabindex");
   });
 
-  it("is in the tab order when visible", () => {
+  it("is a regular interactive control when visible", () => {
     const { container } = render(
       <ScrollToBottomButton
         visible={true}
@@ -71,7 +64,12 @@ describe("ScrollToBottomButton", () => {
     );
 
     const button = container.querySelector("button");
-    expect(button).toHaveAttribute("tabindex", "0");
-    expect(button).toHaveAttribute("aria-hidden", "false");
+    expect(button).not.toHaveAttribute("inert");
+    expect(button).not.toHaveAttribute("aria-hidden");
+    expect(button).not.toHaveAttribute("tabindex");
+    // Reachable via role query.
+    expect(
+      screen.getByRole("button", { name: "Scroll to bottom" }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/ai-chat/scroll-to-bottom-button.tsx
+++ b/src/components/ai-chat/scroll-to-bottom-button.tsx
@@ -21,8 +21,7 @@ export function ScrollToBottomButton({
     <button
       type="button"
       aria-label={label}
-      aria-hidden={!visible}
-      tabIndex={visible ? 0 : -1}
+      inert={!visible}
       onClick={onClick}
       css={[
         buttonReset.base,

--- a/src/components/ai-chat/tool-media-cards.test.tsx
+++ b/src/components/ai-chat/tool-media-cards.test.tsx
@@ -40,8 +40,13 @@ describe("ToolMediaCards", () => {
       </MediaDetailProvider>,
     );
 
-    const buttons = screen.getAllByRole("button");
-    expect(buttons).toHaveLength(2);
+    // One button per card, labelled with the media title.
+    expect(
+      screen.getByRole("button", { name: "Inception" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Breaking Bad" }),
+    ).toBeInTheDocument();
   });
 
   it("renders poster images", () => {
@@ -89,8 +94,12 @@ describe("ToolMediaCards", () => {
       </MediaDetailProvider>,
     );
 
-    const buttons = screen.getAllByRole("button");
-    expect(buttons).toHaveLength(2);
+    expect(
+      screen.getByRole("button", { name: "Same ID Movie" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Same ID TV Show" }),
+    ).toBeInTheDocument();
   });
 
   it("renders cards without buttons when mediaType is null", () => {
@@ -110,7 +119,12 @@ describe("ToolMediaCards", () => {
       </MediaDetailProvider>,
     );
 
-    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    // No media-card button for typeless items — the only buttons present
+    // are the horizontal scroll chevrons (inert when the row doesn't
+    // overflow, which is the jsdom case here).
+    expect(
+      screen.queryByRole("button", { name: "Unknown Type" }),
+    ).not.toBeInTheDocument();
     expect(screen.getByAltText("Unknown Type")).toBeInTheDocument();
   });
 });

--- a/src/components/ai-chat/tool-visual-output.test.tsx
+++ b/src/components/ai-chat/tool-visual-output.test.tsx
@@ -67,7 +67,9 @@ describe("ToolVisualOutput", () => {
       );
 
       expect(screen.getByAltText("Inception")).toBeInTheDocument();
-      expect(screen.getByRole("button")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Inception" }),
+      ).toBeInTheDocument();
     });
 
     it("renders cards for output-available", () => {
@@ -89,8 +91,11 @@ describe("ToolVisualOutput", () => {
         </MediaDetailProvider>,
       );
 
-      const buttons = screen.getAllByRole("button");
-      expect(buttons).toHaveLength(2);
+      // One button per media card, labelled with the title.
+      expect(screen.getByRole("button", { name: "Dark" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Inception" }),
+      ).toBeInTheDocument();
     });
 
     it("renders fallback card when ID not in search results", () => {
@@ -107,7 +112,9 @@ describe("ToolVisualOutput", () => {
         </MediaDetailProvider>,
       );
 
-      expect(screen.getByRole("button")).toBeInTheDocument();
+      // Fallback card still renders as an interactive button — it uses a
+      // generic "Movie" label since no title is available for id 999.
+      expect(screen.getByRole("button", { name: "Movie" })).toBeInTheDocument();
     });
 
     it("shows error for output-error state", () => {
@@ -371,8 +378,13 @@ describe("ToolVisualOutput", () => {
         </MediaDetailProvider>,
       );
 
-      const buttons = screen.getAllByRole("button");
-      expect(buttons).toHaveLength(2);
+      // One button per person, labelled with the name.
+      expect(
+        screen.getByRole("button", { name: "Leonardo DiCaprio" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Christopher Nolan" }),
+      ).toBeInTheDocument();
     });
 
     it("renders fallback card when person ID not in results map", () => {
@@ -389,7 +401,11 @@ describe("ToolVisualOutput", () => {
         </MediaDetailProvider>,
       );
 
-      expect(screen.getByRole("button")).toBeInTheDocument();
+      // Fallback card still renders as an interactive button; generic
+      // "Person" label since no name is available for id 777.
+      expect(
+        screen.getByRole("button", { name: "Person" }),
+      ).toBeInTheDocument();
     });
 
     it("shows error for output-error state", () => {


### PR DESCRIPTION
## Summary

`ScrollToBottomButton` and both `HorizontalScrollButtons` chevrons were hiding themselves via `aria-hidden={!visible}` stacked with `tabIndex={visible ? 0 : -1}` — the "aria-hidden on a focusable element" combination that's a WCAG 4.1.2 anti-pattern flagged by axe and WAVE. They now use the native `inert` attribute instead, which is the single declarative switch that removes the button from the accessibility tree, takes it out of the tab order, and blocks pointer events. This matches the `CollapsedChatInput` pattern already in the codebase and keeps the CSS fade transition untouched. Tests updated to pin the new single-attribute contract and to assert the anti-pattern is gone.