### PR TITLE
fix: notify usePreferences subscribers on store writes

### DIFF
--- a/src/preference-store/preference-store.test.ts
+++ b/src/preference-store/preference-store.test.ts
@@ -4,8 +4,11 @@ import {
   formatPreferencesContext,
   getCachedPreferencesContext,
   getPreferencesContextReady,
+  getPreferencesSnapshot,
   isStoredPreference,
+  loadPreferencesContext,
   makeId,
+  subscribePreferences,
 } from "./preference-store";
 
 function pref(
@@ -255,5 +258,64 @@ describe("getPreferencesContextReady", () => {
     expect(result).toBeNull();
     // Generous bound — the point is "not a fresh IDB open", not a tight SLA.
     expect(elapsed).toBeLessThan(50);
+  });
+});
+
+describe("subscribePreferences", () => {
+  // The subscribe/notify pair is what bridges writers (the AI's
+  // `save_preference` tool call via `mergePreferences`) and readers
+  // (`usePreferences` in `PreferenceManager`). Without this, the panel's
+  // count dot and list stay stale until the component remounts — the bug
+  // fixed here. These tests pin the contract: returned unsubscribe, stable
+  // snapshot, and post-load notification.
+
+  it("returns a stable empty snapshot before any load", () => {
+    const first = getPreferencesSnapshot();
+    const second = getPreferencesSnapshot();
+    // Reference equality is required — `useSyncExternalStore` loops
+    // infinitely if the snapshot identity changes when nothing did.
+    expect(first).toBe(second);
+    expect(first).toEqual([]);
+  });
+
+  it("notifies every active subscriber when a load completes", async () => {
+    let aCount = 0;
+    let bCount = 0;
+    const unsubscribeA = subscribePreferences(() => {
+      aCount += 1;
+    });
+    const unsubscribeB = subscribePreferences(() => {
+      bCount += 1;
+    });
+
+    try {
+      // Simulates the notify path a writer triggers after mergePreferences /
+      // deletePreference / clearPreferences: the shared cache reloads and
+      // every `usePreferences` subscriber re-renders with the new snapshot.
+      // This is the exact mechanism that was missing — before the fix, a
+      // preference saved by the AI never reached the PreferenceTrigger /
+      // PreferencePanel reading via `usePreferences()`.
+      await loadPreferencesContext();
+
+      expect(aCount).toBe(1);
+      expect(bCount).toBe(1);
+    } finally {
+      unsubscribeA();
+      unsubscribeB();
+    }
+  });
+
+  it("stops notifying after unsubscribe", async () => {
+    let notifyCount = 0;
+    const unsubscribe = subscribePreferences(() => {
+      notifyCount += 1;
+    });
+
+    unsubscribe();
+
+    const before = notifyCount;
+    await loadPreferencesContext();
+
+    expect(notifyCount).toBe(before);
   });
 });

--- a/src/preference-store/preference-store.ts
+++ b/src/preference-store/preference-store.ts
@@ -127,7 +127,7 @@ export async function mergePreferences(
     store.put(record);
   }
 
