### PR TITLE
refactor: use inert for CollapsedChatButton hidden state

### DIFF
--- a/src/components/movie-database/collapsed-chat-button.test.tsx
+++ b/src/components/movie-database/collapsed-chat-button.test.tsx
@@ -42,14 +42,24 @@ function renderButton({
 }
 
 describe("CollapsedChatButton", () => {
-  it("renders the button as aria-hidden and not tabbable when hero input is visible", () => {
+  it("is inert (hidden from AT, removed from tab order, non-clickable) when hero input is visible", () => {
     renderButton({ isHeroInputVisible: true });
+    // `hidden: true` is the RTL escape hatch for elements that are inert —
+    // they're still in the DOM, just excluded from the accessibility tree.
     const button = screen.getByRole("button", {
       name: "Ask AI about movies and TV shows",
       hidden: true,
     });
-    expect(button).toHaveAttribute("tabindex", "-1");
-    expect(button.closest("[aria-hidden='true']")).not.toBeNull();
+    // The native `inert` attribute on the wrapper is the single declarative
+    // switch that covers all three concerns — no need to stack aria-hidden
+    // and tabIndex=-1 on top, and the aria-hidden + focusable combo is a
+    // WCAG 4.1.2 anti-pattern (see PR #2165).
+    const wrapper = button.parentElement;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper).toHaveAttribute("inert");
+    expect(wrapper).not.toHaveAttribute("aria-hidden");
+    expect(button).not.toHaveAttribute("aria-hidden");
+    expect(button).not.toHaveAttribute("tabindex");
   });
 
   it("renders a reachable button when hero input is not visible", () => {
@@ -58,7 +68,9 @@ describe("CollapsedChatButton", () => {
       name: "Ask AI about movies and TV shows",
     });
     expect(button).toBeInTheDocument();
-    expect(button).not.toHaveAttribute("tabindex", "-1");
+    expect(button).not.toHaveAttribute("tabindex");
+    expect(button).not.toHaveAttribute("aria-hidden");
+    expect(button.parentElement).not.toHaveAttribute("inert");
   });
 
   it("shows the label text", () => {

--- a/src/components/movie-database/collapsed-chat-button.tsx
+++ b/src/components/movie-database/collapsed-chat-button.tsx
@@ -30,13 +30,12 @@ export function CollapsedChatButton({
         styles.container,
         isHeroInputVisible ? styles.hidden : styles.visible,
       ]}
-      aria-hidden={isHeroInputVisible || undefined}
+      inert={isHeroInputVisible || undefined}
       {...{ [DATA_HERO_COLLAPSED_BUTTON]: "" }}
     >
       <Button
         onClick={openChat}
         aria-label={ariaLabel}
-        tabIndex={isHeroInputVisible ? -1 : undefined}
         icon={
           <span css={[flex.inlineCenter, styles.icon]}>
             <SparkleIcon weight="fill" role="presentation" />


### PR DESCRIPTION
## Summary

`CollapsedChatButton` was the last control in the codebase still stacking `aria-hidden={...}` on the wrapper with `tabIndex={-1}` on the inner `<Button>` to hide itself when the hero input is visible — the exact focusable-but-hidden combo flagged as a WCAG 4.1.2 violation in PR #2165. This swaps both attributes for a single `inert={...}` on the wrapper, matching the `scroll-to-bottom-button` idiom: `inert` takes every descendant out of the tab order, removes them from the accessibility tree, and blocks pointer input as one declarative switch. The visual state styles and the `DATA_HERO_COLLAPSED_BUTTON` data attribute used by `HeroVisibilityProvider` are untouched; the test was rewritten against the `scroll-to-bottom-button.test.tsx` template to pin the new contract and assert the old attributes are gone.