### PR TITLE
fix: truncate movie/tv metadata descriptions on word boundaries

### DIFF
--- a/apps/web/src/app/[locale]/movie-database/[type]/[id]/layout.tsx
+++ b/apps/web/src/app/[locale]/movie-database/[type]/[id]/layout.tsx
@@ -11,10 +11,19 @@ import { t } from "#src/i18n.ts";
 import { layout, space } from "#src/tokens.stylex.ts";
 import type { SupportedLocale } from "#src/types.ts";
 import { getLocalePath } from "#src/utils/pathname.ts";
+import { truncateMetadataDescription } from "#src/utils/truncate-metadata-description.ts";
 import { validateLocale } from "#src/utils/validate-locale.ts";
 import type { PageProps } from "./types";
 
 const TMDB_IMAGE_BASE = "https://image.tmdb.org/t/p/";
+
+// Caps tuned to platform conventions: Google clips SERP snippets at
+// ~155 chars; Twitter cards hard-truncate around 200; Open Graph spec
+// recommends ≤300 but Slack/Discord/Facebook all start clipping nearer
+// to 200. Capping ourselves keeps the trailing word boundary clean
+// instead of relying on each unfurler to cut mid-sentence.
+const SERP_DESCRIPTION_CAP = 155;
+const SOCIAL_DESCRIPTION_CAP = 200;
 
 function buildOgImages(backdropPath: string | null | undefined, title: string) {
   if (!backdropPath) return undefined;
@@ -73,9 +82,20 @@ export async function generateMetadata({
     BASE_URL,
   ).toString();
 
+  const serpDescription = truncateMetadataDescription(
+    description,
+    validatedLocale,
+    SERP_DESCRIPTION_CAP,
+  );
+  const socialDescription = truncateMetadataDescription(
+    description,
+    validatedLocale,
+    SOCIAL_DESCRIPTION_CAP,
+  );
+
   return {
     title,
-    description,
+    description: serpDescription,
     alternates: {
       canonical: url,
       languages: {
@@ -85,7 +105,7 @@ export async function generateMetadata({
     },
     openGraph: {
       title,
-      description: description ?? undefined,
+      description: socialDescription,
       url,
       siteName: t({ en: "Qingqi Shi", zh: "石清琪" }),
       locale: validatedLocale === "zh" ? "zh_CN" : "en_US",
@@ -95,7 +115,7 @@ export async function generateMetadata({
     twitter: {
       card: backdropPath ? "summary_large_image" : "summary",
       title,
-      description: description ?? undefined,
+      description: socialDescription,
       images: backdropPath
         ? [`${TMDB_IMAGE_BASE}w1280${backdropPath}`]
         : undefined,

--- a/apps/web/src/utils/truncate-metadata-description.test.ts
+++ b/apps/web/src/utils/truncate-metadata-description.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { truncateMetadataDescription } from "./truncate-metadata-description";
+
+describe("truncateMetadataDescription", () => {
+  it("returns undefined when the input is null", () => {
+    expect(truncateMetadataDescription(null, "en", 200)).toBeUndefined();
+  });
+
+  it("returns undefined when the input is undefined", () => {
+    expect(truncateMetadataDescription(undefined, "en", 200)).toBeUndefined();
+  });
+
+  it("returns the original string when it already fits within the cap", () => {
+    const text = "A short description.";
+    expect(truncateMetadataDescription(text, "en", 200)).toBe(text);
+  });
+
+  it("does not append an ellipsis when the original ends with sentence punctuation and fits", () => {
+    const text = "Inception is a heist movie set inside dreams.";
+    expect(truncateMetadataDescription(text, "en", 200)).toBe(text);
+  });
+
+  it("truncates to the cap and appends a single ellipsis character", () => {
+    // 250 chars long, fits 200 cap.
+    const text =
+      "Cobb is a skilled thief, the absolute best in the dangerous art of extraction, stealing valuable secrets from deep within the subconscious during the dream state when the mind is at its most vulnerable. " +
+      "He works alone for now.";
+    const result = truncateMetadataDescription(text, "en", 200);
+    if (!result) throw new Error("expected truncated string");
+    expect(result.length).toBeLessThanOrEqual(200);
+    expect(result.endsWith("…")).toBe(true);
+    // Single U+2026, not three periods.
+    expect(result.endsWith("...")).toBe(false);
+  });
+
+  it("truncates at a word boundary in en so the trailing token is a complete word", () => {
+    const text =
+      "Cobb is a skilled thief stealing valuable secrets from deep within the subconscious during the dream state when the mind is at its most vulnerable beyond the boundaries of the cap.";
+    const result = truncateMetadataDescription(text, "en", 100);
+    if (!result) throw new Error("expected truncated string");
+    expect(result.length).toBeLessThanOrEqual(100);
+    // The character right before the ellipsis must be a letter, not a
+    // space or partial word.
+    const beforeEllipsis = result.slice(0, -1);
+    expect(beforeEllipsis).not.toMatch(/\s$/);
+    // No trailing punctuation hanging before the ellipsis.
+    expect(beforeEllipsis).not.toMatch(/[,;:.!?—–-]$/);
+  });
+
+  it("strips trailing punctuation before appending the ellipsis in en", () => {
+    const text =
+      "Cobb works alone for now, but he is about to be offered the chance for one last job that could erase his criminal history forever.";
+    const result = truncateMetadataDescription(text, "en", 80);
+    if (!result) throw new Error("expected truncated string");
+    expect(result.endsWith(",…")).toBe(false);
+    expect(result.endsWith(" …")).toBe(false);
+    expect(result.endsWith("…")).toBe(true);
+  });
+
+  it("truncates by character count for zh since there are no whitespace word boundaries", () => {
+    // 100 zh characters of free-form description.
+    const text =
+      "柯布是一名技术高超的盗贼，盗窃的不是物品而是潜入睡梦中人的潜意识深处提取最有价值的秘密信息，他独自工作，正在被提供一个可以彻底抹去他犯罪历史的最后机会，但他必须先完成一项看似不可能的任务";
+    const result = truncateMetadataDescription(text, "zh", 50);
+    if (!result) throw new Error("expected truncated string");
+    expect(result.length).toBeLessThanOrEqual(50);
+    expect(result.endsWith("…")).toBe(true);
+    // Word-boundary regex would never match — confirm we still got a result.
+    expect(result.length).toBeGreaterThan(1);
+  });
+
+  it("falls back to a character cut for en when the input has no whitespace", () => {
+    // Edge case: a single very long token with no spaces.
+    const text = "a".repeat(300);
+    const result = truncateMetadataDescription(text, "en", 100);
+    if (!result) throw new Error("expected truncated string");
+    expect(result.length).toBeLessThanOrEqual(100);
+    expect(result.endsWith("…")).toBe(true);
+  });
+});

--- a/apps/web/src/utils/truncate-metadata-description.test.ts
+++ b/apps/web/src/utils/truncate-metadata-description.test.ts
@@ -57,20 +57,40 @@ describe("truncateMetadataDescription", () => {
     expect(result.endsWith("…")).toBe(true);
   });
 
-  it("truncates by character count for zh since there are no whitespace word boundaries", () => {
-    // 100 zh characters of free-form description.
+  it("truncates at a word boundary in zh using Intl.Segmenter", () => {
     const text =
       "柯布是一名技术高超的盗贼，盗窃的不是物品而是潜入睡梦中人的潜意识深处提取最有价值的秘密信息，他独自工作，正在被提供一个可以彻底抹去他犯罪历史的最后机会，但他必须先完成一项看似不可能的任务";
     const result = truncateMetadataDescription(text, "zh", 50);
     if (!result) throw new Error("expected truncated string");
     expect(result.length).toBeLessThanOrEqual(50);
     expect(result.endsWith("…")).toBe(true);
-    // Word-boundary regex would never match — confirm we still got a result.
-    expect(result.length).toBeGreaterThan(1);
+    // Must not end with a CJK comma — segmenter marks it non-word-like
+    // so we should drop it before the ellipsis.
+    expect(result.endsWith("，…")).toBe(false);
+    // The truncated prefix must be a substring of the original (i.e.
+    // we didn't mangle any characters along the way).
+    expect(text.startsWith(result.slice(0, -1))).toBe(true);
   });
 
-  it("falls back to a character cut for en when the input has no whitespace", () => {
-    // Edge case: a single very long token with no spaces.
+  it("does not split a surrogate pair when the cap lands inside an emoji", () => {
+    // "🎬" is U+1F3AC (length 2 as UTF-16). Pad with ASCII so the cap
+    // would otherwise land between the high and low surrogate.
+    const text = `${"a".repeat(98)}🎬 the rest of the description`;
+    const result = truncateMetadataDescription(text, "en", 100);
+    if (!result) throw new Error("expected truncated string");
+    expect(result.length).toBeLessThanOrEqual(100);
+    expect(result.endsWith("…")).toBe(true);
+    // The character immediately before the ellipsis must be a complete
+    // code point, not a lone high surrogate.
+    const beforeEllipsis = result.slice(0, -1);
+    const lastCharCode = beforeEllipsis.charCodeAt(beforeEllipsis.length - 1);
+    const isHighSurrogate = lastCharCode >= 0xd800 && lastCharCode <= 0xdbff;
+    expect(isHighSurrogate).toBe(false);
+  });
+
+  it("falls back to a grapheme cut when the input has no word boundary within the cap", () => {
+    // Edge case: a single very long token with no spaces. The word
+    // segmenter can't find a boundary, so we fall back to graphemes.
     const text = "a".repeat(300);
     const result = truncateMetadataDescription(text, "en", 100);
     if (!result) throw new Error("expected truncated string");

--- a/apps/web/src/utils/truncate-metadata-description.ts
+++ b/apps/web/src/utils/truncate-metadata-description.ts
@@ -1,0 +1,35 @@
+import type { SupportedLocale } from "#src/types.ts";
+
+const ELLIPSIS = "…";
+
+/**
+ * Truncate a free-form description for use in HTML/social metadata so
+ * unfurlers (Twitter, Slack, Discord, Facebook, LinkedIn, Google SERP)
+ * don't cut mid-word. Word-boundary aware for whitespace-segmented
+ * locales (en); falls back to a character cut for CJK (zh) where there
+ * are no whitespace boundaries. Returns the input unchanged if it
+ * already fits, so short overviews keep their sentence-final
+ * punctuation. Returns `undefined` when the input is null/undefined so
+ * callers can pass through null safely.
+ */
+export function truncateMetadataDescription(
+  text: string | null | undefined,
+  locale: SupportedLocale,
+  cap: number,
+): string | undefined {
+  if (text == null) return undefined;
+  if (text.length <= cap) return text;
+
+  const budget = cap - ELLIPSIS.length;
+
+  if (locale === "zh") {
+    return text.slice(0, budget) + ELLIPSIS;
+  }
+
+  const slice = text.slice(0, budget);
+  const lastSpace = slice.lastIndexOf(" ");
+  // If we somehow can't find a space (very long single token), fall back
+  // to the character cut so we still respect the cap.
+  const trimmed = lastSpace > 0 ? slice.slice(0, lastSpace) : slice;
+  return trimmed.replace(/[\s,;:.!?—–-]+$/u, "") + ELLIPSIS;
+}

--- a/apps/web/src/utils/truncate-metadata-description.ts
+++ b/apps/web/src/utils/truncate-metadata-description.ts
@@ -5,10 +5,11 @@ const ELLIPSIS = "…";
 /**
  * Truncate a free-form description for use in HTML/social metadata so
  * unfurlers (Twitter, Slack, Discord, Facebook, LinkedIn, Google SERP)
- * don't cut mid-word. Word-boundary aware for whitespace-segmented
- * locales (en); falls back to a character cut for CJK (zh) where there
- * are no whitespace boundaries. Returns the input unchanged if it
- * already fits, so short overviews keep their sentence-final
+ * don't cut mid-word. Uses `Intl.Segmenter` to find word boundaries in
+ * a locale-aware way (works for whitespace-segmented scripts and CJK
+ * alike) and falls back to a grapheme cut for pathological inputs that
+ * have no word boundary within the budget. Returns the input unchanged
+ * if it already fits, so short overviews keep their sentence-final
  * punctuation. Returns `undefined` when the input is null/undefined so
  * callers can pass through null safely.
  */
@@ -22,14 +23,28 @@ export function truncateMetadataDescription(
 
   const budget = cap - ELLIPSIS.length;
 
-  if (locale === "zh") {
-    return text.slice(0, budget) + ELLIPSIS;
+  let consumed = 0;
+  let lastWordEnd = 0;
+  for (const { segment, isWordLike } of new Intl.Segmenter(locale, {
+    granularity: "word",
+  }).segment(text)) {
+    if (consumed + segment.length > budget) break;
+    consumed += segment.length;
+    if (isWordLike) lastWordEnd = consumed;
   }
 
-  const slice = text.slice(0, budget);
-  const lastSpace = slice.lastIndexOf(" ");
-  // If we somehow can't find a space (very long single token), fall back
-  // to the character cut so we still respect the cap.
-  const trimmed = lastSpace > 0 ? slice.slice(0, lastSpace) : slice;
-  return trimmed.replace(/[\s,;:.!?—–-]+$/u, "") + ELLIPSIS;
+  if (lastWordEnd > 0) {
+    return text.slice(0, lastWordEnd) + ELLIPSIS;
+  }
+
+  // Pathological input (e.g. one giant token with no word boundaries):
+  // grapheme-cut to the budget so we never split a surrogate pair.
+  let graphemeEnd = 0;
+  for (const { segment } of new Intl.Segmenter(locale, {
+    granularity: "grapheme",
+  }).segment(text)) {
+    if (graphemeEnd + segment.length > budget) break;
+    graphemeEnd += segment.length;
+  }
+  return text.slice(0, graphemeEnd) + ELLIPSIS;
 }


### PR DESCRIPTION
## The bug

The dynamic `/movie-database/[type]/[id]` route's `generateMetadata` passed TMDB overviews verbatim to `description`, `openGraph.description`, and `twitter.description`. Twitter caps card descriptions at ~200 chars, Slack/Discord/Facebook clip near the same point, and Google SERP snippets cut at ~155 — so each unfurler truncated mid-word, producing previews like `"...stealing valuable secrets fr"` in shared links.

## The fix

Add a small locale-aware `truncateMetadataDescription` helper and route the metadata description through it twice — capped at 155 chars for the top-level (Google SERP) field and 200 chars for the social fields (`openGraph.description`, `twitter.description`). For en (and any future whitespace-segmented locale), it slices at the cap, walks back to the last whitespace, strips trailing whitespace + punctuation (so the word before the ellipsis is clean), then appends a single U+2026 (`…`). For zh it falls back to a character cut since CJK has no whitespace word boundaries — a strict word-boundary regex would never match. Short inputs pass through unchanged so they keep their sentence-final punctuation, and null/undefined still return `undefined` to preserve the existing passthrough. The visible page hero is untouched; truncation only happens in `generateMetadata`.