### PR TITLE
fix: swallow localStorage.setItem throws in setTheme

### DIFF
--- a/src/components/shared/theme-switch.test.tsx
+++ b/src/components/shared/theme-switch.test.tsx
@@ -149,3 +149,45 @@ describe("ThemeSwitch system-button semantics", () => {
     expect(systemButton).not.toBeDisabled();
   });
 });
+
+// Placed last because it drives the Switch's onChange, which updates
+// the module-level `themeSingleton` in `use-theme.ts`. That singleton
+// has no test-time reset hook, so running this test earlier would
+// leave subsequent tests reading the wrong default theme.
+describe("ThemeSwitch localStorage resilience", () => {
+  it("still reflects the new theme on <html> when localStorage.setItem throws", () => {
+    // Safari private mode / lockdown / quota-exceeded all surface as a
+    // throw from setItem. Before the fix, the throw short-circuited the
+    // subscriber notification inside `setTheme`, so useLayoutEffect in
+    // ThemeSwitch never re-ran and toggling produced no visible change.
+    localStorage.setItem("theme", "light");
+    const originalClassName = document.documentElement.className;
+
+    const setItemSpy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new DOMException("QuotaExceededError");
+      });
+
+    try {
+      renderThemeSwitch();
+
+      // Space on role="switch" triggers the Switch component's onChange
+      // (wired to `setTheme("dark" | "light")`). The system button's click
+      // handler is a no-op when theme is already "system", so it can't
+      // drive this transition — Space is the reliable path.
+      fireEvent.keyDown(screen.getByRole("switch"), {
+        code: "Space",
+        key: " ",
+      });
+
+      // The class name must have changed in response to the toggle — the
+      // component subscribes via useSyncExternalStore, so this only
+      // flips if `setTheme` still fires its listeners after the throw.
+      expect(document.documentElement.className).not.toBe(originalClassName);
+      expect(setItemSpy).toHaveBeenCalledWith("theme", "dark");
+    } finally {
+      setItemSpy.mockRestore();
+    }
+  });
+});

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -12,7 +12,13 @@ function subscribe(onStoreChange: () => void) {
 let themeSingleton: string | null = null;
 function setTheme(newTheme: SupportedTheme) {
   themeSingleton = newTheme;
-  localStorage.setItem(STORAGE_KEY, newTheme);
+  try {
+    localStorage.setItem(STORAGE_KEY, newTheme);
+  } catch {
+    // Safari private/lockdown mode and quota-exceeded throw here.
+    // Keep the in-memory singleton and still notify subscribers so the
+    // user's click is reflected in the UI for the session.
+  }
   listeners.forEach((listener) => {
     listener();
   });


### PR DESCRIPTION
## Summary

`setTheme` in `src/hooks/use-theme.ts` calls `localStorage.setItem` and then walks its subscriber list. In Safari private browsing, iOS lockdown mode, and quota-exceeded conditions that `setItem` throws — and because the throw happens before the `listeners.forEach(...)` line, the `useSyncExternalStore` subscribers never fire. The `useLayoutEffect` in `ThemeSwitch` that updates `document.documentElement.className` and the `theme-color` meta tag is one of those subscribers, so on affected browsers the toggle silently no-ops.

Wrap the setItem call in try/catch. The in-memory `themeSingleton` is already updated on the line before the write, so subscribers still get a correct snapshot; the user's click is now reflected in the UI for the session even when persistence fails. Persist-then-notify ordering is preserved — persist is still attempted first, but the notify is now unconditional.

## Context

Mirrors the swallow-and-continue pattern already used by `setStoredSessionId` / `clearStoredSessionId` in `src/ai-chat/use-ai-chat.ts`. A new regression test in `theme-switch.test.tsx` stubs `Storage.prototype.setItem` to throw a `DOMException("QuotaExceededError")`, fires Space on `role="switch"` (the path that drives `onChange` — `onClick` is `preventDefault`-ed), and asserts `<html>.className` changes and `setItem` was called with `("theme", "dark")`. Temporarily reverting only the hook change causes the test to fail with an unhandled DOMException, confirming the assertion gates the fix and isn't a tautology.