### PR TITLE
feat: add sprite editor tool

### DIFF
--- a/apps/web/src/app/[locale]/(home)/page.tsx
+++ b/apps/web/src/app/[locale]/(home)/page.tsx
@@ -2,6 +2,7 @@ import { CalculatorIcon } from "@phosphor-icons/react/dist/ssr/Calculator";
 import { FilmSlateIcon } from "@phosphor-icons/react/dist/ssr/FilmSlate";
 import { GhostIcon } from "@phosphor-icons/react/dist/ssr/Ghost";
 import { GraduationCapIcon } from "@phosphor-icons/react/dist/ssr/GraduationCap";
+import { GridFourIcon } from "@phosphor-icons/react/dist/ssr/GridFour";
 import { PackageIcon } from "@phosphor-icons/react/dist/ssr/Package";
 import * as stylex from "@stylexjs/stylex";
 import { breakpoints } from "#src/breakpoints.stylex.ts";
@@ -79,6 +80,17 @@ export default async function Home(props: PageProps) {
             description={t({
               en: "Build a tiny pixel creature, name it, and conjure its lore.",
               zh: "搭建一个小像素生物，给它取名，并召唤它的传说。",
+            })}
+            scroll
+          />
+          <ProjectCard
+            icon={<GridFourIcon size={64} weight="fill" aria-hidden="true" />}
+            href={getLocalePath("/sprite-editor", locale)}
+            css={[styles.card, styles.spriteEditor]}
+            name={t({ en: "Sprite Editor", zh: "像素编辑器" })}
+            description={t({
+              en: "Slice sprite sheets, clean up pixels, and assemble animation frames.",
+              zh: "切分精灵表、清理像素并组装动画帧。",
             })}
             scroll
           />
@@ -268,6 +280,9 @@ const styles = stylex.create({
     [svgTokens.fill]: color.brandStudentLoan,
   },
   pixelCreatureCreator: {
+    [svgTokens.fill]: color.brandPixelCreatureCreator,
+  },
+  spriteEditor: {
     [svgTokens.fill]: color.brandPixelCreatureCreator,
   },
 });

--- a/apps/web/src/app/[locale]/sprite-editor/layout.tsx
+++ b/apps/web/src/app/[locale]/sprite-editor/layout.tsx
@@ -1,0 +1,69 @@
+import * as stylex from "@stylexjs/stylex";
+import type { Metadata } from "next";
+import { BASE_URL } from "#src/constants.ts";
+import { t } from "#src/i18n.ts";
+import { space } from "#src/tokens.stylex.ts";
+import type { PageProps } from "#src/types.ts";
+import { validateLocale } from "#src/utils/validate-locale.ts";
+
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const params = await props.params;
+  validateLocale(params.locale);
+
+  const title = t({
+    en: "Sprite Editor | Qingqi Shi",
+    zh: "像素编辑器 | 石清琪",
+  });
+  const description = t({
+    en: "Slice sprite sheets, clean up pixels, and assemble animation frames in the browser.",
+    zh: "在浏览器中切分精灵表、清理像素并组装动画帧。",
+  });
+  const url =
+    params.locale === "zh"
+      ? new URL("/zh/sprite-editor", BASE_URL).toString()
+      : new URL("/sprite-editor", BASE_URL).toString();
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: url,
+      languages: {
+        en: new URL("/sprite-editor", BASE_URL).toString(),
+        zh: new URL("/zh/sprite-editor", BASE_URL).toString(),
+      },
+    },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: t({ en: "Qingqi Shi", zh: "石清琪" }),
+      locale: params.locale === "zh" ? "zh_CN" : "en_US",
+      type: "website",
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
+    },
+  } satisfies Metadata;
+}
+
+export default function Layout({
+  children,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  return <main css={styles.container}>{children}</main>;
+}
+
+const styles = stylex.create({
+  container: {
+    paddingBlockStart: `calc(${space._10} + env(safe-area-inset-top))`,
+    paddingBlockEnd: `calc(${space._3} + env(safe-area-inset-bottom))`,
+    paddingInline: space._3,
+    minHeight: "100dvh",
+    boxSizing: "border-box",
+  },
+});

--- a/apps/web/src/app/[locale]/sprite-editor/page.tsx
+++ b/apps/web/src/app/[locale]/sprite-editor/page.tsx
@@ -1,0 +1,28 @@
+import * as stylex from "@stylexjs/stylex";
+import { SpriteEditor } from "#src/components/sprite-editor/sprite-editor.tsx";
+import { t } from "#src/i18n.ts";
+
+export default function Page() {
+  return (
+    <>
+      <h1 css={styles.srOnly}>
+        {t({ en: "Sprite Editor", zh: "像素编辑器" })}
+      </h1>
+      <SpriteEditor />
+    </>
+  );
+}
+
+const styles = stylex.create({
+  srOnly: {
+    position: "absolute",
+    width: "1px",
+    height: "1px",
+    padding: 0,
+    margin: "-1px",
+    overflow: "hidden",
+    clipPath: "inset(50%)",
+    whiteSpace: "nowrap",
+    borderWidth: 0,
+  },
+});

--- a/apps/web/src/components/sprite-editor/animation-mode.tsx
+++ b/apps/web/src/components/sprite-editor/animation-mode.tsx
@@ -1,0 +1,546 @@
+"use client";
+
+import { ArrowDownIcon } from "@phosphor-icons/react/dist/ssr/ArrowDown";
+import { ArrowUpIcon } from "@phosphor-icons/react/dist/ssr/ArrowUp";
+import { DownloadSimpleIcon } from "@phosphor-icons/react/dist/ssr/DownloadSimple";
+import { PauseIcon } from "@phosphor-icons/react/dist/ssr/Pause";
+import { PlayIcon } from "@phosphor-icons/react/dist/ssr/Play";
+import { PlusIcon } from "@phosphor-icons/react/dist/ssr/Plus";
+import { TrashIcon } from "@phosphor-icons/react/dist/ssr/Trash";
+import * as stylex from "@stylexjs/stylex";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "#src/components/shared/button.tsx";
+import { t } from "#src/i18n.ts";
+import { border, color, font, space } from "#src/tokens.stylex.ts";
+import type { CellPixels } from "./types";
+import { downloadBlob } from "./utils/slice";
+import { exportSpriteSheet } from "./utils/sprite-sheet";
+
+export interface AnimationFrame {
+  cellIndex: number;
+  duration: number;
+}
+
+interface AnimationModeProps {
+  cells: readonly (CellPixels | null)[];
+  frames: readonly AnimationFrame[];
+  onFramesChange: (next: readonly AnimationFrame[]) => void;
+  /** Cell currently selected in the editor — used for "Add frame". */
+  selectedCell: number | null;
+  /** Filename stub for downloaded artifacts. */
+  baseFilename: string;
+}
+
+const DEFAULT_DURATION = 120;
+const PREVIEW_SIZE = 240;
+const FRAME_THUMB_SIZE = 48;
+
+export function AnimationMode({
+  cells,
+  frames,
+  onFramesChange,
+  selectedCell,
+  baseFilename,
+}: AnimationModeProps) {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [speed, setSpeed] = useState(1);
+  const [activeFrame, setActiveFrame] = useState(0);
+  const previewCanvasRef = useRef<HTMLCanvasElement>(null);
+
+  // Reset/clamp the active frame whenever the frame count drops. Stored
+  // as a render-time check rather than a useEffect so React handles the
+  // reset in the same render that detects the change (avoids the
+  // react-hooks/set-state-in-effect cascade).
+  const [prevFrameCount, setPrevFrameCount] = useState(frames.length);
+  if (prevFrameCount !== frames.length) {
+    setPrevFrameCount(frames.length);
+    if (frames.length === 0) {
+      setActiveFrame(0);
+      setIsPlaying(false);
+    } else if (activeFrame >= frames.length) {
+      setActiveFrame(0);
+    }
+  }
+
+  // Playback loop. Uses real time + frame durations, scaled by `speed`, so
+  // setting `speed = 2` halves each duration and `speed = 0.5` doubles it.
+  useEffect(() => {
+    if (!isPlaying || frames.length === 0) return;
+    let raf = 0;
+    let lastTime = performance.now();
+    let elapsed = 0;
+    const tick = (now: number) => {
+      elapsed += (now - lastTime) * speed;
+      lastTime = now;
+      let idx = activeFrame;
+      while (elapsed >= frames[idx].duration) {
+        elapsed -= frames[idx].duration;
+        idx = (idx + 1) % frames.length;
+      }
+      if (idx !== activeFrame) {
+        setActiveFrame(idx);
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => {
+      cancelAnimationFrame(raf);
+    };
+  }, [isPlaying, speed, frames, activeFrame]);
+
+  // Render the current frame to the preview canvas at integer scale, centered.
+  useEffect(() => {
+    const canvas = previewCanvasRef.current;
+    if (canvas === null) return;
+    const dpr = typeof window === "undefined" ? 1 : window.devicePixelRatio;
+    const cssSize = PREVIEW_SIZE;
+    canvas.width = Math.floor(cssSize * dpr);
+    canvas.height = Math.floor(cssSize * dpr);
+    canvas.style.width = `${String(cssSize)}px`;
+    canvas.style.height = `${String(cssSize)}px`;
+    const ctx = canvas.getContext("2d");
+    if (ctx === null) return;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, cssSize, cssSize);
+    if (frames.length === 0) return;
+    const frame = frames[activeFrame];
+    const cell = cells[frame.cellIndex];
+    if (cell === null) return;
+    ctx.imageSmoothingEnabled = false;
+    const fit = Math.min(cssSize / cell.width, cssSize / cell.height);
+    const scale = Math.max(1, Math.floor(fit));
+    const drawnW = cell.width * scale;
+    const drawnH = cell.height * scale;
+    const dx = Math.floor((cssSize - drawnW) / 2);
+    const dy = Math.floor((cssSize - drawnH) / 2);
+    const imageData = new ImageData(cell.data, cell.width, cell.height);
+    const off =
+      typeof OffscreenCanvas !== "undefined"
+        ? new OffscreenCanvas(cell.width, cell.height)
+        : null;
+    if (off !== null) {
+      const offCtx = off.getContext("2d");
+      if (offCtx !== null) {
+        offCtx.putImageData(imageData, 0, 0);
+        ctx.drawImage(off, dx, dy, drawnW, drawnH);
+      }
+    } else {
+      ctx.putImageData(imageData, dx, dy);
+    }
+  }, [frames, activeFrame, cells]);
+
+  const addCurrentFrame = () => {
+    if (selectedCell === null) return;
+    const cell = cells[selectedCell];
+    if (cell === null) return;
+    onFramesChange([
+      ...frames,
+      { cellIndex: selectedCell, duration: DEFAULT_DURATION },
+    ]);
+  };
+
+  const removeFrame = (index: number) => {
+    onFramesChange(frames.filter((_, i) => i !== index));
+  };
+
+  const moveFrame = (index: number, delta: number) => {
+    const target = index + delta;
+    if (target < 0 || target >= frames.length) return;
+    const next = frames.slice();
+    [next[index], next[target]] = [next[target], next[index]];
+    onFramesChange(next);
+  };
+
+  const setFrameDuration = (index: number, duration: number) => {
+    onFramesChange(
+      frames.map((f, i) =>
+        i === index ? { ...f, duration: Math.max(1, duration) } : f,
+      ),
+    );
+  };
+
+  const cellLabel = t({ en: "Cell", zh: "单元格" });
+  const msLabel = t({ en: "ms", zh: "毫秒" });
+  const moveUpLabel = t({ en: "Move up", zh: "上移" });
+  const moveDownLabel = t({ en: "Move down", zh: "下移" });
+  const removeLabel = t({ en: "Remove frame", zh: "删除帧" });
+
+  const handleExport = useCallback(async () => {
+    const cellPayload: { cell: CellPixels; duration: number }[] = [];
+    for (const frame of frames) {
+      const cell = cells[frame.cellIndex];
+      if (cell === null) continue;
+      cellPayload.push({ cell, duration: frame.duration });
+    }
+    if (cellPayload.length === 0) return;
+    const result = await exportSpriteSheet(cellPayload);
+    if (result === null) return;
+    downloadBlob(result.png, `${baseFilename}-sheet.png`);
+    const manifestBlob = new Blob([JSON.stringify(result.manifest, null, 2)], {
+      type: "application/json",
+    });
+    downloadBlob(manifestBlob, `${baseFilename}-sheet.json`);
+  }, [baseFilename, cells, frames]);
+
+  return (
+    <div css={styles.root}>
+      <div css={styles.previewArea}>
+        <canvas
+          ref={previewCanvasRef}
+          css={styles.previewCanvas}
+          data-testid="animation-preview"
+        />
+        <div css={styles.previewControls}>
+          <Button
+            icon={
+              isPlaying ? (
+                <PauseIcon size={16} weight="bold" aria-hidden="true" />
+              ) : (
+                <PlayIcon size={16} weight="bold" aria-hidden="true" />
+              )
+            }
+            onClick={() => {
+              setIsPlaying((value) => !value);
+            }}
+            disabled={frames.length === 0}
+            data-testid="play-pause"
+          >
+            {isPlaying
+              ? t({ en: "Pause", zh: "暂停" })
+              : t({ en: "Play", zh: "播放" })}
+          </Button>
+          <label css={styles.speedLabel}>
+            <span>{t({ en: "Speed", zh: "速度" })}</span>
+            <input
+              type="range"
+              min={0.25}
+              max={4}
+              step={0.25}
+              value={speed}
+              onChange={(event) => {
+                setSpeed(Number(event.target.value));
+              }}
+              data-testid="speed"
+            />
+            <span css={styles.speedValue}>{speed.toFixed(2)}×</span>
+          </label>
+          <Button
+            icon={
+              <DownloadSimpleIcon size={16} weight="bold" aria-hidden="true" />
+            }
+            onClick={() => {
+              void handleExport();
+            }}
+            disabled={frames.length === 0}
+            data-testid="export-sheet"
+          >
+            {t({ en: "Export sprite sheet", zh: "导出精灵表" })}
+          </Button>
+        </div>
+      </div>
+
+      <div css={styles.timelineArea}>
+        <div css={styles.timelineHeader}>
+          <h2 css={styles.timelineTitle}>
+            {t({ en: "Frames", zh: "帧" })}{" "}
+            <span css={styles.timelineCount}>({frames.length})</span>
+          </h2>
+          <Button
+            icon={<PlusIcon size={16} weight="bold" aria-hidden="true" />}
+            onClick={addCurrentFrame}
+            disabled={selectedCell === null}
+            data-testid="add-frame"
+          >
+            {t({ en: "Add current cell", zh: "添加当前单元格" })}
+          </Button>
+        </div>
+        {frames.length === 0 ? (
+          <p css={styles.empty}>
+            {t({
+              en: "Select a cell in the strip and click Add to build an animation.",
+              zh: "在单元格列表中选一个，点添加来构建动画。",
+            })}
+          </p>
+        ) : (
+          <ol css={styles.frameList}>
+            {frames.map((frame, index) => (
+              <li
+                // eslint-disable-next-line @eslint-react/no-array-index-key -- frames are positional; index IS the identity
+                key={index}
+                css={[
+                  styles.frameItem,
+                  activeFrame === index && styles.frameItemActive,
+                ]}
+              >
+                <FrameThumb cell={cells[frame.cellIndex] ?? null} />
+                <div css={styles.frameMeta}>
+                  <span css={styles.frameLabel}>
+                    {cellLabel} {frame.cellIndex + 1}
+                  </span>
+                  <label css={styles.frameDurationLabel}>
+                    <span>{msLabel}</span>
+                    <input
+                      type="number"
+                      min={1}
+                      step={10}
+                      value={frame.duration}
+                      onChange={(event) => {
+                        setFrameDuration(index, Number(event.target.value));
+                      }}
+                      css={styles.frameDuration}
+                      data-testid={`frame-duration-${String(index)}`}
+                    />
+                  </label>
+                </div>
+                <div css={styles.frameActions}>
+                  <button
+                    type="button"
+                    css={styles.iconButton}
+                    onClick={() => {
+                      moveFrame(index, -1);
+                    }}
+                    disabled={index === 0}
+                    aria-label={moveUpLabel}
+                  >
+                    <ArrowUpIcon size={14} weight="bold" />
+                  </button>
+                  <button
+                    type="button"
+                    css={styles.iconButton}
+                    onClick={() => {
+                      moveFrame(index, 1);
+                    }}
+                    disabled={index === frames.length - 1}
+                    aria-label={moveDownLabel}
+                  >
+                    <ArrowDownIcon size={14} weight="bold" />
+                  </button>
+                  <button
+                    type="button"
+                    css={styles.iconButton}
+                    onClick={() => {
+                      removeFrame(index);
+                    }}
+                    aria-label={removeLabel}
+                    data-testid={`remove-frame-${String(index)}`}
+                  >
+                    <TrashIcon size={14} weight="bold" />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface FrameThumbProps {
+  cell: CellPixels | null;
+}
+
+function FrameThumb({ cell }: FrameThumbProps) {
+  const ref = useRef<HTMLCanvasElement>(null);
+  useEffect(() => {
+    const canvas = ref.current;
+    if (canvas === null) return;
+    const dpr = typeof window === "undefined" ? 1 : window.devicePixelRatio;
+    canvas.width = Math.floor(FRAME_THUMB_SIZE * dpr);
+    canvas.height = Math.floor(FRAME_THUMB_SIZE * dpr);
+    canvas.style.width = `${String(FRAME_THUMB_SIZE)}px`;
+    canvas.style.height = `${String(FRAME_THUMB_SIZE)}px`;
+    const ctx = canvas.getContext("2d");
+    if (ctx === null) return;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, FRAME_THUMB_SIZE, FRAME_THUMB_SIZE);
+    if (cell === null) return;
+    ctx.imageSmoothingEnabled = false;
+    const fit = Math.min(
+      FRAME_THUMB_SIZE / cell.width,
+      FRAME_THUMB_SIZE / cell.height,
+    );
+    const scale = Math.max(1, Math.floor(fit));
+    const drawnW = cell.width * scale;
+    const drawnH = cell.height * scale;
+    const dx = Math.floor((FRAME_THUMB_SIZE - drawnW) / 2);
+    const dy = Math.floor((FRAME_THUMB_SIZE - drawnH) / 2);
+    const imageData = new ImageData(cell.data, cell.width, cell.height);
+    const off =
+      typeof OffscreenCanvas !== "undefined"
+        ? new OffscreenCanvas(cell.width, cell.height)
+        : null;
+    if (off !== null) {
+      const offCtx = off.getContext("2d");
+      if (offCtx !== null) {
+        offCtx.putImageData(imageData, 0, 0);
+        ctx.drawImage(off, dx, dy, drawnW, drawnH);
+      }
+    } else {
+      ctx.putImageData(imageData, dx, dy);
+    }
+  }, [cell]);
+  return <canvas ref={ref} css={styles.thumb} aria-hidden="true" />;
+}
+
+const styles = stylex.create({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space._3,
+    width: "100%",
+    height: "100%",
+    minHeight: 0,
+  },
+  previewArea: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space._2,
+    padding: space._3,
+    border: `1px solid ${color.border}`,
+    borderRadius: border.radius_3,
+    backgroundColor: color.backgroundRaised,
+  },
+  previewCanvas: {
+    display: "block",
+    backgroundColor: color.backgroundMain,
+    backgroundImage: `linear-gradient(45deg, ${color.border} 25%, transparent 25%), linear-gradient(-45deg, ${color.border} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${color.border} 75%), linear-gradient(-45deg, transparent 75%, ${color.border} 75%)`,
+    backgroundSize: "16px 16px",
+    backgroundPosition: "0 0, 0 8px, 8px -8px, -8px 0px",
+    border: `1px solid ${color.border}`,
+    borderRadius: border.radius_2,
+    imageRendering: "pixelated",
+    alignSelf: "center",
+  },
+  previewControls: {
+    display: "flex",
+    flexWrap: "wrap",
+    alignItems: "center",
+    gap: space._2,
+  },
+  speedLabel: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: space._1,
+    fontSize: font.uiBodySmall,
+    color: color.textMuted,
+  },
+  speedValue: {
+    minWidth: "3em",
+    textAlign: "right",
+    fontSize: font.uiBodySmall,
+    color: color.textMain,
+    fontVariantNumeric: "tabular-nums",
+  },
+  timelineArea: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space._2,
+    padding: space._3,
+    border: `1px solid ${color.border}`,
+    borderRadius: border.radius_3,
+    backgroundColor: color.backgroundRaised,
+    flex: "1",
+    minHeight: 0,
+    overflowY: "auto",
+  },
+  timelineHeader: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: space._2,
+  },
+  timelineTitle: {
+    margin: 0,
+    fontSize: font.uiBodySmall,
+    fontWeight: font.weight_7,
+    color: color.textMuted,
+    textTransform: "uppercase",
+    letterSpacing: ".05em",
+  },
+  timelineCount: {
+    fontWeight: font.weight_4,
+  },
+  empty: {
+    margin: 0,
+    fontSize: font.uiBodySmall,
+    color: color.textMuted,
+  },
+  frameList: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space._1,
+    margin: 0,
+    padding: 0,
+    listStyle: "none",
+  },
+  frameItem: {
+    display: "flex",
+    alignItems: "center",
+    gap: space._2,
+    padding: space._2,
+    border: `1px solid ${color.border}`,
+    borderRadius: border.radius_2,
+    backgroundColor: color.backgroundMain,
+  },
+  frameItemActive: {
+    borderColor: color.brandPixelCreatureCreator,
+  },
+  thumb: {
+    backgroundColor: color.backgroundMain,
+    backgroundImage: `linear-gradient(45deg, ${color.border} 25%, transparent 25%), linear-gradient(-45deg, ${color.border} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${color.border} 75%), linear-gradient(-45deg, transparent 75%, ${color.border} 75%)`,
+    backgroundSize: "8px 8px",
+    backgroundPosition: "0 0, 0 4px, 4px -4px, -4px 0px",
+    borderRadius: border.radius_2,
+    imageRendering: "pixelated",
+  },
+  frameMeta: {
+    flex: "1",
+    display: "flex",
+    flexDirection: "column",
+    gap: "2px",
+  },
+  frameLabel: {
+    fontSize: font.uiBodySmall,
+    color: color.textMain,
+    fontWeight: font.weight_6,
+  },
+  frameDurationLabel: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: space._1,
+    fontSize: font.uiBodySmall,
+    color: color.textMuted,
+  },
+  frameDuration: {
+    width: "5em",
+    paddingBlock: "2px",
+    paddingInline: space._1,
+    border: `1px solid ${color.border}`,
+    borderRadius: border.radius_2,
+    backgroundColor: color.backgroundRaised,
+    color: color.textMain,
+    fontFamily: "inherit",
+    fontSize: font.uiBodySmall,
+  },
+  frameActions: {
+    display: "flex",
+    gap: "2px",
+  },
+  iconButton: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "26px",
+    height: "26px",
+    border: `1px solid ${color.border}`,
+    borderRadius: border.radius_2,
+    backgroundColor: {
+      default: color.backgroundRaised,
+      ":hover:not(:disabled)": color.backgroundHover,
+    },
+    color: color.textMain,
+    cursor: { default: "pointer", ":disabled": "not-allowed" },
+    opacity: { default: 1, ":disabled": 0.4 },
+  },
+});

