### PR TITLE
fix: keep chat textarea editable while assistant streams

### DIFF
--- a/apps/web/src/components/ai-chat/chat-input-bar.test.tsx
+++ b/apps/web/src/components/ai-chat/chat-input-bar.test.tsx
@@ -164,10 +164,28 @@ describe("ChatInputBar loading state", () => {
     expect(props.onStop).toHaveBeenCalledTimes(1);
   });
 
-  it("disables textarea while loading", () => {
+  it("keeps the textarea editable while loading so users can compose a follow-up mid-stream", async () => {
+    const user = userEvent.setup();
     renderInputBar({ status: "streaming" });
 
-    expect(screen.getByPlaceholderText("Ask about movies...")).toBeDisabled();
+    const textarea = screen.getByPlaceholderText("Ask about movies...");
+    expect(textarea).toBeEnabled();
+
+    await user.type(textarea, "follow-up");
+    expect(textarea).toHaveValue("follow-up");
+  });
+
+  it("does not call onSend when Enter is pressed during streaming", async () => {
+    const user = userEvent.setup();
+    const { props } = renderInputBar({ status: "streaming" });
+
+    const textarea = screen.getByPlaceholderText("Ask about movies...");
+    await user.type(textarea, "queued message");
+    await user.keyboard("{Enter}");
+
+    expect(props.onSend).not.toHaveBeenCalled();
+    // Draft text survives the suppressed submit so the user doesn't lose it.
+    expect(textarea).toHaveValue("queued message");
   });
 });
 

--- a/apps/web/src/components/ai-chat/chat-input-bar.tsx
+++ b/apps/web/src/components/ai-chat/chat-input-bar.tsx
@@ -45,7 +45,11 @@ export function ChatInputBar({
       placeholder={placeholder}
       sendLabel={sendLabel}
       onSubmit={onSend}
-      disabled={isLoading}
+      // Keep the textarea editable while the assistant streams so users can
+      // compose follow-ups mid-stream. Submit is still gated via
+      // `submitDisabled`, and the visible send/stop swap below makes the
+      // current state obvious.
+      submitDisabled={isLoading}
       autoGrow
       beforeTextarea={
         attachedMedia && (

--- a/apps/web/src/components/movie-database/collapsed-chat-input.tsx
+++ b/apps/web/src/components/movie-database/collapsed-chat-input.tsx
@@ -38,7 +38,7 @@ export function CollapsedChatInput({
         placeholder={placeholder}
         sendLabel={sendLabel}
         onSubmit={send}
-        disabled={isLoading}
+        submitDisabled={isLoading}
         compact
         beforeTextarea={
           <span css={[flex.inlineCenter, styles.icon]}>

--- a/apps/web/src/components/movie-database/hero-chat-input.tsx
+++ b/apps/web/src/components/movie-database/hero-chat-input.tsx
@@ -65,7 +65,7 @@ export function HeroChatInput({
               placeholder={placeholder}
               sendLabel={sendLabel}
               onSubmit={send}
-              disabled={isLoading}
+              submitDisabled={isLoading}
               beforeTextarea={
                 <span css={[flex.inlineCenter, styles.icon]}>
                   <SparkleIcon weight="fill" role="presentation" />

--- a/apps/web/src/components/shared/chat-textarea.tsx
+++ b/apps/web/src/components/shared/chat-textarea.tsx
@@ -28,7 +28,18 @@ interface ChatTextareaProps {
   placeholder: string;
   sendLabel: string;
   onSubmit: (text: string) => void;
+  /**
+   * Full lockout: textarea is uneditable AND submit is blocked. Use only
+   * when typing genuinely shouldn't happen.
+   */
   disabled?: boolean;
+  /**
+   * Narrower lockout: textarea stays editable so the user can compose the
+   * next message, but submit is blocked. Used while the assistant is
+   * streaming a response — the user expects to be able to draft a follow-up
+   * mid-stream the same way they can in every other modern chat UI.
+   */
+  submitDisabled?: boolean;
   autoGrow?: boolean;
   /** Reduced vertical padding for use inside sticky toolbars. */
   compact?: boolean;
@@ -43,6 +54,7 @@ export function ChatTextarea({
   sendLabel,
   onSubmit,
   disabled = false,
+  submitDisabled = false,
   autoGrow = false,
   compact = false,
   beforeTextarea,
@@ -51,6 +63,7 @@ export function ChatTextarea({
   const [text, setText] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const trimmed = text.trim();
+  const sendBlocked = disabled || submitDisabled;
 
   function resetHeight() {
     if (autoGrow && textareaRef.current) {
@@ -63,7 +76,7 @@ export function ChatTextarea({
   }
 
   function submit() {
-    if (!trimmed || disabled) return;
+    if (!trimmed || sendBlocked) return;
     onSubmit(trimmed);
     setText("");
     resetHeight();
@@ -119,7 +132,7 @@ export function ChatTextarea({
           <button
             type="submit"
             aria-label={sendLabel}
-            disabled={!trimmed || disabled}
+            disabled={!trimmed || sendBlocked}
             css={[
               flex.inlineCenter,
               buttonReset.base,


### PR DESCRIPTION
## The bug

`ChatTextarea` set `<textarea disabled={isLoading}>` while the assistant streamed a response, so users couldn't type a follow-up while reading the reply. Every modern chat UI lets you draft the next message mid-stream; this one didn't. The disable was redundant defense-in-depth on top of three existing layers — `useAIChatSend.send` early-returns on `isLoading`, `ChatTextarea.submit()` early-returns on the same flag, and `ChatInputBar` swaps Send for Stop while loading — so it was paying a real UX cost for no extra protection against duplicate sends.

## The fix

Split `ChatTextarea`'s single `disabled` prop into two narrower concepts. `disabled` keeps its old "full lockout" semantics (textarea uneditable, submit blocked) and is preserved for callers that genuinely want it. The new `submitDisabled` prop blocks submit only — the textarea stays editable. All three chat-input consumers now pass `submitDisabled={isLoading}` instead of `disabled={isLoading}`. Internally the component derives `sendBlocked = disabled || submitDisabled` and uses that for the submit guard plus the default Send button's `disabled` attribute, while the textarea element's `disabled` attribute reflects only the original prop. The IME composition guard, the Send/Stop swap, and the upstream `send` early-return are all untouched, so duplicate sends remain impossible.