### PR TITLE
fix: promote single-select option groups to ARIA radiogroups

### DIFF
--- a/apps/web/e2e/pixel-creature-creator-review.spec.ts
+++ b/apps/web/e2e/pixel-creature-creator-review.spec.ts
@@ -64,7 +64,7 @@ test.describe("Review screen", () => {
       await page.getByTestId(`emotion-button-${emotion}`).click();
       await expect(
         page.getByTestId(`emotion-button-${emotion}`),
-      ).toHaveAttribute("aria-pressed", "true");
+      ).toHaveAttribute("aria-checked", "true");
       // The card stays visible — the sprite swap should not crash the tree.
       await expect(page.getByTestId("creature-card")).toBeVisible();
     }

--- a/apps/web/src/components/pixel-creature-creator/review/emotion-toggle.tsx
+++ b/apps/web/src/components/pixel-creature-creator/review/emotion-toggle.tsx
@@ -4,6 +4,7 @@ import * as stylex from "@stylexjs/stylex";
 import { t } from "#src/i18n.ts";
 import { color, font, space } from "#src/tokens.stylex.ts";
 import { EMOTIONS, type Emotion } from "../state/creature-schema";
+import { useRadioGroup } from "../wizard/use-radio-group";
 
 interface EmotionToggleProps {
   active: Emotion;
@@ -32,9 +33,15 @@ export function EmotionToggle({ active, onChange }: EmotionToggleProps) {
     curious: t({ en: "Curious", zh: "好奇" }),
   };
 
+  const { getOptionProps } = useRadioGroup({
+    values: EMOTIONS,
+    value: active,
+    onChange,
+  });
+
   return (
     <div
-      role="group"
+      role="radiogroup"
       aria-label={t({ en: "Choose emotion", zh: "选择情绪" })}
       css={styles.root}
       data-testid="emotion-toggle"
@@ -45,10 +52,7 @@ export function EmotionToggle({ active, onChange }: EmotionToggleProps) {
           <button
             key={emotion}
             type="button"
-            aria-pressed={isActive}
-            onClick={() => {
-              onChange(emotion);
-            }}
+            {...getOptionProps(emotion)}
             data-testid={`emotion-button-${emotion}`}
             css={[styles.button, isActive && styles.buttonActive]}
           >

--- a/apps/web/src/components/pixel-creature-creator/wizard/option-grid.tsx
+++ b/apps/web/src/components/pixel-creature-creator/wizard/option-grid.tsx
@@ -3,6 +3,10 @@ import { space } from "#src/tokens.stylex.ts";
 
 interface OptionGridProps {
   children: React.ReactNode;
+  /** Optional ARIA role — pass `"radiogroup"` for single-select groups. */
+  role?: "radiogroup";
+  "aria-labelledby"?: string;
+  "aria-label"?: string;
 }
 
 /**
@@ -10,8 +14,22 @@ interface OptionGridProps {
  * the step components so the visual rhythm stays consistent without any
  * step having to import another step's styles.
  */
-export function OptionGrid({ children }: OptionGridProps) {
-  return <div css={styles.grid}>{children}</div>;
+export function OptionGrid({
+  children,
+  role,
+  "aria-labelledby": ariaLabelledBy,
+  "aria-label": ariaLabel,
+}: OptionGridProps) {
+  return (
+    <div
+      css={styles.grid}
+      role={role}
+      aria-labelledby={ariaLabelledBy}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </div>
+  );
 }
 
 const styles = stylex.create({

--- a/apps/web/src/components/pixel-creature-creator/wizard/step-species.tsx
+++ b/apps/web/src/components/pixel-creature-creator/wizard/step-species.tsx
@@ -2,10 +2,12 @@
 
 import * as stylex from "@stylexjs/stylex";
 import Image from "next/image";
+import { useId, useMemo } from "react";
 import { t } from "#src/i18n.ts";
 import { color, font, space } from "#src/tokens.stylex.ts";
 import { species } from "../sprite/species";
 import type { CreatureDef } from "../state/creature-schema";
+import { useRadioGroup } from "./use-radio-group";
 
 interface StepSpeciesProps {
   def: CreatureDef;
@@ -37,9 +39,23 @@ export function StepSpecies({ def, onChange }: StepSpeciesProps) {
     amorphous: t({ en: "Amorphous", zh: "不定形" }),
   };
 
+  const entries = useMemo(
+    () => Object.values(species).filter((entry) => entry !== undefined),
+    [],
+  );
+  const speciesIds = useMemo(() => entries.map((entry) => entry.id), [entries]);
+  const { getOptionProps } = useRadioGroup({
+    values: speciesIds,
+    value: def.species,
+    onChange: (next) => {
+      onChange({ ...def, species: next });
+    },
+  });
+  const headingId = useId();
+
   return (
     <section css={styles.root} data-testid="wizard-step-species">
-      <h3 css={styles.heading}>
+      <h3 css={styles.heading} id={headingId}>
         {t({ en: "Pick a species", zh: "选择物种" })}
       </h3>
       <p css={styles.hint}>
@@ -48,18 +64,14 @@ export function StepSpecies({ def, onChange }: StepSpeciesProps) {
           zh: "16 种手绘造型。每一种都自带独特的眼神与轮廓。",
         })}
       </p>
-      <div css={styles.grid}>
-        {Object.values(species).map((entry) => {
-          if (entry === undefined) return null;
+      <div css={styles.grid} role="radiogroup" aria-labelledby={headingId}>
+        {entries.map((entry) => {
           const selected = def.species === entry.id;
           return (
             <button
               key={entry.id}
               type="button"
-              aria-pressed={selected}
-              onClick={() => {
-                onChange({ ...def, species: entry.id });
-              }}
+              {...getOptionProps(entry.id)}
               data-testid={`species-option-${entry.id}`}
               css={[styles.option, selected && styles.optionSelected]}
             >

--- a/apps/web/src/components/pixel-creature-creator/wizard/step-vibe.tsx
+++ b/apps/web/src/components/pixel-creature-creator/wizard/step-vibe.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
+import { useId, useMemo } from "react";
 import { t } from "#src/i18n.ts";
 import { color, font, space } from "#src/tokens.stylex.ts";
 import { types } from "../sprite/sprites";
@@ -10,6 +11,7 @@ import {
   type Emotion,
 } from "../state/creature-schema";
 import { OptionGrid } from "./option-grid";
+import { useRadioGroup } from "./use-radio-group";
 
 interface StepVibeProps {
   def: CreatureDef;
@@ -37,10 +39,34 @@ export function StepVibe({ def, onChange }: StepVibeProps) {
     void: t({ en: "Void", zh: "虚空系" }),
   };
 
+  const moodHeadingId = useId();
+  const elementHeadingId = useId();
+
+  const moodGroup = useRadioGroup({
+    values: EMOTIONS,
+    value: def.defaultEmotion,
+    onChange: (next) => {
+      onChange({ ...def, defaultEmotion: next });
+    },
+  });
+
+  const typeEntries = useMemo(
+    () => Object.values(types).filter((tp) => tp !== undefined),
+    [],
+  );
+  const typeIds = useMemo(() => typeEntries.map((tp) => tp.id), [typeEntries]);
+  const typeGroup = useRadioGroup({
+    values: typeIds,
+    value: def.type,
+    onChange: (next) => {
+      onChange({ ...def, type: next });
+    },
+  });
+
   return (
     <section css={styles.root} data-testid="wizard-step-vibe">
       <div css={styles.subsection}>
-        <h3 css={styles.heading}>
+        <h3 css={styles.heading} id={moodHeadingId}>
           {t({ en: "Pick a default mood", zh: "选择默认情绪" })}
         </h3>
         <p css={styles.hint}>
@@ -49,15 +75,12 @@ export function StepVibe({ def, onChange }: StepVibeProps) {
             zh: "预览会立即反映你的选择。",
           })}
         </p>
-        <OptionGrid>
+        <OptionGrid role="radiogroup" aria-labelledby={moodHeadingId}>
           {EMOTIONS.map((emotion) => (
             <button
               key={emotion}
               type="button"
-              aria-pressed={def.defaultEmotion === emotion}
-              onClick={() => {
-                onChange({ ...def, defaultEmotion: emotion });
-              }}
+              {...moodGroup.getOptionProps(emotion)}
               data-testid={`vibe-option-${emotion}`}
               css={[
                 styles.pill,
@@ -71,7 +94,7 @@ export function StepVibe({ def, onChange }: StepVibeProps) {
       </div>
 
       <div css={styles.subsection}>
-        <h3 css={styles.heading}>
+        <h3 css={styles.heading} id={elementHeadingId}>
           {t({ en: "Pick an element", zh: "选择元素" })}
         </h3>
         <p css={styles.hint}>
@@ -80,33 +103,26 @@ export function StepVibe({ def, onChange }: StepVibeProps) {
             zh: "为精灵染色并影响生物的属性。",
           })}
         </p>
-        <OptionGrid>
-          {Object.values(types).map((tp) =>
-            tp === undefined ? null : (
-              <button
-                key={tp.id}
-                type="button"
-                aria-pressed={def.type === tp.id}
-                onClick={() => {
-                  onChange({ ...def, type: tp.id });
-                }}
-                data-testid={`type-option-${tp.id}`}
-                css={[
-                  styles.typeOption,
-                  def.type === tp.id && styles.typeOptionSelected,
-                ]}
-              >
-                <span
-                  style={{ backgroundColor: tp.accentColor }}
-                  css={styles.typeAccent}
-                  title={tp.accentColor}
-                />
-                <span css={styles.optionLabel}>
-                  {typeLabels[tp.id] ?? tp.id}
-                </span>
-              </button>
-            ),
-          )}
+        <OptionGrid role="radiogroup" aria-labelledby={elementHeadingId}>
+          {typeEntries.map((tp) => (
+            <button
+              key={tp.id}
+              type="button"
+              {...typeGroup.getOptionProps(tp.id)}
+              data-testid={`type-option-${tp.id}`}
+              css={[
+                styles.typeOption,
+                def.type === tp.id && styles.typeOptionSelected,
+              ]}
+            >
+              <span
+                style={{ backgroundColor: tp.accentColor }}
+                css={styles.typeAccent}
+                title={tp.accentColor}
+              />
+              <span css={styles.optionLabel}>{typeLabels[tp.id] ?? tp.id}</span>
+            </button>
+          ))}
         </OptionGrid>
       </div>
     </section>

--- a/apps/web/src/components/pixel-creature-creator/wizard/use-radio-group.test.tsx
+++ b/apps/web/src/components/pixel-creature-creator/wizard/use-radio-group.test.tsx
@@ -1,0 +1,159 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { useRadioGroup } from "./use-radio-group";
+
+const VALUES = ["a", "b", "c", "d"] as const;
+type Value = (typeof VALUES)[number];
+
+function Harness({ initial = "a" }: { initial?: Value }) {
+  const [value, setValue] = useState<Value>(initial);
+  const { getOptionProps } = useRadioGroup({
+    values: VALUES,
+    value,
+    onChange: setValue,
+  });
+
+  return (
+    <div role="radiogroup" aria-label="test group">
+      {VALUES.map((v) => (
+        <button
+          key={v}
+          type="button"
+          {...getOptionProps(v)}
+          data-testid={`option-${v}`}
+        >
+          {v}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+describe("useRadioGroup", () => {
+  it("marks each option with role=radio and aria-checked reflecting the active value", () => {
+    render(<Harness initial="b" />);
+
+    const a = screen.getByTestId("option-a");
+    const b = screen.getByTestId("option-b");
+
+    expect(a).toHaveAttribute("role", "radio");
+    expect(b).toHaveAttribute("role", "radio");
+    expect(a).toHaveAttribute("aria-checked", "false");
+    expect(b).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("rolls tabIndex so only the active option is in the tab sequence", () => {
+    render(<Harness initial="c" />);
+
+    expect(screen.getByTestId("option-a")).toHaveAttribute("tabIndex", "-1");
+    expect(screen.getByTestId("option-b")).toHaveAttribute("tabIndex", "-1");
+    expect(screen.getByTestId("option-c")).toHaveAttribute("tabIndex", "0");
+    expect(screen.getByTestId("option-d")).toHaveAttribute("tabIndex", "-1");
+  });
+
+  it("clicking an option updates aria-checked + tabIndex", () => {
+    render(<Harness initial="a" />);
+
+    fireEvent.click(screen.getByTestId("option-c"));
+
+    expect(screen.getByTestId("option-a")).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+    expect(screen.getByTestId("option-c")).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(screen.getByTestId("option-c")).toHaveAttribute("tabIndex", "0");
+  });
+
+  it("ArrowRight / ArrowDown move selection forward and focus the new option", () => {
+    render(<Harness initial="b" />);
+
+    const b = screen.getByTestId("option-b");
+    b.focus();
+    fireEvent.keyDown(b, { key: "ArrowRight" });
+
+    const c = screen.getByTestId("option-c");
+    expect(c).toHaveAttribute("aria-checked", "true");
+    expect(c).toHaveFocus();
+
+    fireEvent.keyDown(c, { key: "ArrowDown" });
+
+    const d = screen.getByTestId("option-d");
+    expect(d).toHaveAttribute("aria-checked", "true");
+    expect(d).toHaveFocus();
+  });
+
+  it("ArrowLeft / ArrowUp move selection backward", () => {
+    render(<Harness initial="c" />);
+
+    const c = screen.getByTestId("option-c");
+    c.focus();
+    fireEvent.keyDown(c, { key: "ArrowLeft" });
+
+    const b = screen.getByTestId("option-b");
+    expect(b).toHaveAttribute("aria-checked", "true");
+    expect(b).toHaveFocus();
+
+    fireEvent.keyDown(b, { key: "ArrowUp" });
+
+    const a = screen.getByTestId("option-a");
+    expect(a).toHaveAttribute("aria-checked", "true");
+    expect(a).toHaveFocus();
+  });
+
+  it("ArrowRight wraps around from the last option to the first", () => {
+    render(<Harness initial="d" />);
+
+    const d = screen.getByTestId("option-d");
+    d.focus();
+    fireEvent.keyDown(d, { key: "ArrowRight" });
+
+    const a = screen.getByTestId("option-a");
+    expect(a).toHaveAttribute("aria-checked", "true");
+    expect(a).toHaveFocus();
+  });
+
+  it("ArrowLeft wraps around from the first option to the last", () => {
+    render(<Harness initial="a" />);
+
+    const a = screen.getByTestId("option-a");
+    a.focus();
+    fireEvent.keyDown(a, { key: "ArrowLeft" });
+
+    const d = screen.getByTestId("option-d");
+    expect(d).toHaveAttribute("aria-checked", "true");
+    expect(d).toHaveFocus();
+  });
+
+  it("Home jumps to the first option, End jumps to the last", () => {
+    render(<Harness initial="b" />);
+
+    const b = screen.getByTestId("option-b");
+    b.focus();
+    fireEvent.keyDown(b, { key: "End" });
+
+    const d = screen.getByTestId("option-d");
+    expect(d).toHaveAttribute("aria-checked", "true");
+    expect(d).toHaveFocus();
+
+    fireEvent.keyDown(d, { key: "Home" });
+
+    const a = screen.getByTestId("option-a");
+    expect(a).toHaveAttribute("aria-checked", "true");
+    expect(a).toHaveFocus();
+  });
+
+  it("ignores unrelated keys", () => {
+    render(<Harness initial="b" />);
+
+    const b = screen.getByTestId("option-b");
+    b.focus();
+    fireEvent.keyDown(b, { key: "Tab" });
+    fireEvent.keyDown(b, { key: "a" });
+
+    expect(b).toHaveAttribute("aria-checked", "true");
+  });
+});

--- a/apps/web/src/components/pixel-creature-creator/wizard/use-radio-group.ts
+++ b/apps/web/src/components/pixel-creature-creator/wizard/use-radio-group.ts
@@ -1,0 +1,115 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+
+interface RadioGroupOptions<TValue extends string> {
+  /** Ordered list of option values. */
+  values: readonly TValue[];
+  /** Currently selected value. */
+  value: TValue;
+  /** Called when the user picks a value via click or keyboard. */
+  onChange: (next: TValue) => void;
+}
+
+interface OptionProps {
+  ref: (node: HTMLButtonElement | null) => void;
+  role: "radio";
+  "aria-checked": boolean;
+  tabIndex: 0 | -1;
+  onClick: () => void;
+  onKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
+}
+
+/**
+ * ARIA radiogroup semantics for a single-select group of <button>s. Returns a
+ * `getOptionProps(value)` factory that supplies `role="radio"`,
+ * `aria-checked`, roving `tabIndex`, click + keyboard handlers, and a ref
+ * registration so arrow keys can move focus between options. Pair the
+ * options with a wrapper carrying `role="radiogroup"` and an `aria-label`
+ * (or `aria-labelledby`).
+ *
+ * Keyboard model matches WAI-ARIA: ArrowRight/Down moves to the next option
+ * and selects it; ArrowLeft/Up to the previous; Home / End jump to the
+ * first / last; activation wraps. Focus follows selection so the new option
+ * announces immediately, matching native <input type="radio"> behaviour.
+ */
+export function useRadioGroup<TValue extends string>({
+  values,
+  value,
+  onChange,
+}: RadioGroupOptions<TValue>) {
+  const nodesRef = useRef(new Map<TValue, HTMLButtonElement>());
+
+  const focusValue = useCallback((target: TValue) => {
+    nodesRef.current.get(target)?.focus();
+  }, []);
+
+  const move = useCallback(
+    (delta: 1 | -1) => {
+      if (values.length === 0) return;
+      const currentIndex = values.indexOf(value);
+      // If the current value isn't in the list (shouldn't happen but be
+      // defensive), fall back to the first option.
+      const baseIndex = currentIndex === -1 ? 0 : currentIndex;
+      const nextIndex =
+        (baseIndex + delta + values.length) % values.length;
+      const nextValue = values[nextIndex];
+      onChange(nextValue);
+      focusValue(nextValue);
+    },
+    [focusValue, onChange, value, values],
+  );
+
+  const jump = useCallback(
+    (target: "first" | "last") => {
+      if (values.length === 0) return;
+      const nextValue =
+        target === "first" ? values[0] : values[values.length - 1];
+      onChange(nextValue);
+      focusValue(nextValue);
+    },
+    [focusValue, onChange, values],
+  );
+
+  const getOptionProps = useCallback(
+    (optionValue: TValue): OptionProps => ({
+      ref: (node) => {
+        if (node === null) {
+          nodesRef.current.delete(optionValue);
+        } else {
+          nodesRef.current.set(optionValue, node);
+        }
+      },
+      role: "radio",
+      "aria-checked": optionValue === value,
+      tabIndex: optionValue === value ? 0 : -1,
+      onClick: () => {
+        onChange(optionValue);
+      },
+      onKeyDown: (event) => {
+        if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+          event.preventDefault();
+          move(1);
+          return;
+        }
+        if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+          event.preventDefault();
+          move(-1);
+          return;
+        }
+        if (event.key === "Home") {
+          event.preventDefault();
+          jump("first");
+          return;
+        }
+        if (event.key === "End") {
+          event.preventDefault();
+          jump("last");
+        }
+      },
+    }),
+    [jump, move, onChange, value],
+  );
+
+  return { getOptionProps };
+}

--- a/apps/web/src/components/pixel-creature-creator/wizard/use-radio-group.ts
+++ b/apps/web/src/components/pixel-creature-creator/wizard/use-radio-group.ts
@@ -51,8 +51,7 @@ export function useRadioGroup<TValue extends string>({
       // If the current value isn't in the list (shouldn't happen but be
       // defensive), fall back to the first option.
       const baseIndex = currentIndex === -1 ? 0 : currentIndex;
-      const nextIndex =
-        (baseIndex + delta + values.length) % values.length;
+      const nextIndex = (baseIndex + delta + values.length) % values.length;
       const nextValue = values[nextIndex];
       onChange(nextValue);
       focusValue(nextValue);


### PR DESCRIPTION
## Why

Four single-select option groups in the pixel creature creator were rendering as toggle-button groups (each option carrying `aria-pressed`):

- Step 1 species (16 species)
- Step 3 mood (7 emotions) and element (8 types) — both subgroups of the vibe step
- Review-screen emotion toggle (7 emotions)

Screen readers announced each option as "pressed / not pressed" instead of "X of N selected", and arrow-key navigation between options didn't work. Both wrong for single-select groups — these should be radiogroups per WAI-ARIA.

Multi-select accessory tiles in `step-features.tsx` correctly stayed as toggle buttons.

## What

- New `useRadioGroup` hook in `apps/web/src/components/pixel-creature-creator/wizard/use-radio-group.ts`. Generic over `TValue extends string`, takes `{ values, value, onChange }`, returns `getOptionProps(value)` that supplies `role="radio"`, `aria-checked`, roving `tabIndex` (0 only on the active option), `onClick`, and `onKeyDown`. Keyboard model matches WAI-ARIA: Arrow keys move forward/backward and select; Home/End jump to first/last; activation wraps; focus follows selection.
- Rewired `step-species.tsx`, `step-vibe.tsx` (both mood and element subgroups), and `review/emotion-toggle.tsx` to use the hook. Each wrapper now carries `role="radiogroup"` plus `aria-labelledby` (or `aria-label` for the review toggle which has no visible heading).
- `option-grid.tsx` extended with optional `role` / `aria-labelledby` / `aria-label` so the existing flex-wrap layout can also be the radiogroup container; default behaviour is unchanged for any caller that doesn't pass them.
- Updated one e2e assertion that previously read `aria-pressed` on emotion-toggle buttons to read `aria-checked` instead.

Visible UI is unchanged — every CSS class on every option button is identical to before.

## Test plan

- [x] `pnpm exec vitest run src/components/pixel-creature-creator` - 126 tests pass (117 + 9 new)
- [x] New `use-radio-group.test.tsx` - 9 tests covering role, aria-checked, roving tabIndex, click, Arrow forward/backward, wrap, Home/End, ignores unrelated keys
- [x] `pnpm exec tsc --noEmit` - clean
- [x] Builder ran the two affected Playwright specs - 6 + 5 pass
- [ ] Manual: Tab into species grid - only the active species is in the tab sequence; Arrow keys move selection and announce
- [ ] Manual: same for mood, element, and review emotion-toggle
- [ ] Manual: accessory multi-select still toggles individual tiles (unchanged)