### PR TITLE
fix: annotate locale menu items with lang attributes

### DIFF
--- a/src/components/shared/locale-selector.tsx
+++ b/src/components/shared/locale-selector.tsx
@@ -42,6 +42,7 @@ export function LocaleSelector({
             href={`${getLocalePath(pathname, "en")}${searchString}`}
             isActive={locale === "en"}
             autoFocus={locale !== "en"}
+            lang="en"
             onBeforeNavigation={() => {
               // next-i18n-router respects the locale cookie, so we must keep
               // it in sync to avoid reverting locale on reload or root navigation.
@@ -56,6 +57,7 @@ export function LocaleSelector({
             href={`${getLocalePath(pathname, "zh")}${searchString}`}
             isActive={locale === "zh"}
             autoFocus={locale === "en"}
+            lang="zh"
             onBeforeNavigation={() => {
               setLocaleCookie("zh");
             }}

--- a/src/components/shared/menu-button.test.tsx
+++ b/src/components/shared/menu-button.test.tsx
@@ -356,4 +356,36 @@ describe("MenuItem", () => {
     const item = screen.getByRole("menuitem", { name: "Inactive item" });
     expect(item).not.toHaveAttribute("aria-current");
   });
+
+  it("forwards the lang attribute to the underlying anchor", () => {
+    // WCAG 3.1.2 (Language of Parts): when the item's visible text and
+    // aria-label are in a different language from the surrounding page,
+    // the `lang` attribute must appear on an ancestor of the text (here,
+    // the anchor itself) so screen readers switch pronunciation rules.
+    // This is the load-bearing fix for the locale-switcher menu — see
+    // `LocaleSelector`.
+    render(
+      <RouterProvider>
+        <MenuItem href="/zh" lang="zh" ariaLabel="切换至中文">
+          中文
+        </MenuItem>
+      </RouterProvider>,
+    );
+
+    const item = screen.getByRole("menuitem", { name: "切换至中文" });
+    expect(item).toHaveAttribute("lang", "zh");
+  });
+
+  it("omits the lang attribute when none is provided", () => {
+    render(
+      <RouterProvider>
+        <MenuItem href="/x">Default-language item</MenuItem>
+      </RouterProvider>,
+    );
+
+    const item = screen.getByRole("menuitem", {
+      name: "Default-language item",
+    });
+    expect(item).not.toHaveAttribute("lang");
+  });
 });

--- a/src/components/shared/menu-item.tsx
+++ b/src/components/shared/menu-item.tsx
@@ -10,6 +10,13 @@ interface ItemProps {
   autoFocus?: boolean;
   href: string;
   isActive?: boolean;
+  /**
+   * BCP-47 language tag for the item content. Forwarded to the underlying
+   * `<a>` so the accessible name and visible text are pronounced with the
+   * correct language's phonology — required by WCAG 3.1.2 (Language of
+   * Parts) when the item is in a different language from the page.
+   */
+  lang?: string;
   onBeforeNavigation?: () => void;
   onAfterNavigation?: () => void;
 }
@@ -20,6 +27,7 @@ export function MenuItem({
   href,
   isActive,
   autoFocus,
+  lang,
   onBeforeNavigation,
   onAfterNavigation,
 }: PropsWithChildren<ItemProps>) {
@@ -31,6 +39,7 @@ export function MenuItem({
       href={href}
       aria-label={ariaLabel}
       aria-current={isActive ? "true" : undefined}
+      lang={lang}
       role="menuitem"
       css={[flex.between, styles.item, isActive && styles.itemActive]}
       data-menu-autofocus={autoFocus ? "true" : undefined}


### PR DESCRIPTION
## The bug

The locale switcher renders an English item ("English", `aria-label="Switch to English"`) next to a Chinese item ("中文", `aria-label="切换至中文"`), and the surrounding page is always in one of those two languages. One item therefore always disagrees with the document `lang`, and with no `lang` annotation on the item itself screen readers fall through to the document's phonology — reading "中文" / "切换至中文" with English rules when viewing the English site, and vice versa. This is a WCAG 3.1.2 (Language of Parts) failure on the one control guaranteed to mix languages.

## The fix

Added an optional `lang` prop to `MenuItem` that forwards to the underlying `<a role="menuitem">`, then set `lang="en"` / `lang="zh"` on the two locale items. Putting `lang` on the anchor covers both the accessible name and the visible text without wrapping children in an extra `<span lang>`, matching the precedent in `src/app/not-found.tsx:23-27`. The prop is optional and defaults to undefined, so every other `MenuItem` caller emits the exact same DOM as before — the existing `e2e/language-toggle.spec.ts` selectors (which match on `aria-label`) continue to resolve unchanged.