### PR TITLE
refactor: redesign shadows showcase as elevation diagram and remove orphan tokens

### DIFF
--- a/apps/web/src/components/design-system/sections/tokens/shadows-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/tokens/shadows-showcase.tsx
@@ -1,51 +1,132 @@
+import type { StyleXStyles } from "@stylexjs/stylex";
 import * as stylex from "@stylexjs/stylex";
-import { border, color, shadow } from "@tuja/ui/tokens.stylex";
+import { breakpoints } from "@tuja/ui/breakpoints.stylex";
+import { border, color, font, shadow, space } from "@tuja/ui/tokens.stylex";
 import { t } from "#src/i18n.ts";
-import { Showcase, ShowcaseGrid, ShowcaseItem } from "../../showcase.tsx";
+import { ShowcaseHelper } from "../../showcase-helper.tsx";
+import { Showcase } from "../../showcase.tsx";
 
 export function ShadowsShowcase() {
   return (
     <Showcase label={t({ en: "Shadows", zh: "阴影" })}>
-      <ShowcaseGrid>
-        <ShowcaseItem label="shadow._1">
-          <div css={[styles.block, styles.shadow1]} />
-        </ShowcaseItem>
-        <ShowcaseItem label="shadow._2">
-          <div css={[styles.block, styles.shadow2]} />
-        </ShowcaseItem>
-        <ShowcaseItem label="shadow._3">
-          <div css={[styles.block, styles.shadow3]} />
-        </ShowcaseItem>
-        <ShowcaseItem label="shadow._4">
-          <div css={[styles.block, styles.shadow4]} />
-        </ShowcaseItem>
-        <ShowcaseItem label="shadow._5">
-          <div css={[styles.block, styles.shadow5]} />
-        </ShowcaseItem>
-        <ShowcaseItem label="shadow.glowAccentSoft">
-          <div css={[styles.block, styles.glowSoft]} />
-        </ShowcaseItem>
-        <ShowcaseItem label="shadow.glowAccent">
-          <div css={[styles.block, styles.glow]} />
-        </ShowcaseItem>
-      </ShowcaseGrid>
+      <ShowcaseHelper>
+        {t({
+          en: "Five elevation steps. Each tile lifts further from the stage so the cast shadow can do its job — separating the object from the ground beneath it.",
+          zh: "五级悬浮高度。方块依次抬离台面，让投射出的阴影把物体与底面分开。",
+        })}
+      </ShowcaseHelper>
+      <div css={styles.stage}>
+        <ElevationTile
+          token="shadow._1"
+          shadowStyle={styles.shadow1}
+          liftStyle={styles.lift1}
+        />
+        <ElevationTile
+          token="shadow._2"
+          shadowStyle={styles.shadow2}
+          liftStyle={styles.lift2}
+        />
+        <ElevationTile
+          token="shadow._3"
+          shadowStyle={styles.shadow3}
+          liftStyle={styles.lift3}
+        />
+        <ElevationTile
+          token="shadow._4"
+          shadowStyle={styles.shadow4}
+          liftStyle={styles.lift4}
+        />
+        <ElevationTile
+          token="shadow._5"
+          shadowStyle={styles.shadow5}
+          liftStyle={styles.lift5}
+        />
+      </div>
     </Showcase>
   );
 }
 
