### PR TITLE
fix: prevent canvas resize flash on iOS Safari scroll

### DIFF
--- a/src/components/playground/playground-canvas.tsx
+++ b/src/components/playground/playground-canvas.tsx
@@ -246,14 +246,18 @@ const styles = stylex.create({
     // Lock to the large viewport (`100lvh`) so iOS Safari's URL-bar
     // collapse on scroll doesn't resize the canvas — a resize would fire
     // the ResizeObserver, recreate the FBOs, and flash the page white
-    // between the buffer clear and the next render. `100lvh` also
-    // extends behind the Dynamic Island and home indicator when paired
-    // with `viewport-fit=cover`, eliminating the safe-area white bars.
+    // between the buffer clear and the next render. iOS Safari's
+    // `100lvh` excludes the Dynamic Island / home-indicator safe areas
+    // even with `viewport-fit=cover`, so we negatively offset and grow
+    // by the safe-area insets to cover the full screen — OS chrome just
+    // overlays those extended regions.
     position: "fixed",
-    top: 0,
-    left: 0,
-    width: "100vw",
-    height: "100lvh",
+    top: "calc(-1 * env(safe-area-inset-top))",
+    left: "calc(-1 * env(safe-area-inset-left))",
+    width:
+      "calc(100vw + env(safe-area-inset-left) + env(safe-area-inset-right))",
+    height:
+      "calc(100lvh + env(safe-area-inset-top) + env(safe-area-inset-bottom))",
     pointerEvents: "none",
   },
   scrollSpacer: {

--- a/src/components/playground/playground-canvas.tsx
+++ b/src/components/playground/playground-canvas.tsx
@@ -243,10 +243,17 @@ export function PlaygroundCanvas() {
 
 const styles = stylex.create({
   canvas: {
+    // Lock to the large viewport (`100lvh`) so iOS Safari's URL-bar
+    // collapse on scroll doesn't resize the canvas — a resize would fire
+    // the ResizeObserver, recreate the FBOs, and flash the page white
+    // between the buffer clear and the next render. `100lvh` also
+    // extends behind the Dynamic Island and home indicator when paired
+    // with `viewport-fit=cover`, eliminating the safe-area white bars.
     position: "fixed",
-    inset: 0,
-    width: "100%",
-    height: "100%",
+    top: 0,
+    left: 0,
+    width: "100vw",
+    height: "100lvh",
     pointerEvents: "none",
   },
   scrollSpacer: {
@@ -256,8 +263,8 @@ const styles = stylex.create({
   },
   overlay: {
     position: "fixed",
-    top: "12px",
-    left: "12px",
+    bottom: "calc(12px + env(safe-area-inset-bottom))",
+    left: "calc(12px + env(safe-area-inset-left))",
     padding: "10px 14px",
     borderRadius: "8px",
     backgroundColor: "rgba(0, 0, 0, 0.75)",


### PR DESCRIPTION
## The bug

On iOS Safari, scrolling the `/playground` page causes the URL bar to collapse, which resizes the visual viewport. The canvas was sized via `position: fixed; inset: 0; width: 100%; height: 100%` — on iOS, fixed elements track the visual viewport, so the collapse fires the `ResizeObserver` in `loop.ts`, which recreates the ping-pong FBOs and resets accumulation. The canvas buffer is briefly cleared between the resize and the next render, producing a white flash. Separately, `100%` height on a fixed element didn't reliably extend behind the Dynamic Island and home indicator, leaving white bars at the top and bottom. The debug stats overlay was also anchored at `top: 12px; left: 12px`, placing it over the page's back button.

## The fix

Switch the canvas to `top: 0; left: 0; width: 100vw; height: 100lvh`. `100lvh` is the large viewport height (URL bar fully collapsed), so the canvas size stays constant regardless of whether the controls are expanded — eliminating the `ResizeObserver` fire, FBO recreation, and the white flash. Combined with the existing `viewport-fit=cover` in the root layout's viewport config, `100lvh` also extends the canvas behind the Dynamic Island and home indicator. Move the debug overlay to `bottom: calc(12px + env(safe-area-inset-bottom)); left: calc(12px + env(safe-area-inset-left))` so it clears both the back button and the home indicator.

## Notes

`100dvh` (dynamic) was considered but rejected — it resizes on URL-bar collapse, which defeats the flash fix. `100svh` (small) was also considered but rejected — it leaves an uncovered gap when controls hide. `100lvh` is the only option that is both stable and full-screen.