### PR TITLE
fix: hide user preferences scaffolding from chat bubbles

### DIFF
--- a/apps/web/src/components/ai-chat/chat-message.test.tsx
+++ b/apps/web/src/components/ai-chat/chat-message.test.tsx
@@ -325,6 +325,118 @@ describe("ChatMessage", () => {
     expect(screen.getByText("Here it is again!")).toBeInTheDocument();
   });
 
+  it("hides the [User Preferences] scaffolding from user message bubbles", () => {
+    render(
+      <ChatMessage
+        message={createMessage({
+          role: "user",
+          parts: [
+            {
+              type: "text",
+              text: "[User Preferences]\nLikes: action (genre), Tom Hanks (actor)\nDislikes: horror (genre)",
+            },
+            { type: "text", text: "find me a feel-good movie tonight" },
+          ],
+        })}
+        toolOutputs={emptyToolOutputs}
+      />,
+    );
+
+    expect(
+      screen.getByText("find me a feel-good movie tonight"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/User Preferences/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Likes:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Dislikes:/)).not.toBeInTheDocument();
+  });
+
+  it("hides the [User Preferences] scaffolding when only likes are present", () => {
+    render(
+      <ChatMessage
+        message={createMessage({
+          role: "user",
+          parts: [
+            {
+              type: "text",
+              text: "[User Preferences]\nLikes: sci-fi (genre)",
+            },
+            { type: "text", text: "what should I watch" },
+          ],
+        })}
+        toolOutputs={emptyToolOutputs}
+      />,
+    );
+
+    expect(screen.getByText("what should I watch")).toBeInTheDocument();
+    expect(screen.queryByText(/User Preferences/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Likes:/)).not.toBeInTheDocument();
+  });
+
+  it("renders nothing for a user message that contains only the [User Preferences] scaffolding", () => {
+    const { container } = render(
+      <ChatMessage
+        message={createMessage({
+          role: "user",
+          parts: [
+            {
+              type: "text",
+              text: "[User Preferences]\nLikes: action (genre)\nDislikes: horror (genre)",
+            },
+          ],
+        })}
+        toolOutputs={emptyToolOutputs}
+      />,
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("strips both [User Preferences] and [About: …] scaffolding from the same user message", () => {
+    render(
+      <ChatMessage
+        message={createMessage({
+          role: "user",
+          parts: [
+            {
+              type: "text",
+              text: "[User Preferences]\nLikes: drama (genre)",
+            },
+            {
+              type: "text",
+              text: "[About: Inception (movie, id:27205)] tell me more",
+            },
+          ],
+        })}
+        toolOutputs={emptyToolOutputs}
+      />,
+    );
+
+    expect(screen.getByText("tell me more")).toBeInTheDocument();
+    expect(screen.queryByText(/User Preferences/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/About: Inception/)).not.toBeInTheDocument();
+  });
+
+  it("does not strip [User Preferences] mentions from assistant messages", () => {
+    render(
+      <ChatMessage
+        message={createMessage({
+          role: "assistant",
+          parts: [
+            {
+              type: "text",
+              text: "I noted [User Preferences] in your prior session.",
+            },
+          ],
+        })}
+        toolOutputs={emptyToolOutputs}
+      />,
+    );
+
+    expect(
+      screen.getByText("I noted [User Preferences] in your prior session."),
+    ).toBeInTheDocument();
+  });
+
   it("shows tool activity group for tool parts", () => {
     render(
       <ChatMessage

--- a/apps/web/src/components/ai-chat/chat-message.tsx
+++ b/apps/web/src/components/ai-chat/chat-message.tsx
@@ -47,7 +47,7 @@ export function ChatMessage({
     partKeys,
     textPartCount,
     textPartTrailingBuffers,
-  } = deriveMessageData(message.parts);
+  } = deriveMessageData(message.parts, message.role);
 
   if (!hasVisibleContent) return null;
 
@@ -62,9 +62,14 @@ export function ChatMessage({
         if (isTextUIPart(part)) {
           const currentTextIndex = textPartIndex++;
           if (isUser) {
+            const visibleText = stripUserScaffolding(part.text);
+            // The prefs context (`[User Preferences]…`) is sometimes
+            // pushed as a whole part on its own, so it can vanish entirely
+            // after stripping — don't render an empty bubble line.
+            if (visibleText.length === 0) return null;
             return (
               <p key={key} css={[styles.partBase, styles.text]}>
-                {stripAttachedMediaPrefix(part.text)}
+                {visibleText}
               </p>
             );
           }
@@ -162,16 +167,28 @@ export function ChatMessage({
 }
 
 const ATTACHED_MEDIA_PREFIX = /^\[About: .+ \((?:movie|tv)(?:, id:\d+)?\)] /;
+// The transport prepends `[User Preferences]\nLikes: …\nDislikes: …` to the
+// first user message of a fresh session so the assistant can personalise
+// its first reply. The block is internal scaffolding; users never typed it.
+// The trailing `\n?` covers the (currently unused) shape where the prefs
+// would sit inline with the user's text in a single part.
+const USER_PREFERENCES_PREFIX =
+  /^\[User Preferences\](?:\n(?:Likes|Dislikes): [^\n]*)+\n?/;
 
-function stripAttachedMediaPrefix(text: string): string {
-  return text.replace(ATTACHED_MEDIA_PREFIX, "");
+function stripUserScaffolding(text: string): string {
+  return text
+    .replace(USER_PREFERENCES_PREFIX, "")
+    .replace(ATTACHED_MEDIA_PREFIX, "");
 }
 
 function isCompactionPart(part: TextUIPart): boolean {
   return part.providerMetadata?.anthropic.type === "compaction";
 }
 
-export function deriveMessageData(parts: UIMessage["parts"]) {
+export function deriveMessageData(
+  parts: UIMessage["parts"],
+  role?: UIMessage["role"],
+) {
   const toolParts: Array<{
     toolCallId: string;
     toolName: string;
@@ -214,8 +231,16 @@ export function deriveMessageData(parts: UIMessage["parts"]) {
       if (isTextUIPart(part)) {
         textPartCount++;
         textPartLengths.push(part.text.length);
-        if (!hasVisibleContent && part.text.length > 0)
-          hasVisibleContent = true;
+        if (!hasVisibleContent) {
+          // For user messages, a part that is purely transport scaffolding
+          // contributes nothing visible after stripping — don't let it keep
+          // an otherwise-empty bubble alive.
+          const visibleLength =
+            role === "user"
+              ? stripUserScaffolding(part.text).length
+              : part.text.length;
+          if (visibleLength > 0) hasVisibleContent = true;
+        }
       } else if (!hasVisibleContent && isReasoningUIPart(part)) {
         hasVisibleContent = true;
       }


### PR DESCRIPTION
## The bug

The transport prepends a `[User Preferences]\nLikes: …\nDislikes: …` block as the first part of the user's first message in a fresh chat session, so the assistant can personalise its first reply. The block is stored server-side along with the rest of the user message. When a user later continues the session, the server-stored history is loaded back into the UI and the prefs scaffolding renders verbatim inside the user's chat bubble — internal context the user never typed showing up as if they had.

## The fix

Mirrors the existing `[About: <title>]` attached-media strip pattern: at render time in `ChatMessage`, run a regex strip over each user text part to remove the prefs prefix before it goes into the DOM. The wire format the AI sees is unchanged — the strip only happens after the message is read off the UI store, so `prepareSendMessagesRequest` still injects the same `[User Preferences]` block on the request body and personalisation continues to work. When a user text part contains only the prefs scaffolding (the common shape — prefs is pushed as its own `parts[0]`), the bubble line is skipped so an empty `<p>` doesn't leak into the DOM, and a message that consists solely of stripped scaffolding renders nothing at all rather than an empty bubble.