--- a/apps/web/src/components/sprite-editor/cell-strip.tsx
+++ b/apps/web/src/components/sprite-editor/cell-strip.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { useEffect, useRef, useState } from "react";
+import { t } from "#src/i18n.ts";
+import { border, color, font, space } from "#src/tokens.stylex.ts";
+import type { CellPixels } from "./types";
+
+interface CellStripProps {
+  cells: readonly (CellPixels | null)[];
+  selectedCell: number | null;
+  onSelect: (index: number) => void;
+}
+
+export function CellStrip({ cells, selectedCell, onSelect }: CellStripProps) {
+  const cellLabel = t({ en: "Cell", zh: "单元格" });
+  return (
+    <div css={styles.root}>
+      <h2 css={styles.heading}>
+        {t({ en: "Cells", zh: "单元格" })}{" "}
+        <span css={styles.count}>({cells.length})</span>
+      </h2>
+      <ol css={styles.list}>
+        {cells.map((cell, index) => (
+          <li
+            // eslint-disable-next-line @eslint-react/no-array-index-key -- cells are positional; index IS the identity
+            key={index}
+            css={styles.item}
+          >
+            <button
+              type="button"
+              css={[
+                styles.thumbButton,
+                selectedCell === index && styles.thumbButtonActive,
+              ]}
+              onClick={() => {
+                onSelect(index);
+              }}
+              data-testid={`cell-thumb-${String(index)}`}
+              aria-label={`${cellLabel} ${String(index + 1)}`}
+              aria-pressed={selectedCell === index}
+            >
+              <CellThumbnail cell={cell} />
+              <span css={styles.thumbIndex}>{index + 1}</span>
+            </button>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+interface CellThumbnailProps {
+  cell: CellPixels | null;
+}
+
+function CellThumbnail({ cell }: CellThumbnailProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState(0);
+
+  useEffect(() => {
+    const el = wrapperRef.current;
+    if (el === null) return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      const next = Math.min(entry.contentRect.width, entry.contentRect.height);
+      setSize(next);
+    });
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (canvas === null || size === 0) return;
+    const dpr = typeof window === "undefined" ? 1 : window.devicePixelRatio;
+    canvas.width = Math.floor(size * dpr);
+    canvas.height = Math.floor(size * dpr);
+    canvas.style.width = `${String(size)}px`;
+    canvas.style.height = `${String(size)}px`;
+    const ctx = canvas.getContext("2d");
+    if (ctx === null) return;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, size, size);
+    if (cell === null) return;
+    ctx.imageSmoothingEnabled = false;
+    // Integer-scale the cell pixels into the thumbnail and center — this
+    // avoids the fractional-pixel artifacts you get with CSS-stretching a
+    // small backing buffer up to the thumbnail size.
+    const fit = Math.min(size / cell.width, size / cell.height);
+    const scale = Math.max(1, Math.floor(fit));
+    const drawnW = cell.width * scale;
+    const drawnH = cell.height * scale;
+    const dx = Math.floor((size - drawnW) / 2);
+    const dy = Math.floor((size - drawnH) / 2);
+    const imageData = new ImageData(cell.data, cell.width, cell.height);
+    const off =
+      typeof OffscreenCanvas !== "undefined"
+        ? new OffscreenCanvas(cell.width, cell.height)
+        : null;
+    if (off !== null) {
+      const offCtx = off.getContext("2d");
+      if (offCtx !== null) {
+        offCtx.putImageData(imageData, 0, 0);
+        ctx.drawImage(off, dx, dy, drawnW, drawnH);
+      }
+    } else {
+      ctx.putImageData(imageData, dx, dy);
+    }
+  }, [cell, size]);
+
+  return (
+    <div ref={wrapperRef} css={styles.thumbWrapper}>
+      <canvas ref={canvasRef} css={styles.thumb} aria-hidden="true" />
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space._2,
+    padding: space._3,
+    border: `1px solid ${color.border}`,
+    borderRadius: border.radius_3,
+    backgroundColor: color.backgroundRaised,
+  },
+  heading: {
+    margin: 0,
+    fontSize: font.uiBodySmall,
+    fontWeight: font.weight_7,
+    color: color.textMuted,
+    textTransform: "uppercase",
+    letterSpacing: ".05em",
+  },
+  count: {
+    fontWeight: font.weight_4,
+  },
+  list: {
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fill, minmax(72px, 1fr))",
+    gap: space._2,
+    margin: 0,
+    padding: 0,
+    listStyle: "none",
+    maxHeight: "260px",
+    overflowY: "auto",
+  },
+  item: {
+    margin: 0,
+  },
+  thumbButton: {
+    position: "relative",
+    width: "100%",
+    aspectRatio: "1 / 1",
+    padding: 0,
+    backgroundColor: color.backgroundMain,
+    border: `2px solid ${color.border}`,
+    borderRadius: border.radius_2,
+    cursor: "pointer",
+    overflow: "hidden",
+    display: "block",
+  },
+  thumbButtonActive: {
+    borderColor: color.brandPixelCreatureCreator,
+  },
+  thumbWrapper: {
+    position: "absolute",
+    inset: 0,
+    display: "grid",
+    placeItems: "center",
+    backgroundColor: color.backgroundMain,
+    backgroundImage: `linear-gradient(45deg, ${color.border} 25%, transparent 25%), linear-gradient(-45deg, ${color.border} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${color.border} 75%), linear-gradient(-45deg, transparent 75%, ${color.border} 75%)`,
+    backgroundSize: "8px 8px",
+    backgroundPosition: "0 0, 0 4px, 4px -4px, -4px 0px",
+  },
+  thumb: {
+    display: "block",
+    imageRendering: "pixelated",
+  },
+  thumbIndex: {
+    position: "absolute",
+    insetBlockEnd: "2px",
+    insetInlineEnd: "4px",
+    fontSize: font.uiBodySmall,
+    color: color.textMain,
+    backgroundColor: "rgba(0, 0, 0, 0.6)",
+    paddingInline: "4px",
+    borderRadius: "4px",
+    pointerEvents: "none",
+  },
+});

--- a/apps/web/src/components/sprite-editor/grid-controls.tsx
+++ b/apps/web/src/components/sprite-editor/grid-controls.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { useId } from "react";
+import { t } from "#src/i18n.ts";
+import { border, color, font, space } from "#src/tokens.stylex.ts";
+import type { GridConfig, OutputConfig, SourceImage } from "./types";
+
+interface GridControlsProps {
+  source: SourceImage;
+  grid: GridConfig;
+  onGridChange: (next: GridConfig) => void;
+  output: OutputConfig;
+  onOutputChange: (next: OutputConfig) => void;
+}
+
+interface NumberFieldProps {
+  label: string;
+  value: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  onChange: (value: number) => void;
+  testId?: string;
+}
+
+function NumberField({
+  label,
+  value,
+  min,
+  max,
+  step = 1,
+  onChange,
+  testId,
+}: NumberFieldProps) {
+  const id = useId();
+  return (
+    <label htmlFor={id} css={styles.field}>
+      <span css={styles.fieldLabel}>{label}</span>
+      <input
+        id={id}
+        type="number"
+        value={value}
+        min={min}
+        max={max}
+        step={step}
+        css={styles.input}
+        onChange={(event) => {
+          const next = Number(event.target.value);
+          if (Number.isNaN(next)) return;
+          onChange(next);
+        }}
+        data-testid={testId}
+      />
+    </label>
+  );
+}
+
+export function GridControls({
+  source,
+  grid,
+  onGridChange,
+  output,
+  onOutputChange,
+}: GridControlsProps) {
+  // Helper: set rows/cols and auto-fit cell size to the remaining space so a
+  // fresh import lands with sensible defaults. Gaps are preserved when
+  // adjusting counts so the user's gap choice survives count changes.
+  const updateColsRows = (cols: number, rows: number) => {
+    const safeCols = Math.max(1, cols);
+    const safeRows = Math.max(1, rows);
+    const cellWidth = Math.max(
+      1,
+      Math.floor(
+        (source.width - grid.offsetX - (safeCols - 1) * grid.gapX) / safeCols,
+      ),
+    );
+    const cellHeight = Math.max(
+      1,
+      Math.floor(
+        (source.height - grid.offsetY - (safeRows - 1) * grid.gapY) / safeRows,
+      ),
+    );
+    onGridChange({ ...grid, cols, rows, cellWidth, cellHeight });
+  };
+
+  return (
+    <div css={styles.root}>
+      <fieldset css={styles.group}>
+        <legend css={styles.legend}>{t({ en: "Grid", zh: "网格" })}</legend>
+        <NumberField
+          label={t({ en: "Columns", zh: "列数" })}
+          value={grid.cols}
+          min={1}
+          max={64}
+          onChange={(cols) => {
+            updateColsRows(Math.max(1, cols), grid.rows);
+          }}
+          testId="grid-cols"
+        />
+        <NumberField
+          label={t({ en: "Rows", zh: "行数" })}
+          value={grid.rows}
+          min={1}
+          max={64}
+          onChange={(rows) => {
+            updateColsRows(grid.cols, Math.max(1, rows));
+          }}
+          testId="grid-rows"
+        />
+        <NumberField
+          label={t({ en: "Offset X", zh: "X 偏移" })}
+          value={grid.offsetX}
+          min={0}
+          max={source.width}
+          onChange={(offsetX) => {
+            onGridChange({ ...grid, offsetX });
+          }}
+          testId="grid-offset-x"
+        />
+        <NumberField
+          label={t({ en: "Offset Y", zh: "Y 偏移" })}
+          value={grid.offsetY}
+          min={0}
+          max={source.height}
+          onChange={(offsetY) => {
+            onGridChange({ ...grid, offsetY });
+          }}
+          testId="grid-offset-y"
+        />
+        <NumberField
+          label={t({ en: "Cell W", zh: "格宽" })}
+          value={grid.cellWidth}
+          min={1}
+          onChange={(cellWidth) => {
+            onGridChange({ ...grid, cellWidth: Math.max(1, cellWidth) });
+          }}
+          testId="grid-cell-w"
+        />
+        <NumberField
+          label={t({ en: "Cell H", zh: "格高" })}
+          value={grid.cellHeight}
+          min={1}
+          onChange={(cellHeight) => {
+            onGridChange({ ...grid, cellHeight: Math.max(1, cellHeight) });
+          }}
+          testId="grid-cell-h"
+        />
+        <NumberField
+          label={t({ en: "Gap X", zh: "X 间距" })}
+          value={grid.gapX}
+          min={0}
+          max={source.width}
+          onChange={(gapX) => {
+            onGridChange({ ...grid, gapX: Math.max(0, gapX) });
+          }}
+          testId="grid-gap-x"
+        />
+        <NumberField
+          label={t({ en: "Gap Y", zh: "Y 间距" })}
+          value={grid.gapY}
+          min={0}
+          max={source.height}
+          onChange={(gapY) => {
+            onGridChange({ ...grid, gapY: Math.max(0, gapY) });
+          }}
+          testId="grid-gap-y"
+        />
+      </fieldset>
+
+      <fieldset css={styles.group}>
+        <legend css={styles.legend}>
+          {t({ en: "Output size", zh: "输出尺寸" })}
+        </legend>
+        <NumberField
+          label={t({ en: "Width", zh: "宽" })}
+          value={output.width}
+          min={1}
+          max={1024}
+          onChange={(width) => {
+            onOutputChange({ ...output, width: Math.max(1, width) });
+          }}
+          testId="output-width"
+        />
+        <NumberField
+          label={t({ en: "Height", zh: "高" })}
+          value={output.height}
+          min={1}
+          max={1024}
+          onChange={(height) => {
+            onOutputChange({ ...output, height: Math.max(1, height) });
+          }}
+          testId="output-height"
+        />
+      </fieldset>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space._3,
+  },
+  group: {
+    display: "grid",
+    gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+    gap: space._2,
+    padding: space._3,
+    border: `1px solid ${color.border}`,
+    borderRadius: border.radius_3,
+    backgroundColor: color.backgroundRaised,
+    margin: 0,
+  },
+  legend: {
+    paddingInline: space._2,
+    fontSize: font.uiBodySmall,
+    fontWeight: font.weight_7,
+    color: color.textMuted,
+    textTransform: "uppercase",
+    letterSpacing: ".05em",
+  },
+  field: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space._1,
+  },
+  fieldLabel: {
+    fontSize: font.uiBodySmall,
+    color: color.textMuted,
+  },
+  input: {
+    width: "100%",
+    paddingBlock: space._1,
+    paddingInline: space._2,
+    backgroundColor: color.backgroundMain,
+    color: color.textMain,
+    border: `1px solid ${color.border}`,
+    borderRadius: border.radius_2,
+    fontSize: font.uiBody,
+    fontFamily: "inherit",
+    boxSizing: "border-box",
+  },
+});

