### PR TITLE
fix: add missing project routes to sitemap.xml

### DIFF
--- a/apps/web/src/app/sitemap.xml
+++ b/apps/web/src/app/sitemap.xml
@@ -94,4 +94,57 @@
     <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/calculator" />
     <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/calculator" />
   </url>
+
+  <url>
+    <loc>https://qingqi.dev/pixel-creature-creator</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/pixel-creature-creator" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/pixel-creature-creator" />
+  </url>
+  <url>
+    <loc>https://qingqi.dev/zh/pixel-creature-creator</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/pixel-creature-creator" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/pixel-creature-creator" />
+  </url>
+  <url>
+    <loc>https://qingqi.dev/pixel-creature-creator/create</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/pixel-creature-creator/create" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/pixel-creature-creator/create" />
+  </url>
+  <url>
+    <loc>https://qingqi.dev/zh/pixel-creature-creator/create</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/pixel-creature-creator/create" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/pixel-creature-creator/create" />
+  </url>
+  <url>
+    <loc>https://qingqi.dev/pixel-creature-creator/c</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/pixel-creature-creator/c" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/pixel-creature-creator/c" />
+  </url>
+  <url>
+    <loc>https://qingqi.dev/zh/pixel-creature-creator/c</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/pixel-creature-creator/c" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/pixel-creature-creator/c" />
+  </url>
+
+  <url>
+    <loc>https://qingqi.dev/sprite-editor</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/sprite-editor" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/sprite-editor" />
+  </url>
+  <url>
+    <loc>https://qingqi.dev/zh/sprite-editor</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/sprite-editor" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/sprite-editor" />
+  </url>
+
+  <url>
+    <loc>https://qingqi.dev/design-system</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/design-system" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/design-system" />
+  </url>
+  <url>
+    <loc>https://qingqi.dev/zh/design-system</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/design-system" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/design-system" />
+  </url>
 </urlset>


### PR DESCRIPTION
## The bug

`apps/web/src/app/sitemap.xml` is hand-maintained and omits several real, indexable, link-targeted project routes that ship full SEO metadata (canonical, hreflang, OpenGraph): `/pixel-creature-creator`, `/pixel-creature-creator/create`, `/pixel-creature-creator/c`, `/sprite-editor`, and `/design-system`. Pixel Creature Creator and Sprite Editor are flagship showcase projects, so search engines had to rely on internal links to discover them — a discoverability regression for the public site.

## The fix

Add the missing en+zh URL pairs, mirroring the existing `<xhtml:link rel="alternate">` hreflang pattern. Ten new `<url>` blocks (5 routes × 2 locales), grouped with empty-line separators matching the existing format. Playground and pixel-gallery are correctly excluded — those routes opt out via `robots: { index: false }`.