### PR TITLE
fix: stop closing chat from orphaning the saved session

### DIFF
--- a/apps/web/src/components/movie-database/inline-chat-context.test.tsx
+++ b/apps/web/src/components/movie-database/inline-chat-context.test.tsx
@@ -1,0 +1,97 @@
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { AIChatProvider } from "#src/ai-chat/ai-chat-context.tsx";
+import {
+  BackOverrideProvider,
+  useBackOverride,
+} from "#src/contexts/back-override-context.tsx";
+import { render, screen, userEvent } from "#src/test-utils.tsx";
+import { InlineChatProvider, useInlineChat } from "./inline-chat-context";
+
+const SESSION_KEY = "ai-chat-session:en";
+
+function CloseHarness() {
+  const { isChatActive, openChat, closeChat } = useInlineChat();
+  return (
+    <div>
+      <span data-testid="active">{isChatActive ? "yes" : "no"}</span>
+      <button type="button" onClick={openChat}>
+        Open
+      </button>
+      <button type="button" onClick={closeChat}>
+        Close
+      </button>
+    </div>
+  );
+}
+
+function BackButtonProxy() {
+  const { hasBackOverride, triggerBack } = useBackOverride();
+  if (!hasBackOverride) return null;
+  return (
+    <button type="button" onClick={triggerBack}>
+      Trigger back
+    </button>
+  );
+}
+
+function BackHarness() {
+  const { isChatActive, openChat } = useInlineChat();
+  return (
+    <div>
+      <span data-testid="active">{isChatActive ? "yes" : "no"}</span>
+      <button type="button" onClick={openChat}>
+        Open
+      </button>
+      <BackButtonProxy />
+    </div>
+  );
+}
+
+function renderWithProviders(ui: ReactNode) {
+  return render(
+    <BackOverrideProvider>
+      <AIChatProvider locale="en">
+        <InlineChatProvider>{ui}</InlineChatProvider>
+      </AIChatProvider>
+    </BackOverrideProvider>,
+  );
+}
+
+afterEach(() => {
+  localStorage.removeItem(SESSION_KEY);
+});
+
+describe("InlineChatProvider closeChat", () => {
+  it("preserves the stored session id so the user can restore the conversation on reopen", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(SESSION_KEY, "session-abc");
+
+    renderWithProviders(<CloseHarness />);
+
+    await user.click(screen.getByRole("button", { name: "Open" }));
+    expect(screen.getByTestId("active")).toHaveTextContent("yes");
+
+    await user.click(screen.getByRole("button", { name: "Close" }));
+    expect(screen.getByTestId("active")).toHaveTextContent("no");
+
+    // The conversation is still alive server-side (Redis, 24h TTL); the
+    // saved id is the only handle the client has on it. Closing chat must
+    // not orphan that conversation by clearing the storage key.
+    expect(localStorage.getItem(SESSION_KEY)).toBe("session-abc");
+  });
+
+  it("preserves the stored session id when the back override fires", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(SESSION_KEY, "session-xyz");
+
+    renderWithProviders(<BackHarness />);
+
+    await user.click(screen.getByRole("button", { name: "Open" }));
+    expect(screen.getByTestId("active")).toHaveTextContent("yes");
+
+    await user.click(screen.getByRole("button", { name: "Trigger back" }));
+    expect(screen.getByTestId("active")).toHaveTextContent("no");
+    expect(localStorage.getItem(SESSION_KEY)).toBe("session-xyz");
+  });
+});

--- a/apps/web/src/components/movie-database/inline-chat-context.tsx
+++ b/apps/web/src/components/movie-database/inline-chat-context.tsx
@@ -23,8 +23,7 @@ export const InlineChatContext = createContext<InlineChatState | null>(null);
 
 export function InlineChatProvider({ children }: { children: ReactNode }) {
   const [isChatActive, setIsChatActive] = useState(false);
-  const { setMessages, stop, continueSession, dismissPreviousSession } =
-    useAIChatContext();
+  const { setMessages, stop, continueSession } = useAIChatContext();
   const { setBackOverride } = useBackOverride();
 
   // When chat exits, drop any in-flight stream and clear messages so the next
@@ -53,8 +52,12 @@ export function InlineChatProvider({ children }: { children: ReactNode }) {
     openChat();
   };
 
+  // Closing chat must NOT erase the saved session id. The user might have
+  // just streamed a conversation that `useAIChat`'s onFinish persisted to
+  // localStorage; they should be able to reopen and continue via the
+  // restore banner. Only the banner's explicit Dismiss button should fire
+  // `dismissPreviousSession` (which clears the storage key).
   const closeChat = () => {
-    dismissPreviousSession();
     if (!isChatActive) return;
     startTransition(() => {
       setIsChatActive(false);
@@ -62,14 +65,12 @@ export function InlineChatProvider({ children }: { children: ReactNode }) {
   };
 
   // Register an override on the global Back button while chat is open so the
-  // header's Back returns to browse instead of navigating home. Inlined here
-  // (rather than `closeChat`) to keep the effect deps stable — `dismissPreviousSession`
-  // is the only value from `useChat` that's closed over, and its identity is
-  // stable across renders.
+  // header's Back returns to browse instead of navigating home. Same
+  // rationale as `closeChat`: just flip the active flag, don't touch the
+  // stored session id.
   useEffect(() => {
     if (!isChatActive) return undefined;
     setBackOverride(() => {
-      dismissPreviousSession();
       startTransition(() => {
         setIsChatActive(false);
       });
@@ -77,7 +78,7 @@ export function InlineChatProvider({ children }: { children: ReactNode }) {
     return () => {
       setBackOverride(null);
     };
-  }, [isChatActive, setBackOverride, dismissPreviousSession]);
+  }, [isChatActive, setBackOverride]);
 
   return (
     <InlineChatContext


### PR DESCRIPTION
## The bug

`InlineChatProvider` called `dismissPreviousSession()` on every close — both from `closeChat` and from the back-override callback. That helper clears the per-locale `localStorage["ai-chat-session:<locale>"]` key, sets `dismissed = true`, and resets the continue-session status. So whenever the user closed the chat panel after streaming a fresh conversation, the only client-side handle to that conversation was wiped, even though the conversation itself was still alive in Redis for 24 hours. Reopening the chat showed an empty surface with no way to recover the just-finished thread.

## The fix

Drop the `dismissPreviousSession` call from both close paths and rely solely on the existing active→inactive cleanup effect, which calls `stop()` and `setMessages([])` — the right behavior for closing the panel: drop the in-flight stream, blank the surface, leave the saved session id alone. The banner's `onDismiss` in `inline-chat-view.tsx` still calls `dismissPreviousSession`; that path is the genuine "user said they don't want this prompt anymore" signal and legitimately wipes the storage key. The previously stale comment block on the back-override `useEffect` (which had rationalised inlining around `dismissPreviousSession`'s dep stability) is rewritten to document the new contract, and the helper is removed from the effect's deps so it doesn't re-register on render.