### PR TITLE
chore: mark playground route noindex

### DIFF
--- a/src/app/[locale]/playground/page.tsx
+++ b/src/app/[locale]/playground/page.tsx
@@ -1,4 +1,14 @@
+import type { Metadata } from "next";
 import { PlaygroundCanvas } from "#src/components/playground/playground-canvas.tsx";
+
+// This route is intentionally unlinked (see PR #2029) — keep it out of search
+// engines, AI crawlers, and social preview caches. Robots-meta is the right
+// mechanism here; adding a bare `Disallow: /playground` to robots.txt would
+// announce the URL to anyone who reads it, defeating the "secret" intent.
+export const metadata: Metadata = {
+  title: "Playground",
+  robots: { index: false, follow: false },
+};
 
 export default function Page() {
   return <PlaygroundCanvas />;


### PR DESCRIPTION
## Summary

The `/[locale]/playground` route was introduced in PR #2029 as an intentionally unlinked, experimental surface but never actually told crawlers to stay out — it shipped with no `metadata` export, so Next.js emitted no `<meta name="robots">` and the URL was only shielded by obscurity. Any out-of-band discovery path (Chrome history sync, referrer leaks, prod IP reverse DNS) would expose it as a normal indexable page. This adds a static `export const metadata` with `{ title: "Playground", robots: { index: false, follow: false } }` — matching the `not-found.tsx` precedent for static metadata and keeping the URL off `robots.txt` / the sitemap so the "secret" intent isn't defeated by announcing it. Confirmed against the SSG output that both `en` and `zh` builds emit `<meta name="robots" content="noindex, nofollow"/>`.