### PR TITLE
fix: add rate limiting to ai-chat POST route

### DIFF
--- a/apps/web/src/app/api/ai-chat/rate-limiter.ts
+++ b/apps/web/src/app/api/ai-chat/rate-limiter.ts
@@ -1,0 +1,42 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import "server-only";
+import { getRedisClient } from "#src/session-store/client.ts";
+
+let cached: Ratelimit | null = null;
+
+function getChatRateLimiter(): Ratelimit {
+  if (!cached) {
+    cached = new Ratelimit({
+      redis: getRedisClient(),
+      // Chat is multi-turn and tool-using, so each request can fan out into
+      // several Anthropic calls. 20 / 60 s / IP keeps a single tab usable for
+      // genuine back-and-forth while still capping a runaway script at a
+      // budget the owner can absorb.
+      limiter: Ratelimit.slidingWindow(20, "60 s"),
+      // Distinct prefix from `pcc:lore` so the two limiters don't share a
+      // bucket — a busy chat user shouldn't lock themselves out of lore
+      // generation, and vice versa.
+      prefix: "ai:chat",
+      analytics: false,
+    });
+  }
+  return cached;
+}
+
+export interface ChatRateLimitResult {
+  success: boolean;
+  /** Unix-ms timestamp when the limit resets. */
+  reset: number;
+}
+
+/**
+ * Sliding-window 20 req / 60 s / IP. Returning a narrowed shape (instead of
+ * the full `Ratelimit` instance) keeps the route handler's surface small
+ * and lets tests stub the limiter without reaching into provider internals.
+ */
+export async function limitChatRequest(
+  identifier: string,
+): Promise<ChatRateLimitResult> {
+  const result = await getChatRateLimiter().limit(identifier);
+  return { success: result.success, reset: result.reset };
+}

--- a/apps/web/src/app/api/ai-chat/route.test.ts
+++ b/apps/web/src/app/api/ai-chat/route.test.ts
@@ -23,6 +23,10 @@ vi.mock("#src/ai-chat/chat.ts", () => ({
   chat: vi.fn(),
 }));
 
+vi.mock("./rate-limiter", () => ({
+  limitChatRequest: vi.fn(),
+}));
+
 vi.mock("server-only", () => ({}));
 
 const mockStore = new Map<string, UIMessage[]>();
@@ -108,6 +112,14 @@ describe("POST /api/ai-chat", () => {
       await import("#src/session-store/session-store.ts");
     vi.mocked(getSessionMessages).mockImplementation((sessionId: string) => {
       return Promise.resolve(mockStore.get(sessionId) ?? null);
+    });
+    // Default limiter behaviour: allow the request. Individual tests override
+    // this to exercise the 429 and 502 paths.
+    const { limitChatRequest } = await import("./rate-limiter");
+    vi.mocked(limitChatRequest).mockReset();
+    vi.mocked(limitChatRequest).mockResolvedValue({
+      success: true,
+      reset: Date.now() + 60_000,
     });
   });
 
