### PR TITLE
chore: declare button type on error boundary retry controls

### DIFF
--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -33,7 +33,7 @@ export default function LocaleError({
           zh: "发生了意外错误，请重试。",
         })}
       </p>
-      <button css={styles.button} onClick={unstable_retry}>
+      <button type="button" css={styles.button} onClick={unstable_retry}>
         {t({ en: "Try again", zh: "重试" })}
       </button>
     </div>

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -41,6 +41,7 @@ export default function GlobalError({
           Something went wrong. Please try again.
         </p>
         <button
+          type="button"
           onClick={unstable_retry}
           style={{
             marginTop: "1rem",


### PR DESCRIPTION
## Summary

`RetryableErrorBoundary` already sets `type="button"` on its retry control at `retryable-error-boundary.tsx:19` — the Next.js-managed error boundaries at `src/app/[locale]/error.tsx` and `src/app/global-error.tsx` were the two outliers still relying on the HTML default. That default is `submit`, which happens to be harmless today only because neither boundary sits inside a `<form>`; a future refactor that adds a form wrapper, or a lint rule that flags implicit button types, would silently break retry. Adds `type="button"` on both, matching the shared-component precedent. No behaviour change — purely consistency and defensive correctness.