### PR TITLE
fix: skip pixel editor shortcuts on editable targets

### DIFF
--- a/apps/web/src/components/sprite-editor/pixel-editor.tsx
+++ b/apps/web/src/components/sprite-editor/pixel-editor.tsx
@@ -26,6 +26,7 @@ import type { CellPixels } from "./types";
 import { useHistory } from "./use-history";
 import type { GuideOptions } from "./utils/guides";
 import { computeGuideFractions } from "./utils/guides";
+import { isEditableTarget } from "./utils/is-editable-target";
 import type { Rect } from "./utils/pixel-ops";
 import {
   cloneCell,
@@ -870,6 +871,16 @@ export function PixelEditor({
   // Keyboard shortcuts.
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
+      // Don't hijack keys when the user is typing in a form field or
+      // contenteditable — Ctrl+Z would clobber native input undo, Backspace /
+      // Delete / Enter / Escape would steal keystrokes from inputs like the
+      // grid-controls sidebar or the in-editor color/tolerance pickers.
+      if (
+        isEditableTarget(event.target) ||
+        isEditableTarget(document.activeElement)
+      ) {
+        return;
+      }
       const meta = event.metaKey || event.ctrlKey;
       if (meta) {
         const key = event.key.toLowerCase();

--- a/apps/web/src/components/sprite-editor/utils/is-editable-target.test.ts
+++ b/apps/web/src/components/sprite-editor/utils/is-editable-target.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { isEditableTarget } from "./is-editable-target";
+
+describe("isEditableTarget", () => {
+  it("returns true for text, number, range, and color inputs", () => {
+    for (const type of ["text", "number", "range", "color", "search"]) {
+      const input = document.createElement("input");
+      input.type = type;
+      expect(isEditableTarget(input)).toBe(true);
+    }
+  });
+
+  it("returns true for textarea and select", () => {
+    expect(isEditableTarget(document.createElement("textarea"))).toBe(true);
+    expect(isEditableTarget(document.createElement("select"))).toBe(true);
+  });
+
+  it("returns true for contenteditable elements and their children", () => {
+    const div = document.createElement("div");
+    div.setAttribute("contenteditable", "true");
+    const child = document.createElement("span");
+    div.appendChild(child);
+    document.body.appendChild(div);
+    try {
+      expect(isEditableTarget(div)).toBe(true);
+      expect(isEditableTarget(child)).toBe(true);
+    } finally {
+      div.remove();
+    }
+  });
+
+  it("returns false for non-editable elements", () => {
+    expect(isEditableTarget(document.createElement("button"))).toBe(false);
+    expect(isEditableTarget(document.createElement("canvas"))).toBe(false);
+    expect(isEditableTarget(document.createElement("div"))).toBe(false);
+    expect(isEditableTarget(document.body)).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isEditableTarget(null)).toBe(false);
+  });
+});

--- a/apps/web/src/components/sprite-editor/utils/is-editable-target.ts
+++ b/apps/web/src/components/sprite-editor/utils/is-editable-target.ts
@@ -1,0 +1,21 @@
+/**
+ * Returns true when the given EventTarget is a focusable form field or
+ * contenteditable region — i.e. somewhere the user is typing and where the
+ * editor's global keyboard shortcuts (Ctrl+Z, Backspace, Delete, Enter,
+ * Escape) would clobber the native input behaviour.
+ */
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (target instanceof HTMLInputElement) return true;
+  if (target instanceof HTMLTextAreaElement) return true;
+  if (target instanceof HTMLSelectElement) return true;
+  if (target instanceof HTMLElement) {
+    // `isContentEditable` is the canonical browser API but jsdom (used in
+    // unit tests) doesn't implement it, so fall back to closest() so that
+    // nested children of a contenteditable host are also covered.
+    if (target.isContentEditable) return true;
+    if (target.closest('[contenteditable=""], [contenteditable="true"]')) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## The bug

`PixelEditor` attaches a `keydown` listener on `window` for Ctrl/Cmd+Z/Y, Escape, Enter, Delete, and Backspace. The handler called `event.preventDefault()` and ran `undo()` / `redo()` / selection actions regardless of where the keystroke originated, so typing into the grid-controls inputs (Cols/Rows/Offset/Cell/Gap), the output Width/Height fields, the in-editor color picker, or the bg-remove tolerance range hijacked normal input behaviour — Cmd+Z clobbered native input undo, Backspace/Delete erased the canvas selection instead of deleting digits, and Enter/Escape were silently swallowed.

## The fix

Bail out of the handler before any `preventDefault()` when the keystroke originated from an editable target — `HTMLInputElement`, `HTMLTextAreaElement`, `HTMLSelectElement`, or anything inside a contenteditable region. Detection lives in a small `isEditableTarget` helper so the same predicate can be checked against both `event.target` and `document.activeElement` (window-level keydown can dispatch with either, depending on the browser). Type narrowing uses `instanceof` only — no assertions, no `any`. Canvas-focused shortcuts are unchanged because the body / canvas elements fall through the predicate.