### PR TITLE
fix: hide rating badge when title has no votes

### DIFF
--- a/src/components/ai-chat/media-detail-content.tsx
+++ b/src/components/ai-chat/media-detail-content.tsx
@@ -140,18 +140,24 @@ export function MediaDetailContent({
           ) : null}
           <div css={styles.headerInfo}>
             {detail ? (
-              <div
-                css={styles.ratingRow}
-                role="img"
-                aria-label={`${t({ en: "User rating", zh: "用户评分" })}: ${formatter.format(detail.voteAverage)}${t({ en: " out of 10", zh: "/10" })}, ${formatter.format(detail.voteCount)} ${t({ en: "votes", zh: "票" })}`}
-              >
-                <span css={styles.rating} aria-hidden="true">
-                  {formatter.format(detail.voteAverage)}
-                </span>
-                <span css={styles.voteCount} aria-hidden="true">
-                  ({formatter.format(detail.voteCount)})
-                </span>
-              </div>
+              // TMDB returns voteAverage=0 + voteCount=0 for titles nobody
+              // has rated yet — that's "not yet rated", not an actual zero.
+              // Drop the row entirely in that case (matches the MediaPoster
+              // precedent) rather than render a misleading "0 (0)".
+              detail.voteCount > 0 && (
+                <div
+                  css={styles.ratingRow}
+                  role="img"
+                  aria-label={`${t({ en: "User rating", zh: "用户评分" })}: ${formatter.format(detail.voteAverage)}${t({ en: " out of 10", zh: "/10" })}, ${formatter.format(detail.voteCount)} ${t({ en: "votes", zh: "票" })}`}
+                >
+                  <span css={styles.rating} aria-hidden="true">
+                    {formatter.format(detail.voteAverage)}
+                  </span>
+                  <span css={styles.voteCount} aria-hidden="true">
+                    ({formatter.format(detail.voteCount)})
+                  </span>
+                </div>
+              )
             ) : (
               <Skeleton width={60} height={20} />
             )}

--- a/src/components/movie-database/media-detail-hero.test.tsx
+++ b/src/components/movie-database/media-detail-hero.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "#src/test-utils.tsx";
+import { MediaDetailHero } from "./media-detail-hero";
+
+// TMDB returns voteAverage=0 + voteCount=0 for titles that have never been
+// rated. The old code rendered a "0" badge with aria-label
+// "User rating: 0 out of 10, based on 0 votes" — a falsehood that
+// misrepresented "not yet rated" as "rated zero". These tests pin the
+// MediaPoster-style guard: show the badge when there's at least one vote,
+// drop it entirely otherwise.
+describe("MediaDetailHero rating badge", () => {
+  it("renders the rating badge with a correct accessible name when the title has votes", () => {
+    render(
+      <MediaDetailHero
+        title="Oppenheimer"
+        backdropPath={null}
+        voteAverage={8.1}
+        voteCount={10765}
+        meta="2023 • 180 min"
+        description="A biography of J. Robert Oppenheimer."
+        locale="en"
+        trailer={null}
+      />,
+    );
+
+    // The badge is an ARIA image; its accessible name carries the whole
+    // rating statement. role="img" with `hidden: false` excludes nothing —
+    // use getByRole with the name to assert both presence and correctness.
+    expect(
+      screen.getByRole("img", {
+        name: "User rating: 8.1 out of 10, based on 10,765 votes",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the rating badge when the title has no votes yet", () => {
+    render(
+      <MediaDetailHero
+        title="Obscure Unrated Film"
+        backdropPath={null}
+        voteAverage={0}
+        voteCount={0}
+        meta="2024 • 95 min"
+        description="A film nobody has rated yet."
+        locale="en"
+        trailer={null}
+      />,
+    );
+
+    // The heading still renders — we're only dropping the rating widget.
+    expect(
+      screen.getByRole("heading", { name: "Obscure Unrated Film", level: 1 }),
+    ).toBeInTheDocument();
+
+    // No role="img" and, crucially, no "0 out of 10" claim anywhere —
+    // neither in the visible DOM nor in any accessible name.
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(screen.queryByText("0")).toBeNull();
+    expect(screen.queryByLabelText(/out of 10/)).toBeNull();
+  });
+});

--- a/src/components/movie-database/media-detail-hero.tsx
+++ b/src/components/movie-database/media-detail-hero.tsx
@@ -42,18 +42,24 @@ export function MediaDetailHero({
     <div css={styles.container}>
       {backdropPath && <BackdropImage backdropPath={backdropPath} />}
       <div css={styles.hero}>
-        <div
-          css={styles.ratingContainer}
-          role="img"
-          aria-label={`${t({ en: "User rating", zh: "用户评分" })}: ${formatter.format(voteAverage)}${t({ en: " out of 10", zh: "/10" })}, ${t({ en: "based on", zh: "基于" })} ${voteCount.toLocaleString(locale)} ${t({ en: "votes", zh: "票" })}`}
-        >
-          <div css={styles.rating} aria-hidden="true">
-            {formatter.format(voteAverage)}
+        {voteCount > 0 && (
+          // TMDB returns voteAverage=0 + voteCount=0 for titles nobody has
+          // rated yet — that's "not yet rated", not an actual zero score.
+          // Hide the badge entirely (matches the MediaPoster precedent)
+          // rather than render a misleading "0 out of 10".
+          <div
+            css={styles.ratingContainer}
+            role="img"
+            aria-label={`${t({ en: "User rating", zh: "用户评分" })}: ${formatter.format(voteAverage)}${t({ en: " out of 10", zh: "/10" })}, ${t({ en: "based on", zh: "基于" })} ${voteCount.toLocaleString(locale)} ${t({ en: "votes", zh: "票" })}`}
+          >
+            <div css={styles.rating} aria-hidden="true">
+              {formatter.format(voteAverage)}
+            </div>
+            <div css={styles.count} aria-hidden="true">
+              {formatter.format(voteCount)}
+            </div>
           </div>
-          <div css={styles.count} aria-hidden="true">
-            {formatter.format(voteCount)}
-          </div>
-        </div>
+        )}
         <h1 css={styles.h1}>{title}</h1>
         <div css={styles.meta}>{meta}</div>
         {description && <p css={styles.description}>{description}</p>}


### PR DESCRIPTION
## The bug

TMDB returns `voteAverage: 0, voteCount: 0` for titles that nobody has rated yet — that's "not yet rated", not a zero score. `MediaDetailHero` (on the full detail page) and the rating row in `MediaDetailContent` (inside the AI-chat overlay) both rendered this as a "0" badge with `aria-label="User rating: 0 out of 10, based on 0 votes"`, so sighted and screen-reader users were told the film had been rated zero out of ten when in fact no rating exists.

## The fix

Wrapped each rating block in `voteCount > 0 && (…)` so the badge — and its aria-label — disappear entirely when there are no votes. Matches the existing `MediaPoster` precedent (`media-poster.tsx:58`, `media.rating ? … : null`) and keeps the two surfaces visually and semantically in sync. Both parent layouts are `flex-direction: column` with `gap`, so the removed child collapses cleanly with no leftover spacing. Formatter, `aria-label`, `role="img"`, and `aria-hidden` spans are preserved verbatim inside the guard — only the outer conditional is new. Added a `MediaDetailHero` unit test pinning both the happy-path accessible name (including locale number formatting) and the unrated case (no `role="img"`, no visible "0", no "out of 10" aria-label).