### PR TITLE
fix: coalesce pencil/eraser drag strokes into a single undo step

### DIFF
--- a/apps/web/src/components/sprite-editor/pixel-editor.tsx
+++ b/apps/web/src/components/sprite-editor/pixel-editor.tsx
@@ -126,8 +126,17 @@ export function PixelEditor({
     cloneCell(savedEdit ?? baseCell),
   );
   const history = useHistory<CellPixels>(initial);
-  const { present, presentRef, push, undo, redo, canUndo, canRedo, reset } =
-    history;
+  const {
+    present,
+    presentRef,
+    push,
+    replace,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    reset,
+  } = history;
 
   const isFirstSyncRef = useRef(true);
   const skipNextSyncRef = useRef(false);
@@ -546,15 +555,21 @@ export function PixelEditor({
       const rgba = parseHex(activeColor);
       const transparent = [0, 0, 0, 0] as const;
 
+      // Pencil/eraser drags coalesce into a single undo step: pointer-down
+      // pushes one entry, every subsequent pointer-move replaces present
+      // in-place. Ctrl+Z then restores the cell to its pre-stroke state in
+      // one go instead of one pixel at a time.
+      const commit = isDrag ? replace : push;
+
       if (tool === "pencil") {
         setPixel(next, px, py, rgba);
-        push(next);
+        commit(next);
         if (!isDrag) remember(activeColor);
         return;
       }
       if (tool === "eraser") {
         setPixel(next, px, py, transparent);
-        push(next);
+        commit(next);
         return;
       }
       if (tool === "eyedropper") {
@@ -576,7 +591,7 @@ export function PixelEditor({
       floodFill(next, px, py, transparent, tolerance);
       push(next);
     },
-    [activeColor, presentRef, push, remember, tool, tolerance],
+    [activeColor, presentRef, push, replace, remember, tool, tolerance],
   );
 
   // Pointer handling --------------------------------------------------------

--- a/apps/web/src/components/sprite-editor/use-history.test.ts
+++ b/apps/web/src/components/sprite-editor/use-history.test.ts
@@ -1,0 +1,178 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useHistory } from "./use-history";
+
+describe("useHistory", () => {
+  it("starts with the initial value and no history", () => {
+    const { result } = renderHook(() => useHistory(0));
+
+    expect(result.current.present).toBe(0);
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("push appends entries that can be undone one by one", () => {
+    const { result } = renderHook(() => useHistory(0));
+
+    act(() => {
+      result.current.push(1);
+    });
+    act(() => {
+      result.current.push(2);
+    });
+    act(() => {
+      result.current.push(3);
+    });
+
+    expect(result.current.present).toBe(3);
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.present).toBe(2);
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.present).toBe(1);
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.present).toBe(0);
+    expect(result.current.canUndo).toBe(false);
+  });
+
+  it("replace updates present without growing past — drag-style coalescing", () => {
+    const { result } = renderHook(() => useHistory(0));
+
+    // Simulate a pencil stroke: pointer-down pushes the first frame, every
+    // subsequent pointer-move replaces in place. The whole stroke must be
+    // undoable in a single Ctrl+Z.
+    act(() => {
+      result.current.push(1);
+    });
+    act(() => {
+      result.current.replace(2);
+    });
+    act(() => {
+      result.current.replace(3);
+    });
+    act(() => {
+      result.current.replace(4);
+    });
+
+    expect(result.current.present).toBe(4);
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.present).toBe(0);
+    expect(result.current.canUndo).toBe(false);
+  });
+
+  it("coalesces a stroke between two discrete pushes", () => {
+    const { result } = renderHook(() => useHistory("a"));
+
+    // Discrete edit before the stroke.
+    act(() => {
+      result.current.push("b");
+    });
+    // Stroke: one push + several replaces.
+    act(() => {
+      result.current.push("c1");
+    });
+    act(() => {
+      result.current.replace("c2");
+    });
+    act(() => {
+      result.current.replace("c3");
+    });
+    // Discrete edit after the stroke.
+    act(() => {
+      result.current.push("d");
+    });
+
+    expect(result.current.present).toBe("d");
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.present).toBe("c3");
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.present).toBe("b");
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.present).toBe("a");
+  });
+
+  it("redo restores the value present at the time of undo, including the final stroke frame", () => {
+    const { result } = renderHook(() => useHistory(0));
+
+    act(() => {
+      result.current.push(1);
+    });
+    act(() => {
+      result.current.replace(2);
+    });
+    act(() => {
+      result.current.replace(3);
+    });
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.present).toBe(0);
+
+    act(() => {
+      result.current.redo();
+    });
+    expect(result.current.present).toBe(3);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("replace clears the redo stack just like push", () => {
+    const { result } = renderHook(() => useHistory(0));
+
+    act(() => {
+      result.current.push(1);
+    });
+    act(() => {
+      result.current.push(2);
+    });
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.present).toBe(1);
+    expect(result.current.canRedo).toBe(true);
+
+    act(() => {
+      result.current.replace(99);
+    });
+    expect(result.current.present).toBe(99);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("reset wipes history to a single entry", () => {
+    const { result } = renderHook(() => useHistory(0));
+
+    act(() => {
+      result.current.push(1);
+    });
+    act(() => {
+      result.current.push(2);
+    });
+    act(() => {
+      result.current.reset(42);
+    });
+
+    expect(result.current.present).toBe(42);
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(false);
+  });
+});

