### PR TITLE
feat: keyboard navigation and focus management for the calculator

### DIFF
--- a/apps/web/src/components/calculator/calculator.test.tsx
+++ b/apps/web/src/components/calculator/calculator.test.tsx
@@ -326,3 +326,105 @@ describe("Calculator keyboard activation of focused buttons", () => {
     expect(getDisplay()).toHaveTextContent("5");
   });
 });
+
+describe("Calculator returns focus to the wrapper when typing", () => {
+  it("evaluates with Enter after activating a focused digit and typing more", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    const five = screen.getByRole("button", { name: "5" });
+    five.focus();
+
+    await user.keyboard("{Enter}");
+    expect(getDisplay()).toHaveTextContent("5");
+    expect(five).toHaveFocus();
+
+    await user.keyboard("+6");
+    expect(getDisplay()).toHaveTextContent("5 + 6");
+    expect(screen.getByRole("application")).toHaveFocus();
+
+    await user.keyboard("{Enter}");
+    expect(getDisplay()).toHaveTextContent("11");
+  });
+
+  it("returns focus to the wrapper after Backspace on a focused button", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    await pressButtons(user, ["1", "2"]);
+    const two = screen.getByRole("button", { name: "2" });
+    expect(two).toHaveFocus();
+
+    await user.keyboard("{Backspace}");
+    expect(getDisplay()).toHaveTextContent("1");
+    expect(screen.getByRole("application")).toHaveFocus();
+  });
+});
+
+describe("Calculator arrow key navigation", () => {
+  it("moves focus to the button below on ArrowDown", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    screen.getByRole("button", { name: "5" }).focus();
+    await user.keyboard("{ArrowDown}");
+    expect(screen.getByRole("button", { name: "2" })).toHaveFocus();
+  });
+
+  it("moves focus to the button above on ArrowUp", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    screen.getByRole("button", { name: "5" }).focus();
+    await user.keyboard("{ArrowUp}");
+    expect(screen.getByRole("button", { name: "8" })).toHaveFocus();
+  });
+
+  it("moves focus left and right within a row", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    screen.getByRole("button", { name: "5" }).focus();
+    await user.keyboard("{ArrowRight}");
+    expect(screen.getByRole("button", { name: "6" })).toHaveFocus();
+
+    await user.keyboard("{ArrowLeft}");
+    expect(screen.getByRole("button", { name: "5" })).toHaveFocus();
+  });
+
+  it("lands on the spanning 0 from either column above it", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    screen.getByRole("button", { name: "1" }).focus();
+    await user.keyboard("{ArrowDown}");
+    expect(screen.getByRole("button", { name: "0" })).toHaveFocus();
+
+    screen.getByRole("button", { name: "2" }).focus();
+    await user.keyboard("{ArrowDown}");
+    expect(screen.getByRole("button", { name: "0" })).toHaveFocus();
+  });
+
+  it("skips over the spanning 0 when moving right", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    screen.getByRole("button", { name: "0" }).focus();
+    await user.keyboard("{ArrowRight}");
+    expect(screen.getByRole("button", { name: "Decimal point" })).toHaveFocus();
+  });
+
+  it("does nothing past the grid edges", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    const ac = screen.getByRole("button", { name: "All clear" });
+    ac.focus();
+
+    await user.keyboard("{ArrowUp}");
+    expect(ac).toHaveFocus();
+
+    await user.keyboard("{ArrowLeft}");
+    expect(ac).toHaveFocus();
+  });
+});

--- a/apps/web/src/components/calculator/calculator.test.tsx
+++ b/apps/web/src/components/calculator/calculator.test.tsx
@@ -262,3 +262,67 @@ describe("Calculator unary operators preserve raw input", () => {
     expect(getDisplay()).toHaveTextContent("0.123");
   });
 });
