### PR TITLE
fix: restore focus to the trigger when MenuButton's backdrop is clicked

### DIFF
--- a/apps/web/src/components/shared/menu-button.test.tsx
+++ b/apps/web/src/components/shared/menu-button.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from "@testing-library/react";
 import { AppRouterContext } from "next/dist/shared/lib/app-router-context.shared-runtime";
 import type { ReactNode } from "react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
@@ -179,6 +180,30 @@ describe("MenuButton keyboard navigation", () => {
     expect(getMenuItems()[0]).toHaveFocus();
 
     await user.keyboard("{Escape}");
+    expect(trigger).toHaveFocus();
+  });
+
+  it("returns focus to the trigger when the backdrop is clicked", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <RouterProvider>
+        <TestMenu />
+      </RouterProvider>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Open menu" });
+    await user.click(trigger);
+    expect(getMenuItems()[0]).toHaveFocus();
+
+    // The backdrop is a non-focusable overlay rendered alongside the
+    // container while the menu is open. Use fireEvent so the click lands
+    // exactly on the backdrop without userEvent's focus-shifting heuristics
+    // kicking in (jsdom can't model native pointer focus the same way as a
+    // real browser).
+    const backdrop = container.querySelector('[aria-hidden="true"]');
+    if (!backdrop) throw new Error("expected backdrop");
+    fireEvent.click(backdrop);
+
     expect(trigger).toHaveFocus();
   });
 

--- a/apps/web/src/components/shared/menu-button.tsx
+++ b/apps/web/src/components/shared/menu-button.tsx
@@ -80,6 +80,15 @@ export function MenuButton({
   const targetId = useId();
   const popupId = `${targetId}-popup`;
 
+  // Both intentional close paths (Escape, backdrop click) restore focus to
+  // the trigger per the WAI-ARIA Menu Button pattern. The onBlur close path
+  // deliberately doesn't call this — focus has already moved to wherever
+  // the user tabbed, and snapping it back would fight their intent.
+  const closeAndRestoreFocus = () => {
+    setIsMenuShown(false);
+    document.getElementById(targetId)?.focus();
+  };
+
   return (
     <>
       {isMenuShown && (
@@ -87,8 +96,8 @@ export function MenuButton({
           css={styles.backdrop}
           aria-hidden="true"
           onClick={() => {
-            setIsMenuShown(false);
             outsideClickedRef.current = true;
+            closeAndRestoreFocus();
           }}
         />
       )}
@@ -98,8 +107,7 @@ export function MenuButton({
         onKeyDown={(e) => {
           if (e.key === "Escape" && isMenuShown) {
             e.stopPropagation();
-            setIsMenuShown(false);
-            document.getElementById(targetId)?.focus();
+            closeAndRestoreFocus();
             return;
           }
 


### PR DESCRIPTION
## The bug

`MenuButton` restored focus to the trigger when the user closed the menu with Escape, but the backdrop click handler only flipped `isMenuShown` to false without restoring focus. Per the WAI-ARIA Menu Button pattern, both intentional close paths should land focus back on the trigger; pre-fix, keyboard and AT users dismissing via the backdrop ended up with focus silently dropped onto `<body>`, breaking the tab order.

## The fix

Pull the existing focus-restore step out of the Escape branch into a small `closeAndRestoreFocus` helper and call it from the backdrop click handler too. The helper mirrors the original Escape branch verbatim, so Escape semantics are unchanged. The `outsideClickedRef.current = true` write is preserved (now set before the helper runs) so the existing `onBlur` race-prevention still short-circuits the blur path. The `onBlur` close path deliberately doesn't call the helper — focus has already moved to wherever the user tabbed, and snapping it back would fight their intent. A code comment documents that rationale so the helper isn't later "simplified" into a `useEffect` on `isMenuShown` that would override deliberate tab-aways.