### PR TITLE
fix: preserve all file references when merging duplicate i18n entries

### DIFF
--- a/tooling/i18n-codegen/extractor.test.ts
+++ b/tooling/i18n-codegen/extractor.test.ts
@@ -39,7 +39,7 @@ describe("extractFromSource", () => {
     expect(result.entries[0].en).toBe("Hello");
     expect(result.entries[0].zh).toBe("你好");
     expect(result.entries[0].key).toBe(generateKey("Hello", "你好"));
-    expect(result.entries[0].file).toBe("test.tsx");
+    expect(result.entries[0].files).toEqual(["test.tsx"]);
   });
 
   it("extracts t() calls imported from #src/i18n.ts", () => {
@@ -197,7 +197,7 @@ describe("mergeResults", () => {
     expect(merged.entries).toHaveLength(2);
   });
 
-  it("deduplicates identical translations across files", () => {
+  it("deduplicates identical translations across files but tracks every source file", () => {
     const result1 = extractFromSource(
       `
       import { t } from "#src/i18n";
@@ -216,7 +216,23 @@ describe("mergeResults", () => {
 
     const merged = mergeResults([result1, result2]);
     expect(merged.entries).toHaveLength(1);
+    expect(merged.entries[0].files).toEqual(["file1.tsx", "file2.tsx"]);
     expect(merged.warnings).toHaveLength(0);
+  });
+
+  it("does not register the same file twice when a translation appears multiple times in one file", () => {
+    const result = extractFromSource(
+      `
+      import { t } from "#src/i18n";
+      t({ en: "Hello", zh: "你好" });
+      t({ en: "Hello", zh: "你好" });
+    `,
+      "file1.tsx",
+    );
+
+    const merged = mergeResults([result]);
+    expect(merged.entries).toHaveLength(1);
+    expect(merged.entries[0].files).toEqual(["file1.tsx"]);
   });
 
   it("keeps both entries when same English has different Chinese translations", () => {

--- a/tooling/i18n-codegen/extractor.ts
+++ b/tooling/i18n-codegen/extractor.ts
@@ -21,7 +21,13 @@ export interface TranslationEntry {
   key: string;
   en: string;
   zh: string;
-  file: string;
+  /**
+   * All source files that contain this translation. After extraction this is a
+   * single-element array; after `mergeResults` it lists every file whose t()
+   * call shares the same key+content.
+   */
+  files: string[];
+  /** Line of the first occurrence (best-effort, used for diagnostics). */
   line: number;
 }
 
@@ -156,7 +162,7 @@ export function extractFromSource(
         key: hashKey,
         en: enValue,
         zh: zhValue,
-        file: filePath,
+        files: [filePath],
         line: firstArg.loc?.start.line ?? 0,
       });
     },
@@ -167,24 +173,30 @@ export function extractFromSource(
 
 /**
  * Merge extraction results from multiple files, detecting conflicts.
+ *
+ * When the same translation appears in multiple files, the merged entry
+ * lists every source file in `files` so per-page bundle generation can
+ * find the key for every page that uses it.
  */
 export function mergeResults(results: ExtractionResult[]): ExtractionResult {
   const mergedEntries: TranslationEntry[] = [];
   const mergedWarnings: ExtractionWarning[] = [];
-  const seenKeys = new Map<
-    string,
-    { en: string; zh: string; file: string; line: number }
-  >();
+  const entriesByKey = new Map<string, TranslationEntry>();
 
   for (const result of results) {
     mergedWarnings.push(...result.warnings);
 
     for (const entry of result.entries) {
-      const existing = seenKeys.get(entry.key);
+      const existing = entriesByKey.get(entry.key);
 
       if (existing) {
-        // Same key, same content = exact duplicate across files → deduplicate
+        // Same key, same content = duplicate across files → record every file
         if (existing.en === entry.en && existing.zh === entry.zh) {
+          for (const file of entry.files) {
+            if (!existing.files.includes(file)) {
+              existing.files.push(file);
+            }
+          }
           continue;
         }
 
@@ -195,19 +207,21 @@ export function mergeResults(results: ExtractionResult[]): ExtractionResult {
             `Hash collision: key "${entry.key}" maps to both ` +
             `("${existing.en}", "${existing.zh}") and ("${entry.en}", "${entry.zh}"). ` +
             `One translation will be lost. Change one of the strings slightly to resolve.`,
-          file: entry.file,
+          file: entry.files[0],
           line: entry.line,
         });
         continue;
       }
 
-      seenKeys.set(entry.key, {
+      const merged: TranslationEntry = {
+        key: entry.key,
         en: entry.en,
         zh: entry.zh,
-        file: entry.file,
+        files: [...entry.files],
         line: entry.line,
-      });
-      mergedEntries.push(entry);
+      };
+      entriesByKey.set(entry.key, merged);
+      mergedEntries.push(merged);
     }
   }
 

--- a/tooling/i18n-codegen/generator.ts
+++ b/tooling/i18n-codegen/generator.ts
@@ -126,14 +126,17 @@ function generatePerPageBundles(allEntries: TranslationEntry[]): void {
   const localeDir = path.join(srcDir, "app", "[locale]");
   const entryPoints = collectPageEntryPoints(localeDir);
 
-  // Build a map from relative file path → entries
+  // Build a map from relative file path → entries. Each merged entry can list
+  // multiple source files, so register the entry under every file it appears in.
   const entriesByFile = new Map<string, TranslationEntry[]>();
   for (const entry of allEntries) {
-    const existing = entriesByFile.get(entry.file);
-    if (existing) {
-      existing.push(entry);
-    } else {
-      entriesByFile.set(entry.file, [entry]);
+    for (const file of entry.files) {
+      const existing = entriesByFile.get(file);
+      if (existing) {
+        existing.push(entry);
+      } else {
+        entriesByFile.set(file, [entry]);
+      }
     }
   }
 
@@ -284,13 +287,8 @@ function main(): void {
   console.log(`  ${enPath}`);
   console.log(`  ${zhPath}`);
 
-  // Generate per-page client bundles, loaders, and manifest.
-  // Pass raw (pre-merge) entries so that each file retains all its t() keys.
-  // mergeResults deduplicates by key and keeps only one file reference, which
-  // would cause keys shared across files to be missing from some page bundles.
   console.log("\nGenerating per-page client bundles...");
-  const allFileEntries = results.flatMap((r) => r.entries);
-  generatePerPageBundles(allFileEntries);
+  generatePerPageBundles(merged.entries);
 }
 
 main();


### PR DESCRIPTION
## The bug

`mergeResults` in `tooling/i18n-codegen/extractor.ts` deduplicated entries by hash key but kept only the first file's `file` field, silently dropping every other source file. The per-page bundle generator in `generator.ts` maps entries to pages via the `file` field, so when the same `t({ en, zh })` call appeared in components shared across pages, only the first-sorted file's page got the translation key — every other page dropped it and would crash at runtime with `Missing translation key`. A workaround existed that fed raw pre-merge entries into the per-page generator, masking the symptom while leaving the root cause intact.

## The fix

Replace `file: string` on `TranslationEntry` with `files: string[]`. `mergeResults` now appends every distinct source file when content matches, and `generatePerPageBundles` registers each merged entry under every file in `entry.files`. With the root cause gone, the raw-entries workaround in `generator.ts` is removed in favour of passing `merged.entries` directly.

## Notes

Bundle output is byte-identical to the previous workaround-based output — verified by running `pnpm codegen:i18n` and confirming shared keys (e.g. `Close`) still appear in every page bundle that uses them.

Closes #1724