--- a/apps/web/src/components/sprite-editor/guide-controls.tsx
+++ b/apps/web/src/components/sprite-editor/guide-controls.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { useId } from "react";
+import { t } from "#src/i18n.ts";
+import { border, color, font, space } from "#src/tokens.stylex.ts";
+import type { GuideOptions } from "./utils/guides";
+
+interface GuideControlsProps {
+  guides: GuideOptions;
+  onGuidesChange: (next: GuideOptions) => void;
+}
+
+export function GuideControls({ guides, onGuidesChange }: GuideControlsProps) {
+  return (
+    <fieldset css={styles.group}>
+      <legend css={styles.legend}>{t({ en: "Guides", zh: "辅助线" })}</legend>
+      <Toggle
+        label={t({ en: "Halves", zh: "对半" })}
+        checked={guides.halves}
+        onChange={(checked) => {
+          onGuidesChange({ ...guides, halves: checked });
+        }}
+        testId="guide-halves"
+      />
+      <Toggle
+        label={t({ en: "Thirds", zh: "三等分" })}
+        checked={guides.thirds}
+        onChange={(checked) => {
+          onGuidesChange({ ...guides, thirds: checked });
+        }}
+        testId="guide-thirds"
+      />
+      <Toggle
+        label={t({ en: "Baseline", zh: "基线" })}
+        checked={guides.baseline}
+        onChange={(checked) => {
+          onGuidesChange({ ...guides, baseline: checked });
+        }}
+        testId="guide-baseline"
+      />
+    </fieldset>
+  );
+}
+
+interface ToggleProps {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  testId?: string;
+}
+
+function Toggle({ label, checked, onChange, testId }: ToggleProps) {
+  const id = useId();
+  return (
+    <label htmlFor={id} css={styles.toggle}>
+      <input
+        id={id}
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => {
+          onChange(event.target.checked);
+        }}
+        data-testid={testId}
+      />
+      <span>{label}</span>
+    </label>
+  );
+}
+
+const styles = stylex.create({
+  group: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: space._3,
+    padding: space._3,
+    border: `1px solid ${color.border}`,
+    borderRadius: border.radius_3,
+    backgroundColor: color.backgroundRaised,
+    margin: 0,
+  },
+  legend: {
+    paddingInline: space._2,
+    fontSize: font.uiBodySmall,
+    fontWeight: font.weight_7,
+    color: color.textMuted,
+    textTransform: "uppercase",
+    letterSpacing: ".05em",
+  },
+  toggle: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: space._1,
+    fontSize: font.uiBodySmall,
+    color: color.textMain,
+    cursor: "pointer",
+  },
+});

--- a/apps/web/src/components/sprite-editor/onion-skin-picker.tsx
+++ b/apps/web/src/components/sprite-editor/onion-skin-picker.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { useId } from "react";
+import { t } from "#src/i18n.ts";
+import { border, color, font, space } from "#src/tokens.stylex.ts";
+import type { CellPixels } from "./types";
+
+interface OnionSkinPickerProps {
+  cells: readonly (CellPixels | null)[];
+  /** The cell currently being edited — excluded from the onion options. */
+  currentCell: number;
+  /** Selected onion source, or null when off. */
+  onionSourceCell: number | null;
+  onChange: (next: number | null) => void;
+}
+
+export function OnionSkinPicker({
+  cells,
+  currentCell,
+  onionSourceCell,
+  onChange,
+}: OnionSkinPickerProps) {
+  const id = useId();
+  const cellLabel = t({ en: "Cell", zh: "单元格" });
+  return (
+    <div css={styles.root}>
+      <label htmlFor={id} css={styles.label}>
+        {t({ en: "Onion skin", zh: "洋葱皮" })}
+      </label>
+      <select
+        id={id}
+        css={styles.select}
+        value={onionSourceCell ?? ""}
+        onChange={(event) => {
+          const value = event.target.value;
+          if (value === "") {
+            onChange(null);
+            return;
+          }
+          onChange(Number(value));
+        }}
+        data-testid="onion-source"
+      >
+        <option value="">{t({ en: "Off", zh: "关闭" })}</option>
+        {cells.map((cell, index) => {
+          if (index === currentCell) return null;
+          if (cell === null) return null;
+          return (
+            <option
+              // eslint-disable-next-line @eslint-react/no-array-index-key -- cells are positional; index IS the identity
+              key={index}
+              value={index}
+            >
+              {cellLabel} {index + 1}
+            </option>
+          );
+        })}
+      </select>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  root: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: space._2,
+    paddingBlock: space._1,
+    paddingInline: space._2,
+    border: `1px solid ${color.border}`,
+    borderRadius: border.radius_2,
+    backgroundColor: color.backgroundRaised,
+    fontSize: font.uiBodySmall,
+  },
+  label: {
+    color: color.textMuted,
+  },
+  select: {
+    backgroundColor: color.backgroundMain,
+    color: color.textMain,
+    border: `1px solid ${color.border}`,
+    borderRadius: border.radius_2,
+    paddingBlock: space._1,
+    paddingInline: space._2,
+    fontSize: font.uiBodySmall,
+    fontFamily: "inherit",
+  },
+});

