### PR TITLE
fix: restore locale-aware canonical URLs in metadata

### DIFF
--- a/src/app/[locale]/(home)/(details)/education/altrincham-grammar-school-for-boys/page.tsx
+++ b/src/app/[locale]/(home)/(details)/education/altrincham-grammar-school-for-boys/page.tsx
@@ -30,10 +30,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     title,
     description,
     alternates: {
-      canonical: new URL(
-        "/education/altrincham-grammar-school-for-boys",
-        BASE_URL,
-      ).toString(),
+      canonical: url,
       languages: {
         en: new URL(
           "/education/altrincham-grammar-school-for-boys",

--- a/src/app/[locale]/(home)/(details)/education/university-of-bristol/page.tsx
+++ b/src/app/[locale]/(home)/(details)/education/university-of-bristol/page.tsx
@@ -25,10 +25,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     title,
     description,
     alternates: {
-      canonical: new URL(
-        "/education/university-of-bristol",
-        BASE_URL,
-      ).toString(),
+      canonical: url,
       languages: {
         en: new URL("/education/university-of-bristol", BASE_URL).toString(),
         zh: new URL("/zh/education/university-of-bristol", BASE_URL).toString(),

--- a/src/app/[locale]/(home)/(details)/education/university-of-nottingham/page.tsx
+++ b/src/app/[locale]/(home)/(details)/education/university-of-nottingham/page.tsx
@@ -24,10 +24,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     title,
     description,
     alternates: {
-      canonical: new URL(
-        "/education/university-of-nottingham",
-        BASE_URL,
-      ).toString(),
+      canonical: url,
       languages: {
         en: new URL("/education/university-of-nottingham", BASE_URL).toString(),
         zh: new URL(

--- a/src/app/[locale]/(home)/(details)/experiences/citadel/page.tsx
+++ b/src/app/[locale]/(home)/(details)/experiences/citadel/page.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     title,
     description,
     alternates: {
-      canonical: new URL("/experiences/citadel", BASE_URL).toString(),
+      canonical: url,
       languages: {
         en: new URL("/experiences/citadel", BASE_URL).toString(),
         zh: new URL("/zh/experiences/citadel", BASE_URL).toString(),

--- a/src/app/[locale]/(home)/(details)/experiences/spotify/page.tsx
+++ b/src/app/[locale]/(home)/(details)/experiences/spotify/page.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     title,
     description,
     alternates: {
-      canonical: new URL("/experiences/spotify", BASE_URL).toString(),
+      canonical: url,
       languages: {
         en: new URL("/experiences/spotify", BASE_URL).toString(),
         zh: new URL("/zh/experiences/spotify", BASE_URL).toString(),

--- a/src/app/[locale]/(home)/(details)/experiences/wunderman-thompson-commerce/page.tsx
+++ b/src/app/[locale]/(home)/(details)/experiences/wunderman-thompson-commerce/page.tsx
@@ -30,10 +30,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     title,
     description,
     alternates: {
-      canonical: new URL(
-        "/experiences/wunderman-thompson-commerce",
-        BASE_URL,
-      ).toString(),
+      canonical: url,
       languages: {
         en: new URL(
           "/experiences/wunderman-thompson-commerce",

--- a/src/app/[locale]/(home)/layout.tsx
+++ b/src/app/[locale]/(home)/layout.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     description,
     applicationName: t({ en: "Qingqi Shi", zh: "石清琪" }),
     alternates: {
-      canonical: new URL("/", BASE_URL).toString(),
+      canonical: url,
       languages: {
         en: new URL("/", BASE_URL).toString(),
         zh: new URL("/zh", BASE_URL).toString(),

--- a/src/app/[locale]/calculator/layout.tsx
+++ b/src/app/[locale]/calculator/layout.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     title,
     description,
     alternates: {
-      canonical: new URL("/calculator", BASE_URL).toString(),
+      canonical: url,
       languages: {
         en: new URL("/calculator", BASE_URL).toString(),
         zh: new URL("/zh/calculator", BASE_URL).toString(),

--- a/src/app/[locale]/component-library/layout.tsx
+++ b/src/app/[locale]/component-library/layout.tsx
@@ -33,7 +33,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     },
     description,
     alternates: {
-      canonical: new URL("/component-library", BASE_URL).toString(),
+      canonical: url,
       languages: {
         en: new URL("/component-library", BASE_URL).toString(),
         zh: new URL("/zh/component-library", BASE_URL).toString(),

--- a/src/app/[locale]/movie-database/[type]/[id]/layout.tsx
+++ b/src/app/[locale]/movie-database/[type]/[id]/layout.tsx
@@ -77,7 +77,7 @@ export async function generateMetadata({
     title,
     description,
     alternates: {
-      canonical: canonicalPath,
+      canonical: url,
       languages: {
         en: canonicalPath,
         zh: new URL(getLocalePath(basePath, "zh"), BASE_URL).toString(),

--- a/src/app/[locale]/movie-database/layout.tsx
+++ b/src/app/[locale]/movie-database/layout.tsx
@@ -35,7 +35,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     },
     description,
     alternates: {
-      canonical: new URL("/movie-database", BASE_URL).toString(),
+      canonical: url,
       languages: {
         en: new URL("/movie-database", BASE_URL).toString(),
         zh: new URL("/zh/movie-database", BASE_URL).toString(),


### PR DESCRIPTION
## Summary

Every `generateMetadata` under `src/app/[locale]/**` currently returns `alternates.canonical` as a hardcoded English URL again — PR #2077 silently reverted PR #2073's fix while editing the same `alternates` blocks. The result is that `/zh/experiences/spotify` self-declares `/experiences/spotify` as canonical, so Google treats each Chinese page as a duplicate of its English sibling and de-indexes the zh variant.

Each `generateMetadata` block already computes a locale-aware `url` const for `openGraph.url` (either via an inline ternary or `getLocalePath(basePath, validatedLocale)` in the movie-database dynamic detail page). This reuses that existing value for `canonical` across all 11 blocks, restoring correct per-locale self-referencing. `alternates.languages` (hreflang) is untouched — it was already correct.

## Context

Same fix as #2073 in spirit, but simpler in shape: instead of duplicating the locale ternary on every canonical line, point at the already-computed `url` const that each block uses for `openGraph.url`. Net diff is 23 lines removed, 11 added. In the movie-database detail layout, `canonicalPath` (the English-only value) is retained as the `languages.en` entry — that IS the English hreflang.