### PR TITLE
fix: preserve animation playback carry-over across effect re-runs

### DIFF
--- a/apps/web/src/components/sprite-editor/animation-mode.test.tsx
+++ b/apps/web/src/components/sprite-editor/animation-mode.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, fireEvent, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "#src/test-utils.tsx";
 import { AnimationMode, type AnimationFrame } from "./animation-mode";
 import type { CellPixels } from "./types";
@@ -25,6 +25,19 @@ function setup(frames: readonly AnimationFrame[]) {
     />,
   );
   return { onFramesChange };
+}
+
+/**
+ * Drive `n` rAF ticks each spaced `tickMs` apart. We advance both the
+ * timer and the rAF queue together, mirroring how a real browser couples
+ * its raster clock to its rAF dispatch.
+ */
+function advanceByRaf(n: number, tickMs: number) {
+  for (let i = 0; i < n; i++) {
+    act(() => {
+      vi.advanceTimersByTime(tickMs);
+    });
+  }
 }
 
 describe("AnimationMode frame-duration blank-input handling", () => {
@@ -53,5 +66,48 @@ describe("AnimationMode frame-duration blank-input handling", () => {
     expect(lastCall).toBeDefined();
     if (lastCall === undefined) return;
     expect(lastCall[0][0].duration).toBe(200);
+  });
+});
+
+describe("AnimationMode playback timing", () => {
+  beforeEach(() => {
+    // Vitest's fake timers also mock performance.now() and
+    // requestAnimationFrame (using a 16ms tick by default).
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not re-create the rAF loop on every frame transition", () => {
+    const frames: AnimationFrame[] = [
+      { cellIndex: 0, duration: 20 },
+      { cellIndex: 1, duration: 20 },
+      { cellIndex: 2, duration: 20 },
+    ];
+    setup(frames);
+
+    // Spy *after* mount so we only count rAF calls produced by the
+    // playback loop. Each tick should schedule exactly one new rAF — if
+    // the effect re-runs because `activeFrame` is in its deps, we'd see
+    // multiple cleanup/setup cycles per advance.
+    const rafSpy = vi.spyOn(globalThis, "requestAnimationFrame");
+
+    fireEvent.click(screen.getByTestId("play-pause"));
+
+    // Drive 5 rAF ticks (~80ms at the default 16ms cadence). With 20ms
+    // frame durations that's enough for several frame advances.
+    const initialCalls = rafSpy.mock.calls.length;
+    advanceByRaf(5, 16);
+    const ticksScheduled = rafSpy.mock.calls.length - initialCalls;
+
+    // We expect exactly one rAF schedule per tick we ran (the tick body
+    // re-arms itself). If the effect were tearing down + setting up
+    // because `activeFrame` was in its deps, we'd see strictly more —
+    // the test guards against the regression that caused the drift bug.
+    expect(ticksScheduled).toBeLessThanOrEqual(5);
+
+    rafSpy.mockRestore();
   });
 });

--- a/apps/web/src/components/sprite-editor/animation-mode.tsx
+++ b/apps/web/src/components/sprite-editor/animation-mode.tsx
@@ -62,22 +62,43 @@ export function AnimationMode({
     }
   }
 
+  // Carry-over time across the boundary into the next frame. Lives in a ref
+  // so the value survives effect re-runs (e.g. when `frames` or `speed`
+  // change mid-playback) — earlier the cleanup discarded the leftover and
+  // every frame ran one rAF tick (~16ms) longer than configured.
+  const playbackRef = useRef<{ elapsed: number }>({ elapsed: 0 });
+  // Mirror of `activeFrame` so the rAF tick reads the current value without
+  // needing it in the effect's dep array (which would re-run the effect on
+  // every frame transition, again losing carry-over).
+  const activeFrameRef = useRef(activeFrame);
+  useEffect(() => {
+    activeFrameRef.current = activeFrame;
+  }, [activeFrame]);
+
+  // Drop any leftover carry-over when the user starts (or stops) a play
+  // session — re-entering Play mid-frame should not inherit progress from
+  // the previous run. Carry-over within a session (across `speed`/`frames`
+  // edits) is preserved by the ref.
+  useEffect(() => {
+    playbackRef.current.elapsed = 0;
+  }, [isPlaying]);
+
   // Playback loop. Uses real time + frame durations, scaled by `speed`, so
   // setting `speed = 2` halves each duration and `speed = 0.5` doubles it.
   useEffect(() => {
     if (!isPlaying || frames.length === 0) return;
     let raf = 0;
     let lastTime = performance.now();
-    let elapsed = 0;
     const tick = (now: number) => {
-      elapsed += (now - lastTime) * speed;
+      playbackRef.current.elapsed += (now - lastTime) * speed;
       lastTime = now;
-      let idx = activeFrame;
-      while (elapsed >= frames[idx].duration) {
-        elapsed -= frames[idx].duration;
+      let idx = activeFrameRef.current;
+      while (playbackRef.current.elapsed >= frames[idx].duration) {
+        playbackRef.current.elapsed -= frames[idx].duration;
         idx = (idx + 1) % frames.length;
       }
-      if (idx !== activeFrame) {
+      if (idx !== activeFrameRef.current) {
+        activeFrameRef.current = idx;
         setActiveFrame(idx);
       }
       raf = requestAnimationFrame(tick);
@@ -86,7 +107,7 @@ export function AnimationMode({
     return () => {
       cancelAnimationFrame(raf);
     };
-  }, [isPlaying, speed, frames, activeFrame]);
+  }, [isPlaying, speed, frames]);
 
   // Render the current frame to the preview canvas at integer scale, centered.
   useEffect(() => {


### PR DESCRIPTION
## The bug

`AnimationMode`'s playback effect listed `activeFrame` in its dep array, so every `setActiveFrame(idx)` tore down the rAF loop and re-ran the effect from scratch. Each re-run reset the `elapsed` carry-over and `lastTime`, discarding the leftover time past the frame boundary. Net result: every frame ran ~one rAF tick (~16ms) longer than its configured duration, and any `speed` or `frames` edit mid-playback compounded the drift.

## The fix

Move the playback bookkeeping into refs that survive effect re-runs:

- `playbackRef.current.elapsed` carries leftover time past frame boundaries across `frames` / `speed` re-runs.
- `activeFrameRef` mirrors `activeFrame` so the rAF tick reads the latest value without listing it in the dep array — the effect now only tears down on `isPlaying`, `speed`, or `frames` edges, not on every frame transition.
- A small dedicated effect resets `playbackRef.current.elapsed = 0` on `isPlaying` flips so a fresh play session starts clean while in-session edits preserve timing.

`lastTime` stays a local `let` inside the playback effect — persisting it across pause/resume would scale the entire pause duration by `speed` on the next tick.

## Notes

The regression test asserts a structural property — `requestAnimationFrame` is called at most once per tick across many frame advances — rather than an absolute frame count. An absolute-count assertion was prototyped but the buggy version inadvertently advanced the same number of frames as the fixed version under Vitest's fake-rAF cadence interacting with React's `act` flushing. The rAF-call-count check distinguishes the two cases via the underlying mechanism.