--- a/apps/web/src/components/sprite-editor/pixel-editor.tsx
+++ b/apps/web/src/components/sprite-editor/pixel-editor.tsx
@@ -1,0 +1,1372 @@
+"use client";
+
+import { ArrowCounterClockwiseIcon } from "@phosphor-icons/react/dist/ssr/ArrowCounterClockwise";
+import { ArrowUUpLeftIcon } from "@phosphor-icons/react/dist/ssr/ArrowUUpLeft";
+import { ArrowUUpRightIcon } from "@phosphor-icons/react/dist/ssr/ArrowUUpRight";
+import { CheckIcon } from "@phosphor-icons/react/dist/ssr/Check";
+import { CopyIcon } from "@phosphor-icons/react/dist/ssr/Copy";
+import { EraserIcon } from "@phosphor-icons/react/dist/ssr/Eraser";
+import { EyedropperIcon } from "@phosphor-icons/react/dist/ssr/Eyedropper";
+import { FlipHorizontalIcon } from "@phosphor-icons/react/dist/ssr/FlipHorizontal";
+import { FlipVerticalIcon } from "@phosphor-icons/react/dist/ssr/FlipVertical";
+import { FrameCornersIcon } from "@phosphor-icons/react/dist/ssr/FrameCorners";
+import { MagicWandIcon } from "@phosphor-icons/react/dist/ssr/MagicWand";
+import { PaintBucketIcon } from "@phosphor-icons/react/dist/ssr/PaintBucket";
+import { PencilSimpleIcon } from "@phosphor-icons/react/dist/ssr/PencilSimple";
+import { SelectionIcon } from "@phosphor-icons/react/dist/ssr/Selection";
+import { TrashIcon } from "@phosphor-icons/react/dist/ssr/Trash";
+import { XIcon } from "@phosphor-icons/react/dist/ssr/X";
+import * as stylex from "@stylexjs/stylex";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useMediaQuery } from "#src/hooks/use-media-query.ts";
+import { useTheme } from "#src/hooks/use-theme.ts";
+import { t } from "#src/i18n.ts";
+import { border, color, font, space } from "#src/tokens.stylex.ts";
+import type { CellPixels } from "./types";
+import { useHistory } from "./use-history";
+import type { GuideOptions } from "./utils/guides";
+import { computeGuideFractions } from "./utils/guides";
+import type { Rect } from "./utils/pixel-ops";
+import {
+  cloneCell,
+  cropCell,
+  eraseRect,
+  flipCellH,
+  flipCellV,
+  floodFill,
+  getPixel,
+  normalizeRect,
+  parseHex,
+  pasteCellScaled,
+  rgbaToHex,
+  setPixel,
+} from "./utils/pixel-ops";
+
+type Tool =
+  | "pencil"
+  | "eraser"
+  | "select"
+  | "eyedropper"
+  | "fill"
+  | "bg-remove";
+
+interface PixelEditorProps {
+  /** Source-of-truth cell pixels — what was sliced from the source image. */
+  baseCell: CellPixels;
+  /**
+   * The currently saved edit for this cell, or null if untouched. Drives
+   * initial state when switching cells.
+   */
+  savedEdit: CellPixels | null;
+  /** Called whenever the user makes a change. */
+  onCommit: (next: CellPixels) => void;
+  /** Called when the user clicks "revert" — drop the saved edit. */
+  onRevert: () => void;
+  /** Onion-skin overlay. */
+  onionCell?: CellPixels | null;
+  onionOpacity?: number;
+  /** Optional sub-cell guides drawn over the canvas. */
+  guides?: GuideOptions;
+}
+
+const DEFAULT_PALETTE = [
+  "#000000",
+  "#ffffff",
+  "#f3eded",
+  "#ff8000",
+  "#a855f7",
+  "#0ea5e9",
+  "#10b981",
+  "#fbbf24",
+  "#ef4444",
+  "#1ecc5a",
+];
+
+const RECENT_LIMIT = 8;
+const TOLERANCE_DEFAULT = 32;
+const MIN_SCALE = 1;
+const MAX_SCALE = 64;
+const HANDLE_SIZE = 10; // CSS px for the resize handle hit-area
+
+interface Transform {
+  scale: number; // CSS px per source pixel
+  panX: number; // CSS px offset of the cell origin within the canvas
+  panY: number;
+}
+
+/**
+ * Selection state. `marquee` is just an outline over the current cell —
+ * operations like Erase/Flip apply directly. `floating` means the rect's
+ * pixels have been lifted: `previewBase` is the cell with that rect cleared,
+ * `pixels` is the lifted content (always at its natural size), and `rect`
+ * is where it'll land on Apply (potentially with a different w/h, in which
+ * case the pixels get nearest-neighbor scaled).
+ */
+type Selection =
+  | { mode: "marquee"; rect: Rect }
+  | {
+      mode: "floating";
+      rect: Rect;
+      pixels: CellPixels;
+      previewBase: CellPixels;
+    };
+
+export function PixelEditor({
+  baseCell,
+  savedEdit,
+  onCommit,
+  onRevert,
+  onionCell,
+  onionOpacity = 0.3,
+  guides,
+}: PixelEditorProps) {
+  // The component is remounted with `key={cellIndex}` on cell switches, so
+  // history is naturally fresh per cell — no manual reset needed.
+  const [initial] = useState<CellPixels>(() =>
+    cloneCell(savedEdit ?? baseCell),
+  );
+  const history = useHistory<CellPixels>(initial);
+  const { present, presentRef, push, undo, redo, canUndo, canRedo, reset } =
+    history;
+
+  const isFirstSyncRef = useRef(true);
+  const skipNextSyncRef = useRef(false);
+  useEffect(() => {
+    if (isFirstSyncRef.current) {
+      isFirstSyncRef.current = false;
+      return;
+    }
+    if (skipNextSyncRef.current) {
+      skipNextSyncRef.current = false;
+      return;
+    }
+    onCommit(present);
+  }, [present, onCommit]);
+
+  const [tool, setTool] = useState<Tool>("pencil");
+  const [activeColor, setActiveColor] = useState<string>("#000000");
+  const [recent, setRecent] = useState<readonly string[]>([]);
+  const [tolerance, setTolerance] = useState(TOLERANCE_DEFAULT);
+  const [selection, setSelection] = useState<Selection | null>(null);
+  const [transform, setTransform] = useState<Transform | null>(null);
+
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
+
+  // Track effective theme (light/dark) so we can pick canvas-painted grid
+  // and cell-border colors that contrast with whichever side of the theme
+  // the user is on.
+  const [themePref] = useTheme();
+  const preferDark = useMediaQuery("(prefers-color-scheme: dark)", false);
+  const isDark = themePref === "system" ? preferDark : themePref === "dark";
+  const gridColor = isDark ? "rgba(255,255,255,0.18)" : "rgba(0,0,0,0.18)";
+  const cellBorderColor = isDark ? "rgba(255,255,255,0.4)" : "rgba(0,0,0,0.35)";
+
+  // Canvas size tracks the container so the cell can be panned around inside
+  // the wrapper at varying zoom without having to grow the canvas itself.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (el === null) return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      setContainerSize({
+        width: entry.contentRect.width,
+        height: entry.contentRect.height,
+      });
+    });
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  // Auto-fit transform when container or cell shape changes and there's no
+  // user transform yet. Stored-deps pattern.
+  const fitTransform = useMemo<Transform | null>(() => {
+    if (containerSize.width === 0 || containerSize.height === 0) return null;
+    const sx = Math.floor(containerSize.width / present.width);
+    const sy = Math.floor(containerSize.height / present.height);
+    const fit = Math.max(MIN_SCALE, Math.min(MAX_SCALE, Math.min(sx, sy)));
+    return {
+      scale: fit,
+      panX: Math.floor((containerSize.width - present.width * fit) / 2),
+      panY: Math.floor((containerSize.height - present.height * fit) / 2),
+    };
+  }, [containerSize, present.width, present.height]);
+
+  const [prevFitKey, setPrevFitKey] = useState<string | null>(null);
+  const fitKey =
+    fitTransform === null
+      ? null
+      : `${String(containerSize.width)}x${String(containerSize.height)}@${String(present.width)}x${String(present.height)}`;
+  if (fitKey !== prevFitKey && fitTransform !== null) {
+    setPrevFitKey(fitKey);
+    if (transform === null) setTransform(fitTransform);
+  }
+
+  const fitToView = useCallback(() => {
+    if (fitTransform !== null) setTransform(fitTransform);
+  }, [fitTransform]);
+
+  // Drawing.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (canvas === null || transform === null) return;
+    if (containerSize.width === 0 || containerSize.height === 0) return;
+    const dpr = typeof window === "undefined" ? 1 : window.devicePixelRatio;
+    canvas.width = Math.floor(containerSize.width * dpr);
+    canvas.height = Math.floor(containerSize.height * dpr);
+    canvas.style.width = `${String(containerSize.width)}px`;
+    canvas.style.height = `${String(containerSize.height)}px`;
+    const ctx = canvas.getContext("2d");
+    if (ctx === null) return;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, containerSize.width, containerSize.height);
+    ctx.imageSmoothingEnabled = false;
+
+    const { scale, panX, panY } = transform;
+    const cellW = present.width;
+    const cellH = present.height;
+
+    // 1) Transparency checkerboard is painted by the canvas element's CSS
+    // `background-image`, so it covers the entire viewport — including the
+    // area outside the cell rect. That gives a steady visual anchor when
+    // the user pans/zooms. The canvas itself stays transparent here; opaque
+    // cell pixels drawn below will cover the pattern, and transparent
+    // pixels (or the area outside the cell) let it show through.
+
+    // Determine what the visible cell is — `previewBase` while a selection
+    // is floating (the rect was lifted), otherwise just `present`.
+    const visibleBase =
+      selection !== null && selection.mode === "floating"
+        ? selection.previewBase
+        : present;
+
+    // 2) Cell pixels (drawn via offscreen at native size, then nearest-
+    // neighbor scaled). Alpha-blends naturally over the checker.
+    const off =
+      typeof OffscreenCanvas !== "undefined"
+        ? new OffscreenCanvas(cellW, cellH)
+        : null;
+    const drawCell = (cell: CellPixels) => {
+      if (off !== null) {
+        const offCtx = off.getContext("2d");
+        if (offCtx !== null) {
+          offCtx.clearRect(0, 0, cellW, cellH);
+          offCtx.putImageData(
+            new ImageData(cell.data, cell.width, cell.height),
+            0,
+            0,
+          );
+          ctx.drawImage(off, panX, panY, cellW * scale, cellH * scale);
+        }
+      } else {
+        for (let y = 0; y < cellH; y++) {
+          for (let x = 0; x < cellW; x++) {
+            const i = (y * cellW + x) * 4;
+            const a = cell.data[i + 3];
+            if (a === 0) continue;
+            ctx.fillStyle = `rgba(${String(cell.data[i])}, ${String(cell.data[i + 1])}, ${String(cell.data[i + 2])}, ${String(a / 255)})`;
+            ctx.fillRect(panX + x * scale, panY + y * scale, scale, scale);
+          }
+        }
+      }
+    };
+    drawCell(visibleBase);
+
+    // 3) Onion skin overlay (only when shape matches).
+    if (
+      onionCell !== null &&
+      onionCell !== undefined &&
+      onionCell.width === cellW &&
+      onionCell.height === cellH
+    ) {
+      ctx.globalAlpha = onionOpacity;
+      drawCell(onionCell);
+      ctx.globalAlpha = 1;
+    }
+
+    // 4) Floating selection — draw the lifted pixels at the current rect,
+    // scaled if w/h has changed via resize.
+    if (selection !== null && selection.mode === "floating") {
+      const r = selection.rect;
+      const offFloat =
+        typeof OffscreenCanvas !== "undefined"
+          ? new OffscreenCanvas(selection.pixels.width, selection.pixels.height)
+          : null;
+      if (offFloat !== null) {
+        const offCtx = offFloat.getContext("2d");
+        if (offCtx !== null) {
+          offCtx.putImageData(
+            new ImageData(
+              selection.pixels.data,
+              selection.pixels.width,
+              selection.pixels.height,
+            ),
+            0,
+            0,
+          );
+          ctx.drawImage(
+            offFloat,
+            panX + r.x * scale,
+            panY + r.y * scale,
+            r.w * scale,
+            r.h * scale,
+          );
+        }
+      }
+    }
+
+    // 5) Pixel grid — only when the user has zoomed in past the threshold,
+    // since at typical fit-view scales the grid lines just add visual noise
+    // on top of the diagonal-hash transparency pattern.
+    if (scale >= 24) {
+      ctx.strokeStyle = gridColor;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      for (let x = 0; x <= cellW; x++) {
+        const px = Math.round(panX + x * scale) + 0.5;
+        ctx.moveTo(px, panY);
+        ctx.lineTo(px, panY + cellH * scale);
+      }
+      for (let y = 0; y <= cellH; y++) {
+        const py = Math.round(panY + y * scale) + 0.5;
+        ctx.moveTo(panX, py);
+        ctx.lineTo(panX + cellW * scale, py);
+      }
+      ctx.stroke();
+    }
+
+    // 6) Cell border — always visible so the user knows where the
+    // editable area ends, especially when zoomed out.
+    ctx.strokeStyle = cellBorderColor;
+    ctx.lineWidth = 1;
+    ctx.strokeRect(
+      Math.round(panX) + 0.5,
+      Math.round(panY) + 0.5,
+      cellW * scale,
+      cellH * scale,
+    );
+
+    // 7) Sub-cell alignment guides.
+    if (guides !== undefined) {
+      const fractions = computeGuideFractions(guides);
+      if (fractions.vertical.length > 0 || fractions.horizontal.length > 0) {
+        ctx.strokeStyle = "rgba(251, 191, 36, 0.65)";
+        ctx.lineWidth = 1;
+        ctx.setLineDash([4, 4]);
+        ctx.beginPath();
+        for (const fx of fractions.vertical) {
+          const x = Math.round(panX + fx * cellW * scale) + 0.5;
+          ctx.moveTo(x, panY);
+          ctx.lineTo(x, panY + cellH * scale);
+        }
+        for (const fy of fractions.horizontal) {
+          const y = Math.round(panY + fy * cellH * scale) + 0.5;
+          ctx.moveTo(panX, y);
+          ctx.lineTo(panX + cellW * scale, y);
+        }
+        ctx.stroke();
+        ctx.setLineDash([]);
+      }
+    }
+
+    // 8) Selection marquee + bottom-right resize handle.
+    if (selection !== null) {
+      const r = selection.rect;
+      const sx = panX + r.x * scale;
+      const sy = panY + r.y * scale;
+      const sw = r.w * scale;
+      const sh = r.h * scale;
+      ctx.strokeStyle = "rgba(168, 85, 247, 0.95)";
+      ctx.lineWidth = 1.5;
+      ctx.setLineDash([6, 4]);
+      ctx.strokeRect(Math.round(sx) + 0.5, Math.round(sy) + 0.5, sw, sh);
+      ctx.setLineDash([]);
+
+      // Resize handle at bottom-right.
+      const hx = sx + sw;
+      const hy = sy + sh;
+      ctx.fillStyle = "rgba(168, 85, 247, 0.95)";
+      ctx.fillRect(
+        hx - HANDLE_SIZE / 2,
+        hy - HANDLE_SIZE / 2,
+        HANDLE_SIZE,
+        HANDLE_SIZE,
+      );
+      ctx.strokeStyle = "#ffffff";
+      ctx.lineWidth = 1;
+      ctx.strokeRect(
+        hx - HANDLE_SIZE / 2 + 0.5,
+        hy - HANDLE_SIZE / 2 + 0.5,
+        HANDLE_SIZE - 1,
+        HANDLE_SIZE - 1,
+      );
+    }
+  }, [
+    present,
+    transform,
+    containerSize,
+    onionCell,
+    onionOpacity,
+    guides,
+    selection,
+    gridColor,
+    cellBorderColor,
+  ]);
+
+  const remember = useCallback((hex: string) => {
+    setRecent((current) => {
+      const next = [hex, ...current.filter((c) => c !== hex)];
+      return next.slice(0, RECENT_LIMIT);
+    });
+  }, []);
+
+  // Selection action helpers ------------------------------------------------
+
+  /**
+   * Commit a floating selection back into the cell at its current rect
+   * (scaled if rect.w/h differ from the lifted pixels' natural size). For
+   * marquee selections, this is a no-op. Either way, the selection is
+   * cleared. Pushes a single history entry so the whole edit can be undone.
+   */
+  const commitSelection = useCallback(() => {
+    if (selection === null) return;
+    if (selection.mode === "floating") {
+      const next = cloneCell(selection.previewBase);
+      pasteCellScaled(
+        next,
+        selection.pixels,
+        selection.rect.x,
+        selection.rect.y,
+        selection.rect.w,
+        selection.rect.h,
+      );
+      push(next);
+    }
+    setSelection(null);
+  }, [push, selection]);
+
+  const cancelSelection = useCallback(() => {
+    setSelection(null);
+  }, []);
+
+  const eraseSelection = useCallback(() => {
+    if (selection === null) return;
+    if (selection.mode === "floating") {
+      // Already cleared in previewBase — just commit that.
+      push(cloneCell(selection.previewBase));
+    } else {
+      const next = cloneCell(presentRef.current);
+      eraseRect(next, selection.rect);
+      push(next);
+    }
+    setSelection(null);
+  }, [presentRef, push, selection]);
+
+  const flipSelection = useCallback(
+    (axis: "h" | "v") => {
+      if (selection === null) return;
+      if (selection.mode === "floating") {
+        const next = cloneCell(selection.pixels);
+        if (axis === "h") flipCellH(next);
+        else flipCellV(next);
+        setSelection({ ...selection, pixels: next });
+        return;
+      }
+      // Marquee: lift, flip the lifted pixels, but keep them floating so the
+      // user can still move/resize/erase.
+      const cropped = cropCell(presentRef.current, selection.rect);
+      if (axis === "h") flipCellH(cropped);
+      else flipCellV(cropped);
+      const previewBase = cloneCell(presentRef.current);
+      eraseRect(previewBase, selection.rect);
+      setSelection({
+        mode: "floating",
+        rect: selection.rect,
+        pixels: cropped,
+        previewBase,
+      });
+    },
+    [presentRef, selection],
+  );
+
+  const copySelection = useCallback(() => {
+    if (selection === null) return;
+    // "Copy" duplicates the contents at a +2,+2 offset and leaves the
+    // duplicate floating. The original stays in place.
+    const offset = 2;
+    const sourceCell =
+      selection.mode === "floating" ? selection.pixels : presentRef.current;
+    const sourceRect =
+      selection.mode === "floating"
+        ? { x: 0, y: 0, w: selection.pixels.width, h: selection.pixels.height }
+        : selection.rect;
+    const cropped = cropCell(sourceCell, sourceRect);
+    // The previewBase needs to reflect the original still being present,
+    // because we're DUPLICATING, not moving.
+    const previewBase =
+      selection.mode === "floating"
+        ? // Bake the original lifted pixels back into previewBase before
+          // creating the duplicate, otherwise we'd lose the original on
+          // commit.
+          (() => {
+            const baked = cloneCell(selection.previewBase);
+            pasteCellScaled(
+              baked,
+              selection.pixels,
+              selection.rect.x,
+              selection.rect.y,
+              selection.rect.w,
+              selection.rect.h,
+            );
+            return baked;
+          })()
+        : cloneCell(presentRef.current);
+    setSelection({
+      mode: "floating",
+      rect: {
+        x: selection.rect.x + offset,
+        y: selection.rect.y + offset,
+        w: selection.rect.w,
+        h: selection.rect.h,
+      },
+      pixels: cropped,
+      previewBase,
+    });
+  }, [presentRef, selection]);
+
+  // Tool actions ------------------------------------------------------------
+
+  const applyAtPixel = useCallback(
+    (px: number, py: number, isDrag: boolean) => {
+      const current = presentRef.current;
+      const next = cloneCell(current);
+      const rgba = parseHex(activeColor);
+      const transparent = [0, 0, 0, 0] as const;
+
+      if (tool === "pencil") {
+        setPixel(next, px, py, rgba);
+        push(next);
+        if (!isDrag) remember(activeColor);
+        return;
+      }
+      if (tool === "eraser") {
+        setPixel(next, px, py, transparent);
+        push(next);
+        return;
+      }
+      if (tool === "eyedropper") {
+        const sample = getPixel(current, px, py);
+        if (sample === null) return;
+        if (sample[3] === 0) return;
+        const hex = rgbaToHex(sample[0], sample[1], sample[2]);
+        setActiveColor(hex);
+        remember(hex);
+        return;
+      }
+      if (tool === "fill") {
+        floodFill(next, px, py, rgba, 0);
+        push(next);
+        remember(activeColor);
+        return;
+      }
+      // bg-remove
+      floodFill(next, px, py, transparent, tolerance);
+      push(next);
+    },
+    [activeColor, presentRef, push, remember, tool, tolerance],
+  );
+
+  // Pointer handling --------------------------------------------------------
+
+  type DragKind =
+    | { kind: "paint"; lastX: number; lastY: number }
+    | {
+        kind: "pan";
+        startX: number;
+        startY: number;
+        basePan: { x: number; y: number };
+      }
+    | { kind: "marquee"; startX: number; startY: number }
+    | { kind: "move"; startX: number; startY: number; baseRect: Rect }
+    | { kind: "resize"; baseRect: Rect };
+
+  const dragRef = useRef<({ pointerId: number } & DragKind) | null>(null);
+
+  const pointerToCanvas = (
+    event: React.PointerEvent<HTMLCanvasElement>,
+  ): { cx: number; cy: number } => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    return {
+      cx: event.clientX - rect.left,
+      cy: event.clientY - rect.top,
+    };
+  };
+
+  const canvasToPixel = (
+    cx: number,
+    cy: number,
+  ): readonly [number, number] | null => {
+    if (transform === null) return null;
+    const px = Math.floor((cx - transform.panX) / transform.scale);
+    const py = Math.floor((cy - transform.panY) / transform.scale);
+    if (px < 0 || py < 0 || px >= present.width || py >= present.height) {
+      return null;
+    }
+    return [px, py];
+  };
+
+  const isOnResizeHandle = (cx: number, cy: number): boolean => {
+    if (selection === null || transform === null) return false;
+    const r = selection.rect;
+    const hx = transform.panX + (r.x + r.w) * transform.scale;
+    const hy = transform.panY + (r.y + r.h) * transform.scale;
+    return (
+      Math.abs(cx - hx) <= HANDLE_SIZE / 2 + 2 &&
+      Math.abs(cy - hy) <= HANDLE_SIZE / 2 + 2
+    );
+  };
+
+  const isInsideSelectionRect = (px: number, py: number): boolean => {
+    if (selection === null) return false;
+    const r = selection.rect;
+    return px >= r.x && py >= r.y && px < r.x + r.w && py < r.y + r.h;
+  };
+
+  /** Lift the current marquee selection to floating state. No-op otherwise. */
+  const liftIfMarquee = (sel: Selection): Selection => {
+    if (sel.mode === "floating") return sel;
+    const cropped = cropCell(presentRef.current, sel.rect);
+    const previewBase = cloneCell(presentRef.current);
+    eraseRect(previewBase, sel.rect);
+    return {
+      mode: "floating",
+      rect: sel.rect,
+      pixels: cropped,
+      previewBase,
+    };
+  };
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLCanvasElement>) => {
+    if (event.button !== 0 && event.button !== 1) return;
+    if (transform === null) return;
+    const { cx, cy } = pointerToCanvas(event);
+
+    // Pan: middle-click or Shift + left-click.
+    if (event.button === 1 || event.shiftKey) {
+      event.currentTarget.setPointerCapture(event.pointerId);
+      dragRef.current = {
+        pointerId: event.pointerId,
+        kind: "pan",
+        startX: cx,
+        startY: cy,
+        basePan: { x: transform.panX, y: transform.panY },
+      };
+      return;
+    }
+
+    if (tool === "select") {
+      // Resize-handle takes priority over inside-selection so users can
+      // grab the corner even when it's near the rect edge.
+      if (isOnResizeHandle(cx, cy) && selection !== null) {
+        event.currentTarget.setPointerCapture(event.pointerId);
+        const lifted = liftIfMarquee(selection);
+        setSelection(lifted);
+        dragRef.current = {
+          pointerId: event.pointerId,
+          kind: "resize",
+          baseRect: { ...lifted.rect },
+        };
+        return;
+      }
+      const point = canvasToPixel(cx, cy);
+      if (
+        point !== null &&
+        isInsideSelectionRect(point[0], point[1]) &&
+        selection !== null
+      ) {
+        event.currentTarget.setPointerCapture(event.pointerId);
+        const lifted = liftIfMarquee(selection);
+        setSelection(lifted);
+        dragRef.current = {
+          pointerId: event.pointerId,
+          kind: "move",
+          startX: cx,
+          startY: cy,
+          baseRect: { ...lifted.rect },
+        };
+        return;
+      }
+      // Click outside: commit any existing floating selection, then start a
+      // new marquee from the click point.
+      if (selection !== null) {
+        commitSelection();
+      }
+      if (point === null) return;
+      event.currentTarget.setPointerCapture(event.pointerId);
+      setSelection({
+        mode: "marquee",
+        rect: { x: point[0], y: point[1], w: 0, h: 0 },
+      });
+      dragRef.current = {
+        pointerId: event.pointerId,
+        kind: "marquee",
+        startX: point[0],
+        startY: point[1],
+      };
+      return;
+    }
+
+    // Painting tools.
+    const point = canvasToPixel(cx, cy);
+    if (point === null) return;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    dragRef.current = {
+      pointerId: event.pointerId,
+      kind: "paint",
+      lastX: point[0],
+      lastY: point[1],
+    };
+    applyAtPixel(point[0], point[1], false);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLCanvasElement>) => {
+    const drag = dragRef.current;
+    if (drag === null || event.pointerId !== drag.pointerId) return;
+    if (transform === null) return;
+    const { cx, cy } = pointerToCanvas(event);
+
+    if (drag.kind === "pan") {
+      setTransform({
+        scale: transform.scale,
+        panX: drag.basePan.x + (cx - drag.startX),
+        panY: drag.basePan.y + (cy - drag.startY),
+      });
+      return;
+    }
+    if (drag.kind === "marquee") {
+      const point = canvasToPixel(cx, cy);
+      if (point === null) return;
+      // The rectangle covers from start to end inclusive.
+      const x = Math.min(drag.startX, point[0]);
+      const y = Math.min(drag.startY, point[1]);
+      const w = Math.abs(point[0] - drag.startX) + 1;
+      const h = Math.abs(point[1] - drag.startY) + 1;
+      setSelection({ mode: "marquee", rect: { x, y, w, h } });
+      return;
+    }
+    if (drag.kind === "move") {
+      const sel = selection;
+      if (sel === null || sel.mode !== "floating") return;
+      const dx = Math.round((cx - drag.startX) / transform.scale);
+      const dy = Math.round((cy - drag.startY) / transform.scale);
+      setSelection({
+        ...sel,
+        rect: {
+          x: drag.baseRect.x + dx,
+          y: drag.baseRect.y + dy,
+          w: drag.baseRect.w,
+          h: drag.baseRect.h,
+        },
+      });
+      return;
+    }
+    if (drag.kind === "resize") {
+      const sel = selection;
+      if (sel === null || sel.mode !== "floating") return;
+      const handlePixelX = Math.round((cx - transform.panX) / transform.scale);
+      const handlePixelY = Math.round((cy - transform.panY) / transform.scale);
+      const w = Math.max(1, handlePixelX - drag.baseRect.x);
+      const h = Math.max(1, handlePixelY - drag.baseRect.y);
+      setSelection({ ...sel, rect: { ...drag.baseRect, w, h } });
+      return;
+    }
+    // Paint — drag.kind is narrowed to "paint" here.
+    if (tool !== "pencil" && tool !== "eraser") return;
+    const point = canvasToPixel(cx, cy);
+    if (point === null) return;
+    if (point[0] === drag.lastX && point[1] === drag.lastY) return;
+    drag.lastX = point[0];
+    drag.lastY = point[1];
+    applyAtPixel(point[0], point[1], true);
+  };
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLCanvasElement>) => {
+    if (
+      dragRef.current !== null &&
+      event.pointerId === dragRef.current.pointerId &&
+      event.currentTarget.hasPointerCapture(event.pointerId)
+    ) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    const drag = dragRef.current;
+    dragRef.current = null;
+    if (drag === null) return;
+    // Drop a zero-area marquee — can happen on a quick click.
+    if (drag.kind === "marquee" && selection !== null) {
+      const r = normalizeRect(selection.rect);
+      if (r.w < 1 || r.h < 1) {
+        setSelection(null);
+      } else {
+        setSelection({ mode: "marquee", rect: r });
+      }
+    }
+  };
+
+  // Wheel zoom — native non-passive listener so preventDefault stops the page
+  // from scrolling.
+  const transformRef = useRef(transform);
+  useEffect(() => {
+    transformRef.current = transform;
+  }, [transform]);
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (canvas === null) return;
+    const onWheel = (event: WheelEvent) => {
+      const current = transformRef.current;
+      if (current === null) return;
+      event.preventDefault();
+      const rect = canvas.getBoundingClientRect();
+      const cx = event.clientX - rect.left;
+      const cy = event.clientY - rect.top;
+      // Integer scale steps so pixels stay crisp.
+      const dir = event.deltaY < 0 ? 1 : -1;
+      const nextScale = Math.max(
+        MIN_SCALE,
+        Math.min(MAX_SCALE, current.scale + dir),
+      );
+      if (nextScale === current.scale) return;
+      const px = (cx - current.panX) / current.scale;
+      const py = (cy - current.panY) / current.scale;
+      setTransform({
+        scale: nextScale,
+        panX: cx - px * nextScale,
+        panY: cy - py * nextScale,
+      });
+    };
+    canvas.addEventListener("wheel", onWheel, { passive: false });
+    return () => {
+      canvas.removeEventListener("wheel", onWheel);
+    };
+  }, []);
+
+  // Keyboard shortcuts.
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      const meta = event.metaKey || event.ctrlKey;
+      if (meta) {
+        const key = event.key.toLowerCase();
+        if (key === "z" && !event.shiftKey) {
+          event.preventDefault();
+          undo();
+          return;
+        }
+        if ((key === "z" && event.shiftKey) || key === "y") {
+          event.preventDefault();
+          redo();
+          return;
+        }
+      }
+      if (selection !== null) {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          cancelSelection();
+        } else if (event.key === "Enter") {
+          event.preventDefault();
+          commitSelection();
+        } else if (event.key === "Delete" || event.key === "Backspace") {
+          event.preventDefault();
+          eraseSelection();
+        }
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [undo, redo, selection, cancelSelection, commitSelection, eraseSelection]);
+
+  const switchTool = useCallback(
+    (next: Tool) => {
+      if (selection !== null) commitSelection();
+      setTool(next);
+    },
+    [commitSelection, selection],
+  );
+
+  const cursorClass = (() => {
+    if (tool === "select") return styles.canvasSelect;
+    return styles.canvasPaint;
+  })();
+
+  const flipHLabel = t({ en: "Flip horizontal", zh: "水平翻转" });
+  const flipVLabel = t({ en: "Flip vertical", zh: "垂直翻转" });
+  const eraseLabel = t({ en: "Erase", zh: "擦除" });
+  const copyLabel = t({ en: "Copy", zh: "复制" });
+  const applyLabel = t({ en: "Apply", zh: "应用" });
+  const cancelLabel = t({ en: "Cancel", zh: "取消" });
+
+  return (
+    <div css={styles.root}>
+      <div
+        css={styles.toolbar}
+        role="toolbar"
+        aria-label={t({ en: "Tools", zh: "工具" })}
+      >
+        <ToolButton
+          icon={<PencilSimpleIcon size={18} weight="bold" />}
+          label={t({ en: "Pencil", zh: "铅笔" })}
+          active={tool === "pencil"}
+          onClick={() => {
+            switchTool("pencil");
+          }}
+          testId="tool-pencil"
+        />
+        <ToolButton
+          icon={<EraserIcon size={18} weight="bold" />}
+          label={t({ en: "Eraser", zh: "橡皮" })}
+          active={tool === "eraser"}
+          onClick={() => {
+            switchTool("eraser");
+          }}
+          testId="tool-eraser"
+        />
+        <ToolButton
+          icon={<SelectionIcon size={18} weight="bold" />}
+          label={t({ en: "Range select", zh: "区域选择" })}
+          active={tool === "select"}
+          onClick={() => {
+            switchTool("select");
+          }}
+          testId="tool-select"
+        />
+        <ToolButton
+          icon={<EyedropperIcon size={18} weight="bold" />}
+          label={t({ en: "Eyedropper", zh: "取色" })}
+          active={tool === "eyedropper"}
+          onClick={() => {
+            switchTool("eyedropper");
+          }}
+          testId="tool-eyedropper"
+        />
+        <ToolButton
+          icon={<PaintBucketIcon size={18} weight="bold" />}
+          label={t({ en: "Fill", zh: "填充" })}
+          active={tool === "fill"}
+          onClick={() => {
+            switchTool("fill");
+          }}
+          testId="tool-fill"
+        />
+        <ToolButton
+          icon={<MagicWandIcon size={18} weight="bold" />}
+          label={t({ en: "Remove background", zh: "去背景" })}
+          active={tool === "bg-remove"}
+          onClick={() => {
+            switchTool("bg-remove");
+          }}
+          testId="tool-bg-remove"
+        />
+        <span css={styles.spacer} />
+        <ToolButton
+          icon={<FrameCornersIcon size={18} weight="bold" />}
+          label={t({ en: "Fit view", zh: "适应视图" })}
+          onClick={fitToView}
+          testId="tool-fit"
+        />
+        <ToolButton
+          icon={<ArrowUUpLeftIcon size={18} weight="bold" />}
+          label={t({ en: "Undo", zh: "撤销" })}
+          onClick={undo}
+          disabled={!canUndo}
+          testId="tool-undo"
+        />
+        <ToolButton
+          icon={<ArrowUUpRightIcon size={18} weight="bold" />}
+          label={t({ en: "Redo", zh: "重做" })}
+          onClick={redo}
+          disabled={!canRedo}
+          testId="tool-redo"
+        />
+        <ToolButton
+          icon={<ArrowCounterClockwiseIcon size={18} weight="bold" />}
+          label={t({ en: "Revert", zh: "还原" })}
+          onClick={() => {
+            skipNextSyncRef.current = true;
+            reset(cloneCell(baseCell));
+            onRevert();
+          }}
+          testId="tool-revert"
+        />
+      </div>
+
+      <div css={styles.colorRow}>
+        <label css={styles.colorLabel}>
+          <span>{t({ en: "Color", zh: "颜色" })}</span>
+          <input
+            type="color"
+            value={activeColor}
+            onChange={(event) => {
+              setActiveColor(event.target.value);
+            }}
+            css={styles.colorInput}
+            data-testid="color-input"
+          />
+        </label>
+        <div css={styles.swatches}>
+          {DEFAULT_PALETTE.map((hex) => (
+            <button
+              key={hex}
+              type="button"
+              css={[styles.swatch, activeColor === hex && styles.swatchActive]}
+              style={{ backgroundColor: hex }}
+              aria-label={hex}
+              onClick={() => {
+                setActiveColor(hex);
+                remember(hex);
+              }}
+            />
+          ))}
+        </div>
+        {recent.length > 0 ? (
+          <div
+            css={styles.swatches}
+            aria-label={t({ en: "Recent colors", zh: "最近颜色" })}
+          >
+            {recent.map((hex) => (
+              <button
+                key={hex}
+                type="button"
+                css={[
+                  styles.swatch,
+                  activeColor === hex && styles.swatchActive,
+                ]}
+                style={{ backgroundColor: hex }}
+                aria-label={hex}
+                onClick={() => {
+                  setActiveColor(hex);
+                }}
+              />
+            ))}
+          </div>
+        ) : null}
+        {tool === "bg-remove" ? (
+          <label css={styles.colorLabel}>
+            <span>{t({ en: "Tolerance", zh: "容差" })}</span>
+            <input
+              type="range"
+              min={0}
+              max={128}
+              value={tolerance}
+              onChange={(event) => {
+                setTolerance(Number(event.target.value));
+              }}
+              data-testid="tolerance"
+            />
+            <span css={styles.toleranceValue}>{tolerance}</span>
+          </label>
+        ) : null}
+      </div>
+
+      <div ref={containerRef} css={styles.canvasArea}>
+        <canvas
+          ref={canvasRef}
+          css={[styles.canvas, cursorClass]}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
+          data-testid="pixel-canvas"
+        />
+        {selection !== null ? (
+          <div
+            css={styles.selectionBar}
+            role="toolbar"
+            aria-label={t({ en: "Selection actions", zh: "选区操作" })}
+          >
+            <SelectionButton
+              icon={<TrashIcon size={16} weight="bold" />}
+              label={eraseLabel}
+              onClick={eraseSelection}
+              testId="selection-erase"
+            />
+            <SelectionButton
+              icon={<CopyIcon size={16} weight="bold" />}
+              label={copyLabel}
+              onClick={copySelection}
+              testId="selection-copy"
+            />
+            <SelectionButton
+              icon={<FlipHorizontalIcon size={16} weight="bold" />}
+              label={flipHLabel}
+              onClick={() => {
+                flipSelection("h");
+              }}
+              testId="selection-flip-h"
+            />
+            <SelectionButton
+              icon={<FlipVerticalIcon size={16} weight="bold" />}
+              label={flipVLabel}
+              onClick={() => {
+                flipSelection("v");
+              }}
+              testId="selection-flip-v"
+            />
+            <span css={styles.selectionDivider} aria-hidden="true" />
+            <SelectionButton
+              icon={<CheckIcon size={16} weight="bold" />}
+              label={applyLabel}
+              onClick={commitSelection}
+              testId="selection-apply"
+              variant="primary"
+            />
+            <SelectionButton
+              icon={<XIcon size={16} weight="bold" />}
+              label={cancelLabel}
+              onClick={cancelSelection}
+              testId="selection-cancel"
+            />
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+interface ToolButtonProps {
+  icon: React.ReactNode;
+  label: string;
+  active?: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+  testId?: string;
+}
+
+function ToolButton({
+  icon,
+  label,
+  active,
+  disabled,
+  onClick,
+  testId,
+}: ToolButtonProps) {
+  return (
+    <button
+      type="button"
+      css={[styles.toolButton, active && styles.toolButtonActive]}
+      title={label}
+      aria-label={label}
+      aria-pressed={active}
+      disabled={disabled}
+      onClick={onClick}
+      data-testid={testId}
+    >
+      {icon}
+    </button>
+  );
+}
+
+interface SelectionButtonProps {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  testId?: string;
+  variant?: "primary";
+}
+
+function SelectionButton({
+  icon,
+  label,
+  onClick,
+  testId,
+  variant,
+}: SelectionButtonProps) {
+  return (
+    <button
+      type="button"
+      css={[
+        styles.selectionButton,
+        variant === "primary" && styles.selectionButtonPrimary,
+      ]}
+      onClick={onClick}
+      data-testid={testId}
+    >
+      <span css={styles.selectionIcon} aria-hidden="true">
+        {icon}
+      </span>
+      <span>{label}</span>
+    </button>
+  );
+}
+
+const styles = stylex.create({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space._2,
+    height: "100%",
+    minHeight: 0,
+  },
+  toolbar: {
+    display: "flex",
+    flexWrap: "wrap",
+    alignItems: "center",
+    gap: space._1,
+    padding: space._2,
+    backgroundColor: color.backgroundRaised,
+    border: `1px solid ${color.border}`,
+    borderRadius: border.radius_2,
+  },
+  spacer: {
+    flex: "1",
+  },
+  toolButton: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "32px",
+    height: "32px",
+    border: `1px solid ${color.border}`,
+    borderRadius: border.radius_2,
+    backgroundColor: {
+      default: color.backgroundMain,
+      ":hover:not(:disabled)": color.backgroundHover,
+    },
+    color: color.textMain,
+    cursor: { default: "pointer", ":disabled": "not-allowed" },
+    opacity: { default: 1, ":disabled": 0.4 },
+  },
+  toolButtonActive: {
+    backgroundColor: color.brandPixelCreatureCreator,
+    color: color.textOnActive,
+    borderColor: color.brandPixelCreatureCreator,
+  },
+  colorRow: {
+    display: "flex",
+    flexWrap: "wrap",
+    alignItems: "center",
+    gap: space._2,
+    padding: space._2,
+    backgroundColor: color.backgroundRaised,
+    border: `1px solid ${color.border}`,
+    borderRadius: border.radius_2,
+  },
+  colorLabel: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: space._1,
+    fontSize: font.uiBodySmall,
+    color: color.textMuted,
+  },
+  colorInput: {
+    width: "32px",
+    height: "32px",
+    padding: 0,
+    border: `1px solid ${color.border}`,
+    borderRadius: border.radius_2,
+    backgroundColor: "transparent",
+    cursor: "pointer",
+  },
+  swatches: {
+    display: "flex",
+    gap: "2px",
+  },
+  swatch: {
+    width: "24px",
+    height: "24px",
+    border: `1px solid ${color.border}`,
+    borderRadius: "4px",
+    cursor: "pointer",
+    padding: 0,
+  },
+  swatchActive: {
+    outline: `2px solid ${color.brandPixelCreatureCreator}`,
+    outlineOffset: "1px",
+  },
+  toleranceValue: {
+    minWidth: "2.5em",
+    textAlign: "right",
+    fontSize: font.uiBodySmall,
+    color: color.textMain,
+    fontVariantNumeric: "tabular-nums",
+  },
+  canvasArea: {
+    position: "relative",
+    backgroundColor: color.backgroundRaised,
+    border: `1px solid ${color.border}`,
+    borderRadius: border.radius_3,
+    flex: "1",
+    minHeight: 0,
+    overflow: "hidden",
+  },
+  canvas: {
+    display: "block",
+    width: "100%",
+    height: "100%",
+    touchAction: "none",
+    imageRendering: "pixelated",
+    backgroundColor: color.backgroundMain,
+    backgroundImage: `linear-gradient(45deg, ${color.border} 25%, transparent 25%), linear-gradient(-45deg, ${color.border} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${color.border} 75%), linear-gradient(-45deg, transparent 75%, ${color.border} 75%)`,
+    backgroundSize: "16px 16px",
+    backgroundPosition: "0 0, 0 8px, 8px -8px, -8px 0px",
+  },
+  canvasPaint: {
+    cursor: "crosshair",
+  },
+  canvasSelect: {
+    cursor: "cell",
+  },
+  selectionBar: {
+    position: "absolute",
+    insetBlockStart: space._2,
+    insetInlineStart: "50%",
+    transform: "translateX(-50%)",
+    display: "flex",
+    alignItems: "center",
+    gap: "2px",
+    padding: "4px",
+    backgroundColor: color.backgroundMain,
+    border: `1px solid ${color.border}`,
+    borderRadius: border.radius_2,
+    boxShadow: "0 2px 8px rgba(0,0,0,0.18)",
+    flexWrap: "wrap",
+    maxInlineSize: "calc(100% - 24px)",
+    justifyContent: "center",
+  },
+  selectionButton: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "4px",
+    paddingBlock: "4px",
+    paddingInline: space._1,
+    backgroundColor: {
+      default: "transparent",
+      ":hover": color.backgroundHover,
+    },
+    color: color.textMain,
+    border: "none",
+    borderRadius: border.radius_1,
+    fontSize: font.uiBodySmall,
+    fontWeight: font.weight_6,
+    cursor: "pointer",
+    fontFamily: "inherit",
+  },
+  selectionButtonPrimary: {
+    backgroundColor: {
+      default: color.brandPixelCreatureCreator,
+      ":hover": color.controlActive,
+    },
+    color: color.textOnActive,
+  },
+  selectionIcon: {
+    display: "inline-flex",
+  },
+  selectionDivider: {
+    width: "1px",
+    height: "18px",
+    backgroundColor: color.border,
+    marginInline: "2px",
+  },
+});

