### PR TITLE
fix: skip frame-duration blank-input dispatch mid-edit

### DIFF
--- a/apps/web/src/components/sprite-editor/animation-mode.test.tsx
+++ b/apps/web/src/components/sprite-editor/animation-mode.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { render } from "#src/test-utils.tsx";
+import { AnimationMode, type AnimationFrame } from "./animation-mode";
+import type { CellPixels } from "./types";
+
+function makeCell(): CellPixels {
+  return {
+    width: 1,
+    height: 1,
+    data: new Uint8ClampedArray([0, 0, 0, 255]),
+  };
+}
+
+function setup(frames: readonly AnimationFrame[]) {
+  const cells = [makeCell(), makeCell(), makeCell()];
+  const onFramesChange = vi.fn<(next: readonly AnimationFrame[]) => void>();
+  render(
+    <AnimationMode
+      cells={cells}
+      frames={frames}
+      onFramesChange={onFramesChange}
+      selectedCell={0}
+      baseFilename="test"
+    />,
+  );
+  return { onFramesChange };
+}
+
+describe("AnimationMode frame-duration blank-input handling", () => {
+  it("does not dispatch when the user clears the duration field", () => {
+    const frames: AnimationFrame[] = [{ cellIndex: 0, duration: 150 }];
+    const { onFramesChange } = setup(frames);
+
+    const input = screen.getByTestId("frame-duration-0");
+    // Simulate "Cmd+A, Delete" — input briefly empty. With the bug present,
+    // this would dispatch a numeric 0 which `setFrameDuration` clamps to
+    // 1ms, silently persisting an invisible-during-playback frame.
+    fireEvent.change(input, { target: { value: "" } });
+
+    expect(onFramesChange).not.toHaveBeenCalled();
+  });
+
+  it("still dispatches a typed numeric duration", () => {
+    const frames: AnimationFrame[] = [{ cellIndex: 0, duration: 150 }];
+    const { onFramesChange } = setup(frames);
+
+    const input = screen.getByTestId("frame-duration-0");
+    fireEvent.change(input, { target: { value: "200" } });
+
+    expect(onFramesChange).toHaveBeenCalledTimes(1);
+    const lastCall = onFramesChange.mock.calls.at(-1);
+    expect(lastCall).toBeDefined();
+    if (lastCall === undefined) return;
+    expect(lastCall[0][0].duration).toBe(200);
+  });
+});

--- a/apps/web/src/components/sprite-editor/animation-mode.tsx
+++ b/apps/web/src/components/sprite-editor/animation-mode.tsx
@@ -285,6 +285,12 @@ export function AnimationMode({
                       step={10}
                       value={frame.duration}
                       onChange={(event) => {
+                        // Skip mid-edit blank state — `Number("")` is 0,
+                        // and `setFrameDuration` clamps to 1ms, which
+                        // would silently persist a frame that's invisible
+                        // during playback. Match the grid-controls
+                        // NumberField pattern (PR #2281).
+                        if (event.target.value === "") return;
                         setFrameDuration(index, Number(event.target.value));
                       }}
                       css={styles.frameDuration}


### PR DESCRIPTION
## The bug

`AnimationMode`'s per-frame Duration `<input type="number">` parsed `event.target.value` with `Number()` and dispatched the result through `setFrameDuration`, which clamps to `Math.max(1, …)`. The moment the user cleared the field — Cmd+A then Delete — `Number("")` returned `0` and the clamp committed a 1ms duration. A 1ms frame is invisible during playback, so if the user looked away before retyping, the destructive write also leaked into the exported sprite-sheet manifest.

## The fix

Bail before the `Number()` parse when `event.target.value === ""`. The browser keeps the field visually blank until the user types a digit or blurs (at which point the parent's controlled `value` repaints with the previously-committed duration). This matches the pattern PR #2281 introduced for the grid-controls `NumberField`; the comment cites the precedent so the next reader sees this is intentional.

## Notes

A shared `parseNumberInput` helper was considered and rejected — only two callsites exist, and the helper would have to either return `number | null` (forcing each callsite to null-check) or take a callback (heavier than the inline guard). Two literal lines stays below the abstraction threshold; if a third callsite shows up the pattern can be promoted then. The Tolerance and Speed inputs in the same surface are `<input type="range">`, which never produces an empty value, so the bug is unique to this number input.