+
+describe("Calculator keyboard activation of focused buttons", () => {
+  it("activates a focused digit button on Enter instead of evaluating the expression", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    const five = screen.getByRole("button", { name: "5" });
+    five.focus();
+    expect(five).toHaveFocus();
+
+    await user.keyboard("{Enter}");
+
+    // Pressing Enter while "5" is focused should enter "5", not run "=".
+    expect(getDisplay()).toHaveTextContent("5");
+  });
+
+  it("activates a focused operator button on Enter instead of evaluating the expression", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    await pressButtons(user, ["7"]);
+    expect(getDisplay()).toHaveTextContent("7");
+
+    const plus = screen.getByRole("button", { name: "Add" });
+    plus.focus();
+    expect(plus).toHaveFocus();
+
+    await user.keyboard("{Enter}");
+
+    // Enter should activate the focused "+" button, not the wrapper's "=" mapping.
+    expect(getDisplay()).toHaveTextContent("7 +");
+  });
+
+  it("still evaluates the expression when Enter is pressed while the wrapper has focus", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    const wrapper = screen.getByRole("application");
+    wrapper.focus();
+    expect(wrapper).toHaveFocus();
+
+    // Wrapper-level keyboard input should keep working.
+    await user.keyboard("2+3");
+    expect(getDisplay()).toHaveTextContent("2 + 3");
+
+    await user.keyboard("{Enter}");
+    expect(getDisplay()).toHaveTextContent("5");
+  });
+
+  it("activates a focused equals button on Enter", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    await pressButtons(user, ["4", "Add", "1"]);
+    expect(getDisplay()).toHaveTextContent("4 + 1");
+
+    const equals = screen.getByRole("button", { name: "Equals" });
+    equals.focus();
+    expect(equals).toHaveFocus();
+
+    await user.keyboard("{Enter}");
+    expect(getDisplay()).toHaveTextContent("5");
+  });
+});

--- a/apps/web/src/components/calculator/calculator.tsx
+++ b/apps/web/src/components/calculator/calculator.tsx
@@ -27,6 +27,53 @@ function createInitialToken(): Token {
   return { type: "number", value: 0, raw: "0" };
 }
 
