### PR TITLE
fix: expose theme system button as aria-pressed toggle

### DIFF
--- a/e2e/theme-toggle.spec.ts
+++ b/e2e/theme-toggle.spec.ts
@@ -124,7 +124,7 @@ test.describe("Theme Toggle", () => {
 
     // Hover/focus to show reset button
     await themeToggle.hover();
-    const resetButton = page.getByRole("radio", {
+    const resetButton = page.getByRole("button", {
       name: /switch to system theme/i,
     });
     await expect(resetButton).toBeVisible();

--- a/src/components/shared/theme-switch.test.tsx
+++ b/src/components/shared/theme-switch.test.tsx
@@ -103,7 +103,7 @@ describe("ThemeSwitch keyboard reveal", () => {
     const root = renderThemeSwitch();
 
     const switchControl = screen.getByRole("switch");
-    const systemButton = screen.getByRole("radio", {
+    const systemButton = screen.getByRole("button", {
       name: "Use system theme",
     });
 
@@ -114,5 +114,38 @@ describe("ThemeSwitch keyboard reveal", () => {
     // relatedTarget is still inside the container, so the blur should be a
     // no-op for `hasFocus`.
     expect(root.className).toContain("showSystemButton");
+  });
+});
+
+describe("ThemeSwitch system-button semantics", () => {
+  it("exposes the system control as a toggle button with aria-pressed", () => {
+    // Explicit light theme so "system" is the non-active state.
+    localStorage.setItem("theme", "light");
+    renderThemeSwitch();
+
+    const systemButton = screen.getByRole("button", {
+      name: "Use system theme",
+    });
+
+    // It's a plain <button>, not a stranded `role="radio"` with no
+    // radiogroup. `aria-pressed` — supplied by the shared `Button`
+    // primitive when `isActive` is set — is the correct toggle semantic.
+    expect(systemButton).toHaveAttribute("aria-pressed", "false");
+    expect(systemButton).not.toHaveAttribute("role", "radio");
+    expect(systemButton).not.toHaveAttribute("aria-checked");
+    // Active toggles stay interactive; `disabled` would misrepresent
+    // "this is the current choice" as "this choice is unavailable".
+    expect(systemButton).not.toBeDisabled();
+  });
+
+  it("reflects active state via aria-pressed when system is the current theme", () => {
+    // Default theme (no seeded value) resolves to "system".
+    renderThemeSwitch();
+
+    const systemButton = screen.getByRole("button", {
+      name: "Use system theme",
+    });
+    expect(systemButton).toHaveAttribute("aria-pressed", "true");
+    expect(systemButton).not.toBeDisabled();
   });
 });

--- a/src/components/shared/theme-switch.tsx
+++ b/src/components/shared/theme-switch.tsx
@@ -80,13 +80,12 @@ export function ThemeSwitch({ labels }: ThemeSwitchProps) {
     >
       <div css={styles.systemButton}>
         <Button
-          role="radio"
           aria-label={labels[2]}
-          aria-checked={theme === "system"}
+          isActive={theme === "system"}
           onClick={() => {
+            if (theme === "system") return;
             setTheme("system");
           }}
-          disabled={theme === "system"}
           title={labels[2]}
         >
           <div css={styles.systemIcon}>


### PR DESCRIPTION
## Summary

The theme system button was a stranded `role="radio"` with `aria-checked` but no enclosing `role="radiogroup"` — an invalid ARIA pattern that makes screen readers announce "radio, checked/not checked" without group context. It also used `disabled={theme === "system"}` to prevent no-op clicks, which announces the currently-selected option as "dimmed/unavailable" instead of "active choice". The button now uses the shared `Button` primitive's `isActive` → `aria-pressed` convention (the toggle-button pattern already used elsewhere in the codebase), stays interactive while active, and preserves the no-op-when-active behaviour via an early-return in the click handler.