### PR TITLE
fix: sync useTheme across tabs via storage event

### DIFF
--- a/src/components/shared/theme-switch.test.tsx
+++ b/src/components/shared/theme-switch.test.tsx
@@ -1,5 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen } from "#src/test-utils.tsx";
+import { act, fireEvent, render, screen } from "#src/test-utils.tsx";
 import { ThemeSwitch } from "./theme-switch";
 
 const LABELS: [string, string, string] = [
@@ -147,6 +147,77 @@ describe("ThemeSwitch system-button semantics", () => {
     });
     expect(systemButton).toHaveAttribute("aria-pressed", "true");
     expect(systemButton).not.toBeDisabled();
+  });
+});
+
+// Placed near the end because the dispatched `storage` event mutates the
+// module-level `themeSingleton` in `use-theme.ts`. The final assertion
+// leaves it set to "light" so the resilience block below can still start
+// from a light theme.
+describe("ThemeSwitch cross-tab sync", () => {
+  it("re-renders with the theme written by another tab via a storage event", () => {
+    localStorage.setItem("theme", "light");
+    renderThemeSwitch();
+
+    const switchControl = screen.getByRole("switch");
+    expect(switchControl).toHaveAttribute("aria-label", "Switch to dark");
+
+    // Simulate another tab writing "dark" to the same localStorage key.
+    // jsdom doesn't fire `storage` on same-tab writes, which mirrors real
+    // browser behaviour — we have to dispatch the event explicitly.
+    act(() => {
+      localStorage.setItem("theme", "dark");
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "theme",
+          newValue: "dark",
+          oldValue: "light",
+          storageArea: localStorage,
+        }),
+      );
+    });
+
+    // The aria-label flips to "Switch to light" only if `useTheme` re-emitted,
+    // which only happens if the storage listener updated the singleton and
+    // notified subscribers.
+    expect(switchControl).toHaveAttribute("aria-label", "Switch to light");
+    expect(document.documentElement.className).toContain("dark");
+
+    // Reset to "light" (both storage and singleton) so the resilience test
+    // below starts from the theme it expects.
+    act(() => {
+      localStorage.setItem("theme", "light");
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "theme",
+          newValue: "light",
+          oldValue: "dark",
+          storageArea: localStorage,
+        }),
+      );
+    });
+  });
+
+  it("ignores storage events for unrelated keys", () => {
+    localStorage.setItem("theme", "light");
+    renderThemeSwitch();
+
+    const switchControl = screen.getByRole("switch");
+    expect(switchControl).toHaveAttribute("aria-label", "Switch to dark");
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "some-other-key",
+          newValue: "dark",
+          oldValue: null,
+          storageArea: localStorage,
+        }),
+      );
+    });
+
+    // Unrelated keys must not thrash subscribers.
+    expect(switchControl).toHaveAttribute("aria-label", "Switch to dark");
   });
 });
 

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -4,12 +4,44 @@ import type { SupportedTheme } from "#src/types.ts";
 const STORAGE_KEY = "theme";
 
 const listeners: Set<() => void> = new Set();
-function subscribe(onStoreChange: () => void) {
-  listeners.add(onStoreChange);
-  return () => listeners.delete(onStoreChange);
+let themeSingleton: string | null = null;
+
+function notifyListeners() {
+  listeners.forEach((listener) => {
+    listener();
+  });
 }
 
-let themeSingleton: string | null = null;
+// Fires only in *other* tabs, never the tab that wrote. Updating
+// `themeSingleton` here keeps `getSnapshot` from masking the new value.
+function handleStorage(event: StorageEvent) {
+  if (event.key !== STORAGE_KEY && event.key !== null) return;
+  themeSingleton = event.newValue;
+  notifyListeners();
+}
+
+function subscribe(onStoreChange: () => void) {
+  if (listeners.size === 0) {
+    try {
+      window.addEventListener("storage", handleStorage);
+    } catch {
+      // Defensive: environments without `window` shouldn't reach here, but
+      // a throw must not prevent local subscriber registration.
+    }
+  }
+  listeners.add(onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+    if (listeners.size === 0) {
+      try {
+        window.removeEventListener("storage", handleStorage);
+      } catch {
+        // See above.
+      }
+    }
+  };
+}
+
 function setTheme(newTheme: SupportedTheme) {
   themeSingleton = newTheme;
   try {
@@ -19,9 +51,7 @@ function setTheme(newTheme: SupportedTheme) {
     // Keep the in-memory singleton and still notify subscribers so the
     // user's click is reflected in the UI for the session.
   }
-  listeners.forEach((listener) => {
-    listener();
-  });
+  notifyListeners();
 }
 
 function getSupportedTheme(theme: string | null): SupportedTheme {


### PR DESCRIPTION
## The bug

`useTheme` relies on `useSyncExternalStore`, but `subscribe` only tracked an in-memory listener set — it never listened to the browser's `storage` event. Writing `theme` in localStorage from another tab updated persistent storage but did not re-render already-mounted consumers in this tab (ThemeSwitch, PlaygroundCanvas, FlowGradient, the theme-color meta tag). The tab would only pick up the new preference on a full reload.

## The fix

`subscribe` now attaches a `storage` listener on the first subscriber and removes it on the last (refcount, so there's no permanent module-scope listener leak). The handler filters to `event.key === STORAGE_KEY || event.key === null` — the `null` branch covers `localStorage.clear()` per spec — assigns `event.newValue` to the module singleton, then notifies listeners. Same-tab `setTheme` is unchanged aside from extracting a shared `notifyListeners` helper, and `getServerSnapshot` still returns `"system"` so SSR bootstrap is unaffected.