### PR TITLE
fix: correct preference panel privacy copy in en and zh

### DIFF
--- a/apps/web/src/components/ai-chat/preference-panel.tsx
+++ b/apps/web/src/components/ai-chat/preference-panel.tsx
@@ -194,8 +194,8 @@ export function PreferencePanel({
         <InfoIcon size={16} css={styles.infoIcon} role="presentation" />
         <p css={styles.infoText}>
           {t({
-            en: "Preferences are stored locally on your device. They help the AI personalise recommendations. Nothing is sent to a server.",
-            zh: "偏好仅存储在你的设备上，用于帮助 AI 个性化推荐，不会发送至服务器。",
+            en: "Preferences are stored locally in your browser. When you chat with the AI, they're included as context to personalise its replies.",
+            zh: "偏好仅存储在你的浏览器中。当你与 AI 对话时，它们会作为上下文一起发送，以便个性化回复。",
           })}
         </p>
       </div>


### PR DESCRIPTION
## The bug

The info banner in the AI chat preference panel stated "Nothing is sent to a server." in both English and Chinese. This is materially false: on the first send of every chat session, the client reads `getCachedPreferencesContext()` and prepends a `[User Preferences]\nLikes: …\nDislikes: …` text part to the outgoing message before forwarding it to Anthropic. The `chat-message.tsx` renderer even maintains a dedicated `USER_PREFERENCES_PREFIX` regex to strip the block back out of the visible chat history — confirming the block is part of the wire payload. The banner was a privacy misrepresentation shown to users in two locales.

## The fix

Rewrote the banner copy in both `en` and `zh` to accurately state that preferences are stored locally in the browser and are included as context when chatting with the AI. Copy-only change; no code-path changes were needed.