--- a/apps/web/src/components/sprite-editor/source-canvas.tsx
+++ b/apps/web/src/components/sprite-editor/source-canvas.tsx
@@ -1,0 +1,359 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { useEffect, useId, useRef, useState } from "react";
+import { t } from "#src/i18n.ts";
+import { border, color } from "#src/tokens.stylex.ts";
+import type { GridConfig, SourceImage } from "./types";
+
+interface SourceCanvasProps {
+  source: SourceImage;
+  grid: GridConfig;
+  selectedCell: number | null;
+  onCellSelect: (index: number | null) => void;
+  /** Optional overlay drawn over the grid (e.g. sub-cell guides in Phase 3). */
+  drawOverlay?: (
+    ctx: CanvasRenderingContext2D,
+    pixelToCanvas: (x: number, y: number) => readonly [number, number],
+    pixelsPerUnit: number,
+  ) => void;
+}
+
+interface ViewTransform {
+  /** Top-left of the source image in canvas-pixel space. */
+  panX: number;
+  panY: number;
+  /** Source pixels per canvas pixel. */
+  scale: number;
+}
+
+const MIN_SCALE = 0.05;
+const MAX_SCALE = 32;
+
+export function SourceCanvas({
+  source,
+  grid,
+  selectedCell,
+  onCellSelect,
+  drawOverlay,
+}: SourceCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [viewport, setViewport] = useState({ width: 0, height: 0 });
+  const [transform, setTransform] = useState<ViewTransform | null>(null);
+  const [isPanning, setIsPanning] = useState(false);
+  const panStateRef = useRef<{
+    pointerId: number;
+    startCanvasX: number;
+    startCanvasY: number;
+    startPanX: number;
+    startPanY: number;
+  } | null>(null);
+  const headingId = useId();
+
+  // Track container size with ResizeObserver — canvas size in CSS pixels
+  // drives the device-pixel buffer size below.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (el === null) return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      const rect = entry.contentRect;
+      setViewport({ width: rect.width, height: rect.height });
+    });
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  // Reset transform whenever the source or viewport size changes — fit the
+  // image into the available area. Stored-deps pattern so the reset happens
+  // during the render that detects the change, rather than in an effect
+  // (avoids the react-hooks/set-state-in-effect cascade).
+  const [prevFit, setPrevFit] = useState<{
+    source: SourceImage | null;
+    width: number;
+    height: number;
+  }>({ source: null, width: 0, height: 0 });
+  if (
+    prevFit.source !== source ||
+    prevFit.width !== viewport.width ||
+    prevFit.height !== viewport.height
+  ) {
+    setPrevFit({
+      source,
+      width: viewport.width,
+      height: viewport.height,
+    });
+    if (viewport.width > 0 && viewport.height > 0) {
+      const scaleX = viewport.width / source.width;
+      const scaleY = viewport.height / source.height;
+      const fit = Math.min(scaleX, scaleY) * 0.95;
+      const scale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, fit));
+      const drawnW = source.width * scale;
+      const drawnH = source.height * scale;
+      setTransform({
+        panX: (viewport.width - drawnW) / 2,
+        panY: (viewport.height - drawnH) / 2,
+        scale,
+      });
+    }
+  }
+
+  // Render whenever the source, transform, grid, or selection changes.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (canvas === null || transform === null) return;
+    if (viewport.width === 0 || viewport.height === 0) return;
+    const dpr = typeof window === "undefined" ? 1 : window.devicePixelRatio;
+    canvas.width = Math.floor(viewport.width * dpr);
+    canvas.height = Math.floor(viewport.height * dpr);
+    canvas.style.width = `${String(viewport.width)}px`;
+    canvas.style.height = `${String(viewport.height)}px`;
+    const ctx = canvas.getContext("2d");
+    if (ctx === null) return;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, viewport.width, viewport.height);
+
+    // Transparency checkerboard is painted by the container's CSS background
+    // (theme-aware) so it shows through transparent regions of the source.
+
+    // Source image.
+    ctx.imageSmoothingEnabled = false;
+    const drawnW = source.width * transform.scale;
+    const drawnH = source.height * transform.scale;
+    ctx.drawImage(
+      source.bitmap,
+      transform.panX,
+      transform.panY,
+      drawnW,
+      drawnH,
+    );
+
+    const pixelToCanvas = (x: number, y: number): readonly [number, number] => [
+      transform.panX + x * transform.scale,
+      transform.panY + y * transform.scale,
+    ];
+
+    // Grid cell outlines — each cell drawn as its own rectangle so gaps
+    // between cells are visually obvious.
+    ctx.lineWidth = 1;
+    ctx.strokeStyle = "rgba(168, 85, 247, 0.85)";
+    const cellPitchX = grid.cellWidth + grid.gapX;
+    const cellPitchY = grid.cellHeight + grid.gapY;
+    for (let r = 0; r < grid.rows; r++) {
+      for (let c = 0; c < grid.cols; c++) {
+        const [x0, y0] = pixelToCanvas(
+          grid.offsetX + c * cellPitchX,
+          grid.offsetY + r * cellPitchY,
+        );
+        const w = grid.cellWidth * transform.scale;
+        const h = grid.cellHeight * transform.scale;
+        ctx.strokeRect(Math.round(x0) + 0.5, Math.round(y0) + 0.5, w, h);
+      }
+    }
+
+    // Selection highlight.
+    if (selectedCell !== null) {
+      const col = selectedCell % grid.cols;
+      const row = Math.floor(selectedCell / grid.cols);
+      const [x0, y0] = pixelToCanvas(
+        grid.offsetX + col * cellPitchX,
+        grid.offsetY + row * cellPitchY,
+      );
+      const w = grid.cellWidth * transform.scale;
+      const h = grid.cellHeight * transform.scale;
+      ctx.lineWidth = 2;
+      ctx.strokeStyle = "#fbbf24";
+      ctx.strokeRect(Math.round(x0) - 1, Math.round(y0) - 1, w + 2, h + 2);
+    }
+
+    if (drawOverlay !== undefined) {
+      drawOverlay(ctx, pixelToCanvas, transform.scale);
+    }
+  }, [
+    source,
+    transform,
+    viewport.width,
+    viewport.height,
+    grid,
+    selectedCell,
+    drawOverlay,
+  ]);
+
+  const canvasToImage = (
+    canvasX: number,
+    canvasY: number,
+  ): readonly [number, number] | null => {
+    if (transform === null) return null;
+    const ix = (canvasX - transform.panX) / transform.scale;
+    const iy = (canvasY - transform.panY) / transform.scale;
+    return [ix, iy];
+  };
+
+  // Native non-passive wheel listener so preventDefault() actually stops the
+  // page from scrolling while the user zooms. React's JSX `onWheel` is
+  // attached as passive in modern browsers, which silently swallows
+  // event.preventDefault().
+  const transformRef = useRef(transform);
+  useEffect(() => {
+    transformRef.current = transform;
+  }, [transform]);
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (canvas === null) return;
+    const onWheel = (event: WheelEvent) => {
+      const current = transformRef.current;
+      if (current === null) return;
+      event.preventDefault();
+      const rect = canvas.getBoundingClientRect();
+      const cx = event.clientX - rect.left;
+      const cy = event.clientY - rect.top;
+      const factor = Math.exp(-event.deltaY * 0.0015);
+      const nextScale = Math.max(
+        MIN_SCALE,
+        Math.min(MAX_SCALE, current.scale * factor),
+      );
+      // Anchor zoom on the cursor: the source-space point under the cursor
+      // should stay under the cursor after the scale change.
+      const ix = (cx - current.panX) / current.scale;
+      const iy = (cy - current.panY) / current.scale;
+      setTransform({
+        scale: nextScale,
+        panX: cx - ix * nextScale,
+        panY: cy - iy * nextScale,
+      });
+    };
+    canvas.addEventListener("wheel", onWheel, { passive: false });
+    return () => {
+      canvas.removeEventListener("wheel", onWheel);
+    };
+  }, []);
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLCanvasElement>) => {
+    if (transform === null) return;
+    const rect = event.currentTarget.getBoundingClientRect();
+    const cx = event.clientX - rect.left;
+    const cy = event.clientY - rect.top;
+
+    // Middle-click or Shift+left-click pans; plain left-click selects a cell.
+    const wantsPan = event.button === 1 || event.shiftKey;
+    if (wantsPan || event.button !== 0) {
+      event.currentTarget.setPointerCapture(event.pointerId);
+      panStateRef.current = {
+        pointerId: event.pointerId,
+        startCanvasX: cx,
+        startCanvasY: cy,
+        startPanX: transform.panX,
+        startPanY: transform.panY,
+      };
+      setIsPanning(true);
+      return;
+    }
+
+    const imagePoint = canvasToImage(cx, cy);
+    if (imagePoint === null) return;
+    const [ix, iy] = imagePoint;
+    const localX = ix - grid.offsetX;
+    const localY = iy - grid.offsetY;
+    const pitchX = grid.cellWidth + grid.gapX;
+    const pitchY = grid.cellHeight + grid.gapY;
+    const col = Math.floor(localX / pitchX);
+    const row = Math.floor(localY / pitchY);
+    if (col < 0 || col >= grid.cols || row < 0 || row >= grid.rows) {
+      onCellSelect(null);
+      return;
+    }
+    // Treat clicks on the gap (between cell edges) as misses so users can't
+    // select what isn't drawable.
+    const xWithinPitch = localX - col * pitchX;
+    const yWithinPitch = localY - row * pitchY;
+    if (xWithinPitch > grid.cellWidth || yWithinPitch > grid.cellHeight) {
+      onCellSelect(null);
+      return;
+    }
+    onCellSelect(row * grid.cols + col);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLCanvasElement>) => {
+    const pan = panStateRef.current;
+    if (pan === null || transform === null) return;
+    if (event.pointerId !== pan.pointerId) return;
+    const rect = event.currentTarget.getBoundingClientRect();
+    const cx = event.clientX - rect.left;
+    const cy = event.clientY - rect.top;
+    setTransform({
+      scale: transform.scale,
+      panX: pan.startPanX + (cx - pan.startCanvasX),
+      panY: pan.startPanY + (cy - pan.startCanvasY),
+    });
+  };
+
+  const endPan = (event: React.PointerEvent<HTMLCanvasElement>) => {
+    const pan = panStateRef.current;
+    if (pan === null) return;
+    if (event.pointerId !== pan.pointerId) return;
+    panStateRef.current = null;
+    setIsPanning(false);
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  return (
+    <section ref={containerRef} css={styles.root} aria-labelledby={headingId}>
+      <h2 id={headingId} css={styles.srOnly}>
+        {t({ en: "Source viewport", zh: "源图视图" })}
+      </h2>
+      <canvas
+        ref={canvasRef}
+        css={[styles.canvas, isPanning && styles.panning]}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={endPan}
+        onPointerCancel={endPan}
+        data-testid="source-canvas"
+      />
+    </section>
+  );
+}
+
+const styles = stylex.create({
+  root: {
+    position: "relative",
+    width: "100%",
+    height: "100%",
+    minHeight: "320px",
+    backgroundColor: color.backgroundMain,
+    backgroundImage: `linear-gradient(45deg, ${color.border} 25%, transparent 25%), linear-gradient(-45deg, ${color.border} 25%, transparent 25%), linear-gradient(45deg, transparent 75%, ${color.border} 75%), linear-gradient(-45deg, transparent 75%, ${color.border} 75%)`,
+    backgroundSize: "16px 16px",
+    backgroundPosition: "0 0, 0 8px, 8px -8px, -8px 0px",
+    borderRadius: border.radius_3,
+    border: `1px solid ${color.border}`,
+    overflow: "hidden",
+  },
+  canvas: {
+    display: "block",
+    width: "100%",
+    height: "100%",
+    cursor: "crosshair",
+    touchAction: "none",
+  },
+  panning: {
+    cursor: "grabbing",
+  },
+  srOnly: {
+    position: "absolute",
+    width: "1px",
+    height: "1px",
+    padding: 0,
+    margin: "-1px",
+    overflow: "hidden",
+    clipPath: "inset(50%)",
+    whiteSpace: "nowrap",
+    borderWidth: 0,
+    insetBlockStart: 0,
+    insetInlineStart: 0,
+  },
+});

