### PR TITLE
fix: remove side effect from useIsElementVisible state updater

### DIFF
--- a/apps/web/src/hooks/use-is-element-visible.ts
+++ b/apps/web/src/hooks/use-is-element-visible.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /**
  * Tracks whether an element is visible in the viewport using
@@ -13,17 +13,20 @@ import { useCallback, useEffect, useState } from "react";
 export function useIsElementVisible() {
   const [isVisible, setIsVisible] = useState(true);
   const [el, setEl] = useState<HTMLElement | null>(null);
+  // Mirror of the latest observed element so `setRef` can compare against the
+  // previous node without reading state inside a setState updater (which would
+  // violate the Rules of React — updaters must be pure).
+  const prevElRef = useRef<HTMLElement | null>(null);
 
-  // Reset optimistically to the default when the observed target changes —
-  // the observer fires asynchronously, so without this the previous target's
-  // final value would briefly persist and flash the wrong style on remount.
   const setRef = useCallback((node: HTMLElement | null) => {
-    setEl((previous) => {
-      if (previous !== node) {
-        setIsVisible(true);
-      }
-      return node;
-    });
+    if (prevElRef.current === node) return;
+    prevElRef.current = node;
+    // Reset optimistically to the default when the observed target changes —
+    // the observer fires asynchronously, so without this the previous
+    // target's final value would briefly persist and flash the wrong style
+    // on remount.
+    setIsVisible(true);
+    setEl(node);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## The bug

`useIsElementVisible` called `setIsVisible(true)` from inside a `setEl(previous => …)` state-updater function. The Rules of React require updaters to be pure — calling another `setState` from within is a side effect that is forbidden on the state-update path. Under StrictMode and Concurrent rendering, React may invoke the updater multiple times, dispatching `setIsVisible(true)` for each invocation. Today the call is idempotent, but the pattern is a latent bug and explicitly violates rules the project enforces.

## The fix

Lift the previous-element comparison out of the state updater into a `useRef` mirror (`prevElRef`). The callback ref now early-returns when the node is unchanged, then directly assigns the ref and calls `setIsVisible(true)` and `setEl(node)` as two simple, non-nested setter calls outside any updater. Refs mutate during the commit phase (allowed), so no Rules of React constraint is violated. Existing semantics are preserved: `isVisible` resets to `true` whenever the observed element identity changes, and the `IntersectionObserver` effect still re-attaches via its `[el]` dep.