### PR TITLE
fix: hide decorative empty-state emoji from screen readers

### DIFF
--- a/apps/web/src/components/movie-database/media-virtuoso-grid.test.tsx
+++ b/apps/web/src/components/movie-database/media-virtuoso-grid.test.tsx
@@ -1,6 +1,6 @@
 import type { UseSuspenseInfiniteQueryResult } from "@tanstack/react-query";
 import { describe, expect, it } from "vitest";
-import { render } from "#src/test-utils.tsx";
+import { render, screen } from "#src/test-utils.tsx";
 import type { MediaListItem } from "#src/utils/types.ts";
 import { MediaVirtuosoGrid } from "./media-virtuoso-grid";
 
@@ -53,6 +53,30 @@ function makeQueryResult(
 }
 
 describe("MediaVirtuosoGrid", () => {
+  it("hides the decorative emoji in the empty state from assistive tech", () => {
+    const { container } = render(
+      <MediaVirtuosoGrid
+        queryResult={makeQueryResult([])}
+        virtuosoKey="test-key"
+        notFoundLabel="No movies found that match the criteria"
+      />,
+    );
+
+    // Sighted users still see the emoji.
+    expect(container.textContent).toContain("🙉");
+
+    // The emoji lives inside an aria-hidden span so screen readers skip it
+    // and announce only the localized label.
+    const decorative = container.querySelector("[aria-hidden='true']");
+    expect(decorative?.textContent).toBe("🙉 ");
+
+    // The localized message is rendered as a sibling text node so AT users
+    // hear it directly, with no emoji prefix bleeding through.
+    expect(
+      screen.getByText(/No movies found that match the criteria/),
+    ).toBeInTheDocument();
+  });
+
   it("does not crash when data shrinks below the initial item count", () => {
     const fiveItems = makeItems(5);
     const twoItems = makeItems(2);

--- a/apps/web/src/components/movie-database/media-virtuoso-grid.tsx
+++ b/apps/web/src/components/movie-database/media-virtuoso-grid.tsx
@@ -27,7 +27,12 @@ export function MediaVirtuosoGrid({
   const initialItemCount = Math.min(storedInitialItemCount, items.length);
 
   if (!items.length) {
-    return <div css={styles.notFound}>🙉 {notFoundLabel}</div>;
+    return (
+      <div css={styles.notFound}>
+        <span aria-hidden="true">🙉 </span>
+        {notFoundLabel}
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## The bug

`MediaVirtuosoGrid`'s empty state rendered `🙉 {notFoundLabel}` directly in the DOM, so screen readers (NVDA, JAWS, VoiceOver, TalkBack) announced the emoji's CLDR annotation — "hear-no-evil monkey" — before the localized empty-state message. The emoji is purely decorative; AT users got pointless noise on every empty grid.

## The fix

Wrap the glyph in `<span aria-hidden="true">🙉 </span>` so the accessibility tree skips it and announces only the localized label. The visible glyph and spacing are unchanged for sighted users (the trailing space lives inside the hidden span, so the visual gap is preserved without leaving a stray double-space when AT skips it). Both consumers of the empty-state path benefit at once — the movie/TV browse grid via `media-list.tsx` and the chat-surface `SimilarMedia` via `similar-media-list.tsx` both route through this component. The pattern matches the decorative-content idiom already used elsewhere in the codebase (`external-link-indicator.tsx`, phosphor-icon usages).