@@ -429,5 +441,75 @@ describe("POST /api/ai-chat", () => {
 
     const text = await response.text();
     expect(text).toContain("generated-session-id");
+  });
+
+  it("returns 429 with retryAfter and Retry-After header when rate-limited", async () => {
+    const reset = Date.now() + 30_000;
+    const { limitChatRequest } = await import("./rate-limiter");
+    vi.mocked(limitChatRequest).mockResolvedValueOnce({
+      success: false,
+      reset,
+    });
+
+    const { chat } = await import("#src/ai-chat/chat.ts");
+
+    const response = await POST(
+      chatRequest({
+        message: validMessage(),
+        trigger: "submit-message",
+      }),
+    );
+
+    expect(response.status).toBe(429);
+    const body: unknown = await response.json();
+    expect(body).toMatchObject({ error: "rate_limited" });
+    expect(response.headers.get("Retry-After")).not.toBeNull();
+    // The limiter must short-circuit before any Anthropic work — burning
+    // budget on calls we already decided to refuse defeats the purpose.
+    expect(vi.mocked(chat)).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 chat_unavailable when the limiter throws (fail-closed)", async () => {
+    const { limitChatRequest } = await import("./rate-limiter");
+    vi.mocked(limitChatRequest).mockRejectedValueOnce(new Error("redis down"));
+
+    const { chat } = await import("#src/ai-chat/chat.ts");
+
+    const response = await POST(
+      chatRequest({
+        message: validMessage(),
+        trigger: "submit-message",
+      }),
+    );
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({ error: "chat_unavailable" });
+    // Fail-closed must not let the request reach Anthropic.
+    expect(vi.mocked(chat)).not.toHaveBeenCalled();
+  });
+
+  it("calls the limiter with the resolved client IP from x-vercel-forwarded-for", async () => {
+    const { chat } = await import("#src/ai-chat/chat.ts");
+    vi.mocked(chat).mockResolvedValueOnce(mockStreamResult());
+    const { limitChatRequest } = await import("./rate-limiter");
+
+    const request = new NextRequest("http://localhost:3000/api/ai-chat", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        // x-vercel-forwarded-for must beat the spoofable x-forwarded-for so
+        // a malicious client can't bypass the limiter by forging headers.
+        "x-vercel-forwarded-for": "203.0.113.42",
+        "x-forwarded-for": "1.2.3.4",
+      },
+      body: JSON.stringify({
+        message: validMessage(),
+        trigger: "submit-message",
+      }),
+    });
+
+    await POST(request);
+
+    expect(vi.mocked(limitChatRequest)).toHaveBeenCalledWith("203.0.113.42");
   });
 });

--- a/apps/web/src/app/api/ai-chat/route.ts
+++ b/apps/web/src/app/api/ai-chat/route.ts
@@ -13,9 +13,38 @@ import {
   getSessionMessages,
   saveSessionMessages,
 } from "#src/session-store/session-store.ts";
+import { resolveClientIp } from "#src/utils/resolve-client-ip.ts";
 import { buildChatMessageMetadata } from "./build-chat-message-metadata";
