### PR TITLE
fix: merge cast/crew rows so person_credits keeps character and department

### DIFF
--- a/apps/web/src/ai-chat/tools/person-credits.test.ts
+++ b/apps/web/src/ai-chat/tools/person-credits.test.ts
@@ -131,17 +131,23 @@ describe("person credits execute", () => {
     expect(result.map((entry) => entry.id)).not.toContain(31);
   });
 
-  it("dedupes entries that appear in both cast and crew before applying the cap", async () => {
+  it("merges cast and crew entries for the same film into one credit carrying both character and department", async () => {
     server.use(
       http.get(`${TMDB_BASE}/3/person/287/combined_credits`, () =>
         HttpResponse.json({
           id: 287,
-          cast: [castEntry({ id: 100, title: "Dual Role", vote_average: 8 })],
+          cast: [
+            castEntry({
+              id: 100,
+              title: "Million Dollar Baby",
+              vote_average: 8,
+            }),
+          ],
           crew: [
             {
               id: 100,
               media_type: "movie",
-              title: "Dual Role",
+              title: "Million Dollar Baby",
               poster_path: "/p.jpg",
               vote_average: 8,
               release_date: "2020-01-01",
@@ -157,6 +163,128 @@ describe("person credits execute", () => {
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe(100);
     expect(result[0].character).toBe("Test Character");
+    expect(result[0].department).toBe("Directing");
+  });
+
+  it("merges cast and crew when the crew entry is processed first", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/person/287/combined_credits`, () =>
+        HttpResponse.json({
+          id: 287,
+          cast: [castEntry({ id: 200, title: "Argo", vote_average: 7.7 })],
+          crew: [
+            // Standalone crew entry (no matching cast row) — should be kept.
+            {
+              id: 999,
+              media_type: "movie",
+              title: "Crew Only",
+              poster_path: "/c.jpg",
+              vote_average: 6,
+              release_date: "2018-01-01",
+              department: "Writing",
+            },
+            // Crew entry that matches a cast entry — should merge.
+            {
+              id: 200,
+              media_type: "movie",
+              title: "Argo",
+              poster_path: "/p.jpg",
+              vote_average: 7.7,
+              release_date: "2012-01-01",
+              department: "Directing",
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = await executeTool({ person_id: 287 });
+    const argo = result.find((entry) => entry.id === 200);
+    expect(argo).toBeDefined();
+    if (!argo) throw new Error("expected argo entry");
+    expect(argo.character).toBe("Test Character");
+    expect(argo.department).toBe("Directing");
+
+    const crewOnly = result.find((entry) => entry.id === 999);
+    expect(crewOnly).toBeDefined();
+    if (!crewOnly) throw new Error("expected crew-only entry");
+    expect(crewOnly.character).toBeUndefined();
+    expect(crewOnly.department).toBe("Writing");
+  });
+
+  it("keeps the highest-priority department when a film has multiple crew rows", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/person/287/combined_credits`, () =>
+        HttpResponse.json({
+          id: 287,
+          cast: [],
+          crew: [
+            {
+              id: 300,
+              media_type: "movie",
+              title: "Triple Threat",
+              poster_path: "/t.jpg",
+              vote_average: 7,
+              release_date: "2019-01-01",
+              department: "Production",
+            },
+            {
+              id: 300,
+              media_type: "movie",
+              title: "Triple Threat",
+              poster_path: "/t.jpg",
+              vote_average: 7,
+              release_date: "2019-01-01",
+              department: "Directing",
+            },
+            {
+              id: 300,
+              media_type: "movie",
+              title: "Triple Threat",
+              poster_path: "/t.jpg",
+              vote_average: 7,
+              release_date: "2019-01-01",
+              department: "Writing",
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = await executeTool({ person_id: 287 });
+    expect(result).toHaveLength(1);
+    expect(result[0].department).toBe("Directing");
+  });
+
+  it("preserves character-only and department-only entries when there is no overlap", async () => {
+    server.use(
+      http.get(`${TMDB_BASE}/3/person/287/combined_credits`, () =>
+        HttpResponse.json({
+          id: 287,
+          cast: [castEntry({ id: 1, title: "Acted Only", vote_average: 8 })],
+          crew: [
+            {
+              id: 2,
+              media_type: "movie",
+              title: "Directed Only",
+              poster_path: "/d.jpg",
+              vote_average: 7,
+              release_date: "2015-01-01",
+              department: "Directing",
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = await executeTool({ person_id: 287 });
+
+    const acted = result.find((entry) => entry.id === 1);
+    const directed = result.find((entry) => entry.id === 2);
+    expect(acted?.character).toBe("Test Character");
+    expect(acted?.department).toBeUndefined();
+    expect(directed?.character).toBeUndefined();
+    expect(directed?.department).toBe("Directing");
   });
 
   it("returns a structured tool error when TMDB fails", async () => {

--- a/apps/web/src/ai-chat/tools/person-credits.ts
+++ b/apps/web/src/ai-chat/tools/person-credits.ts
@@ -63,6 +63,32 @@ interface CreditResult {
 // Trimming after sort preserves the highest-rated entries.
 const MAX_RESULTS = 30;
 
+// When a single film has multiple crew rows for the same person (Director +
+// Producer + Writer is common), keep the most query-relevant department.
+// Surfacing "Directing" for an actor-director answers the most common
+// "what has X directed?" question; "Acting" is implicit in `character` and
+// has no value here.
+const DEPARTMENT_PRIORITY: ReadonlyArray<string> = [
+  "Directing",
+  "Writing",
+  "Production",
+];
+
+function pickHigherPriorityDepartment(
+  current: string | undefined,
+  next: string | undefined,
+): string | undefined {
+  if (!current) return next;
+  if (!next) return current;
+  if (current === next) return current;
+  const currentRank = DEPARTMENT_PRIORITY.indexOf(current);
+  const nextRank = DEPARTMENT_PRIORITY.indexOf(next);
+  // Lower index = higher priority. Departments not in the list rank last.
+  const currentScore = currentRank === -1 ? Infinity : currentRank;
+  const nextScore = nextRank === -1 ? Infinity : nextRank;
+  return nextScore < currentScore ? next : current;
+}
+
 export function createPersonCreditsTool(locale: SupportedLocale) {
   return tool({
     description: TOOL_DESCRIPTION,
@@ -82,17 +108,24 @@ export function createPersonCreditsTool(locale: SupportedLocale) {
         );
       }
 
-      const seen = new Set<string>();
-      const results: CreditResult[] = [];
+      // Merge cast + crew by `${mediaType}:${id}` so an actor-director's
+      // single film carries both `character` and `department`. The previous
+      // first-wins dedup silently dropped the crew row whenever the cast
+      // row was processed first — losing every "Directed by" signal for
+      // hybrids like Eastwood, Affleck, Gibson, etc.
+      const merged = new Map<string, CreditResult>();
 
       for (const raw of credits.cast ?? []) {
         if (!isRecord(raw)) continue;
         if (typeof raw.id !== "number") continue;
         const mediaType = getMediaType(raw);
         const key = `${String(mediaType)}:${String(raw.id)}`;
-        if (seen.has(key)) continue;
-        seen.add(key);
-        results.push({
+        const existing = merged.get(key);
+        if (existing) {
+          existing.character ??= getString(raw, "character");
+          continue;
+        }
+        merged.set(key, {
           id: raw.id,
           media_type: mediaType,
           title: getTitle(raw),
@@ -109,9 +142,16 @@ export function createPersonCreditsTool(locale: SupportedLocale) {
         if (typeof raw.id !== "number") continue;
         const mediaType = getMediaType(raw);
         const key = `${String(mediaType)}:${String(raw.id)}`;
-        if (seen.has(key)) continue;
-        seen.add(key);
-        results.push({
+        const department = getString(raw, "department");
+        const existing = merged.get(key);
+        if (existing) {
+          existing.department = pickHigherPriorityDepartment(
+            existing.department,
+            department,
+          );
+          continue;
+        }
+        merged.set(key, {
           id: raw.id,
           media_type: mediaType,
           title: getTitle(raw),
@@ -119,10 +159,11 @@ export function createPersonCreditsTool(locale: SupportedLocale) {
           vote_average: getNumber(raw, "vote_average"),
           release_date: getReleaseDate(raw),
           character: undefined,
-          department: getString(raw, "department"),
+          department,
         });
       }
 
+      const results = [...merged.values()];
       results.sort((a, b) => b.vote_average - a.vote_average);
 
       return results.slice(0, MAX_RESULTS);


### PR DESCRIPTION
## The bug

`person_credits` deduped cast and crew with a single `Set<string>` keyed on `${mediaType}:${id}`, first-wins. For an actor-director's film that appears in both arrays, the cast row was processed first — pushed with `character` set and `department: undefined` — and the crew row was then discarded as a duplicate. The result: every "Directing" / "Writing" / "Production" signal was silently lost for hybrids like Eastwood, Affleck, or Gibson, so the LLM could no longer answer "what has X directed?" from this tool's output.

## The fix

Replace the first-wins `Set` with a `Map<string, CreditResult>` and merge cast and crew into one entry per `${mediaType}:${id}`. The cast loop seeds `character`; the crew loop populates `department` on the existing entry instead of dropping the row. Crew-only films (directed but not acted in) still create a fresh entry with `character: undefined`. When TMDB emits multiple crew rows for the same film (Director + Producer + Writer is common), a small priority list — Directing > Writing > Production > everything else — picks the most query-relevant department deterministically, so the merged entry doesn't depend on TMDB's row order. Sort and `MAX_RESULTS` cap run after the merge and are unchanged. The sibling UI consumer in `person-detail-content.tsx` is untouched: it projects to a `MediaListItem` shape that doesn't read `character` or `department`, so the same first-wins dedup there produces visually identical output regardless of which row wins.