### PR TITLE
fix: add visually-hidden h1 to pixel creature creator wizard page

### DIFF
--- a/apps/web/src/app/[locale]/pixel-creature-creator/create/page.tsx
+++ b/apps/web/src/app/[locale]/pixel-creature-creator/create/page.tsx
@@ -1,3 +1,4 @@
+import * as stylex from "@stylexjs/stylex";
 import type { Metadata } from "next";
 import { WizardShell } from "#src/components/pixel-creature-creator/wizard/wizard-shell.tsx";
 import { BASE_URL } from "#src/constants.ts";
@@ -47,5 +48,26 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
 }
 
 export default function Page() {
-  return <WizardShell />;
+  return (
+    <>
+      <h1 css={styles.srOnly}>
+        {t({ en: "Create your creature", zh: "创建你的生物" })}
+      </h1>
+      <WizardShell />
+    </>
+  );
 }
+
+const styles = stylex.create({
+  srOnly: {
+    position: "absolute",
+    width: "1px",
+    height: "1px",
+    padding: 0,
+    margin: "-1px",
+    overflow: "hidden",
+    clipPath: "inset(50%)",
+    whiteSpace: "nowrap",
+    borderWidth: 0,
+  },
+});


### PR DESCRIPTION
## Why

The wizard route at `/[locale]/pixel-creature-creator/create` rendered no `<h1>`. The first heading on the page was the wizard shell's visible `<h2>` ("Pixel Creature Creator"), so the document outline started at h2. Every page should have exactly one h1 for accessibility (screen-reader navigation) and SEO.

## What

- Add a visually-hidden `<h1>` above `<WizardShell />` in `apps/web/src/app/[locale]/pixel-creature-creator/create/page.tsx`.
- H1 text is `"Create your creature"` / `"创建你的生物"` — matches the page metadata title (without the brand suffix). The visible h2 ("Pixel Creature Creator") and h3 step headings are unchanged.
- Mirrors the existing pattern at `apps/web/src/app/[locale]/sprite-editor/page.tsx` — same `srOnly` style block, same fragment shape.

Sighted users see no visual change.

## Test plan

- [x] `pnpm exec vitest run src/components/pixel-creature-creator` - 117 tests pass
- [x] `pnpm lint:changed` - clean (only pre-existing `no-html-link-for-pages` notice)
- [ ] Manual: screen reader announces "Create your creature, heading level 1" on `/pixel-creature-creator/create`
- [ ] Manual: visible layout unchanged
- [ ] Manual: `/zh/pixel-creature-creator/create` announces "创建你的生物, heading level 1"