-  return new Promise((resolve, reject) => {
+  await new Promise<void>((resolve, reject) => {
     tx.oncomplete = () => {
       resolve();
     };
@@ -135,6 +135,7 @@ export async function mergePreferences(
       reject(tx.error ?? new Error("Failed to merge preferences"));
     };
   });
+  await refreshPreferencesCache();
 }
 
 export async function deletePreference(id: string): Promise<void> {
@@ -143,7 +144,7 @@ export async function deletePreference(id: string): Promise<void> {
   const store = tx.objectStore(STORE_NAME);
   store.delete(id);
 
-  return new Promise((resolve, reject) => {
+  await new Promise<void>((resolve, reject) => {
     tx.oncomplete = () => {
       resolve();
     };
@@ -151,6 +152,7 @@ export async function deletePreference(id: string): Promise<void> {
       reject(tx.error ?? new Error("Failed to delete preference"));
     };
   });
+  await refreshPreferencesCache();
 }
 
 export async function clearPreferences(): Promise<void> {
@@ -159,7 +161,7 @@ export async function clearPreferences(): Promise<void> {
   const store = tx.objectStore(STORE_NAME);
   store.clear();
 
-  return new Promise((resolve, reject) => {
+  await new Promise<void>((resolve, reject) => {
     tx.oncomplete = () => {
       resolve();
     };
@@ -167,11 +169,63 @@ export async function clearPreferences(): Promise<void> {
       reject(tx.error ?? new Error("Failed to clear preferences"));
     };
   });
+  await refreshPreferencesCache();
 }
 
 let cachedContext: string | null = null;
 let cacheLoaded = false;
 let inFlightLoad: Promise<string | null> | null = null;
+
+// Stable empty reference so `useSyncExternalStore` sees reference equality
+// when the cache is unloaded or resolves to an empty list — otherwise React
+// treats every snapshot as a change and loops infinitely.
+const EMPTY_PREFERENCES: ReadonlyArray<StoredPreference> = [];
+let cachedPreferences: ReadonlyArray<StoredPreference> = EMPTY_PREFERENCES;
+let preferencesCacheLoaded = false;
+const preferenceListeners: Set<() => void> = new Set();
+
+function notifyPreferenceListeners() {
+  preferenceListeners.forEach((listener) => {
+    listener();
+  });
+}
+
+/**
+ * Refreshes both the preferences array cache (for the UI) and the chat
+ * context cache (for `getCachedPreferencesContext`) from IndexedDB, then
+ * notifies subscribers. Called after every successful write so readers
+ * see the new state without remounting.
+ */
+async function refreshPreferencesCache(): Promise<void> {
+  await loadPreferencesContext();
+}
+
+/**
+ * Subscribes to preference store changes. Intended for use with
+ * `useSyncExternalStore`. Returns an unsubscribe function.
+ *
+ * Triggers a lazy initial load on the first subscriber so the snapshot
+ * reflects persisted data without requiring callers to separately await
+ * `getPreferencesContextReady`.
+ */
+export function subscribePreferences(listener: () => void): () => void {
+  preferenceListeners.add(listener);
+  if (!preferencesCacheLoaded && !inFlightLoad) {
+    void loadPreferencesContext();
+  }
+  return () => {
+    preferenceListeners.delete(listener);
+  };
+}
+
+/**
+ * Synchronous snapshot for `useSyncExternalStore`. Returns a stable empty
+ * array reference until the first load resolves — React requires reference
+ * equality between renders when nothing changed.
+ */
+export function getPreferencesSnapshot(): ReadonlyArray<StoredPreference> {
+  return cachedPreferences;
+}
 
 export function formatPreferencesContext(
   prefs: ReadonlyArray<StoredPreference>,
@@ -207,13 +261,17 @@ export function formatPreferencesContext(
  */
 export function loadPreferencesContext(): Promise<string | null> {
   const p = (async () => {
+    let prefs: ReadonlyArray<StoredPreference>;
     try {
-      const prefs = await getAllPreferences();
-      cachedContext = formatPreferencesContext(prefs);
+      prefs = await getAllPreferences();
     } catch {
-      cachedContext = null;
+      prefs = EMPTY_PREFERENCES;
     }
+    cachedPreferences = prefs;
+    preferencesCacheLoaded = true;
+    cachedContext = formatPreferencesContext(prefs);
     cacheLoaded = true;
+    notifyPreferenceListeners();
     return cachedContext;
   })();
   inFlightLoad = p;

--- a/src/preference-store/use-preference-persistence.ts
+++ b/src/preference-store/use-preference-persistence.ts
@@ -3,7 +3,7 @@
 import { getToolName, isToolUIPart, type UIMessage } from "ai";
 import { useEffect, useRef } from "react";
 import { savePreferenceInputSchema } from "#src/ai-chat/tools/save-preference.ts";
-import { loadPreferencesContext, mergePreferences } from "./preference-store";
+import { mergePreferences } from "./preference-store";
 
 /**
  * Observes chat messages for `save_preference` tool calls and persists
@@ -32,11 +32,12 @@ export function usePreferencePersistence(
         const parsed = savePreferenceInputSchema.safeParse(part.input);
         if (!parsed.success) continue;
 
-        mergePreferences(parsed.data.preferences)
-          .then(() => loadPreferencesContext())
-          .catch(() => {
-            // IndexedDB write failed — preference is lost but non-critical
-          });
+        // `mergePreferences` refreshes the shared store cache and notifies
+        // `usePreferences` subscribers once the transaction completes, so
+        // `PreferenceTrigger` / `PreferencePanel` update in place.
+        mergePreferences(parsed.data.preferences).catch(() => {
+          // IndexedDB write failed — preference is lost but non-critical
+        });
       }
     }
   }, [messages]);

--- a/src/preference-store/use-preferences.ts
+++ b/src/preference-store/use-preferences.ts
@@ -1,64 +1,52 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 import {
   clearPreferences,
   deletePreference,
-  getAllPreferences,
+  getPreferencesSnapshot,
   loadPreferencesContext,
-  type StoredPreference,
+  subscribePreferences,
 } from "./preference-store";
 
+const EMPTY: ReadonlyArray<never> = [];
+function getServerSnapshot() {
+  return EMPTY;
+}
+
 /**
- * Loads all stored preferences from IndexedDB and provides mutators
- * for deleting individual items or clearing everything.
+ * Reads the current preferences from the shared store and exposes mutators
+ * for deleting individual items or clearing everything. Every write — whether
+ * it originates from this hook, from `usePreferencePersistence` (when the AI
+ * saves a preference), or from any future caller of the store's write
+ * functions — propagates to every subscriber through `useSyncExternalStore`,
+ * so the `PreferenceTrigger` count, the `PreferencePanel` list, and any other
+ * consumer stay in sync without remounting.
  */
 export function usePreferences() {
-  const [preferences, setPreferences] = useState<
-    ReadonlyArray<StoredPreference>
-  >([]);
-
-  async function reload() {
-    try {
-      const all = await getAllPreferences();
-      setPreferences(all);
-    } catch {
-      setPreferences([]);
-    }
-  }
-
-  useEffect(() => {
-    void (async () => {
-      try {
-        const all = await getAllPreferences();
-        setPreferences(all);
-      } catch {
-        setPreferences([]);
-      }
-    })();
-  }, []);
+  const preferences = useSyncExternalStore(
+    subscribePreferences,
+    getPreferencesSnapshot,
+    getServerSnapshot,
+  );
 
   async function remove(id: string) {
     try {
       await deletePreference(id);
-      await Promise.all([loadPreferencesContext(), reload()]);
     } catch {
       // IndexedDB may be unavailable (private browsing, quota exceeded).
-      // Reload to keep the UI consistent with what is actually stored.
-      await reload();
+      // Reload so the snapshot reflects the actual persisted state.
+      await loadPreferencesContext();
     }
   }
 
   async function clearAll() {
     try {
       await clearPreferences();
-      await Promise.all([loadPreferencesContext(), reload()]);
     } catch {
-      // IndexedDB may be unavailable (private browsing, quota exceeded).
-      // Reload to keep the UI consistent with what is actually stored.
-      await reload();
+      await loadPreferencesContext();
     }
   }
 
-  return { preferences, reload, remove, clearAll } as const;
+  return { preferences, remove, clearAll } as const;
 }


### PR DESCRIPTION
## The bug

`usePreferences` bootstrapped its data with a per-hook `useState` + one-shot `useEffect` that read IndexedDB once on mount. Writes that happened elsewhere — most notably `usePreferencePersistence` calling `mergePreferences` when the AI invoked `save_preference` — updated the database and the module-level context cache but had no way to tell any already-mounted `usePreferences` consumer to re-read. The result: `PreferenceTrigger`'s count dot and `PreferencePanel`'s list stayed stale until the component remounted.

## The fix

Gave the store a proper subscribe/notify surface. `preference-store.ts` now owns a `cachedPreferences` snapshot (seeded with a stable `EMPTY_PREFERENCES` reference so `useSyncExternalStore` doesn't loop), a `preferenceListeners` set, and `subscribePreferences` / `getPreferencesSnapshot` exports. `loadPreferencesContext` populates the snapshot and notifies; `mergePreferences`, `deletePreference`, and `clearPreferences` all await it after their transactions commit. `usePreferences` swaps its `useState` + `useEffect` pair for `useSyncExternalStore`, matching the existing `use-theme` / `use-media-query` / `use-viewport-height` pattern, and `usePreferencePersistence` drops its manual `.then(loadPreferencesContext)` — the writer propagates it now.