### PR TITLE
fix: put h1 before h2 in DetailPageTitle DOM order

### DIFF
--- a/src/components/home/detail-page-title.test.tsx
+++ b/src/components/home/detail-page-title.test.tsx
@@ -35,4 +35,28 @@ describe("DetailPageTitle", () => {
     expect(timeEl?.textContent).toBe("Sep 2016 - Jan 2018");
     expect(timeEl).toHaveAttribute("datetime", "2016-09");
   });
+
+  it("puts the primary h1 before the subordinate h2 in DOM order", () => {
+    // WCAG 1.3.1 / 2.4.6: screen-reader heading navigation follows DOM
+    // order. The h1 is the page's primary heading and must be reachable
+    // first. The kicker-above-title visual order is preserved via flexbox
+    // `order` in the stylesheet — don't swap the JSX back without also
+    // re-introducing a layout workaround.
+    const { container } = render(
+      <DetailPageTitle
+        type="experience"
+        title="Citadel"
+        role="Software Engineer"
+        date="Aug 2021 - Now"
+        dateTime="2021-08"
+      />,
+    );
+
+    const headings = container.querySelectorAll("h1, h2");
+    expect(headings).toHaveLength(2);
+    expect(headings[0].tagName).toBe("H1");
+    expect(headings[0]).toHaveTextContent("Software Engineer");
+    expect(headings[1].tagName).toBe("H2");
+    expect(headings[1]).toHaveTextContent("Experience - Citadel");
+  });
 });

--- a/src/components/home/detail-page-title.tsx
+++ b/src/components/home/detail-page-title.tsx
@@ -25,11 +25,15 @@ export function DetailPageTitle({
       : t({ en: "Education", zh: "学习" });
 
   return (
+    // DOM order is h1 → h2 → time so screen-reader heading navigation lands
+    // on the page's primary heading first (WCAG 1.3.1 / 2.4.6). Flexbox
+    // `order` restores the visual layout: kicker on top, role in the middle,
+    // date at the bottom.
     <header css={[flex.col, styles.container]}>
+      <h1 css={styles.title}>{role}</h1>
       <h2 css={styles.subtitle}>
         {typeLabel} - {title}
       </h2>
-      <h1 css={styles.title}>{role}</h1>
       <time dateTime={dateTime} css={styles.date}>
         {date}
       </time>
@@ -43,16 +47,19 @@ const styles = stylex.create({
     paddingBottom: space._8,
   },
   subtitle: {
+    order: 0,
     fontSize: font.vpHeading3,
     fontWeight: font.weight_7,
     color: color.textMuted,
     margin: 0,
   },
   title: {
+    order: 1,
     fontSize: font.vpHeading1,
     margin: 0,
   },
   date: {
+    order: 2,
     display: "block",
     fontSize: font.uiBody,
     color: color.textMuted,


### PR DESCRIPTION
## The bug

`DetailPageTitle` rendered the subordinate `<h2>` kicker ("Experience - Citadel") before the primary `<h1>` ("Software Engineer") in the DOM to match the visual kicker-above-title layout. Because screen-reader heading navigation (the `H` rotor key on VoiceOver / NVDA, the mobile SR rotor) follows DOM order, users would land on the category kicker first and only reach the page's actual subject on the next press. That inverts the programmatic heading hierarchy — a WCAG 1.3.1 (Info and Relationships) / 2.4.6 (Headings and Labels) issue on all 6 experience and education detail pages.

## The fix

Swapped the JSX so `<h1>` now comes before `<h2>` in the DOM, then used flexbox `order` on the existing StyleX rules (`subtitle: 0`, `title: 1`, `date: 2`) to keep the visual kicker-on-top layout identical. DOM order drives heading navigation and reading order for AT; `order` only affects the visual flow, and the component has no focusable children so WCAG 2.4.3 (focus order) doesn't apply. Added an inline comment and a regression test that asserts `container.querySelectorAll("h1, h2")` lands on H1 ("Software Engineer") first so a future reader can't "tidy" the JSX back.