--- a/apps/web/src/components/sprite-editor/source-image-input.tsx
+++ b/apps/web/src/components/sprite-editor/source-image-input.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { UploadSimpleIcon } from "@phosphor-icons/react/dist/ssr/UploadSimple";
+import * as stylex from "@stylexjs/stylex";
+import { useRef, useState } from "react";
+import { Button } from "#src/components/shared/button.tsx";
+import { t } from "#src/i18n.ts";
+import { border, color, font, space } from "#src/tokens.stylex.ts";
+import type { SourceImage } from "./types";
+
+interface SourceImageInputProps {
+  source: SourceImage | null;
+  onSourceChange: (source: SourceImage) => void;
+}
+
+export function SourceImageInput({
+  source,
+  onSourceChange,
+}: SourceImageInputProps) {
+  const [isDragging, setIsDragging] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  // Hoist translations to render scope — `t()` cannot be called from async
+  // callbacks per the i18n/no-t-outside-render rule.
+  const notImageError = t({ en: "Not an image file.", zh: "不是图片文件。" });
+  const decodeError = t({
+    en: "Could not decode image.",
+    zh: "无法解码图片。",
+  });
+
+  const ingest = async (file: File) => {
+    if (!file.type.startsWith("image/")) {
+      setError(notImageError);
+      return;
+    }
+    try {
+      const bitmap = await createImageBitmap(file);
+      onSourceChange({
+        bitmap,
+        width: bitmap.width,
+        height: bitmap.height,
+        name: file.name,
+      });
+      setError(null);
+    } catch {
+      setError(decodeError);
+    }
+  };
+
+  const handleFile = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file === undefined) return;
+    void ingest(file);
+    event.target.value = "";
+  };
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragging(false);
+    const file = event.dataTransfer.files.item(0);
+    if (file === null) return;
+    void ingest(file);
+  };
+
+  return (
+    <div
+      css={[styles.root, isDragging && styles.rootActive]}
+      onDragEnter={(event) => {
+        event.preventDefault();
+        setIsDragging(true);
+      }}
+      onDragOver={(event) => {
+        event.preventDefault();
+      }}
+      onDragLeave={() => {
+        setIsDragging(false);
+      }}
+      onDrop={handleDrop}
+    >
+      <Button
+        variant="primary"
+        icon={<UploadSimpleIcon size={18} weight="bold" aria-hidden="true" />}
+        onClick={() => {
+          inputRef.current?.click();
+        }}
+        data-testid="source-pick"
+      >
+        {source === null
+          ? t({ en: "Choose source image", zh: "选择源图" })
+          : t({ en: "Replace source image", zh: "替换源图" })}
+      </Button>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        onChange={handleFile}
+        css={styles.input}
+        data-testid="source-input"
+      />
+      <p css={styles.hint}>
+        {source === null
+          ? t({
+              en: "Drop a sprite sheet here or click to choose. PNG, JPG, WebP supported.",
+              zh: "在此拖放精灵表或点击选择。支持 PNG、JPG、WebP。",
+            })
+          : `${source.name} — ${String(source.width)}×${String(source.height)}`}
+      </p>
+      {error !== null ? <p css={styles.error}>{error}</p> : null}
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space._2,
+    padding: space._3,
+    border: `1px dashed ${color.border}`,
+    borderRadius: border.radius_3,
+    backgroundColor: color.backgroundRaised,
+  },
+  rootActive: {
+    borderColor: color.brandPixelCreatureCreator,
+    backgroundColor: color.backgroundHover,
+  },
+  input: {
+    position: "absolute",
+    width: "1px",
+    height: "1px",
+    padding: 0,
+    margin: "-1px",
+    overflow: "hidden",
+    clipPath: "inset(50%)",
+    whiteSpace: "nowrap",
+    borderWidth: 0,
+  },
+  hint: {
+    margin: 0,
+    fontSize: font.uiBodySmall,
+    color: color.textMuted,
+  },
+  error: {
+    margin: 0,
+    fontSize: font.uiBodySmall,
+    color: color.brandBristol,
+  },
+});

