### PR TITLE
fix: promote cell strip thumbnails to an ARIA radiogroup

### DIFF
--- a/apps/web/src/components/sprite-editor/cell-strip.test.tsx
+++ b/apps/web/src/components/sprite-editor/cell-strip.test.tsx
@@ -1,0 +1,133 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { render } from "#src/test-utils.tsx";
+import { CellStrip } from "./cell-strip";
+import type { CellPixels } from "./types";
+
+// jsdom doesn't implement ResizeObserver, which the cell thumbnail uses to
+// size its canvas. We don't care about the canvas in these tests — only
+// the radiogroup wiring on the surrounding buttons — so a no-op stub is
+// sufficient. Same pattern is used in calculator.test.tsx.
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+function makeCell(): CellPixels {
+  return {
+    width: 1,
+    height: 1,
+    data: new Uint8ClampedArray([0, 0, 0, 255]),
+  };
+}
+
+function setup(selectedCell: number | null, cellCount = 4) {
+  const cells: (CellPixels | null)[] = Array.from({ length: cellCount }, () =>
+    makeCell(),
+  );
+  const onSelect = vi.fn<(index: number) => void>();
+  const result = render(
+    <CellStrip cells={cells} selectedCell={selectedCell} onSelect={onSelect} />,
+  );
+  return { ...result, onSelect };
+}
+
+describe("CellStrip ARIA semantics", () => {
+  it("wraps the cells in a radiogroup labelled by the heading", () => {
+    setup(0);
+
+    const group = screen.getByRole("radiogroup");
+    const headingId = group.getAttribute("aria-labelledby");
+    expect(headingId).not.toBeNull();
+    if (headingId === null) return;
+    const heading = document.getElementById(headingId);
+    expect(heading).not.toBeNull();
+    expect(heading?.textContent ?? "").toContain("Cells");
+  });
+
+  it("renders each thumbnail as role=radio with aria-checked reflecting selection (no aria-pressed)", () => {
+    setup(2);
+
+    const thumbs = screen.getAllByRole("radio");
+    expect(thumbs.length).toBe(4);
+    expect(thumbs[0]).toHaveAttribute("aria-checked", "false");
+    expect(thumbs[1]).toHaveAttribute("aria-checked", "false");
+    expect(thumbs[2]).toHaveAttribute("aria-checked", "true");
+    expect(thumbs[3]).toHaveAttribute("aria-checked", "false");
+    for (const thumb of thumbs) {
+      expect(thumb).not.toHaveAttribute("aria-pressed");
+    }
+  });
+
+  it("rolls tabindex so only the selected thumb is in the tab sequence", () => {
+    setup(1);
+
+    expect(screen.getByTestId("cell-thumb-0")).toHaveAttribute(
+      "tabIndex",
+      "-1",
+    );
+    expect(screen.getByTestId("cell-thumb-1")).toHaveAttribute("tabIndex", "0");
+    expect(screen.getByTestId("cell-thumb-2")).toHaveAttribute(
+      "tabIndex",
+      "-1",
+    );
+    expect(screen.getByTestId("cell-thumb-3")).toHaveAttribute(
+      "tabIndex",
+      "-1",
+    );
+  });
+
+  it("when no cell is selected yet, the first cell is the tab stop but reads as unchecked", () => {
+    setup(null);
+
+    const first = screen.getByTestId("cell-thumb-0");
+    expect(first).toHaveAttribute("tabIndex", "0");
+    // Critical: the tab-stop seed must NOT lie about selection state.
+    expect(first).toHaveAttribute("aria-checked", "false");
+    for (const thumb of screen.getAllByRole("radio")) {
+      expect(thumb).toHaveAttribute("aria-checked", "false");
+    }
+  });
+
+  it("ArrowRight on the focused cell selects the next cell and moves focus there", () => {
+    const { onSelect } = setup(1);
+
+    const second = screen.getByTestId("cell-thumb-1");
+    second.focus();
+    fireEvent.keyDown(second, { key: "ArrowRight" });
+
+    expect(onSelect).toHaveBeenCalledWith(2);
+  });
+
+  it("ArrowLeft wraps from the first cell to the last", () => {
+    const { onSelect } = setup(0);
+
+    const first = screen.getByTestId("cell-thumb-0");
+    first.focus();
+    fireEvent.keyDown(first, { key: "ArrowLeft" });
+
+    expect(onSelect).toHaveBeenCalledWith(3);
+  });
+
+  it("End jumps to the last cell, Home to the first", () => {
+    const { onSelect } = setup(1);
+
+    const second = screen.getByTestId("cell-thumb-1");
+    second.focus();
+    fireEvent.keyDown(second, { key: "End" });
+    expect(onSelect).toHaveBeenLastCalledWith(3);
+
+    fireEvent.keyDown(second, { key: "Home" });
+    expect(onSelect).toHaveBeenLastCalledWith(0);
+  });
+
+  it("clicking a thumb selects it via onSelect with the numeric index", () => {
+    const { onSelect } = setup(0);
+
+    fireEvent.click(screen.getByTestId("cell-thumb-2"));
+    expect(onSelect).toHaveBeenCalledWith(2);
+  });
+});

