### PR TITLE
fix: trigger anchor prefetch on keyboard focus, not just hover

### DIFF
--- a/apps/web/src/components/shared/anchor.test.tsx
+++ b/apps/web/src/components/shared/anchor.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "#src/test-utils.tsx";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, userEvent } from "#src/test-utils.tsx";
 import { Anchor } from "./anchor";
 
 describe("Anchor", () => {
@@ -100,5 +100,34 @@ describe("Anchor", () => {
 
     const link = screen.getByRole("link", { name: "External" });
     expect(link).toHaveAccessibleName("External");
+  });
+
+  it("invokes the consumer-supplied onMouseEnter handler", async () => {
+    const user = userEvent.setup();
+    const onMouseEnter = vi.fn();
+    render(
+      <Anchor href="/about" onMouseEnter={onMouseEnter}>
+        About
+      </Anchor>,
+    );
+
+    await user.hover(screen.getByRole("link", { name: "About" }));
+
+    expect(onMouseEnter).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes the consumer-supplied onFocus handler so keyboard users opt in to prefetch", async () => {
+    const user = userEvent.setup();
+    const onFocus = vi.fn();
+    render(
+      <Anchor href="/about" onFocus={onFocus}>
+        About
+      </Anchor>,
+    );
+
+    await user.tab();
+
+    expect(screen.getByRole("link", { name: "About" })).toHaveFocus();
+    expect(onFocus).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/components/shared/anchor.tsx
+++ b/apps/web/src/components/shared/anchor.tsx
@@ -22,6 +22,7 @@ export function Anchor({
   style,
   prefetch,
   onMouseEnter,
+  onFocus,
   rel,
   target,
   ref,
@@ -29,7 +30,11 @@ export function Anchor({
   indicateExternal = true,
   ...props
 }: React.ComponentProps<typeof Link> & AnchorExtraProps) {
-  const [hovered, setHovered] = useState(false);
+  // Defer Next.js's hover/focus prefetching until the user signals intent,
+  // then hand control back to the framework by flipping `prefetch` to `null`.
+  // Wiring both pointer and keyboard signals keeps prefetch parity for
+  // keyboard and assistive-tech users.
+  const [intent, setIntent] = useState(false);
 
   // Automatically ensure noopener and noreferrer are present for _blank links
   const resolvedRel =
@@ -43,10 +48,14 @@ export function Anchor({
       target={target}
       rel={resolvedRel}
       ref={ref}
-      prefetch={prefetch === false ? false : hovered ? null : false}
+      prefetch={prefetch === false ? false : intent ? null : false}
       onMouseEnter={(e) => {
-        setHovered(true);
+        setIntent(true);
         onMouseEnter?.(e);
+      }}
+      onFocus={(e) => {
+        setIntent(true);
+        onFocus?.(e);
       }}
       className={className}
       style={style}


### PR DESCRIPTION
## The bug

`Anchor` only flipped `prefetch` from `false` to `null` (Next.js's hover/focus prefetch mode) inside an `onMouseEnter` handler. Keyboard and assistive-tech users who tab to a link without ever generating a `mouseenter` event stayed permanently opted out of prefetching, so navigating via keyboard was slower than navigating via mouse for the same link.

## The fix

Added a parallel `onFocus` handler that flips the same intent state and forwards to any consumer-supplied `onFocus`. Renamed the local state from `hovered` to `intent` to reflect that it now tracks both pointer and keyboard intent. The deferred-then-handed-off shape is preserved: prefetch stays `false` until the user signals intent, then flips to `null` so Next.js takes over its hover-or-focus prefetch logic.