### PR TITLE
fix: wire creature name input with required, invalid, and describedby

### DIFF
--- a/apps/web/src/components/pixel-creature-creator/wizard/step-name.test.tsx
+++ b/apps/web/src/components/pixel-creature-creator/wizard/step-name.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { render } from "#src/test-utils.tsx";
+import { type CreatureDef, DEFAULT_CREATURE } from "../state/creature-schema";
+import { StepName } from "./step-name";
+
+function renderStep(name: string) {
+  const def: CreatureDef = { ...DEFAULT_CREATURE, name };
+  const onChange = vi.fn<(next: CreatureDef) => void>();
+  const result = render(<StepName def={def} onChange={onChange} />);
+  const input = screen.getByTestId("creature-name-input");
+  return { ...result, input, onChange };
+}
+
+describe("StepName accessibility wiring", () => {
+  it("marks the input as required", () => {
+    const { input } = renderStep("Mochi");
+    expect(input).toHaveAttribute("aria-required", "true");
+  });
+
+  it("ties aria-describedby to the visible hint paragraph", () => {
+    const { input } = renderStep("Mochi");
+
+    const describedBy = input.getAttribute("aria-describedby");
+    expect(describedBy).not.toBeNull();
+    if (describedBy === null) return;
+
+    // Every id listed in aria-describedby resolves to a real element.
+    const ids = describedBy.split(/\s+/).filter((id) => id.length > 0);
+    expect(ids.length).toBeGreaterThanOrEqual(1);
+    for (const id of ids) {
+      expect(document.getElementById(id)).not.toBeNull();
+    }
+
+    // One of those elements is the constraint hint with the bilingual copy.
+    const hintEl = ids
+      .map((id) => document.getElementById(id))
+      .find((el) => el !== null && el.textContent.includes("1–20"));
+    expect(hintEl).not.toBeUndefined();
+  });
+
+  it("flips aria-invalid to true when the trimmed name is empty", () => {
+    const { input } = renderStep("");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("treats whitespace-only names as empty", () => {
+    const { input } = renderStep("   ");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("flips aria-invalid back to false once the user types a real character", () => {
+    const { input } = renderStep("Mochi");
+    expect(input).toHaveAttribute("aria-invalid", "false");
+  });
+
+  it("includes the error message id in aria-describedby when invalid", () => {
+    const { input } = renderStep("");
+    const error = screen.getByTestId("creature-name-error");
+    const describedBy = input.getAttribute("aria-describedby");
+    expect(describedBy).not.toBeNull();
+    expect(describedBy?.split(/\s+/)).toContain(error.id);
+    expect(error.textContent).not.toBe("");
+  });
+
+  it("excludes the error message id from aria-describedby when valid", () => {
+    const { input } = renderStep("Mochi");
+    const error = screen.getByTestId("creature-name-error");
+    const describedBy = input.getAttribute("aria-describedby");
+    expect(describedBy).not.toBeNull();
+    expect(describedBy?.split(/\s+/)).not.toContain(error.id);
+    // The live region stays mounted for stable announcements but its body is
+    // empty when the field is valid.
+    expect(error.textContent).toBe("");
+  });
+
+  it("propagates typed values back to the parent via onChange", () => {
+    const { input, onChange } = renderStep("");
+    fireEvent.change(input, { target: { value: "Mochi" } });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Mochi" }),
+    );
+  });
+
+  it("clamps input to the schema's max length", () => {
+    const { input, onChange } = renderStep("");
+    // 25 chars; schema cap is 20.
+    fireEvent.change(input, { target: { value: "abcdefghijklmnopqrstuvwxy" } });
+    const lastCall = onChange.mock.calls.at(-1);
+    expect(lastCall).toBeDefined();
+    if (lastCall === undefined) return;
+    const [next] = lastCall;
+    expect(next.name.length).toBeLessThanOrEqual(20);
+  });
+});

--- a/apps/web/src/components/pixel-creature-creator/wizard/step-name.tsx
+++ b/apps/web/src/components/pixel-creature-creator/wizard/step-name.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
+import { useId } from "react";
 import { t } from "#src/i18n.ts";
 import { color, font, space } from "#src/tokens.stylex.ts";
 import { type CreatureDef, NAME_MAX_LENGTH } from "../state/creature-schema";
@@ -13,12 +14,21 @@ interface StepNameProps {
 export function StepName({ def, onChange }: StepNameProps) {
   // Trim happens at submit time (the wizard "Finish" handler) so the user
   // can still type whitespace mid-edit; the input shows the raw value.
+  // Keep this empty-name rule in lockstep with `wizard-shell.tsx`'s
+  // `nameTooShort` — both gate Finish on the trimmed length.
+  const isEmpty = def.name.trim().length === 0;
+  const hintId = useId();
+  const errorId = useId();
+  // Always include hintId so the constraint announces alongside the field;
+  // append errorId only when the empty-state error message is rendered.
+  const describedBy = isEmpty ? `${hintId} ${errorId}` : hintId;
+
   return (
     <section css={styles.root} data-testid="wizard-step-name">
       <h3 css={styles.heading}>
         {t({ en: "Name your creature", zh: "为生物命名" })}
       </h3>
-      <p css={styles.hint}>
+      <p id={hintId} css={styles.hint}>
         {t({
           en: "1–20 characters. We will auto-trim leading and trailing spaces when you finish.",
           zh: "1–20 个字符。完成时会自动去除首尾空格。",
@@ -36,11 +46,34 @@ export function StepName({ def, onChange }: StepNameProps) {
             onChange({ ...def, name: next });
           }}
           maxLength={NAME_MAX_LENGTH}
+          aria-required="true"
+          aria-invalid={isEmpty}
+          aria-describedby={describedBy}
           placeholder={t({ en: "e.g. Mochi", zh: "例如:团子" })}
           data-testid="creature-name-input"
           css={styles.input}
         />
       </label>
+      {/*
+        Empty-name error is the *reason* the Finish button is disabled, so
+        announce it alongside the input via aria-describedby + an
+        aria-live="polite" region. `aria-live` makes the message also
+        announce the moment the user backspaces the last character without
+        having to re-focus the field.
+      */}
+      <p
+        id={errorId}
+        aria-live="polite"
+        css={styles.error}
+        data-testid="creature-name-error"
+      >
+        {isEmpty
+          ? t({
+              en: "Name is required to finish.",
+              zh: "需要填写名字才能完成。",
+            })
+          : ""}
+      </p>
       <div css={styles.lorePanel} data-testid="lore-placeholder">
         <h4 css={styles.loreTitle}>
           {t({ en: "Lore coming next", zh: "下一步:背景故事" })}
@@ -95,6 +128,14 @@ const styles = stylex.create({
     outlineWidth: 0,
     transitionProperty: "border-color",
     transitionDuration: "120ms",
+  },
+  // Always reserve a line of vertical space so the input doesn't jump as
+  // the message appears/disappears.
+  error: {
+    margin: 0,
+    minHeight: "1.2em",
+    fontSize: font.uiBodySmall,
+    color: color.brandBristol,
   },
   lorePanel: {
     marginTop: space._2,


### PR DESCRIPTION
## Why

The pixel-creature-creator wizard's name input (step 4) had:
- No `aria-required`, despite being mandatory to finish.
- No `aria-invalid`, despite the Finish button being disabled when empty.
- No `aria-describedby` connecting the visible "1–20 characters…" hint to the field.
- No error message explaining why Finish is disabled.

Screen-reader users had no way to discover the constraint, the required state, or why the next step was blocked.

## What

`apps/web/src/components/pixel-creature-creator/wizard/step-name.tsx`:

- Derive `isEmpty = def.name.trim().length === 0` — same predicate `wizard-shell.tsx`'s `nameTooShort` uses to gate Finish, so `aria-invalid` and the disabled state stay in lockstep without threading a new prop.
- Add `useId()` for `hintId` and `errorId`.
- Set `aria-required="true"` on the `<input>`.
- Set `aria-invalid={isEmpty}`.
- Set `aria-describedby={hintId}` always; append `errorId` when invalid so screen readers concatenate hint + error.
- Add a new `<p id={errorId} aria-live="polite">` that reserves a line of vertical space and shows "Name is required to finish." / "需要填写名字才能完成。" when empty. Polite (not assertive) so the message announces friendly on first arrival to step 4 and re-announces when the user backspaces to empty.

Visible UI hint copy and the existing wizard data flow are unchanged.

## Test plan

- [x] New `step-name.test.tsx` (9 tests, all pass): `aria-required`, hint resolution via `aria-describedby`, `aria-invalid` for empty, whitespace-only, valid, conditional `errorId` inclusion, error message presence/emptiness, `onChange` propagation, max-length clamp
- [x] `pnpm exec vitest run src/components/pixel-creature-creator` - 126 tests pass
- [x] `pnpm lint:changed` - clean
- [ ] Manual: focus the field empty - VoiceOver announces name + required + hint + error
- [ ] Manual: type a name - re-focusing announces hint only (no error)
- [ ] Manual: backspace to empty while focused - error announces politely