### PR TITLE
fix: announce source image rejection to screen readers

### DIFF
--- a/apps/web/src/components/sprite-editor/source-image-input.test.tsx
+++ b/apps/web/src/components/sprite-editor/source-image-input.test.tsx
@@ -1,0 +1,25 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { render } from "#src/test-utils.tsx";
+import { SourceImageInput } from "./source-image-input";
+
+describe("SourceImageInput error announcement", () => {
+  it("renders the rejection message in a role=alert live region when a non-image is chosen", async () => {
+    const onSourceChange = vi.fn();
+    render(<SourceImageInput source={null} onSourceChange={onSourceChange} />);
+
+    const input = screen.getByTestId("source-input");
+    const file = new File(["hello"], "notes.txt", { type: "text/plain" });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toBe("Not an image file.");
+    expect(onSourceChange).not.toHaveBeenCalled();
+  });
+
+  it("does not render an alert region in the resting state", () => {
+    const onSourceChange = vi.fn();
+    render(<SourceImageInput source={null} onSourceChange={onSourceChange} />);
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/apps/web/src/components/sprite-editor/source-image-input.tsx
+++ b/apps/web/src/components/sprite-editor/source-image-input.tsx
@@ -105,7 +105,11 @@ export function SourceImageInput({
             })
           : `${source.name} — ${String(source.width)}×${String(source.height)}`}
       </p>
-      {error !== null ? <p css={styles.error}>{error}</p> : null}
+      {error !== null ? (
+        <p role="alert" css={styles.error}>
+          {error}
+        </p>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## The bug

When `SourceImageInput` rejects a chosen or dropped file — non-image MIME, or `createImageBitmap` decode failure — the rejection text was rendered in a plain `<p>`. Sighted users see the message; screen reader users get nothing, leaving them stuck wondering why their file silently disappeared.

## The fix

Add `role="alert"` to the rejection `<p>`. The element only renders when `error !== null`, so the alert mounts in response to the user's action and is announced by assistive tech. `role="alert"` over `aria-live="polite"` matches the closer in-repo precedent for discrete operation-failure messages (`tool-visual-output.tsx`, `media-detail-content.tsx`, `person-detail-content.tsx`); the `aria-live="polite"` + persistent-container pattern fits live constraint hints, not one-shot file rejections.

## Notes

The drop path funnels through the same `ingest()` helper as the file-picker path, so the new test exercising the file-picker covers both. A "successful upload clears the alert" test would require mocking `createImageBitmap` (jsdom has no implementation), which the project rules forbid without explicit permission.