+interface ElevationTileProps {
+  token: string;
+  shadowStyle: StyleXStyles;
+  liftStyle: StyleXStyles;
+}
+
+function ElevationTile({ token, shadowStyle, liftStyle }: ElevationTileProps) {
+  return (
+    <div css={styles.cell}>
+      <div css={styles.floor}>
+        <div css={[styles.tile, shadowStyle, liftStyle]} />
+      </div>
+      <div css={styles.caption}>
+        <span css={styles.token}>{token}</span>
+      </div>
+    </div>
+  );
+}
+
 const styles = stylex.create({
-  block: {
-    inlineSize: "80px",
-    blockSize: "80px",
+  stage: {
+    display: "grid",
+    gridTemplateColumns: {
+      default: "minmax(0, 1fr)",
+      [breakpoints.md]: "repeat(5, minmax(0, 1fr))",
+    },
+    gap: space._00,
     borderRadius: border.radius_2,
+    overflow: "hidden",
     backgroundColor: color.background3,
-    border: `1px solid ${color.neutralBorder}`,
+    boxShadow: `inset 0 0 0 1px ${color.neutralBorder}`,
   },
+  cell: {
+    display: "flex",
+    flexDirection: "column",
+    minInlineSize: 0,
+  },
+  floor: {
+    display: "flex",
+    alignItems: "flex-end",
+    justifyContent: "center",
+    blockSize: {
+      default: "96px",
+      [breakpoints.md]: "128px",
+    },
+    paddingBlockStart: space._4,
+    paddingBlockEnd: space._2,
+    paddingInline: space._3,
+  },
+  tile: {
+    inlineSize: "56px",
+    blockSize: "56px",
+    borderRadius: border.radius_2,
+    backgroundColor: color.background5,
+  },
+  lift1: { transform: "translateY(0)" },
+  lift2: { transform: "translateY(-2px)" },
+  lift3: { transform: "translateY(-5px)" },
+  lift4: { transform: "translateY(-9px)" },
+  lift5: { transform: "translateY(-14px)" },
   shadow1: { boxShadow: shadow._1 },
   shadow2: { boxShadow: shadow._2 },
   shadow3: { boxShadow: shadow._3 },
   shadow4: { boxShadow: shadow._4 },
   shadow5: { boxShadow: shadow._5 },
-  glowSoft: { boxShadow: shadow.glowAccentSoft },
-  glow: { boxShadow: shadow.glowAccent },
+  caption: {
+    display: "flex",
+    justifyContent: "center",
+    paddingBlock: space._2,
+    paddingInline: space._3,
+    borderBlockStartWidth: "1px",
+    borderBlockStartStyle: "solid",
+    borderBlockStartColor: color.neutralBorder,
+    minInlineSize: 0,
+  },
+  token: {
+    fontFamily: font.familyMono,
+    fontSize: font.uiOverline,
+    color: color.textSubtle,
+    lineHeight: font.lineHeight_2,
+    textAlign: "center",
+    overflowWrap: "anywhere",
+  },
 });

--- a/packages/ui/src/tokens.stylex.ts
+++ b/packages/ui/src/tokens.stylex.ts
@@ -49,7 +49,6 @@ const light = {
 
   shadowColor: "220 3% 15%",
   shadowStrength: "1%",
-  accentShadow: "rgba(126, 16, 194, 0.25)",
 
   // Semantic colors — bold (foreground), hover (interactive lift), subtle (background tint), text (on subtle), on (on bold)
   info: "#0284c7",
@@ -129,7 +128,6 @@ const dark: { [key in keyof typeof light]: string } = {
 
   shadowColor: "220 40% 2%",
   shadowStrength: "25%",
-  accentShadow: "rgba(147, 59, 201, 0.45)",
 
   info: "#38bdf8",
   infoHover: "#7dd3fc",
@@ -323,10 +321,6 @@ export const color = stylex.defineVars({
   shadowStrength: {
     default: light.shadowStrength,
     [constants.DARK]: dark.shadowStrength,
-  },
-  accentShadow: {
-    default: light.accentShadow,
-    [constants.DARK]: dark.accentShadow,
   },
 
   info: { default: light.info, [constants.DARK]: dark.info },
@@ -563,11 +557,6 @@ export const shadow = stylex.defineVars({
   _4: `0 -2px 5px 0 hsl(${color.shadowColor} / calc(${color.shadowStrength} + 2%)), 0 1px 1px -2px hsl(${color.shadowColor} / calc(${color.shadowStrength} + 3%)), 0 2px 2px -2px hsl(${color.shadowColor} / calc(${color.shadowStrength} + 3%)), 0 5px 5px -2px hsl(${color.shadowColor} / calc(${color.shadowStrength} + 4%)), 0 9px 9px -2px hsl(${color.shadowColor} / calc(${color.shadowStrength} + 5%)), 0 16px 16px -2px hsl(${color.shadowColor} / calc(${color.shadowStrength} + 6%))`,
   _5: `0 -1px 2px 0 hsl(${color.shadowColor} / calc(${color.shadowStrength} + 2%)), 0 2px 1px -2px hsl(${color.shadowColor} / calc(${color.shadowStrength} + 3%)), 0 5px 5px -2px hsl(${color.shadowColor} / calc(${color.shadowStrength} + 3%)), 0 10px 10px -2px hsl(${color.shadowColor} / calc(${color.shadowStrength} + 4%)), 0 20px 20px -2px hsl(${color.shadowColor} / calc(${color.shadowStrength} + 5%)), 0 40px 40px -2px hsl(${color.shadowColor} / calc(${color.shadowStrength} + 7%))`,
   _6: `0 -1px 2px 0 hsl(${color.shadowColor} / calc(${color.shadowStrength} + 2%)), 0 3px 2px -2px hsl(${color.shadowColor} / calc(${color.shadowStrength} + 3%)), 0 7px 5px -2px hsl(${color.shadowColor} / calc(${color.shadowStrength} + 3%)), 0 12px 10px -2px hsl(${color.shadowColor} / calc(${color.shadowStrength} + 4%)), 0 22px 18px -2px hsl(${color.shadowColor} / calc(${color.shadowStrength} + 5%)), 0 41px 33px -2px hsl(${color.shadowColor} / calc(${color.shadowStrength} + 6%)), 0 100px 80px -2px hsl(${color.shadowColor} / calc(${color.shadowStrength} + 7%))`,
-
-  // Accent-tinted glow shadows for highlighted or interactive surfaces
-  glowAccentSoft: `0 4px 16px -2px ${color.accentShadow}`,
-  glowAccent: `0 0 0 1px ${color.accentBorder}, 0 8px 28px -4px ${color.accentShadow}`,
-  glowAccentStrong: `0 0 0 1px ${color.accentBorder}, 0 4px 12px -2px ${color.accentShadow}, 0 16px 40px -4px ${color.accentShadow}`,
 
   // Inset shadow for sunken/inset surfaces
   inset: `inset 0 1px 2px hsl(${color.shadowColor} / calc(${color.shadowStrength} + 6%))`,


### PR DESCRIPTION
## Summary

Reframes the shadows showcase as a side-elevation diagram — five tiles on a brighter stage (`color.background3`) stair-stepped upward so each shadow lands visibly on the ground beneath — and removes the three orphan glow-accent shadow tokens (`glowAccent`, `glowAccentSoft`, `glowAccentStrong`) along with the `accentShadow` color token that existed solely to feed them.

The previous showcase rendered five near-identical dark swatches against a dark parent surface, making the elevation ramp imperceptible. By lifting tiles via `translateY` (0, −2, −5, −9, −14px) against a brighter stage, the cast shadow is legible without adjusting any token values.

## Notes

Tile color is held constant at `color.background5` across all five tiles so shadow is the only variable on display. Pairing tile colors with `background_N` was considered and rejected: tiles 1–3 would read as sunken (darker than the stage) and would imply a token pairing the codebase doesn't honor.

Semantic role labels ("Whisper", "Raised", "Floating") were explored and dropped — they are invented vocabulary not committed as convention, and `shadow._3` is used as both a default and a hover state across different components, so labeling it would have implied a contract that doesn't exist.

`shadow._6` and `shadow.inset` exist in the token set but remain out of scope for this showcase; flag for a follow-up if desired.