+import { limitChatRequest } from "./rate-limiter";
 
 export async function POST(request: NextRequest) {
+  // Rate-limit before parsing the body or starting any Anthropic work — the
+  // whole point is to refuse the request before it can spend the owner's
+  // Anthropic budget. We fail closed on Redis errors (502) rather than
+  // silently allowing unmetered traffic past a broken limiter.
+  const ip = resolveClientIp(request.headers);
+  let limitOutcome;
+  try {
+    limitOutcome = await limitChatRequest(ip);
+  } catch (error) {
+    console.error("AI Chat rate-limit error:", error);
+    return Response.json({ error: "chat_unavailable" }, { status: 502 });
+  }
+
+  if (!limitOutcome.success) {
+    const retryAfter = Math.max(
+      0,
+      Math.ceil((limitOutcome.reset - Date.now()) / 1000),
+    );
+    return Response.json(
+      { error: "rate_limited", retryAfter },
+      {
+        status: 429,
+        headers: { "Retry-After": String(retryAfter) },
+      },
+    );
+  }
+
   try {
     const body: unknown = await request.json();
     const input = sessionChatInputSchema.parse(body);

--- a/apps/web/src/app/api/pixel-creature-creator/lore/rate-limiter.ts
+++ b/apps/web/src/app/api/pixel-creature-creator/lore/rate-limiter.ts
@@ -33,33 +33,3 @@ export async function limitLoreRequest(
   const result = await getLoreRateLimiter().limit(identifier);
   return { success: result.success, reset: result.reset };
 }
-
-/**
- * Resolve the client IP for rate-limit bucketing.
- *
- * Header preference order (most-trusted first):
- *   1. `x-vercel-forwarded-for` — set by Vercel's edge and not forwardable
- *      from the client, so it's the safest source of the original IP.
- *   2. `x-forwarded-for` — broadly used but client-spoofable, so only
- *      consulted when the platform-trusted header is absent.
- *   3. `"unknown"` — a stable bucket so misconfigured deployments still
- *      apply *some* throttling rather than offering an unmetered escape
- *      hatch.
- *
- * Both header values are comma-separated lists; we take the first non-empty
- * trimmed entry (the original client IP as recorded by the proxy).
- */
-export function resolveClientIp(headers: Headers): string {
-  const candidates = [
-    headers.get("x-vercel-forwarded-for"),
-    headers.get("x-forwarded-for"),
-  ];
-  for (const value of candidates) {
-    if (value === null) continue;
-    for (const part of value.split(",")) {
-      const trimmed = part.trim();
-      if (trimmed.length > 0) return trimmed;
-    }
-  }
-  return "unknown";
-}

--- a/apps/web/src/app/api/pixel-creature-creator/lore/route.ts
+++ b/apps/web/src/app/api/pixel-creature-creator/lore/route.ts
@@ -8,11 +8,8 @@ import {
   type CreatureDef,
 } from "#src/components/pixel-creature-creator/state/creature-schema.ts";
 import type { SupportedLocale } from "#src/types.ts";
-import {
-  limitLoreRequest,
-  resolveClientIp,
-  type LoreRateLimitResult,
-} from "./rate-limiter";
+import { resolveClientIp } from "#src/utils/resolve-client-ip.ts";
+import { limitLoreRequest, type LoreRateLimitResult } from "./rate-limiter";
 
 const requestSchema = z.object({
   def: creatureDefSchema,

--- a/apps/web/src/utils/resolve-client-ip.test.ts
+++ b/apps/web/src/utils/resolve-client-ip.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveClientIp } from "./rate-limiter";
+import { resolveClientIp } from "./resolve-client-ip";
 
 describe("resolveClientIp", () => {
   it("prefers x-vercel-forwarded-for over x-forwarded-for", () => {

--- a/apps/web/src/utils/resolve-client-ip.ts
+++ b/apps/web/src/utils/resolve-client-ip.ts
@@ -1,0 +1,32 @@
+/**
+ * Resolve the client IP for rate-limit bucketing.
+ *
+ * Header preference order (most-trusted first):
+ *   1. `x-vercel-forwarded-for` — set by Vercel's edge and not forwardable
+ *      from the client, so it's the safest source of the original IP.
+ *   2. `x-forwarded-for` — broadly used but client-spoofable, so only
+ *      consulted when the platform-trusted header is absent.
+ *   3. `"unknown"` — a stable bucket so misconfigured deployments still
+ *      apply *some* throttling rather than offering an unmetered escape
+ *      hatch.
+ *
+ * Both header values are comma-separated lists; we take the first non-empty
+ * trimmed entry (the original client IP as recorded by the proxy).
+ *
+ * Shared between API routes that bucket rate limits per IP — keep this as
+ * the single source of truth so header-priority semantics stay consistent.
+ */
+export function resolveClientIp(headers: Headers): string {
+  const candidates = [
+    headers.get("x-vercel-forwarded-for"),
+    headers.get("x-forwarded-for"),
+  ];
+  for (const value of candidates) {
+    if (value === null) continue;
+    for (const part of value.split(",")) {
+      const trimmed = part.trim();
+      if (trimmed.length > 0) return trimmed;
+    }
+  }
+  return "unknown";
+}


### PR DESCRIPTION
## The bug

The public `POST /api/ai-chat` route forwarded every request to Anthropic via `chat()` using the server's `ANTHROPIC_API_KEY` with no rate limiting, no auth, and no per-IP gating. A scripted client could open thousands of streaming sessions in a loop and burn through the owner's Anthropic budget unchecked. Chat is the higher-cost endpoint (multi-turn tool-using conversations), yet shipped completely unmetered — while the sibling `/api/pixel-creature-creator/lore` route already demonstrated the right pattern in the codebase.

## The fix

Adds a chat-specific Upstash sliding-window limiter (20 req / 60 s per IP, key prefix `ai:chat`) and wires it into the chat POST handler before any Anthropic work begins. The handler returns `429 { error: "rate_limited", retryAfter }` with a `Retry-After` header on rejection, and `502 { error: ... }` when the limiter Redis call throws (fail-closed, mirroring the lore precedent). To avoid duplicating the spoof-resistant header-priority logic, `resolveClientIp` is promoted to a shared utility (`src/utils/resolve-client-ip.ts`) and the lore route is updated to import from there.