--- a/apps/web/src/components/sprite-editor/cell-strip.tsx
+++ b/apps/web/src/components/sprite-editor/cell-strip.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { useRadioGroup } from "#src/components/pixel-creature-creator/wizard/use-radio-group.ts";
 import { t } from "#src/i18n.ts";
 import { border, color, font, space } from "#src/tokens.stylex.ts";
 import type { CellPixels } from "./types";
@@ -14,37 +15,60 @@ interface CellStripProps {
 
 export function CellStrip({ cells, selectedCell, onSelect }: CellStripProps) {
   const cellLabel = t({ en: "Cell", zh: "单元格" });
+  const headingId = useId();
+  // The radio-group hook is generic over `string`, so convert at the
+  // boundary. Stringified indices are stable identifiers since cells are
+  // positional.
+  const values = useMemo(() => cells.map((_, index) => String(index)), [cells]);
+  // When nothing is selected yet, point `value` at the first cell so the
+  // group still has exactly one tab stop (canonical radiogroup-with-no-
+  // default pattern). We override `aria-checked` below to stay honest about
+  // selection state.
+  const value = selectedCell === null ? "0" : String(selectedCell);
+  const { getOptionProps } = useRadioGroup({
+    values,
+    value,
+    onChange: (next) => {
+      onSelect(Number(next));
+    },
+  });
+
   return (
     <div css={styles.root}>
-      <h2 css={styles.heading}>
+      <h2 css={styles.heading} id={headingId}>
         {t({ en: "Cells", zh: "单元格" })}{" "}
         <span css={styles.count}>({cells.length})</span>
       </h2>
-      <ol css={styles.list}>
-        {cells.map((cell, index) => (
-          <li
-            // eslint-disable-next-line @eslint-react/no-array-index-key -- cells are positional; index IS the identity
-            key={index}
-            css={styles.item}
-          >
-            <button
-              type="button"
-              css={[
-                styles.thumbButton,
-                selectedCell === index && styles.thumbButtonActive,
-              ]}
-              onClick={() => {
-                onSelect(index);
-              }}
-              data-testid={`cell-thumb-${String(index)}`}
-              aria-label={`${cellLabel} ${String(index + 1)}`}
-              aria-pressed={selectedCell === index}
+      <ol css={styles.list} role="radiogroup" aria-labelledby={headingId}>
+        {cells.map((cell, index) => {
+          const isSelected = selectedCell === index;
+          return (
+            <li
+              // eslint-disable-next-line @eslint-react/no-array-index-key -- cells are positional; index IS the identity
+              key={index}
+              css={styles.item}
             >
-              <CellThumbnail cell={cell} />
-              <span css={styles.thumbIndex}>{index + 1}</span>
-            </button>
-          </li>
-        ))}
+              <button
+                type="button"
+                {...getOptionProps(String(index))}
+                // Override `aria-checked` from the hook: when nothing is
+                // selected the hook would mark cell 0 as checked because
+                // `value` is "0" to seed the tab stop. We need it to read
+                // as unchecked until the user actually picks a cell.
+                aria-checked={isSelected}
+                css={[
+                  styles.thumbButton,
+                  isSelected && styles.thumbButtonActive,
+                ]}
+                data-testid={`cell-thumb-${String(index)}`}
+                aria-label={`${cellLabel} ${String(index + 1)}`}
+              >
+                <CellThumbnail cell={cell} />
+                <span css={styles.thumbIndex}>{index + 1}</span>
+              </button>
+            </li>
+          );
+        })}
       </ol>
     </div>
   );


### PR DESCRIPTION
## The bug

`CellStrip` rendered each cell thumbnail as a `<button aria-pressed={selected}>`, communicating toggle-button semantics for what is actually a single-select group. Screen reader users heard "pressed/not pressed" instead of "radio button, N of M, selected/not selected", and the buttons did not participate in the WAI-ARIA roving-focus keyboard model — Tab cycled through every thumbnail, and Arrow keys did nothing. The wizard side of the codebase already fixed the same shape via #2263 with a `useRadioGroup` hook.

## The fix

Reuse `useRadioGroup` from the wizard. The `<ol>` wrapper now carries `role="radiogroup"` with `aria-labelledby` pointing at the existing "Cells" heading (no new translated string). Each `<button>` spreads `getOptionProps(String(index))` to get `role="radio"`, `aria-checked`, roving `tabIndex`, click + Arrow / Home / End handlers, and ref registration. The hook is generic over `string`, so indices are stringified at the boundary and `onChange` converts back to a number — no widening of the hook, no assertions.

The "no cell selected yet" state seeds `value = "0"` so the group has exactly one tab stop (the canonical radiogroup-with-no-default pattern), then explicitly overrides `aria-checked={selectedCell === index}` after the hook spread so AT users hear "not checked" rather than a misleading "checked" lie on cell 0.

## Notes

The new test polyfills `globalThis.ResizeObserver` with a no-op stub in `beforeAll` because jsdom doesn't ship one and the cell thumbnail's canvas-sizing effect uses it. This is a missing-platform-API stub, not a behavior mock — the same pattern is used in `calculator.test.tsx`. The `<ol>` is kept rather than swapping to a `<div>`; the explicit `role="radiogroup"` cleanly overrides the implicit list semantics, and dropping the list element would have been a separate scope change.