### PR TITLE
fix: use role=group on the calculator wrapper instead of role=application

### DIFF
--- a/apps/web/src/components/calculator/calculator.test.tsx
+++ b/apps/web/src/components/calculator/calculator.test.tsx
@@ -299,7 +299,7 @@ describe("Calculator keyboard activation of focused buttons", () => {
     const user = userEvent.setup();
     render(<Calculator />);
 
-    const wrapper = screen.getByRole("application");
+    const wrapper = screen.getByRole("group", { name: "Calculator" });
     wrapper.focus();
     expect(wrapper).toHaveFocus();
 
@@ -341,7 +341,7 @@ describe("Calculator returns focus to the wrapper when typing", () => {
 
     await user.keyboard("+6");
     expect(getDisplay()).toHaveTextContent("5 + 6");
-    expect(screen.getByRole("application")).toHaveFocus();
+    expect(screen.getByRole("group", { name: "Calculator" })).toHaveFocus();
 
     await user.keyboard("{Enter}");
     expect(getDisplay()).toHaveTextContent("11");
@@ -357,7 +357,7 @@ describe("Calculator returns focus to the wrapper when typing", () => {
 
     await user.keyboard("{Backspace}");
     expect(getDisplay()).toHaveTextContent("1");
-    expect(screen.getByRole("application")).toHaveFocus();
+    expect(screen.getByRole("group", { name: "Calculator" })).toHaveFocus();
   });
 });
 
@@ -426,5 +426,28 @@ describe("Calculator arrow key navigation", () => {
 
     await user.keyboard("{ArrowLeft}");
     expect(ac).toHaveFocus();
+  });
+});
+
+describe("Calculator wrapper accessibility", () => {
+  it("exposes the wrapper as a labelled group, not an application region", () => {
+    render(<Calculator />);
+
+    expect(
+      screen.getByRole("group", { name: "Calculator" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("application")).not.toBeInTheDocument();
+  });
+
+  it("keeps the wrapper focusable so keyboard users can tab to it and type", async () => {
+    const user = userEvent.setup();
+    render(<Calculator />);
+
+    const wrapper = screen.getByRole("group", { name: "Calculator" });
+    wrapper.focus();
+    expect(wrapper).toHaveFocus();
+
+    await user.keyboard("2+3{Enter}");
+    expect(getDisplay()).toHaveTextContent("5");
   });
 });

--- a/apps/web/src/components/calculator/calculator.tsx
+++ b/apps/web/src/components/calculator/calculator.tsx
@@ -303,7 +303,7 @@ export function Calculator() {
       css={[flex.col, styles.container]}
       onKeyDown={handleKeyDown}
       tabIndex={0}
-      role="application"
+      role="group"
       aria-label={t({ en: "Calculator", zh: "计算器" })}
     >
       <CalculatorDisplay tokens={tokens} currentToken={currentToken} />


### PR DESCRIPTION
## The bug

The calculator wrapper was marked `role="application"`. Per WAI-ARIA 1.2, `application` is the strongest AT mode-switch available — it disables NVDA / JAWS / VoiceOver browse and virtual-cursor mode inside the region and forwards every keystroke to the page handler. The calculator does not need that override: every interactive child is a real `<button>` with its own accessible name, the display already announces results via `role="status" aria-live="polite"` (live regions fire inside `application` too, so this isn't what's at stake), and PR #2239's keyboard interactions (Enter/Space on a focused button, arrow-key grid nav, focus-return after typing) all trigger from a focused `<button>` or the tabbed-to wrapper — both of which engage focus mode automatically. None of that needed `application` to work. What `application` *was* costing is browse-mode reading of the buttons: AT users couldn't navigate digit-by-digit, hear each label, or use heading / landmark / list quick-nav while their virtual cursor was inside the calculator.

## The fix

Replace `role="application"` with `role="group"` and keep the existing `aria-label`. `group` is the documented WAI-ARIA idiom for a labelled set of related controls and matches how the calculator actually behaves: AT users can now browse the buttons individually and hear each label. The wrapper stays `tabIndex={0}` so a keyboard user can still tab to it and type `2 + 3 =` directly, and the `handleKeyDown` keyMap is untouched.

## Trade-off

One niche path is mildly degraded: an AT user in browse mode pressing a digit key while the virtual cursor is inside the calculator (without first Tab'ing to the wrapper or a button) won't type into the calculator — NVDA's browse-mode quick-nav (digits 1–6 jump to headings) takes the keystroke. Under `application`, the keystroke would have been forwarded. This is acceptable: every interactive path that actually expresses intent (Tab to wrapper, Tab to a button, click) still works exactly as before, and we recover full browse-mode exploration in exchange.