### PR TITLE
fix: reset TmdbImage state when path changes

### DIFF
--- a/src/components/movie-database/tmdb-image.test.tsx
+++ b/src/components/movie-database/tmdb-image.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import { render, screen } from "#src/test-utils.tsx";
+import { act, render, screen } from "#src/test-utils.tsx";
 import { TmdbImage } from "./tmdb-image";
 
 const COMMON_PROPS = {
@@ -110,5 +110,58 @@ describe("TmdbImage", () => {
 
     expect(screen.getByText("fallback ui")).toBeInTheDocument();
     expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("resets the error state when the path prop changes", () => {
+    // Reproduces the virtuoso-slot reuse bug: the same component instance
+    // receives path "/a.jpg", errors, then is reused with "/b.jpg". Before
+    // the fix the prior errored=true stuck and the slot rendered the
+    // fallback forever. After the fix the new path restores the <img>.
+    restore = stubImageElement({ complete: false, naturalWidth: 0 });
+    const { rerender } = render(
+      <TmdbImage
+        {...COMMON_PROPS}
+        path="/a.jpg"
+        errorFallback={<span>fallback ui</span>}
+      />,
+    );
+
+    act(() => {
+      fireEvent.error(screen.getByRole("img"));
+    });
+
+    expect(screen.getByText("fallback ui")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+
+    rerender(
+      <TmdbImage
+        {...COMMON_PROPS}
+        path="/b.jpg"
+        errorFallback={<span>fallback ui</span>}
+      />,
+    );
+
+    expect(screen.getByRole("img")).toBeInTheDocument();
+    expect(screen.queryByText("fallback ui")).not.toBeInTheDocument();
+  });
+
+  it("resets the loaded state when the path prop changes so the skeleton re-appears", () => {
+    // The twin failure mode: loaded=true from the previous path would
+    // suppress the skeleton while the new src is still decoding,
+    // briefly revealing stale pixels or a blank frame.
+    restore = stubImageElement({ complete: false, naturalWidth: 0 });
+    const { container, rerender } = render(
+      <TmdbImage {...COMMON_PROPS} path="/a.jpg" />,
+    );
+
+    fireEvent.load(screen.getByRole("img"));
+
+    // Skeleton gone after load settles for path A.
+    expect(container.querySelectorAll("div, img")).toHaveLength(1);
+
+    rerender(<TmdbImage {...COMMON_PROPS} path="/b.jpg" />);
+
+    // Skeleton back while path B loads.
+    expect(container.querySelectorAll("div, img")).toHaveLength(2);
   });
 });

--- a/src/components/movie-database/tmdb-image.tsx
+++ b/src/components/movie-database/tmdb-image.tsx
@@ -38,6 +38,21 @@ export function TmdbImage({
   const [loaded, setLoaded] = useState(false);
   const [errored, setErrored] = useState(false);
 
+  // Reset on `path` change so a prior success/error verdict doesn't poison
+  // the next image. This matters when the same component instance is reused
+  // with a new path — e.g. `react-virtuoso`'s default viewport-slot keying
+  // in `MediaVirtuosoGrid` cycles posters through a fixed set of slots, so
+  // without this reset a single 404 would stick the slot on the error
+  // fallback for the rest of the session. Canonical React pattern from the
+  // "Resetting state when a prop changes" docs — don't swap for useEffect,
+  // that would add an extra render + paint.
+  const [prevPath, setPrevPath] = useState(path);
+  if (prevPath !== path) {
+    setPrevPath(path);
+    setLoaded(false);
+    setErrored(false);
+  }
+
   if (errored) {
     return <>{errorFallback}</>;
   }


### PR DESCRIPTION
## The bug

`TmdbImage` holds `loaded` and `errored` in component-local state but never resets them when the `path` prop changes. `react-virtuoso` reuses the same React instance for each viewport slot as items scroll through `MediaVirtuosoGrid`, so once a slot's `TmdbImage` errored on a 404 — or settled `loaded=true` for a prior image — that verdict stuck across every subsequent item that rotated through the slot. The visible symptoms were persistent error fallbacks where a real poster belonged, and skeletons skipped in favour of a blank frame of stale pixels while the new src was still decoding.

## The fix

Adopted the canonical React "Resetting state when a prop changes" pattern: a `prevPath` sentinel held in `useState`, and an inline `if (prevPath !== path) { setPrevPath(path); setLoaded(false); setErrored(false); }` at the top of the render. React short-circuits and re-renders with the reset state before committing, so there's no extra paint relative to a `useEffect`-based reset. The existing cached-image `ref` callback (PR #2127) is untouched and still probes the new `<img>` on the post-reset render to pick up cache hits without firing `onLoad`. The fix is entirely inside the component that owns the state — every downstream consumer (`MediaCard`, `PosterImage`, `CompactMediaCard`, `CompactPersonCard`, `RecommendedMediaRow`, `MediaDetailContent`) benefits without changes.