--- a/apps/web/src/components/sprite-editor/use-history.ts
+++ b/apps/web/src/components/sprite-editor/use-history.ts
@@ -10,11 +10,14 @@ interface HistoryState<T> {
 
 /**
  * Generic linear undo/redo history. Pass an initial value; the hook returns
- * `[present, push, undo, redo, canUndo, canRedo, reset]`.
+ * `[present, push, replace, undo, redo, canUndo, canRedo, reset]`.
  *
  * `push` appends a new entry, discarding the redo stack — standard editor
- * behavior. `reset` replaces the entire history (e.g. when the user opens a
- * different cell to edit).
+ * behavior. `replace` updates `present` in-place without growing `past`,
+ * which lets a continuous user gesture (e.g. a pencil drag) coalesce into a
+ * single undo step: call `push` for the gesture's first frame, then
+ * `replace` for every subsequent frame. `reset` replaces the entire history
+ * (e.g. when the user opens a different cell to edit).
  */
 export function useHistory<T>(initial: T) {
   const [state, setState] = useState<HistoryState<T>>({
@@ -32,6 +35,14 @@ export function useHistory<T>(initial: T) {
   const push = useCallback((next: T) => {
     setState((prev) => ({
       past: [...prev.past, prev.present],
+      present: next,
+      future: [],
+    }));
+  }, []);
+
+  const replace = useCallback((next: T) => {
+    setState((prev) => ({
+      past: prev.past,
       present: next,
       future: [],
     }));
@@ -69,6 +80,7 @@ export function useHistory<T>(initial: T) {
     present: state.present,
     presentRef,
     push,
+    replace,
     undo,
     redo,
     canUndo: state.past.length > 0,


### PR DESCRIPTION
## Why

In the sprite editor, a pencil or eraser drag pushed one history entry per painted pixel. A 30-pixel stroke needed 30 Ctrl+Z presses to revert, and each entry stored a fresh `Uint8ClampedArray` clone of the cell, so memory grew with stroke length. Standard editor behavior coalesces a continuous stroke into a single undo step.

## What

- Add a `replace` primitive to `useHistory` that updates `present` in place (clearing the redo stack) without growing `past`.
- In `pixel-editor.tsx`, `applyAtPixel` now uses `replace` for pencil/eraser pointer-move frames (`isDrag === true`) and `push` for the initial pointer-down frame.
- Single-click pencil dot, fill, bg-remove, and eyedropper are unchanged: they still hit `push` (or no-op for eyedropper) since `isDrag === false` on pointer-down.

## Test plan

- [x] `pnpm exec vitest run` for `use-history.test.ts` (7 tests covering coalescing, redo-after-coalesce, replace-clears-redo, mixed sequences) - all pass
- [ ] Manual: pencil drag across multiple pixels; one Ctrl+Z restores pre-stroke state
- [ ] Manual: redo after the single Ctrl+Z restores the stroke's final frame
- [ ] Manual: single-click pencil/eraser still produces one undo step
- [ ] Manual: fill / bg-remove still produce one undo step each