### PR TITLE
fix: improve trending row skeleton fidelity on wide viewports

### DIFF
--- a/src/components/ai-chat/recommended-media-row-skeleton.tsx
+++ b/src/components/ai-chat/recommended-media-row-skeleton.tsx
@@ -3,7 +3,7 @@ import { breakpoints } from "#src/breakpoints.stylex.ts";
 import { border, ratio, space } from "#src/tokens.stylex.ts";
 import { Skeleton } from "../shared/skeleton";
 
-const SKELETON_COUNT = 6;
+const SKELETON_COUNT = 14;
 
 interface RecommendedMediaRowSkeletonProps {
   inset?: "chat" | "standalone";
@@ -16,7 +16,7 @@ export function RecommendedMediaRowSkeleton({
   const cardStyle = inset === "standalone" ? styles.cardLarge : styles.card;
   return (
     <div css={styles.section}>
-      <Skeleton width={120} height={14} />
+      <Skeleton width={220} height={16} />
       <div css={rowStyle}>
         {Array.from({ length: SKELETON_COUNT }, (_, i) => (
           <div key={i} css={cardStyle}>
@@ -48,6 +48,7 @@ const styles = stylex.create({
     marginRight: `calc(-1 * ${chatInsetRight})`,
     paddingLeft: chatInsetLeft,
     paddingRight: chatInsetRight,
+    paddingBottom: space._1,
   },
   rowStandalone: {
     display: "flex",
@@ -57,6 +58,7 @@ const styles = stylex.create({
     marginRight: `calc(-1 * ${standaloneInsetRight})`,
     paddingLeft: standaloneInsetLeft,
     paddingRight: standaloneInsetRight,
+    paddingBottom: space._1,
   },
   card: {
     flexShrink: 0,


### PR DESCRIPTION
## The bug

The loading skeleton for the trending movies/TV rows on `/movie-database` rendered only 6 placeholder cards, leaving a large empty gap on wide viewports — the real data loads 14 items into a horizontally-scrolling row that extends edge-to-edge. The title placeholder was a `120×14` pill, much narrower and shorter than the real `~220×16px` uppercase heading, so it read as a broken fragment rather than a heading stand-in. The row container also lacked the `8px` `paddingBottom` present on the real scroll container, causing a visible vertical layout shift when data resolved.

## The fix

Three targeted changes in `RecommendedMediaRowSkeleton`: bump `SKELETON_COUNT` from 6 to 14 so the skeleton fills wide viewports (cards overflow and clip on narrower ones, matching the real scroll row's behaviour); widen the title skeleton to `220×16` to match the rendered heading's footprint; add `paddingBottom: space._1` to both `row` and `rowStandalone` so the skeleton's total height matches the real scroll container (368px), eliminating the layout shift on load.

## Notes

Verified visually via Playwright by temporarily suspending the trending server functions and resizing to 2560×1440 to confirm the 14-card skeleton fills the full width without a gap.