--- a/apps/web/src/components/sprite-editor/sprite-editor.tsx
+++ b/apps/web/src/components/sprite-editor/sprite-editor.tsx
@@ -1,0 +1,464 @@
+"use client";
+
+import { ArrowLeftIcon } from "@phosphor-icons/react/dist/ssr/ArrowLeft";
+import { DownloadSimpleIcon } from "@phosphor-icons/react/dist/ssr/DownloadSimple";
+import { FilmStripIcon } from "@phosphor-icons/react/dist/ssr/FilmStrip";
+import { PencilSimpleIcon } from "@phosphor-icons/react/dist/ssr/PencilSimple";
+import * as stylex from "@stylexjs/stylex";
+import { useCallback, useMemo, useState } from "react";
+import { breakpoints } from "#src/breakpoints.stylex.ts";
+import { Button } from "#src/components/shared/button.tsx";
+import { t } from "#src/i18n.ts";
+import { border, color, font, space } from "#src/tokens.stylex.ts";
+import type { AnimationFrame } from "./animation-mode";
+import { AnimationMode } from "./animation-mode";
+import { CellStrip } from "./cell-strip";
+import { GridControls } from "./grid-controls";
+import { GuideControls } from "./guide-controls";
+import { OnionSkinPicker } from "./onion-skin-picker";
+import { PixelEditor } from "./pixel-editor";
+import { SourceCanvas } from "./source-canvas";
+import { SourceImageInput } from "./source-image-input";
+import type {
+  CellPixels,
+  GridConfig,
+  OutputConfig,
+  SourceImage,
+} from "./types";
+import type { GuideOptions } from "./utils/guides";
+import { computeGuideFractions, DEFAULT_GUIDES } from "./utils/guides";
+import { downloadBlob, pixelsToPng, sliceCell } from "./utils/slice";
+
+const DEFAULT_GRID: GridConfig = {
+  cols: 4,
+  rows: 4,
+  offsetX: 0,
+  offsetY: 0,
+  cellWidth: 313,
+  cellHeight: 313,
+  gapX: 0,
+  gapY: 0,
+};
+
+const DEFAULT_OUTPUT: OutputConfig = { width: 42, height: 42 };
+
+function basenameFor(source: SourceImage): string {
+  return source.name.replace(/\.[^.]+$/, "") || "sprite";
+}
+
+type Mode = "slice" | "edit" | "animation";
+
+export function SpriteEditor() {
+  const [source, setSource] = useState<SourceImage | null>(null);
+  const [grid, setGrid] = useState<GridConfig>(DEFAULT_GRID);
+  const [output, setOutput] = useState<OutputConfig>(DEFAULT_OUTPUT);
+  const [selectedCell, setSelectedCell] = useState<number | null>(null);
+  const [mode, setMode] = useState<Mode>("slice");
+  // User edits — keyed by cell index. Cleared on grid/output change.
+  const [edits, setEdits] = useState<Record<number, CellPixels>>({});
+  const [guides, setGuides] = useState<GuideOptions>(DEFAULT_GUIDES);
+  const [onionSourceCell, setOnionSourceCell] = useState<number | null>(null);
+  const [animationFrames, setAnimationFrames] = useState<
+    readonly AnimationFrame[]
+  >([]);
+
+  const baseCells = useMemo<readonly (CellPixels | null)[]>(() => {
+    if (source === null) return [];
+    const total = grid.cols * grid.rows;
+    const result: (CellPixels | null)[] = [];
+    for (let i = 0; i < total; i++) {
+      const col = i % grid.cols;
+      const row = Math.floor(i / grid.cols);
+      result.push(sliceCell(source.bitmap, grid, output, col, row));
+    }
+    return result;
+  }, [source, grid, output]);
+
+  // Edited > base for display + download.
+  const cells = useMemo<readonly (CellPixels | null)[]>(
+    () => baseCells.map((base, index) => edits[index] ?? base),
+    [baseCells, edits],
+  );
+
+  // Drop derived state whenever the grid/output shape changes — the cell
+  // bytes no longer match the new shape, so silently keeping them would
+  // corrupt output. Implemented via the "store previous deps in state"
+  // pattern so React handles the reset during the same render that detects
+  // the change (the alternative — useEffect with setState — wastes a render
+  // and trips the react-hooks/set-state-in-effect rule).
+  const shapeKey = `${String(grid.cols)}x${String(grid.rows)}@${String(output.width)}x${String(output.height)}`;
+  const [prevShapeKey, setPrevShapeKey] = useState(shapeKey);
+  if (prevShapeKey !== shapeKey) {
+    setPrevShapeKey(shapeKey);
+    setEdits({});
+    setOnionSourceCell(null);
+    setAnimationFrames([]);
+  }
+
+  // Auto-fit grid + reset selection when the source image changes.
+  const [prevSource, setPrevSource] = useState(source);
+  if (prevSource !== source) {
+    setPrevSource(source);
+    if (source !== null) {
+      const fitsCurrent =
+        grid.offsetX +
+          grid.cols * grid.cellWidth +
+          (grid.cols - 1) * grid.gapX <=
+          source.width &&
+        grid.offsetY +
+          grid.rows * grid.cellHeight +
+          (grid.rows - 1) * grid.gapY <=
+          source.height;
+      if (!fitsCurrent) {
+        const cols = grid.cols || 1;
+        const rows = grid.rows || 1;
+        setGrid({
+          cols,
+          rows,
+          offsetX: 0,
+          offsetY: 0,
+          cellWidth: Math.max(1, Math.floor(source.width / cols)),
+          cellHeight: Math.max(1, Math.floor(source.height / rows)),
+          gapX: 0,
+          gapY: 0,
+        });
+      }
+    }
+    setSelectedCell(null);
+    setMode("slice");
+    setEdits({});
+  }
+
+  const commitEdit = useCallback((cellIndex: number, next: CellPixels) => {
+    setEdits((current) => ({ ...current, [cellIndex]: next }));
+  }, []);
+
+  const revertEdit = useCallback((cellIndex: number) => {
+    setEdits((current) => {
+      if (!(cellIndex in current)) return current;
+      // Drop the entry without `delete` so eslint's no-dynamic-delete passes.
+      const { [cellIndex]: _removed, ...rest } = current;
+      return rest;
+    });
+  }, []);
+
+  const handleDownloadCell = async (index: number) => {
+    if (source === null) return;
+    const cell = cells[index];
+    if (cell === null) return;
+    const blob = await pixelsToPng(cell);
+    if (blob === null) return;
+    downloadBlob(
+      blob,
+      `${basenameFor(source)}-cell-${String(index + 1).padStart(2, "0")}.png`,
+    );
+  };
+
+  const handleDownloadAll = async () => {
+    if (source === null) return;
+    for (let i = 0; i < cells.length; i++) {
+      const cell = cells[i];
+      if (cell === null) continue;
+      const blob = await pixelsToPng(cell);
+      if (blob === null) continue;
+      downloadBlob(
+        blob,
+        `${basenameFor(source)}-cell-${String(i + 1).padStart(2, "0")}.png`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  };
+
+  const selectedBaseCell =
+    selectedCell !== null ? (baseCells[selectedCell] ?? null) : null;
+  const selectedEdit =
+    selectedCell !== null ? (edits[selectedCell] ?? null) : null;
+
+  // Stable callbacks for the pixel editor. Otherwise its sync effect re-fires
+  // every render of this parent, looping with `setEdits`.
+  const handleEditorCommit = useCallback(
+    (next: CellPixels) => {
+      if (selectedCell === null) return;
+      commitEdit(selectedCell, next);
+    },
+    [commitEdit, selectedCell],
+  );
+  const handleEditorRevert = useCallback(() => {
+    if (selectedCell === null) return;
+    revertEdit(selectedCell);
+  }, [revertEdit, selectedCell]);
+
+  // Draw sub-cell guides on the source canvas — same fractional positions
+  // applied within every grid cell so users can sanity-check alignment of
+  // baselines, eyelines, etc. across all cells of the sheet at once.
+  const drawSourceGuides = useCallback(
+    (
+      ctx: CanvasRenderingContext2D,
+      pixelToCanvas: (x: number, y: number) => readonly [number, number],
+    ) => {
+      const fractions = computeGuideFractions(guides);
+      if (
+        fractions.vertical.length === 0 &&
+        fractions.horizontal.length === 0
+      ) {
+        return;
+      }
+      ctx.save();
+      ctx.strokeStyle = "rgba(251, 191, 36, 0.55)";
+      ctx.lineWidth = 1;
+      ctx.setLineDash([3, 3]);
+      ctx.beginPath();
+      const pitchX = grid.cellWidth + grid.gapX;
+      const pitchY = grid.cellHeight + grid.gapY;
+      for (let row = 0; row < grid.rows; row++) {
+        for (let col = 0; col < grid.cols; col++) {
+          const x0 = grid.offsetX + col * pitchX;
+          const y0 = grid.offsetY + row * pitchY;
+          for (const fx of fractions.vertical) {
+            const px = x0 + fx * grid.cellWidth;
+            const [a, b] = pixelToCanvas(px, y0);
+            const [, d] = pixelToCanvas(px, y0 + grid.cellHeight);
+            ctx.moveTo(Math.round(a) + 0.5, b);
+            ctx.lineTo(Math.round(a) + 0.5, d);
+          }
+          for (const fy of fractions.horizontal) {
+            const py = y0 + fy * grid.cellHeight;
+            const [a, b] = pixelToCanvas(x0, py);
+            const [c] = pixelToCanvas(x0 + grid.cellWidth, py);
+            ctx.moveTo(a, Math.round(b) + 0.5);
+            ctx.lineTo(c, Math.round(b) + 0.5);
+          }
+        }
+      }
+      ctx.stroke();
+      ctx.setLineDash([]);
+      ctx.restore();
+    },
+    [grid, guides],
+  );
+
+  const onionCell =
+    onionSourceCell !== null && onionSourceCell !== selectedCell
+      ? (cells[onionSourceCell] ?? null)
+      : null;
+
+  return (
+    <div css={styles.root}>
+      <div css={styles.sidebar}>
+        <SourceImageInput source={source} onSourceChange={setSource} />
+        {source !== null ? (
+          <>
+            <GridControls
+              source={source}
+              grid={grid}
+              onGridChange={setGrid}
+              output={output}
+              onOutputChange={setOutput}
+            />
+            <GuideControls guides={guides} onGuidesChange={setGuides} />
+            <div css={styles.actions}>
+              <Button
+                icon={
+                  <DownloadSimpleIcon
+                    size={16}
+                    weight="bold"
+                    aria-hidden="true"
+                  />
+                }
+                onClick={() => {
+                  if (selectedCell === null) return;
+                  void handleDownloadCell(selectedCell);
+                }}
+                disabled={selectedCell === null}
+                data-testid="download-selected"
+              >
+                {t({ en: "Download selected", zh: "下载选中" })}
+              </Button>
+              <Button
+                icon={
+                  <DownloadSimpleIcon
+                    size={16}
+                    weight="bold"
+                    aria-hidden="true"
+                  />
+                }
+                onClick={() => {
+                  void handleDownloadAll();
+                }}
+                disabled={cells.length === 0}
+                data-testid="download-all"
+              >
+                {t({ en: "Download all", zh: "全部下载" })}
+              </Button>
+              <Button
+                icon={
+                  <PencilSimpleIcon
+                    size={16}
+                    weight="bold"
+                    aria-hidden="true"
+                  />
+                }
+                isActive={mode === "edit"}
+                onClick={() => {
+                  setMode((current) => (current === "edit" ? "slice" : "edit"));
+                }}
+                disabled={selectedCell === null}
+                data-testid="toggle-edit"
+              >
+                {mode === "edit"
+                  ? t({ en: "Back to slice view", zh: "返回切片视图" })
+                  : t({ en: "Edit selected cell", zh: "编辑选中" })}
+              </Button>
+              <Button
+                icon={
+                  <FilmStripIcon size={16} weight="bold" aria-hidden="true" />
+                }
+                isActive={mode === "animation"}
+                onClick={() => {
+                  setMode((current) =>
+                    current === "animation" ? "slice" : "animation",
+                  );
+                }}
+                data-testid="toggle-animation"
+              >
+                {mode === "animation"
+                  ? t({ en: "Back to slice view", zh: "返回切片视图" })
+                  : t({ en: "Animation", zh: "动画" })}
+              </Button>
+            </div>
+            <CellStrip
+              cells={cells}
+              selectedCell={selectedCell}
+              onSelect={setSelectedCell}
+            />
+          </>
+        ) : null}
+      </div>
+
+      <div css={styles.canvasArea}>
+        {source === null ? (
+          <div css={styles.empty}>
+            <p>
+              {t({
+                en: "Choose a source image to start slicing.",
+                zh: "选择源图开始切分。",
+              })}
+            </p>
+          </div>
+        ) : mode === "animation" ? (
+          <AnimationMode
+            cells={cells}
+            frames={animationFrames}
+            onFramesChange={setAnimationFrames}
+            selectedCell={selectedCell}
+            baseFilename={basenameFor(source)}
+          />
+        ) : mode === "edit" &&
+          selectedCell !== null &&
+          selectedBaseCell !== null ? (
+          <div css={styles.editorWrap}>
+            <div css={styles.editorHeader}>
+              <Button
+                icon={
+                  <ArrowLeftIcon size={16} weight="bold" aria-hidden="true" />
+                }
+                onClick={() => {
+                  setMode("slice");
+                }}
+                data-testid="back-to-slice"
+              >
+                {t({ en: "Back", zh: "返回" })}
+              </Button>
+              <span css={styles.editorTitle}>
+                {t({ en: "Editing cell", zh: "编辑单元格" })} {selectedCell + 1}
+              </span>
+            </div>
+            <OnionSkinPicker
+              cells={cells}
+              currentCell={selectedCell}
+              onionSourceCell={onionSourceCell}
+              onChange={setOnionSourceCell}
+            />
+            <PixelEditor
+              key={selectedCell}
+              baseCell={selectedBaseCell}
+              savedEdit={selectedEdit}
+              onCommit={handleEditorCommit}
+              onRevert={handleEditorRevert}
+              guides={guides}
+              onionCell={onionCell}
+            />
+          </div>
+        ) : (
+          <SourceCanvas
+            source={source}
+            grid={grid}
+            selectedCell={selectedCell}
+            onCellSelect={setSelectedCell}
+            drawOverlay={drawSourceGuides}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  root: {
+    display: "grid",
+    gap: space._3,
+    gridTemplateColumns: { default: "1fr", [breakpoints.md]: "320px 1fr" },
+    gridTemplateRows: { default: "auto 1fr", [breakpoints.md]: "1fr" },
+    height: { default: "auto", [breakpoints.md]: "calc(100dvh - 96px)" },
+    maxInlineSize: "1400px",
+    width: "100%",
+    marginInline: "auto",
+  },
+  sidebar: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space._3,
+    overflowY: { default: "visible", [breakpoints.md]: "auto" },
+    paddingInlineEnd: { default: 0, [breakpoints.md]: space._1 },
+  },
+  canvasArea: {
+    display: "flex",
+    flexDirection: "column",
+    minHeight: "320px",
+    height: { default: "60dvh", [breakpoints.md]: "100%" },
+  },
+  empty: {
+    display: "grid",
+    placeItems: "center",
+    width: "100%",
+    height: "100%",
+    color: color.textMuted,
+    fontSize: font.uiBody,
+    border: `1px dashed ${color.border}`,
+    borderRadius: border.radius_3,
+    backgroundColor: color.backgroundRaised,
+  },
+  actions: {
+    display: "flex",
+    gap: space._2,
+    flexWrap: "wrap",
+  },
+  editorWrap: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space._2,
+    width: "100%",
+    height: "100%",
+    minHeight: 0,
+  },
+  editorHeader: {
+    display: "flex",
+    alignItems: "center",
+    gap: space._3,
+  },
+  editorTitle: {
+    fontSize: font.uiBody,
+    fontWeight: font.weight_6,
+    color: color.textMain,
+  },
+});

--- a/apps/web/src/components/sprite-editor/types.ts
+++ b/apps/web/src/components/sprite-editor/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared types for the sprite editor.
+ *
+ * The editor's mental model: a single source image is overlaid with a grid
+ * (rows × cols, with offset + cell-size in source-pixel space). Each grid
+ * cell can be sliced out, optionally edited at the configured output
+ * resolution, and exported as PNG (Phase 1) or assembled into an animation
+ * sprite sheet (Phase 4).
+ */
+
+export interface GridConfig {
+  /** Number of columns in the slicing grid. */
+  cols: number;
+  /** Number of rows in the slicing grid. */
+  rows: number;
+  /** X offset of the first cell's top-left in source-pixel space. */
+  offsetX: number;
+  /** Y offset of the first cell's top-left in source-pixel space. */
+  offsetY: number;
+  /** Width of each cell in source-pixel space. */
+  cellWidth: number;
+  /** Height of each cell in source-pixel space. */
+  cellHeight: number;
+  /** Horizontal gap between cells in source-pixel space. */
+  gapX: number;
+  /** Vertical gap between cells in source-pixel space. */
+  gapY: number;
+}
+
+export interface OutputConfig {
+  /** Output cell width in pixels (e.g. 42 for the species sprites). */
+  width: number;
+  /** Output cell height in pixels. */
+  height: number;
+}
+
+export interface SourceImage {
+  bitmap: ImageBitmap;
+  width: number;
+  height: number;
+  /** Filename of the imported source, for default download names. */
+  name: string;
+}
+
+/** Pixel data for an output-resolution cell, stored as RGBA bytes. */
+export interface CellPixels {
+  width: number;
+  height: number;
+  /**
+   * RGBA bytes, length === width * height * 4. Typed against `ArrayBuffer`
+   * (not the looser `ArrayBufferLike`) so the buffer is assignable to
+   * `ImageDataArray` and the bytes can be passed straight to
+   * `new ImageData(...)` without a defensive copy.
+   */
+  data: Uint8ClampedArray<ArrayBuffer>;
+}

--- a/apps/web/src/components/sprite-editor/use-history.ts
+++ b/apps/web/src/components/sprite-editor/use-history.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface HistoryState<T> {
+  past: readonly T[];
+  present: T;
+  future: readonly T[];
+}
+
+/**
+ * Generic linear undo/redo history. Pass an initial value; the hook returns
+ * `[present, push, undo, redo, canUndo, canRedo, reset]`.
+ *
+ * `push` appends a new entry, discarding the redo stack — standard editor
+ * behavior. `reset` replaces the entire history (e.g. when the user opens a
+ * different cell to edit).
+ */
+export function useHistory<T>(initial: T) {
+  const [state, setState] = useState<HistoryState<T>>({
+    past: [],
+    present: initial,
+    future: [],
+  });
+  // Latest value, also exposed as a ref so callbacks can read it without
+  // closing over a stale snapshot.
+  const presentRef = useRef(initial);
+  useEffect(() => {
+    presentRef.current = state.present;
+  }, [state.present]);
+
+  const push = useCallback((next: T) => {
+    setState((prev) => ({
+      past: [...prev.past, prev.present],
+      present: next,
+      future: [],
+    }));
+  }, []);
+
+  const undo = useCallback(() => {
+    setState((prev) => {
+      if (prev.past.length === 0) return prev;
+      const previous = prev.past[prev.past.length - 1];
+      return {
+        past: prev.past.slice(0, -1),
+        present: previous,
+        future: [prev.present, ...prev.future],
+      };
+    });
+  }, []);
+
+  const redo = useCallback(() => {
+    setState((prev) => {
+      if (prev.future.length === 0) return prev;
+      const next = prev.future[0];
+      return {
+        past: [...prev.past, prev.present],
+        present: next,
+        future: prev.future.slice(1),
+      };
+    });
+  }, []);
+
+  const reset = useCallback((next: T) => {
+    setState({ past: [], present: next, future: [] });
+  }, []);
+
+  return {
+    present: state.present,
+    presentRef,
+    push,
+    undo,
+    redo,
+    canUndo: state.past.length > 0,
+    canRedo: state.future.length > 0,
+    reset,
+  };
+}

--- a/apps/web/src/components/sprite-editor/utils/canvas.ts
+++ b/apps/web/src/components/sprite-editor/utils/canvas.ts
@@ -1,0 +1,59 @@
+/**
+ * Canvas factory shared by slicing + PNG export. Mirrors the pattern in
+ * `pixel-creature-creator/review/png-export.ts`: prefer `OffscreenCanvas`
+ * (no DOM thrash, worker-friendly), fall back to a hidden DOM canvas.
+ */
+
+type Ctx = OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D;
+
+export interface CanvasHandle {
+  ctx: Ctx;
+  toBlob: () => Promise<Blob>;
+  cleanup: () => void;
+}
+
+export function makeCanvas(width: number, height: number): CanvasHandle | null {
+  if (typeof OffscreenCanvas !== "undefined") {
+    const canvas = new OffscreenCanvas(width, height);
+    const ctx = canvas.getContext("2d");
+    if (ctx !== null) {
+      return {
+        ctx,
+        toBlob: () => canvas.convertToBlob({ type: "image/png" }),
+        cleanup: () => {},
+      };
+    }
+  }
+
+  if (typeof document === "undefined") return null;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  canvas.style.position = "fixed";
+  canvas.style.left = "-99999px";
+  canvas.style.top = "0";
+  canvas.style.pointerEvents = "none";
+  document.body.appendChild(canvas);
+  const ctx = canvas.getContext("2d");
+  if (ctx === null) {
+    canvas.remove();
+    return null;
+  }
+  return {
+    ctx,
+    toBlob: () =>
+      new Promise<Blob>((resolve, reject) => {
+        canvas.toBlob((blob) => {
+          if (blob === null) {
+            reject(new Error("canvas.toBlob returned null"));
+            return;
+          }
+          resolve(blob);
+        }, "image/png");
+      }),
+    cleanup: () => {
+      canvas.remove();
+    },
+  };
+}

--- a/apps/web/src/components/sprite-editor/utils/guides.ts
+++ b/apps/web/src/components/sprite-editor/utils/guides.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure helpers for computing sub-cell guide positions. Returns fractional
+ * offsets in `[0, 1]` along an axis — callers convert to source-pixel or
+ * canvas-pixel space.
+ */
+
+export interface GuideOptions {
+  halves: boolean;
+  thirds: boolean;
+  baseline: boolean;
+}
+
+export const DEFAULT_GUIDES: GuideOptions = {
+  halves: false,
+  thirds: false,
+  baseline: false,
+};
+
+/**
+ * Vertical lines (offsets along x) and horizontal lines (offsets along y).
+ * Returned as separate arrays so callers can draw them independently.
+ */
+export function computeGuideFractions(options: GuideOptions): {
+  vertical: readonly number[];
+  horizontal: readonly number[];
+} {
+  const v: number[] = [];
+  const h: number[] = [];
+  if (options.halves) {
+    v.push(0.5);
+    h.push(0.5);
+  }
+  if (options.thirds) {
+    v.push(1 / 3, 2 / 3);
+    h.push(1 / 3, 2 / 3);
+  }
+  if (options.baseline) {
+    // Baseline is conventionally a horizontal line near the bottom of the cell;
+    // 0.85 keeps a foot/floor reference for sprites without dictating an exact
+    // pixel row across all output sizes.
+    h.push(0.85);
+  }
+  return { vertical: v, horizontal: h };
+}

--- a/apps/web/src/components/sprite-editor/utils/pixel-ops.ts
+++ b/apps/web/src/components/sprite-editor/utils/pixel-ops.ts
@@ -1,0 +1,257 @@
+import type { CellPixels } from "../types";
+
+export interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** Normalize a possibly-inverted rect to positive width/height. */
+export function normalizeRect(rect: Rect): Rect {
+  const x = rect.w < 0 ? rect.x + rect.w : rect.x;
+  const y = rect.h < 0 ? rect.y + rect.h : rect.y;
+  return { x, y, w: Math.abs(rect.w), h: Math.abs(rect.h) };
+}
+
+/** Clamp `rect` to the bounds of `cell` and return the clipped result. */
+export function clampRect(rect: Rect, w: number, h: number): Rect {
+  const x0 = Math.max(0, rect.x);
+  const y0 = Math.max(0, rect.y);
+  const x1 = Math.min(w, rect.x + rect.w);
+  const y1 = Math.min(h, rect.y + rect.h);
+  return { x: x0, y: y0, w: Math.max(0, x1 - x0), h: Math.max(0, y1 - y0) };
+}
+
+/** Allocate an empty (fully transparent) CellPixels of the given size. */
+export function emptyCell(width: number, height: number): CellPixels {
+  return {
+    width,
+    height,
+    data: new Uint8ClampedArray(new ArrayBuffer(width * height * 4)),
+  };
+}
+
+/** Crop `rect` from `cell` into a freshly-allocated CellPixels. */
+export function cropCell(cell: CellPixels, rect: Rect): CellPixels {
+  const out = emptyCell(rect.w, rect.h);
+  for (let y = 0; y < rect.h; y++) {
+    for (let x = 0; x < rect.w; x++) {
+      const sx = rect.x + x;
+      const sy = rect.y + y;
+      if (sx < 0 || sy < 0 || sx >= cell.width || sy >= cell.height) continue;
+      const si = (sy * cell.width + sx) * 4;
+      const di = (y * rect.w + x) * 4;
+      out.data[di] = cell.data[si];
+      out.data[di + 1] = cell.data[si + 1];
+      out.data[di + 2] = cell.data[si + 2];
+      out.data[di + 3] = cell.data[si + 3];
+    }
+  }
+  return out;
+}
+
+/** Erase pixels inside `rect` (clamped to bounds) by writing transparent. */
+export function eraseRect(cell: CellPixels, rect: Rect): void {
+  const c = clampRect(rect, cell.width, cell.height);
+  for (let y = c.y; y < c.y + c.h; y++) {
+    for (let x = c.x; x < c.x + c.w; x++) {
+      const i = (y * cell.width + x) * 4;
+      cell.data[i] = 0;
+      cell.data[i + 1] = 0;
+      cell.data[i + 2] = 0;
+      cell.data[i + 3] = 0;
+    }
+  }
+}
+
+/**
+ * Paste `source` (its full content) into `target` at (dx, dy), nearest-neighbor
+ * scaled to (dw × dh). Fully-transparent source pixels are skipped so the
+ * existing target pixel shows through.
+ */
+export function pasteCellScaled(
+  target: CellPixels,
+  source: CellPixels,
+  dx: number,
+  dy: number,
+  dw: number,
+  dh: number,
+): void {
+  if (dw <= 0 || dh <= 0) return;
+  for (let y = 0; y < dh; y++) {
+    const ty = dy + y;
+    if (ty < 0 || ty >= target.height) continue;
+    const sy = Math.min(
+      source.height - 1,
+      Math.floor((y / dh) * source.height),
+    );
+    for (let x = 0; x < dw; x++) {
+      const tx = dx + x;
+      if (tx < 0 || tx >= target.width) continue;
+      const sx = Math.min(
+        source.width - 1,
+        Math.floor((x / dw) * source.width),
+      );
+      const si = (sy * source.width + sx) * 4;
+      const a = source.data[si + 3];
+      if (a === 0) continue;
+      const ti = (ty * target.width + tx) * 4;
+      target.data[ti] = source.data[si];
+      target.data[ti + 1] = source.data[si + 1];
+      target.data[ti + 2] = source.data[si + 2];
+      target.data[ti + 3] = a;
+    }
+  }
+}
+
+/** Flip a CellPixels horizontally (in place). */
+export function flipCellH(cell: CellPixels): void {
+  const half = Math.floor(cell.width / 2);
+  for (let y = 0; y < cell.height; y++) {
+    for (let x = 0; x < half; x++) {
+      const li = (y * cell.width + x) * 4;
+      const ri = (y * cell.width + (cell.width - 1 - x)) * 4;
+      for (let k = 0; k < 4; k++) {
+        const tmp = cell.data[li + k];
+        cell.data[li + k] = cell.data[ri + k];
+        cell.data[ri + k] = tmp;
+      }
+    }
+  }
+}
+
+/** Flip a CellPixels vertically (in place). */
+export function flipCellV(cell: CellPixels): void {
+  const half = Math.floor(cell.height / 2);
+  for (let y = 0; y < half; y++) {
+    for (let x = 0; x < cell.width; x++) {
+      const ti = (y * cell.width + x) * 4;
+      const bi = ((cell.height - 1 - y) * cell.width + x) * 4;
+      for (let k = 0; k < 4; k++) {
+        const tmp = cell.data[ti + k];
+        cell.data[ti + k] = cell.data[bi + k];
+        cell.data[bi + k] = tmp;
+      }
+    }
+  }
+}
+
+/** Parse a `#rrggbb` or `#rrggbbaa` string into 0-255 RGBA components. */
+export function parseHex(
+  hex: string,
+): readonly [number, number, number, number] {
+  const value = hex.startsWith("#") ? hex.slice(1) : hex;
+  if (value.length === 6) {
+    return [
+      parseInt(value.slice(0, 2), 16),
+      parseInt(value.slice(2, 4), 16),
+      parseInt(value.slice(4, 6), 16),
+      255,
+    ];
+  }
+  if (value.length === 8) {
+    return [
+      parseInt(value.slice(0, 2), 16),
+      parseInt(value.slice(2, 4), 16),
+      parseInt(value.slice(4, 6), 16),
+      parseInt(value.slice(6, 8), 16),
+    ];
+  }
+  return [0, 0, 0, 255];
+}
+
+/** Format an RGBA tuple as `#rrggbb` (alpha ignored). */
+export function rgbaToHex(r: number, g: number, b: number): string {
+  const h = (n: number) => n.toString(16).padStart(2, "0");
+  return `#${h(r)}${h(g)}${h(b)}`;
+}
+
+/** Clone a CellPixels into a new buffer so callers can mutate freely. */
+export function cloneCell(cell: CellPixels): CellPixels {
+  return {
+    width: cell.width,
+    height: cell.height,
+    data: new Uint8ClampedArray(cell.data),
+  };
+}
+
+/** Get RGBA at `(x, y)`. Returns `null` if out of bounds. */
+export function getPixel(
+  cell: CellPixels,
+  x: number,
+  y: number,
+): readonly [number, number, number, number] | null {
+  if (x < 0 || y < 0 || x >= cell.width || y >= cell.height) return null;
+  const i = (y * cell.width + x) * 4;
+  return [cell.data[i], cell.data[i + 1], cell.data[i + 2], cell.data[i + 3]];
+}
+
+/** Set RGBA at `(x, y)` (in place). Out-of-bounds writes are ignored. */
+export function setPixel(
+  cell: CellPixels,
+  x: number,
+  y: number,
+  rgba: readonly [number, number, number, number],
+): void {
+  if (x < 0 || y < 0 || x >= cell.width || y >= cell.height) return;
+  const i = (y * cell.width + x) * 4;
+  cell.data[i] = rgba[0];
+  cell.data[i + 1] = rgba[1];
+  cell.data[i + 2] = rgba[2];
+  cell.data[i + 3] = rgba[3];
+}
+
+function colorDistanceSquared(
+  a: readonly [number, number, number, number],
+  b: readonly [number, number, number, number],
+): number {
+  // Plain RGBA distance — perceptual distance is overkill at 42×42.
+  const dr = a[0] - b[0];
+  const dg = a[1] - b[1];
+  const db = a[2] - b[2];
+  const da = a[3] - b[3];
+  return dr * dr + dg * dg + db * db + da * da;
+}
+
+/**
+ * 4-connected flood fill starting at `(x, y)`. Replaces every reachable pixel
+ * whose color is within `tolerance` of the seed pixel with `replacement`.
+ * Mutates `cell` in place.
+ */
+export function floodFill(
+  cell: CellPixels,
+  x: number,
+  y: number,
+  replacement: readonly [number, number, number, number],
+  tolerance = 0,
+): void {
+  const seed = getPixel(cell, x, y);
+  if (seed === null) return;
+  const tolSq = tolerance * tolerance * 4; // distance² scaled to 4 components
+  // Avoid infinite loops when the seed already matches the replacement.
+  if (
+    seed[0] === replacement[0] &&
+    seed[1] === replacement[1] &&
+    seed[2] === replacement[2] &&
+    seed[3] === replacement[3]
+  ) {
+    return;
+  }
+  const stack: [number, number][] = [[x, y]];
+  const visited = new Uint8Array(cell.width * cell.height);
+  while (stack.length > 0) {
+    const point = stack.pop();
+    if (point === undefined) break;
+    const [cx, cy] = point;
+    if (cx < 0 || cy < 0 || cx >= cell.width || cy >= cell.height) continue;
+    const flatIndex = cy * cell.width + cx;
+    if (visited[flatIndex] === 1) continue;
+    const current = getPixel(cell, cx, cy);
+    if (current === null) continue;
+    if (colorDistanceSquared(current, seed) > tolSq) continue;
+    visited[flatIndex] = 1;
+    setPixel(cell, cx, cy, replacement);
+    stack.push([cx + 1, cy], [cx - 1, cy], [cx, cy + 1], [cx, cy - 1]);
+  }
+}

--- a/apps/web/src/components/sprite-editor/utils/slice.ts
+++ b/apps/web/src/components/sprite-editor/utils/slice.ts
@@ -1,0 +1,71 @@
+import type { CellPixels, GridConfig, OutputConfig } from "../types";
+import { makeCanvas } from "./canvas";
+
+/**
+ * Slice a single grid cell out of the source image and downsample to the
+ * output resolution. Uses nearest-neighbor (`imageSmoothingEnabled = false`)
+ * so 313×313 → 42×42 produces a clean pixel-art result.
+ *
+ * Returns the rendered output as `CellPixels` (RGBA byte array). Callers
+ * convert to PNG via `cellsToPng`.
+ */
+export function sliceCell(
+  source: ImageBitmap | HTMLCanvasElement,
+  grid: GridConfig,
+  output: OutputConfig,
+  col: number,
+  row: number,
+): CellPixels | null {
+  const handle = makeCanvas(output.width, output.height);
+  if (handle === null) return null;
+  try {
+    const { ctx } = handle;
+    ctx.imageSmoothingEnabled = false;
+    ctx.clearRect(0, 0, output.width, output.height);
+    ctx.drawImage(
+      source,
+      grid.offsetX + col * (grid.cellWidth + grid.gapX),
+      grid.offsetY + row * (grid.cellHeight + grid.gapY),
+      grid.cellWidth,
+      grid.cellHeight,
+      0,
+      0,
+      output.width,
+      output.height,
+    );
+    const imageData = ctx.getImageData(0, 0, output.width, output.height);
+    return {
+      width: output.width,
+      height: output.height,
+      data: imageData.data,
+    };
+  } finally {
+    handle.cleanup();
+  }
+}
+
+/** Convert a `CellPixels` back to a PNG `Blob`. */
+export async function pixelsToPng(cell: CellPixels): Promise<Blob | null> {
+  const handle = makeCanvas(cell.width, cell.height);
+  if (handle === null) return null;
+  try {
+    const { ctx } = handle;
+    const imageData = new ImageData(cell.data, cell.width, cell.height);
+    ctx.putImageData(imageData, 0, 0);
+    return await handle.toBlob();
+  } finally {
+    handle.cleanup();
+  }
+}
+
+/** Trigger a browser download for a Blob. */
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/apps/web/src/components/sprite-editor/utils/sprite-sheet.ts
+++ b/apps/web/src/components/sprite-editor/utils/sprite-sheet.ts
@@ -1,0 +1,60 @@
+import type { CellPixels } from "../types";
+import { makeCanvas } from "./canvas";
+
+export interface SpriteSheetManifest {
+  frameWidth: number;
+  frameHeight: number;
+  frameCount: number;
+  /** Per-frame durations in milliseconds, in playback order. */
+  durations: readonly number[];
+}
+
+export interface SpriteSheetExport {
+  png: Blob;
+  manifest: SpriteSheetManifest;
+}
+
+/**
+ * Composite an animation's frames into a horizontal sprite sheet PNG, plus a
+ * JSON-friendly manifest describing the frame size and per-frame durations.
+ *
+ * Frames must all share the same dimensions (the same `OutputConfig` produced
+ * them); empty inputs return null.
+ */
+export async function exportSpriteSheet(
+  frames: readonly { cell: CellPixels; duration: number }[],
+): Promise<SpriteSheetExport | null> {
+  if (frames.length === 0) return null;
+  const first = frames[0].cell;
+  const sheetW = first.width * frames.length;
+  const sheetH = first.height;
+  const handle = makeCanvas(sheetW, sheetH);
+  if (handle === null) return null;
+  try {
+    const { ctx } = handle;
+    ctx.imageSmoothingEnabled = false;
+    ctx.clearRect(0, 0, sheetW, sheetH);
+    for (let i = 0; i < frames.length; i++) {
+      const { cell } = frames[i];
+      // Frames coming in might mismatch if grid changed mid-build — bail
+      // rather than stretch them, since the manifest assumes uniform size.
+      if (cell.width !== first.width || cell.height !== first.height) {
+        return null;
+      }
+      const imageData = new ImageData(cell.data, cell.width, cell.height);
+      ctx.putImageData(imageData, i * first.width, 0);
+    }
+    const png = await handle.toBlob();
+    return {
+      png,
+      manifest: {
+        frameWidth: first.width,
+        frameHeight: first.height,
+        frameCount: frames.length,
+        durations: frames.map((f) => f.duration),
+      },
+    };
+  } finally {
+    handle.cleanup();
+  }
+}


### PR DESCRIPTION
## Summary

Adds a browser-based sprite editor at `/sprite-editor` as a companion to the pixel-creature-creator portfolio piece, enabling pixel-art assets to be authored end-to-end on the site. The editor ships three modes: a slice view that overlays a configurable grid on an uploaded sheet and downloads individual cells or a bulk PNG batch; a pixel editor with pencil, eraser, range-select (move, resize, erase, copy, flip-H/V), eyedropper, fill, and flood-fill background remover, plus integer-zoom + pan, alignment guides, onion-skin overlay, and undo/redo; and an animation mode with a frame timeline, real-time preview, variable-speed playback, and sprite-sheet PNG + JSON manifest export. A home-page card links to the new route.

## Notes

Pure client-side — no backend, API, or database changes. Transparency uses a diagonal-checker pattern consistently across all surfaces (slice canvas, pixel editor, cell strip thumbnails, animation preview); the per-pixel grid is only revealed once the user zooms past the editing threshold. Follows the project's StyleX tokens, inline `t()` i18n (en + zh), the shared `Button` component, and the existing brand color for the portfolio card.