### PR TITLE
fix: skip grid-controls blank-input dispatch mid-edit

### DIFF
--- a/apps/web/src/components/sprite-editor/grid-controls.test.tsx
+++ b/apps/web/src/components/sprite-editor/grid-controls.test.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { render } from "#src/test-utils.tsx";
+import { GridControls } from "./grid-controls";
+import type { GridConfig, OutputConfig, SourceImage } from "./types";
+
+// Structural ImageBitmap — `GridControls` doesn't touch the bitmap, only
+// `source.width` / `source.height`, but the prop type still requires one.
+const FAKE_BITMAP: ImageBitmap = {
+  width: 256,
+  height: 256,
+  close: () => undefined,
+};
+
+const SOURCE: SourceImage = {
+  bitmap: FAKE_BITMAP,
+  width: 256,
+  height: 256,
+  name: "sheet.png",
+};
+
+const GRID: GridConfig = {
+  cols: 4,
+  rows: 4,
+  offsetX: 8,
+  offsetY: 8,
+  cellWidth: 32,
+  cellHeight: 32,
+  gapX: 0,
+  gapY: 0,
+};
+
+const OUTPUT: OutputConfig = { width: 32, height: 32 };
+
+function setup() {
+  const onGridChange = vi.fn<(next: GridConfig) => void>();
+  const onOutputChange = vi.fn<(next: OutputConfig) => void>();
+  render(
+    <GridControls
+      source={SOURCE}
+      grid={GRID}
+      onGridChange={onGridChange}
+      output={OUTPUT}
+      onOutputChange={onOutputChange}
+    />,
+  );
+  return { onGridChange, onOutputChange };
+}
+
+describe("GridControls blank-input handling", () => {
+  it.each([
+    ["grid-cols", "onGridChange"],
+    ["grid-rows", "onGridChange"],
+    ["grid-cell-w", "onGridChange"],
+    ["grid-cell-h", "onGridChange"],
+    ["grid-offset-x", "onGridChange"],
+    ["grid-offset-y", "onGridChange"],
+    ["grid-gap-x", "onGridChange"],
+    ["grid-gap-y", "onGridChange"],
+    ["output-width", "onOutputChange"],
+    ["output-height", "onOutputChange"],
+  ] as const)(
+    "%s does not dispatch when the field is cleared mid-edit",
+    (testId, callbackName) => {
+      const callbacks = setup();
+      const callback = callbacks[callbackName];
+
+      const input = screen.getByTestId(testId);
+      // Simulate the "Cmd+A, Delete" gesture — the input briefly sees an
+      // empty string. With the bug present, this dispatches a numeric 0
+      // (which the destructive Cols/Rows/Cell-W/H clamps then snap to 1).
+      fireEvent.change(input, { target: { value: "" } });
+
+      expect(callback).not.toHaveBeenCalled();
+    },
+  );
+
+  it("still dispatches non-empty numeric input", () => {
+    const { onGridChange } = setup();
+    const input = screen.getByTestId("grid-cols");
+
+    fireEvent.change(input, { target: { value: "8" } });
+
+    expect(onGridChange).toHaveBeenCalledTimes(1);
+    const lastCall = onGridChange.mock.calls.at(-1);
+    expect(lastCall).toBeDefined();
+    if (lastCall === undefined) return;
+    expect(lastCall[0].cols).toBe(8);
+  });
+
+  it("dispatches 0 when the user explicitly types '0' (distinct from blank)", () => {
+    // Offset/gap fields legitimately accept 0; the fix must not block that.
+    const { onGridChange } = setup();
+    const input = screen.getByTestId("grid-offset-x");
+
+    fireEvent.change(input, { target: { value: "0" } });
+
+    expect(onGridChange).toHaveBeenCalledTimes(1);
+    const lastCall = onGridChange.mock.calls.at(-1);
+    expect(lastCall).toBeDefined();
+    if (lastCall === undefined) return;
+    expect(lastCall[0].offsetX).toBe(0);
+  });
+});

--- a/apps/web/src/components/sprite-editor/grid-controls.tsx
+++ b/apps/web/src/components/sprite-editor/grid-controls.tsx
@@ -46,6 +46,11 @@ function NumberField({
         step={step}
         css={styles.input}
         onChange={(event) => {
+          // Skip mid-edit blank state — `Number("")` is 0, which would
+          // commit a destructive 0 (or 1, after the callsite's clamp) and
+          // overwrite the digit the user is about to type. The browser
+          // keeps the field visually empty until the user blurs or types.
+          if (event.target.value === "") return;
           const next = Number(event.target.value);
           if (Number.isNaN(next)) return;
           onChange(next);


### PR DESCRIPTION
## The bug

`NumberField`'s change handler in `grid-controls.tsx` parsed the input value with `Number()` and only bailed when the result was `NaN`. But `Number("")` is `0`, not `NaN`, so the moment the user cleared a field — Cmd+A then Delete — a numeric `0` was dispatched. The callsites clamp it (`Math.max(1, …)` for cols/rows/cell-w/h, `Math.max(0, …)` for offsets/gaps), then re-render the controlled input with the clamped value, snapping the field to "1" or "0" while the user was still typing. For Cols/Rows/Output Width/Height the destructive blank also crossed the `prevShapeKey` reset in `sprite-editor.tsx` and wiped `edits`, `onionSourceCell`, and `animationFrames` mid-edit.

## The fix

Bail before the `Number()` parse when `event.target.value === ""`. The browser keeps the field visually empty until the user types a digit or blurs (at which point the parent's controlled `value` repaints with the previously-committed value, matching the project's existing pattern). The existing `Number.isNaN` guard still catches partial signs and decimals like `"-"` or `"."`. No new state, no input-type swap, no clamp relocation — exactly the path the field's existing controlled-input shape supports.

## Notes

The new test parameterizes over all ten inputs (Cols, Rows, Cell W/H, Offset X/Y, Gap X/Y, Output Width/Height) and asserts no dispatch on blank, plus one regression-protection test for non-blank input and one explicit-zero test (Offset X must still accept `"0"` so the fix distinguishes "blank mid-edit" from "user typed zero"). Verified by stash/unstash that 10 of the 12 tests fail without the fix.