### PR TITLE
chore: add nofollow to 404 page robots meta

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -9,6 +9,11 @@ export const metadata: Metadata = {
   title: "404 | Qingqi Shi",
   description:
     "You're looking for a page about Qingqi Shi that doesn't exist. 您正在寻找的石清琪的页面不存在。",
+  // Belt-and-braces with the 404 status code — compliant crawlers already
+  // drop the URL on status, but non-compliant AI scrapers and social-preview
+  // unfurlers read metadata regardless. `noindex, nofollow` keeps the
+  // title/description out of those pipelines. Mirrors PR #2190's playground.
+  robots: { index: false, follow: false },
 };
 
 export default function NotFound() {


### PR DESCRIPTION
## Summary

Next.js already emits `<meta name="robots" content="noindex"/>` on 404 pages by default, which covers compliant crawlers following the 404 status — but AI scrapers and social-preview unfurlers often ignore status codes and read metadata regardless, and the default tag doesn't carry `nofollow` so any outbound links on the 404 page (the home `Link`) are still fair game. Adds `robots: { index: false, follow: false }` to `src/app/not-found.tsx`'s existing `Metadata` export, mirroring the PR #2190 playground idiom so the two "don't index me" surfaces use the same shape. Verified against the SSG output that `.next/server/app/_not-found.html` now carries both the Next.js default `noindex` tag and our new `noindex, nofollow` tag — crawlers merge multiple robots-meta directives per spec.