### PR TITLE
fix: pass locale to media_credits TMDB request

### DIFF
--- a/src/ai-chat/chat.ts
+++ b/src/ai-chat/chat.ts
@@ -45,7 +45,7 @@ export async function chat({
       watch_providers: createWatchProvidersTool(),
       present_watch_providers: createPresentWatchProvidersTool(),
       present_provider_regions: createPresentProviderRegionsTool(),
-      media_credits: createMediaCreditsTool(),
+      media_credits: createMediaCreditsTool(locale),
       person_credits: createPersonCreditsTool(locale),
       present_person: createPresentPersonTool(),
       review_summary: createReviewSummaryTool(locale),

--- a/src/ai-chat/tools/media-credits.test.ts
+++ b/src/ai-chat/tools/media-credits.test.ts
@@ -1,0 +1,110 @@
+import { http, HttpResponse } from "msw";
+import { beforeAll, describe, expect, it } from "vitest";
+import { server } from "#src/test-msw.ts";
+import {
+  createMediaCreditsTool,
+  mediaCreditsInputSchema,
+} from "./media-credits";
+import { isToolError } from "./tool-error";
+
+beforeAll(() => {
+  process.env.TMDB_API_TOKEN = "test-token";
+});
+
+const TMDB_BASE = "https://api.themoviedb.org";
+
+const executeContext = {
+  toolCallId: "test",
+  messages: [] as never[],
+  abortSignal: AbortSignal.timeout(5000),
+};
+
+async function executeTool(
+  input: { media_id: number; media_type: "movie" | "tv" },
+  locale: "en" | "zh" = "en",
+) {
+  const tool = createMediaCreditsTool(locale);
+  if (!tool.execute) throw new Error("expected execute");
+  const result = await tool.execute(input, executeContext);
+  return JSON.parse(JSON.stringify(result)) as unknown;
+}
+
+describe("mediaCreditsInputSchema", () => {
+  it("accepts a numeric media_id with a movie media_type", () => {
+    expect(
+      mediaCreditsInputSchema.parse({ media_id: 550, media_type: "movie" }),
+    ).toEqual({ media_id: 550, media_type: "movie" });
+  });
+
+  it("rejects an invalid media_type", () => {
+    expect(() =>
+      mediaCreditsInputSchema.parse({ media_id: 550, media_type: "book" }),
+    ).toThrow();
+  });
+});
+
+describe("createMediaCreditsTool", () => {
+  it("returns a tool with description and inputSchema", () => {
+    const tool = createMediaCreditsTool("en");
+    expect(tool.description).toBeDefined();
+    expect(tool.description).toContain("cast and crew");
+    expect(tool.inputSchema).toBeDefined();
+  });
+});
+
+describe("media credits execute", () => {
+  it("returns a structured tool error when TMDB fails", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/credits`, () =>
+        HttpResponse.json(
+          { status_message: "Service unavailable" },
+          { status: 503 },
+        ),
+      ),
+    );
+
+    const tool = createMediaCreditsTool("en");
+    if (!tool.execute) throw new Error("expected execute");
+    const result = await tool.execute(
+      { media_id: 550, media_type: "movie" },
+      executeContext,
+    );
+
+    expect(isToolError(result)).toBe(true);
+    if (isToolError(result)) {
+      expect(result.reason).toBe("tmdb_unavailable");
+    }
+  });
+
+  it("passes locale as the language parameter to TMDB for movies", async () => {
+    let capturedLanguage: string | null = null;
+
+    server.use(
+      http.get(`${TMDB_BASE}/3/movie/550/credits`, ({ request }) => {
+        const url = new URL(request.url);
+        capturedLanguage = url.searchParams.get("language");
+        return HttpResponse.json({ id: 550, cast: [], crew: [] });
+      }),
+    );
+
+    await executeTool({ media_id: 550, media_type: "movie" }, "zh");
+
+    expect(capturedLanguage).toBe("zh");
+  });
+
+  it("passes locale as the language parameter to TMDB for tv shows", async () => {
+    let capturedLanguage: string | null = null;
+
+    server.use(
+      http.get(`${TMDB_BASE}/3/tv/1399/credits`, ({ request }) => {
+        const url = new URL(request.url);
+        capturedLanguage = url.searchParams.get("language");
+        return HttpResponse.json({ id: 1399, cast: [], crew: [] });
+      }),
+    );
+
+    await executeTool({ media_id: 1399, media_type: "tv" }, "zh");
+
+    expect(capturedLanguage).toBe("zh");
+  });
+});

--- a/src/ai-chat/tools/media-credits.ts
+++ b/src/ai-chat/tools/media-credits.ts
@@ -4,6 +4,7 @@ import {
   getMovieCredits,
   getTvShowCredits,
 } from "#src/_generated/tmdb-server-functions.ts";
+import type { SupportedLocale } from "#src/types.ts";
 import { toolError } from "./tool-error";
 
 export const mediaCreditsInputSchema = z.object({
@@ -19,7 +20,7 @@ const TOOL_DESCRIPTION =
 const MAX_CAST = 20;
 const MAX_CREW = 20;
 
-export function createMediaCreditsTool() {
+export function createMediaCreditsTool(locale: SupportedLocale) {
   return tool({
     description: TOOL_DESCRIPTION,
     inputSchema: mediaCreditsInputSchema,
@@ -29,8 +30,8 @@ export function createMediaCreditsTool() {
       try {
         credits =
           media_type === "tv"
-            ? await getTvShowCredits({ series_id: idString })
-            : await getMovieCredits({ movie_id: idString });
+            ? await getTvShowCredits({ series_id: idString, language: locale })
+            : await getMovieCredits({ movie_id: idString, language: locale });
       } catch (error) {
         console.error("media_credits failed", error);
         return toolError(

--- a/src/app/api/ai-chat/route.test.ts
+++ b/src/app/api/ai-chat/route.test.ts
@@ -80,7 +80,7 @@ function mockStreamResult() {
       watch_providers: createWatchProvidersTool(),
       present_watch_providers: createPresentWatchProvidersTool(),
       present_provider_regions: createPresentProviderRegionsTool(),
-      media_credits: createMediaCreditsTool(),
+      media_credits: createMediaCreditsTool("en"),
       person_credits: createPersonCreditsTool("en"),
       present_person: createPresentPersonTool(),
       review_summary: createReviewSummaryTool("en"),


### PR DESCRIPTION
## Summary

The `media_credits` AI-chat tool called TMDB's `/movie/{id}/credits` and `/tv/{id}/credits` endpoints without a `language` parameter, so Chinese-locale users saw mixed-English `character`, `job`, `department`, and `known_for_department` strings in the cast/crew the assistant renders — the exact follow-up flagged in PR #2152's "Context" section. This threads `locale` through `createMediaCreditsTool` as a required argument and forwards it as the `language` query param on both the movie and TV paths. The required-arg shape forces TypeScript to validate the single call site in `chat.ts`.

## Context

Sibling fix of #2152 (`person_credits`), applying the same pattern (`createPersonCreditsTool(locale)` → `language: locale` on the TMDB call). Codegen already exposes `language` on `getMovieCredits` / `getTvShowCredits` via `QueryParams`, so no regeneration is needed. Tests mirror `person-credits.test.ts` using `msw` to assert `language=zh` is forwarded for both paths.