+// Visual layout for arrow-key navigation. Mirrors the rendered grid; the "0"
+// button visually spans cols 0-1, so it appears twice here so navigating Down
+// from "1" or "2" both land on it.
+const VISUAL_GRID: readonly (readonly string[])[] = [
+  [BUTTON_CLEAR, BUTTON_NEGATE, BUTTON_PERCENT, "÷"],
+  ["7", "8", "9", "×"],
+  ["4", "5", "6", "−"],
+  ["1", "2", "3", "+"],
+  [BUTTON_ZERO, BUTTON_ZERO, BUTTON_DECIMAL, BUTTON_EQUALS],
+];
+
+function getArrowDelta(key: string): readonly [number, number] | null {
+  switch (key) {
+    case "ArrowUp":
+      return [-1, 0];
+    case "ArrowDown":
+      return [1, 0];
+    case "ArrowLeft":
+      return [0, -1];
+    case "ArrowRight":
+      return [0, 1];
+    default:
+      return null;
+  }
+}
+
+function findGridPosition(label: string): readonly [number, number] | null {
+  for (let row = 0; row < VISUAL_GRID.length; row++) {
+    const cells = VISUAL_GRID[row];
+    for (let col = 0; col < cells.length; col++) {
+      if (cells[col] === label) return [row, col];
+    }
+  }
+  return null;
+}
+
+function findButtonByLabel(
+  wrapper: HTMLElement,
+  label: string,
+): HTMLButtonElement | null {
+  const all = wrapper.querySelectorAll("button");
+  for (const button of all) {
+    if (button.textContent === label) return button;
+  }
+  return null;
+}
+
 function negateRaw(raw: string): string {
   if (Number(raw) === 0) return raw;
   return raw.startsWith("-") ? raw.slice(1) : `-${raw}`;
@@ -86,24 +133,46 @@ export function Calculator() {
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const key = event.key;
+    const wrapper = event.currentTarget;
+    const buttonHasFocus = event.target instanceof HTMLButtonElement;
 
-    // When a calculator button has focus, let the browser dispatch its
-    // native click for Enter/Space. Without this guard, the wrapper's
-    // `preventDefault` would cancel that click and run the keyMap action
-    // instead — e.g. tabbing to "5" and pressing Enter would trigger "=".
-    // Other keys (digits, operators, Backspace, Escape) keep working so
-    // the user can keep typing into the calculator after activating a
-    // button with the mouse, which leaves focus on that button.
-    if (
-      (key === "Enter" || key === " ") &&
-      event.target instanceof HTMLButtonElement
-    ) {
+    // Enter/Space on a focused button: let the browser dispatch its native
+    // click. Focus stays on the button.
+    if ((key === "Enter" || key === " ") && buttonHasFocus) {
+      return;
+    }
+
+    // Arrow keys move focus between buttons, skipping across the spanning "0".
+    const arrowDelta = getArrowDelta(key);
+    if (arrowDelta && event.target instanceof HTMLButtonElement) {
+      event.preventDefault();
+      const currentLabel = event.target.textContent;
+      if (!currentLabel) return;
+      const pos = findGridPosition(currentLabel);
+      if (!pos) return;
+      let row = pos[0];
+      let col = pos[1];
+      do {
+        row += arrowDelta[0];
+        col += arrowDelta[1];
+        if (
+          row < 0 ||
+          row >= VISUAL_GRID.length ||
+          col < 0 ||
+          col >= VISUAL_GRID[row].length
+        ) {
+          return;
+        }
+      } while (VISUAL_GRID[row][col] === currentLabel);
+      const next = findButtonByLabel(wrapper, VISUAL_GRID[row][col]);
+      next?.focus();
       return;
     }
 
     if (key === "Backspace") {
       event.preventDefault();
       handleBackspace();
+      if (buttonHasFocus) wrapper.focus();
       return;
     }
 
@@ -132,6 +201,9 @@ export function Calculator() {
     if (key in keyMap) {
       event.preventDefault();
       handleClick(keyMap[key]);
+      // Once the user starts driving the calculator from the keyboard, take
+      // focus off the previously-clicked button so the next Enter is "=".
+      if (buttonHasFocus) wrapper.focus();
     }
   };
 

--- a/apps/web/src/components/calculator/calculator.tsx
+++ b/apps/web/src/components/calculator/calculator.tsx
@@ -84,8 +84,22 @@ export function Calculator() {
     }
   };
 
-  const handleKeyDown = (event: React.KeyboardEvent) => {
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const key = event.key;
+
+    // When a calculator button has focus, let the browser dispatch its
+    // native click for Enter/Space. Without this guard, the wrapper's
+    // `preventDefault` would cancel that click and run the keyMap action
+    // instead — e.g. tabbing to "5" and pressing Enter would trigger "=".
+    // Other keys (digits, operators, Backspace, Escape) keep working so
+    // the user can keep typing into the calculator after activating a
+    // button with the mouse, which leaves focus on that button.
+    if (
+      (key === "Enter" || key === " ") &&
+      event.target instanceof HTMLButtonElement
+    ) {
+      return;
+    }
 
     if (key === "Backspace") {
       event.preventDefault();


### PR DESCRIPTION
## Summary

Establishes a complete keyboard interaction model for the calculator. When a button is focused, Enter and Space now dispatch the browser's native click on that button — previously the wrapper's `preventDefault` cancelled the click, so tabbing to "5" and pressing Enter ran `=` instead of inserting "5". To avoid the resulting trap where focus stays on the activated button and subsequent Enter presses re-activate it, typing a digit, operator, Backspace, or Escape with a button focused returns focus to the wrapper so the next Enter evaluates the expression. Arrow keys move focus directionally between buttons, skipping across the spanning "0" so right-from-zero lands on ".".