### PR TITLE
feat: add curated trending rows to movie-database landing page

### DIFF
--- a/src/app/[locale]/movie-database/(list)/layout.tsx
+++ b/src/app/[locale]/movie-database/(list)/layout.tsx
@@ -3,6 +3,7 @@ import { Suspense } from "react";
 import { DotGridBackground } from "#src/components/ai-chat/dot-grid-background.tsx";
 import { RecommendedMedia } from "#src/components/ai-chat/recommended-media.tsx";
 import { SuggestionChips } from "#src/components/ai-chat/suggestion-chips.tsx";
+import { CuratedMediaRows } from "#src/components/movie-database/curated-media-rows.tsx";
 import { FiltersSkeleton } from "#src/components/movie-database/filters-skeleton.tsx";
 import { Grid } from "#src/components/movie-database/grid.tsx";
 import { HeroSection } from "#src/components/movie-database/hero-section.tsx";
@@ -64,6 +65,7 @@ export default async function Layout({
             browseContent={
               <>
                 <HeroSection />
+                <CuratedMediaRows locale={validatedLocale} />
                 <Suspense
                   fallback={
                     <>

--- a/src/components/ai-chat/compact-media-card.test.tsx
+++ b/src/components/ai-chat/compact-media-card.test.tsx
@@ -199,6 +199,45 @@ describe("CompactMediaCard", () => {
     expect(screen.getByRole("button", { name: "TV show" })).toBeInTheDocument();
   });
 
+  it("renders as a link when href is provided", () => {
+    render(
+      <CompactMediaCard
+        media={{
+          id: 1,
+          title: "Inception",
+          posterPath: "/inception.jpg",
+          rating: 8.4,
+          mediaType: "movie",
+        }}
+        href="/movie-database/movie/1"
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: "Inception" });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/movie-database/movie/1");
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("prefers href over onClick when both are provided", () => {
+    render(
+      <CompactMediaCard
+        media={{
+          id: 1,
+          title: "Inception",
+          posterPath: "/inception.jpg",
+          rating: 8.4,
+          mediaType: "movie",
+        }}
+        href="/movie-database/movie/1"
+        onClick={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "Inception" })).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
   it("falls back to 'Media' aria-label when title and mediaType are missing", () => {
     render(
       <CompactMediaCard

--- a/src/components/ai-chat/compact-media-card.tsx
+++ b/src/components/ai-chat/compact-media-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
+import { Anchor } from "#src/components/shared/anchor.tsx";
 import { t } from "#src/i18n.ts";
 import { motionConstants } from "#src/primitives/motion.stylex.ts";
 import { buttonReset } from "#src/primitives/reset.stylex.ts";
@@ -11,6 +12,7 @@ import { MediaPoster } from "../movie-database/media-poster";
 interface CompactMediaCardProps {
   media: MediaListItem;
   onClick?: () => void;
+  href?: string;
 }
 
 function getMediaLabel(media: MediaListItem): string {
@@ -20,7 +22,24 @@ function getMediaLabel(media: MediaListItem): string {
   return t({ en: "Media", zh: "媒体" });
 }
 
-export function CompactMediaCard({ media, onClick }: CompactMediaCardProps) {
+export function CompactMediaCard({
+  media,
+  onClick,
+  href,
+}: CompactMediaCardProps) {
+  if (href) {
+    return (
+      <Anchor
+        href={href}
+        indicateExternal={false}
+        css={[styles.compactCard, styles.interactive, styles.linkReset]}
+        aria-label={getMediaLabel(media)}
+      >
+        <MediaPoster media={media} compact decorative />
+      </Anchor>
+    );
+  }
+
   if (onClick) {
     return (
       <button
@@ -70,5 +89,9 @@ const styles = stylex.create({
       ":focus-visible": `2px solid ${color.controlActive}`,
     },
     outlineOffset: { default: null, ":focus-visible": "2px" },
+  },
+  linkReset: {
+    textDecoration: "none",
+    color: "inherit",
   },
 });

--- a/src/components/ai-chat/recommended-media-row-skeleton.tsx
+++ b/src/components/ai-chat/recommended-media-row-skeleton.tsx
@@ -5,13 +5,21 @@ import { Skeleton } from "../shared/skeleton";
 
 const SKELETON_COUNT = 6;
 
-export function RecommendedMediaRowSkeleton() {
+interface RecommendedMediaRowSkeletonProps {
+  inset?: "chat" | "standalone";
+}
+
+export function RecommendedMediaRowSkeleton({
+  inset = "chat",
+}: RecommendedMediaRowSkeletonProps = {}) {
+  const rowStyle = inset === "standalone" ? styles.rowStandalone : styles.row;
+  const cardStyle = inset === "standalone" ? styles.cardLarge : styles.card;
   return (
     <div css={styles.section}>
       <Skeleton width={120} height={14} />
-      <div css={styles.row}>
+      <div css={rowStyle}>
         {Array.from({ length: SKELETON_COUNT }, (_, i) => (
-          <div key={i} css={styles.card}>
+          <div key={i} css={cardStyle}>
             <Skeleton fill delay={i * 100} />
           </div>
         ))}
@@ -20,8 +28,11 @@ export function RecommendedMediaRowSkeleton() {
   );
 }
 
-const contentInsetLeft = `calc(${space._3} + ${space._3} + env(safe-area-inset-left, 0px))`;
-const contentInsetRight = `calc(${space._3} + ${space._3} + env(safe-area-inset-right, 0px))`;
+const chatInsetLeft = `calc(${space._3} + ${space._3} + env(safe-area-inset-left, 0px))`;
+const chatInsetRight = `calc(${space._3} + ${space._3} + env(safe-area-inset-right, 0px))`;
+
+const standaloneInsetLeft = `calc(${space._3} + env(safe-area-inset-left, 0px))`;
+const standaloneInsetRight = `calc(${space._3} + env(safe-area-inset-right, 0px))`;
 
 const styles = stylex.create({
   section: {
@@ -33,10 +44,19 @@ const styles = stylex.create({
     display: "flex",
     gap: space._2,
     overflow: "hidden",
-    marginLeft: `calc(-1 * ${contentInsetLeft})`,
-    marginRight: `calc(-1 * ${contentInsetRight})`,
-    paddingLeft: contentInsetLeft,
-    paddingRight: contentInsetRight,
+    marginLeft: `calc(-1 * ${chatInsetLeft})`,
+    marginRight: `calc(-1 * ${chatInsetRight})`,
+    paddingLeft: chatInsetLeft,
+    paddingRight: chatInsetRight,
+  },
+  rowStandalone: {
+    display: "flex",
+    gap: space._2,
+    overflow: "hidden",
+    marginLeft: `calc(-1 * ${standaloneInsetLeft})`,
+    marginRight: `calc(-1 * ${standaloneInsetRight})`,
+    paddingLeft: standaloneInsetLeft,
+    paddingRight: standaloneInsetRight,
   },
   card: {
     flexShrink: 0,
@@ -52,6 +72,22 @@ const styles = stylex.create({
     },
     [breakpoints.lg]: {
       width: "175px",
+    },
+  },
+  cardLarge: {
+    flexShrink: 0,
+    width: "150px",
+    aspectRatio: ratio.poster,
+    borderRadius: border.radius_2,
+    overflow: "hidden",
+    [breakpoints.sm]: {
+      width: "175px",
+    },
+    [breakpoints.md]: {
+      width: "210px",
+    },
+    [breakpoints.lg]: {
+      width: "240px",
     },
   },
 });

--- a/src/components/ai-chat/recommended-media-row.test.tsx
+++ b/src/components/ai-chat/recommended-media-row.test.tsx
@@ -106,4 +106,41 @@ describe("RecommendedMediaRow", () => {
     );
     expect(container.querySelector("section")).toBeNull();
   });
+
+  it("renders cards as links when items carry an href", () => {
+    const itemsWithHref = mockItems.map((item) => ({
+      ...item,
+      href: `/movie-database/${String(item.mediaType)}/${item.id.toString()}`,
+    }));
+    render(
+      <RecommendedMediaRow title="Trending Movies" items={itemsWithHref} />,
+    );
+    const linkOne = screen.getByRole("link", { name: "Movie One" });
+    const linkTwo = screen.getByRole("link", { name: "Movie Two" });
+    expect(linkOne).toHaveAttribute("href", "/movie-database/movie/1");
+    expect(linkTwo).toHaveAttribute("href", "/movie-database/movie/2");
+    // Cards themselves must not be buttons — the only <button>s rendered are
+    // the horizontal scroll nav buttons inside HorizontalScrollRow.
+    expect(
+      screen.queryByRole("button", { name: "Movie One" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Movie Two" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders as links without a MediaDetailProvider when items carry an href", () => {
+    const itemsWithHref = mockItems.map((item) => ({
+      ...item,
+      href: "/movie-database/movie/1",
+    }));
+    render(
+      <RecommendedMediaRow
+        title="Trending Movies"
+        items={itemsWithHref}
+        inset="standalone"
+      />,
+    );
+    expect(screen.getByRole("link", { name: "Movie One" })).toBeInTheDocument();
+  });
 });

--- a/src/components/ai-chat/recommended-media-row.tsx
+++ b/src/components/ai-chat/recommended-media-row.tsx
@@ -9,55 +9,89 @@ import { CompactMediaCard } from "./compact-media-card";
 import { HorizontalScrollRow } from "./horizontal-scroll-row";
 import { useMediaDetail } from "./media-detail-context";
 
+type RowInset = "chat" | "standalone";
+
+export type RecommendedMediaRowItem = MediaListItem & {
+  /**
+   * When provided, the card renders as a Next.js link to this href. When
+   * absent, the card opens the in-chat detail overlay via `useMediaDetail`
+   * (which requires a `MediaDetailProvider` ancestor).
+   */
+  href?: string;
+};
+
 interface RecommendedMediaRowProps {
   title: string;
-  items: ReadonlyArray<MediaListItem>;
+  items: ReadonlyArray<RecommendedMediaRowItem>;
+  /**
+   * Selects which horizontal inset to use. `"chat"` (default) matches the
+   * two-level padding inside `ChatMessageList`; `"standalone"` matches the
+   * single-level page padding used by the movie-database landing page.
+   */
+  inset?: RowInset;
 }
 
 export function RecommendedMediaRow({
   title,
   items,
+  inset = "chat",
 }: RecommendedMediaRowProps) {
-  const { setFocusedMedia } = useMediaDetail();
-
   if (items.length === 0) return null;
+
+  const rowStyles = inset === "standalone" ? standaloneStyles : chatStyles;
 
   return (
     <section css={[flex.col, styles.section]}>
       <h2 css={styles.title}>{title}</h2>
       <HorizontalScrollRow
         ariaLabel={title}
-        wrapperCss={styles.scrollWrapper}
-        containerCss={styles.scrollContainer}
-        fadeLeftCss={styles.fadeLeft}
-        fadeRightCss={styles.fadeRight}
-        scrollButtonLeftCss={styles.scrollButtonLeft}
-        scrollButtonRightCss={styles.scrollButtonRight}
+        wrapperCss={rowStyles.scrollWrapper}
+        containerCss={rowStyles.scrollContainer}
+        fadeLeftCss={rowStyles.fadeLeft}
+        fadeRightCss={rowStyles.fadeRight}
+        scrollButtonLeftCss={rowStyles.scrollButtonLeft}
+        scrollButtonRightCss={rowStyles.scrollButtonRight}
       >
-        {items.map((item) => {
-          const { mediaType } = item;
-          return (
-            <div key={item.id} role="listitem" css={styles.cardWrapper}>
-              <CompactMediaCard
-                media={item}
-                onClick={
-                  mediaType
-                    ? () => {
-                        setFocusedMedia({
-                          id: item.id,
-                          mediaType,
-                          title: item.title,
-                          posterPath: item.posterPath,
-                        });
-                      }
-                    : undefined
-                }
-              />
-            </div>
-          );
-        })}
+        {items.map((item) => (
+          <div
+            key={item.id}
+            role="listitem"
+            css={[
+              styles.cardWrapper,
+              inset === "standalone" && styles.cardWrapperLarge,
+            ]}
+          >
+            {item.href ? (
+              <CompactMediaCard media={item} href={item.href} />
+            ) : (
+              <FocusCard item={item} />
+            )}
+          </div>
+        ))}
       </HorizontalScrollRow>
     </section>
+  );
+}
+
+function FocusCard({ item }: { item: MediaListItem }) {
+  const { setFocusedMedia } = useMediaDetail();
+  const { mediaType } = item;
+  return (
+    <CompactMediaCard
+      media={item}
+      onClick={
+        mediaType
+          ? () => {
+              setFocusedMedia({
+                id: item.id,
+                mediaType,
+                title: item.title,
+                posterPath: item.posterPath,
+              });
+            }
+          : undefined
+      }
+    />
   );
 }
 
@@ -66,8 +100,69 @@ export function RecommendedMediaRow({
  * Padding chain: layout (space._3 + safe-area) + ChatMessageList (space._3).
  * See also: ai-chat-view.tsx inputArea which uses the same offsets.
  */
-const contentInsetLeft = `calc(${space._3} + ${space._3} + env(safe-area-inset-left, 0px))`;
-const contentInsetRight = `calc(${space._3} + ${space._3} + env(safe-area-inset-right, 0px))`;
+const chatInsetLeft = `calc(${space._3} + ${space._3} + env(safe-area-inset-left, 0px))`;
+const chatInsetRight = `calc(${space._3} + ${space._3} + env(safe-area-inset-right, 0px))`;
+
+/**
+ * Single-level page padding used on the movie-database landing page, matching
+ * `HeroSection` so cards visually align with the hero heading and chat input.
+ */
+const standaloneInsetLeft = `calc(${space._3} + env(safe-area-inset-left, 0px))`;
+const standaloneInsetRight = `calc(${space._3} + env(safe-area-inset-right, 0px))`;
+
+const chatStyles = stylex.create({
+  scrollWrapper: {
+    marginLeft: `calc(-1 * ${chatInsetLeft})`,
+    marginRight: `calc(-1 * ${chatInsetRight})`,
+  },
+  scrollContainer: {
+    paddingTop: 0,
+    paddingBottom: space._1,
+    paddingLeft: chatInsetLeft,
+    paddingRight: chatInsetRight,
+    scrollPaddingLeft: chatInsetLeft,
+    scrollPaddingRight: chatInsetRight,
+  },
+  fadeLeft: {
+    backgroundImage: `linear-gradient(to left, rgba(${color.backgroundMainChannels}, 0), rgba(${color.backgroundMainChannels}, 1))`,
+  },
+  fadeRight: {
+    backgroundImage: `linear-gradient(to right, rgba(${color.backgroundMainChannels}, 0), rgba(${color.backgroundMainChannels}, 1))`,
+  },
+  scrollButtonLeft: {
+    left: chatInsetLeft,
+  },
+  scrollButtonRight: {
+    right: chatInsetRight,
+  },
+});
+
+const standaloneStyles = stylex.create({
+  scrollWrapper: {
+    marginLeft: `calc(-1 * ${standaloneInsetLeft})`,
+    marginRight: `calc(-1 * ${standaloneInsetRight})`,
+  },
+  scrollContainer: {
+    paddingTop: 0,
+    paddingBottom: space._1,
+    paddingLeft: standaloneInsetLeft,
+    paddingRight: standaloneInsetRight,
+    scrollPaddingLeft: standaloneInsetLeft,
+    scrollPaddingRight: standaloneInsetRight,
+  },
+  fadeLeft: {
+    backgroundImage: `linear-gradient(to left, rgba(${color.backgroundMainChannels}, 0), rgba(${color.backgroundMainChannels}, 1))`,
+  },
+  fadeRight: {
+    backgroundImage: `linear-gradient(to right, rgba(${color.backgroundMainChannels}, 0), rgba(${color.backgroundMainChannels}, 1))`,
+  },
+  scrollButtonLeft: {
+    left: standaloneInsetLeft,
+  },
+  scrollButtonRight: {
+    right: standaloneInsetRight,
+  },
+});
 
 const styles = stylex.create({
   section: {
@@ -81,30 +176,6 @@ const styles = stylex.create({
     letterSpacing: "0.05em",
     margin: 0,
   },
-  scrollWrapper: {
-    marginLeft: `calc(-1 * ${contentInsetLeft})`,
-    marginRight: `calc(-1 * ${contentInsetRight})`,
-  },
-  scrollContainer: {
-    paddingTop: 0,
-    paddingBottom: space._1,
-    paddingLeft: contentInsetLeft,
-    paddingRight: contentInsetRight,
-    scrollPaddingLeft: contentInsetLeft,
-    scrollPaddingRight: contentInsetRight,
-  },
-  fadeLeft: {
-    backgroundImage: `linear-gradient(to left, rgba(${color.backgroundMainChannels}, 0), rgba(${color.backgroundMainChannels}, 1))`,
-  },
-  fadeRight: {
-    backgroundImage: `linear-gradient(to right, rgba(${color.backgroundMainChannels}, 0), rgba(${color.backgroundMainChannels}, 1))`,
-  },
-  scrollButtonLeft: {
-    left: contentInsetLeft,
-  },
-  scrollButtonRight: {
-    right: contentInsetRight,
-  },
   cardWrapper: {
     flexShrink: 0,
     scrollSnapAlign: "start",
@@ -117,6 +188,18 @@ const styles = stylex.create({
     },
     [breakpoints.lg]: {
       width: "175px",
+    },
+  },
+  cardWrapperLarge: {
+    width: "150px",
+    [breakpoints.sm]: {
+      width: "175px",
+    },
+    [breakpoints.md]: {
+      width: "210px",
+    },
+    [breakpoints.lg]: {
+      width: "240px",
     },
   },
 });

--- a/src/components/movie-database/curated-media-rows.tsx
+++ b/src/components/movie-database/curated-media-rows.tsx
@@ -1,0 +1,121 @@
+import * as stylex from "@stylexjs/stylex";
+import { Suspense } from "react";
+import {
+  getTrendingMovies,
+  getTrendingTvShows,
+} from "#src/_generated/tmdb-server-functions.ts";
+import { breakpoints } from "#src/breakpoints.stylex.ts";
+import { RecommendedMediaRowSkeleton } from "#src/components/ai-chat/recommended-media-row-skeleton.tsx";
+import {
+  RecommendedMediaRow,
+  type RecommendedMediaRowItem,
+} from "#src/components/ai-chat/recommended-media-row.tsx";
+import { t } from "#src/i18n.ts";
+import { space } from "#src/tokens.stylex.ts";
+import type { SupportedLocale } from "#src/types.ts";
+import { getLocalePath } from "#src/utils/pathname.ts";
+
+const ITEMS_PER_ROW = 14;
+
+interface CuratedMediaRowsProps {
+  locale: SupportedLocale;
+}
+
+export function CuratedMediaRows({ locale }: CuratedMediaRowsProps) {
+  return (
+    <section
+      aria-label={t({ en: "Curated picks", zh: "精选推荐" })}
+      css={styles.container}
+    >
+      <Suspense fallback={<RecommendedMediaRowSkeleton inset="standalone" />}>
+        <TrendingMoviesRow locale={locale} />
+      </Suspense>
+      <Suspense fallback={<RecommendedMediaRowSkeleton inset="standalone" />}>
+        <TrendingTvShowsRow locale={locale} />
+      </Suspense>
+    </section>
+  );
+}
+
+function buildMovieHref(locale: SupportedLocale, id: number): string {
+  return getLocalePath(`/movie-database/movie/${id.toString()}`, locale);
+}
+
+function buildTvHref(locale: SupportedLocale, id: number): string {
+  return getLocalePath(`/movie-database/tv/${id.toString()}`, locale);
+}
+
+async function TrendingMoviesRow({ locale }: { locale: SupportedLocale }) {
+  const response = await getTrendingMovies({
+    time_window: "week",
+    language: locale,
+  }).catch((error: unknown) => {
+    console.error("Failed to fetch trending movies:", error);
+    return null;
+  });
+  if (!response) return null;
+
+  const items: RecommendedMediaRowItem[] = (response.results ?? [])
+    .filter((movie) => movie.title)
+    .slice(0, ITEMS_PER_ROW)
+    .map((movie) => ({
+      id: movie.id,
+      title: movie.title,
+      posterPath: movie.poster_path,
+      mediaType: "movie" as const,
+      href: buildMovieHref(locale, movie.id),
+    }));
+
+  return (
+    <RecommendedMediaRow
+      title={t({ en: "Trending Movies This Week", zh: "本周热门电影" })}
+      items={items}
+      inset="standalone"
+    />
+  );
+}
+
+async function TrendingTvShowsRow({ locale }: { locale: SupportedLocale }) {
+  const response = await getTrendingTvShows({
+    time_window: "week",
+    language: locale,
+  }).catch((error: unknown) => {
+    console.error("Failed to fetch trending TV shows:", error);
+    return null;
+  });
+  if (!response) return null;
+
+  const items: RecommendedMediaRowItem[] = (response.results ?? [])
+    .filter((show) => show.name)
+    .slice(0, ITEMS_PER_ROW)
+    .map((show) => ({
+      id: show.id,
+      title: show.name,
+      posterPath: show.poster_path,
+      mediaType: "tv" as const,
+      href: buildTvHref(locale, show.id),
+    }));
+
+  return (
+    <RecommendedMediaRow
+      title={t({ en: "Trending TV Shows This Week", zh: "本周热门剧集" })}
+      items={items}
+      inset="standalone"
+    />
+  );
+}
+
+const styles = stylex.create({
+  container: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space._5,
+    paddingLeft: `calc(${space._3} + env(safe-area-inset-left, 0px))`,
+    paddingRight: `calc(${space._3} + env(safe-area-inset-right, 0px))`,
+    paddingBlockEnd: space._5,
+    [breakpoints.md]: {
+      gap: space._6,
+      paddingBlockEnd: space._6,
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Adds a `CuratedMediaRows` server component between the hero chat input and the filter+grid section on the movie-database landing page, rendering "Trending Movies This Week" and "Trending TV Shows This Week" as edge-to-edge horizontally scrollable rows with locale-aware navigation to each title's detail page.

The implementation reuses `RecommendedMediaRow` from the AI-mode empty state by introducing an `inset="standalone"` variant (single-level page padding, larger cards) and an `href`-per-item pathway that renders cards as Next.js links instead of opening the in-chat detail overlay — so the row works outside a `MediaDetailProvider`.

## Notes

Only the two trending rows are included; genre-based rows (Popular Sci-Fi, Top Rated Dramas) were considered but dropped because the issue framed them as optional. Card design follows an editorial aesthetic: rows span viewport edge-to-edge with no max-width gutter, cards are wider than the chat-mode compact variant, and rating badges are omitted. Both the English and Chinese row titles specify "This Week" to accurately reflect the `time_window: "week"` TMDB call.

Closes #2027