### PR TITLE
fix: only accept YouTube-hosted trailers from TMDB

### DIFF
--- a/src/components/ai-chat/media-detail-content.tsx
+++ b/src/components/ai-chat/media-detail-content.tsx
@@ -85,8 +85,11 @@ export function MediaDetailContent({
 
   const overview = detail ? detail.overview || detail.tagline : null;
 
+  // The trailer link points at youtube.com/watch, so skip videos on other
+  // sites (e.g. Vimeo) rather than building a broken YouTube URL.
   const trailer = videos?.results?.find(
-    (video) => video.type === "Trailer" && video.official,
+    (video) =>
+      video.type === "Trailer" && video.official && video.site === "YouTube",
   );
 
   const hasBackdrop = Boolean(detail?.backdropPath && imageBaseUrl);

--- a/src/components/movie-database/trailer.tsx
+++ b/src/components/movie-database/trailer.tsx
@@ -28,8 +28,11 @@ export async function Trailer({ mediaType, id, locale }: TrailerProps) {
           language: "en",
         });
 
+  // The trailer UI embeds a YouTube iframe, so skip videos on other sites
+  // (e.g. Vimeo) rather than constructing a broken YouTube embed URL.
   const trailer = trailers.results?.find(
-    (video) => video.type === "Trailer" && video.official,
+    (video) =>
+      video.type === "Trailer" && video.official && video.site === "YouTube",
   );
   if (!trailer || !trailer.key) return null;
 


### PR DESCRIPTION
## Summary

TMDB's `/videos` results include a `site` field (YouTube, Vimeo, etc.), but both trailer consumers assume YouTube: `trailer.tsx` renders a `youtube.com/embed/<key>` iframe via `TrailerButton`, and the chat overlay's media-detail view builds a `youtube.com/watch?v=<key>` link. When TMDB's first official trailer was hosted on Vimeo (or any non-YouTube site), we'd hand that site's video ID to a YouTube URL and produce a broken link/embed.

This adds `video.site === "YouTube"` to both `.find` predicates so non-YouTube trailers fall through to the existing "no trailer" branch — the detail page hides `TrailerButton`, and the chat overlay hides the Trailer link. Happy-path UX is unchanged.

## Context

Left both predicates as inline three-argument expressions rather than extracting a shared helper; at two call sites the abstraction would cost more than the duplication. A short comment at each site captures the non-obvious invariant (the consumer is YouTube-specific, so the filter must be too). No new tests — both call sites are render-layer components with no existing test harness and the fix is a single literal comparison.