### PR TITLE
chore: refresh vendored agent skills and add next-best-practices

### DIFF
--- a/.claude/skills/next-best-practices/SKILL.md
+++ b/.claude/skills/next-best-practices/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: next-best-practices
+description: Next.js best practices - file conventions, RSC boundaries, data patterns, async APIs, metadata, error handling, route handlers, image/font optimization, bundling
+user-invocable: false
+---
+
+# Next.js Best Practices
+
+Apply these rules when writing or reviewing Next.js code.
+
+## File Conventions
+
+See [file-conventions.md](./file-conventions.md) for:
+- Project structure and special files
+- Route segments (dynamic, catch-all, groups)
+- Parallel and intercepting routes
+- Middleware rename in v16 (middleware → proxy)
+
+## RSC Boundaries
+
+Detect invalid React Server Component patterns.
+
+See [rsc-boundaries.md](./rsc-boundaries.md) for:
+- Async client component detection (invalid)
+- Non-serializable props detection
+- Server Action exceptions
+
+## Async Patterns
+
+Next.js 15+ async API changes.
+
+See [async-patterns.md](./async-patterns.md) for:
+- Async `params` and `searchParams`
+- Async `cookies()` and `headers()`
+- Migration codemod
+
+## Runtime Selection
+
+See [runtime-selection.md](./runtime-selection.md) for:
+- Default to Node.js runtime
+- When Edge runtime is appropriate
+
+## Directives
+
+See [directives.md](./directives.md) for:
+- `'use client'`, `'use server'` (React)
+- `'use cache'` (Next.js)
+
+## Functions
+
+See [functions.md](./functions.md) for:
+- Navigation hooks: `useRouter`, `usePathname`, `useSearchParams`, `useParams`
+- Server functions: `cookies`, `headers`, `draftMode`, `after`
+- Generate functions: `generateStaticParams`, `generateMetadata`
+
+## Error Handling
+
+See [error-handling.md](./error-handling.md) for:
+- `error.tsx`, `global-error.tsx`, `not-found.tsx`
+- `redirect`, `permanentRedirect`, `notFound`
+- `forbidden`, `unauthorized` (auth errors)
+- `unstable_rethrow` for catch blocks
+
+## Data Patterns
+
+See [data-patterns.md](./data-patterns.md) for:
+- Server Components vs Server Actions vs Route Handlers
+- Avoiding data waterfalls (`Promise.all`, Suspense, preload)
+- Client component data fetching
+
+## Route Handlers
+
+See [route-handlers.md](./route-handlers.md) for:
+- `route.ts` basics
+- GET handler conflicts with `page.tsx`
+- Environment behavior (no React DOM)
+- When to use vs Server Actions
+
+## Metadata & OG Images
+
+See [metadata.md](./metadata.md) for:
+- Static and dynamic metadata
+- `generateMetadata` function
+- OG image generation with `next/og`
+- File-based metadata conventions
+
+## Image Optimization
+
+See [image.md](./image.md) for:
+- Always use `next/image` over `<img>`
+- Remote images configuration
+- Responsive `sizes` attribute
+- Blur placeholders
+- Priority loading for LCP
+
+## Font Optimization
+
+See [font.md](./font.md) for:
+- `next/font` setup
+- Google Fonts, local fonts
+- Tailwind CSS integration
+- Preloading subsets
+
+## Bundling
+
+See [bundling.md](./bundling.md) for:
+- Server-incompatible packages
+- CSS imports (not link tags)
+- Polyfills (already included)
+- ESM/CommonJS issues
+- Bundle analysis
+
+## Scripts
+
+See [scripts.md](./scripts.md) for:
+- `next/script` vs native script tags
+- Inline scripts need `id`
+- Loading strategies
+- Google Analytics with `@next/third-parties`
+
+## Hydration Errors
+
+See [hydration-error.md](./hydration-error.md) for:
+- Common causes (browser APIs, dates, invalid HTML)
+- Debugging with error overlay
+- Fixes for each cause
+
+## Suspense Boundaries
+
+See [suspense-boundaries.md](./suspense-boundaries.md) for:
+- CSR bailout with `useSearchParams` and `usePathname`
+- Which hooks require Suspense boundaries
+
+## Parallel & Intercepting Routes
+
+See [parallel-routes.md](./parallel-routes.md) for:
+- Modal patterns with `@slot` and `(.)` interceptors
+- `default.tsx` for fallbacks
+- Closing modals correctly with `router.back()`
+
+## Self-Hosting
+
+See [self-hosting.md](./self-hosting.md) for:
+- `output: 'standalone'` for Docker
+- Cache handlers for multi-instance ISR
+- What works vs needs extra setup
+
+## Debug Tricks
+
+See [debug-tricks.md](./debug-tricks.md) for:
+- MCP endpoint for AI-assisted debugging
+- Rebuild specific routes with `--debug-build-paths`
+

--- a/.claude/skills/next-best-practices/async-patterns.md
+++ b/.claude/skills/next-best-practices/async-patterns.md
@@ -1,0 +1,87 @@
+# Async Patterns
+
+In Next.js 15+, `params`, `searchParams`, `cookies()`, and `headers()` are asynchronous.
+
+## Async Params and SearchParams
+
+Always type them as `Promise<...>` and await them.
+
+### Pages and Layouts
+
+```tsx
+type Props = { params: Promise<{ slug: string }> }
+
+export default async function Page({ params }: Props) {
+  const { slug } = await params
+}
+```
+
+### Route Handlers
+
+```tsx
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+}
+```
+
+### SearchParams
+
+```tsx
+type Props = {
+  params: Promise<{ slug: string }>
+  searchParams: Promise<{ query?: string }>
+}
+
+export default async function Page({ params, searchParams }: Props) {
+  const { slug } = await params
+  const { query } = await searchParams
+}
+```
+
+### Synchronous Components
+
+Use `React.use()` for non-async components:
+
+```tsx
+import { use } from 'react'
+
+type Props = { params: Promise<{ slug: string }> }
+
+export default function Page({ params }: Props) {
+  const { slug } = use(params)
+}
+```
+
+### generateMetadata
+
+```tsx
+type Props = { params: Promise<{ slug: string }> }
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params
+  return { title: slug }
+}
+```
+
+## Async Cookies and Headers
+
+```tsx
+import { cookies, headers } from 'next/headers'
+
+export default async function Page() {
+  const cookieStore = await cookies()
+  const headersList = await headers()
+
+  const theme = cookieStore.get('theme')
+  const userAgent = headersList.get('user-agent')
+}
+```
+
+## Migration Codemod
+
+```bash
+npx @next/codemod@latest next-async-request-api .
+```

--- a/.claude/skills/next-best-practices/bundling.md
+++ b/.claude/skills/next-best-practices/bundling.md
@@ -1,0 +1,180 @@
+# Bundling
+
+Fix common bundling issues with third-party packages.
+
+## Server-Incompatible Packages
+
+Some packages use browser APIs (`window`, `document`, `localStorage`) and fail in Server Components.
+
+### Error Signs
+
+```
+ReferenceError: window is not defined
+ReferenceError: document is not defined
+ReferenceError: localStorage is not defined
+Module not found: Can't resolve 'fs'
+```
+
+### Solution 1: Mark as Client-Only
+
+If the package is only needed on client:
+
+```tsx
+// Bad: Fails - package uses window
+import SomeChart from 'some-chart-library'
+
+export default function Page() {
+  return <SomeChart />
+}
+
+// Good: Use dynamic import with ssr: false
+import dynamic from 'next/dynamic'
+
+const SomeChart = dynamic(() => import('some-chart-library'), {
+  ssr: false,
+})
+
+export default function Page() {
+  return <SomeChart />
+}
+```
+
+### Solution 2: Externalize from Server Bundle
+
+For packages that should run on server but have bundling issues:
+
+```js
+// next.config.js
+module.exports = {
+  serverExternalPackages: ['problematic-package'],
+}
+```
+
+Use this for:
+- Packages with native bindings (sharp, bcrypt)
+- Packages that don't bundle well (some ORMs)
+- Packages with circular dependencies
+
+### Solution 3: Client Component Wrapper
+
+Wrap the entire usage in a client component:
+
+```tsx
+// components/ChartWrapper.tsx
+'use client'
+
+import { Chart } from 'chart-library'
+
+export function ChartWrapper(props) {
+  return <Chart {...props} />
+}
+
+// app/page.tsx (server component)
+import { ChartWrapper } from '@/components/ChartWrapper'
+
+export default function Page() {
+  return <ChartWrapper data={data} />
+}
+```
+
+## CSS Imports
+
+Import CSS files instead of using `<link>` tags. Next.js handles bundling and optimization.
+
+```tsx
+// Bad: Manual link tag
+<link rel="stylesheet" href="/styles.css" />
+
+// Good: Import CSS
+import './styles.css'
+
+// Good: CSS Modules
+import styles from './Button.module.css'
+```
+
+## Polyfills
+
+Next.js includes common polyfills automatically. Don't load redundant ones from polyfill.io or similar CDNs.
+
+Already included: `Array.from`, `Object.assign`, `Promise`, `fetch`, `Map`, `Set`, `Symbol`, `URLSearchParams`, and 50+ others.
+
+```tsx
+// Bad: Redundant polyfills
+<script src="https://polyfill.io/v3/polyfill.min.js?features=fetch,Promise,Array.from" />
+
+// Good: Next.js includes these automatically
+```
+
+## ESM/CommonJS Issues
+
+### Error Signs
+
+```
+SyntaxError: Cannot use import statement outside a module
+Error: require() of ES Module
+Module not found: ESM packages need to be imported
+```
+
+### Solution: Transpile Package
+
+```js
+// next.config.js
+module.exports = {
+  transpilePackages: ['some-esm-package', 'another-package'],
+}
+```
+
+## Common Problematic Packages
+
+| Package | Issue | Solution |
+|---------|-------|----------|
+| `sharp` | Native bindings | `serverExternalPackages: ['sharp']` |
+| `bcrypt` | Native bindings | `serverExternalPackages: ['bcrypt']` or use `bcryptjs` |
+| `canvas` | Native bindings | `serverExternalPackages: ['canvas']` |
+| `recharts` | Uses window | `dynamic(() => import('recharts'), { ssr: false })` |
+| `react-quill` | Uses document | `dynamic(() => import('react-quill'), { ssr: false })` |
+| `mapbox-gl` | Uses window | `dynamic(() => import('mapbox-gl'), { ssr: false })` |
+| `monaco-editor` | Uses window | `dynamic(() => import('@monaco-editor/react'), { ssr: false })` |
+| `lottie-web` | Uses document | `dynamic(() => import('lottie-react'), { ssr: false })` |
+
+## Bundle Analysis
+
+Analyze bundle size with the built-in analyzer (Next.js 16.1+):
+
+```bash
+next experimental-analyze
+```
+
+This opens an interactive UI to:
+- Filter by route, environment (client/server), and type
+- Inspect module sizes and import chains
+- View treemap visualization
+
+Save output for comparison:
+
+```bash
+next experimental-analyze --output
+# Output saved to .next/diagnostics/analyze
+```
+
+Reference: https://nextjs.org/docs/app/guides/package-bundling
+
+## Migrating from Webpack to Turbopack
+
+Turbopack is the default bundler in Next.js 15+. If you have custom webpack config, migrate to Turbopack-compatible alternatives:
+
+```js
+// next.config.js
+module.exports = {
+  // Good: Works with Turbopack
+  serverExternalPackages: ['package'],
+  transpilePackages: ['package'],
+
+  // Bad: Webpack-only - migrate away from this
+  webpack: (config) => {
+    // custom webpack config
+  },
+}
+```
+
+Reference: https://nextjs.org/docs/app/building-your-application/upgrading/from-webpack-to-turbopack

--- a/.claude/skills/next-best-practices/data-patterns.md
+++ b/.claude/skills/next-best-practices/data-patterns.md
@@ -1,0 +1,297 @@
+# Data Patterns
+
+Choose the right data fetching pattern for each use case.
+
+## Decision Tree
+
+```
+Need to fetch data?
+├── From a Server Component?
+│   └── Use: Fetch directly (no API needed)
+│
+├── From a Client Component?
+│   ├── Is it a mutation (POST/PUT/DELETE)?
+│   │   └── Use: Server Action
+│   └── Is it a read (GET)?
+│       └── Use: Route Handler OR pass from Server Component
+│
+├── Need external API access (webhooks, third parties)?
+│   └── Use: Route Handler
+│
+└── Need REST API for mobile app / external clients?
+    └── Use: Route Handler
+```
+
+## Pattern 1: Server Components (Preferred for Reads)
+
+Fetch data directly in Server Components - no API layer needed.
+
+```tsx
+// app/users/page.tsx
+async function UsersPage() {
+  // Direct database access - no API round-trip
+  const users = await db.user.findMany();
+
+  // Or fetch from external API
+  const posts = await fetch('https://api.example.com/posts').then(r => r.json());
+
+  return (
+    <ul>
+      {users.map(user => <li key={user.id}>{user.name}</li>)}
+    </ul>
+  );
+}
+```
+
+**Benefits**:
+- No API to maintain
+- No client-server waterfall
+- Secrets stay on server
+- Direct database access
+
+## Pattern 2: Server Actions (Preferred for Mutations)
+
+Server Actions are the recommended way to handle mutations.
+
+```tsx
+// app/actions.ts
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+export async function createPost(formData: FormData) {
+  const title = formData.get('title') as string;
+
+  await db.post.create({ data: { title } });
+
+  revalidatePath('/posts');
+}
+
+export async function deletePost(id: string) {
+  await db.post.delete({ where: { id } });
+
+  revalidateTag('posts');
+}
+```
+
+```tsx
+// app/posts/new/page.tsx
+import { createPost } from '@/app/actions';
+
+export default function NewPost() {
+  return (
+    <form action={createPost}>
+      <input name="title" required />
+      <button type="submit">Create</button>
+    </form>
+  );
+}
+```
+
+**Benefits**:
+- End-to-end type safety
+- Progressive enhancement (works without JS)
+- Automatic request handling
+- Integrated with React transitions
+
+**Constraints**:
+- POST only (no GET caching semantics)
+- Internal use only (no external access)
+- Cannot return non-serializable data
+
+## Pattern 3: Route Handlers (APIs)
+
+Use Route Handlers when you need a REST API.
+
+```tsx
+// app/api/posts/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+
+// GET is cacheable
+export async function GET(request: NextRequest) {
+  const posts = await db.post.findMany();
+  return NextResponse.json(posts);
+}
+
+// POST for mutations
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const post = await db.post.create({ data: body });
+  return NextResponse.json(post, { status: 201 });
+}
+```
+
+**When to use**:
+- External API access (mobile apps, third parties)
+- Webhooks from external services
+- GET endpoints that need HTTP caching
+- OpenAPI/Swagger documentation needed
+
+**When NOT to use**:
+- Internal data fetching (use Server Components)
+- Mutations from your UI (use Server Actions)
+
+## Avoiding Data Waterfalls
+
+### Problem: Sequential Fetches
+
+```tsx
+// Bad: Sequential waterfalls
+async function Dashboard() {
+  const user = await getUser();        // Wait...
+  const posts = await getPosts();      // Then wait...
+  const comments = await getComments(); // Then wait...
+
+  return <div>...</div>;
+}
+```
+
+### Solution 1: Parallel Fetching with Promise.all
+
+```tsx
+// Good: Parallel fetching
+async function Dashboard() {
+  const [user, posts, comments] = await Promise.all([
+    getUser(),
+    getPosts(),
+    getComments(),
+  ]);
+
+  return <div>...</div>;
+}
+```
+
+### Solution 2: Streaming with Suspense
+
+```tsx
+// Good: Show content progressively
+import { Suspense } from 'react';
+
+async function Dashboard() {
+  return (
+    <div>
+      <Suspense fallback={<UserSkeleton />}>
+        <UserSection />
+      </Suspense>
+      <Suspense fallback={<PostsSkeleton />}>
+        <PostsSection />
+      </Suspense>
+    </div>
+  );
+}
+
+async function UserSection() {
+  const user = await getUser(); // Fetches independently
+  return <div>{user.name}</div>;
+}
+
+async function PostsSection() {
+  const posts = await getPosts(); // Fetches independently
+  return <PostList posts={posts} />;
+}
+```
+
+### Solution 3: Preload Pattern
+
+```tsx
+// lib/data.ts
+import { cache } from 'react';
+
+export const getUser = cache(async (id: string) => {
+  return db.user.findUnique({ where: { id } });
+});
+
+export const preloadUser = (id: string) => {
+  void getUser(id); // Fire and forget
+};
+```
+
+```tsx
+// app/user/[id]/page.tsx
+import { getUser, preloadUser } from '@/lib/data';
+
+export default async function UserPage({ params }) {
+  const { id } = await params;
+
+  // Start fetching early
+  preloadUser(id);
+
+  // Do other work...
+
+  // Data likely ready by now
+  const user = await getUser(id);
+  return <div>{user.name}</div>;
+}
+```
+
+## Client Component Data Fetching
+
+When Client Components need data:
+
+### Option 1: Pass from Server Component (Preferred)
+
+```tsx
+// Server Component
+async function Page() {
+  const data = await fetchData();
+  return <ClientComponent initialData={data} />;
+}
+
+// Client Component
+'use client';
+function ClientComponent({ initialData }) {
+  const [data, setData] = useState(initialData);
+  // ...
+}
+```
+
+### Option 2: Fetch on Mount (When Necessary)
+
+```tsx
+'use client';
+import { useEffect, useState } from 'react';
+
+function ClientComponent() {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/data')
+      .then(r => r.json())
+      .then(setData);
+  }, []);
+
+  if (!data) return <Loading />;
+  return <div>{data.value}</div>;
+}
+```
+
+### Option 3: Server Action for Reads (Works But Not Ideal)
+
+Server Actions can be called from Client Components for reads, but this is not their intended purpose:
+
+```tsx
+'use client';
+import { getData } from './actions';
+import { useEffect, useState } from 'react';
+
+function ClientComponent() {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    getData().then(setData);
+  }, []);
+
+  return <div>{data?.value}</div>;
+}
+```
+
+**Note**: Server Actions always use POST, so no HTTP caching. Prefer Route Handlers for cacheable reads.
+
+## Quick Reference
+
+| Pattern | Use Case | HTTP Method | Caching |
+|---------|----------|-------------|---------|
+| Server Component fetch | Internal reads | Any | Full Next.js caching |
+| Server Action | Mutations, form submissions | POST only | No |
+| Route Handler | External APIs, webhooks | Any | GET can be cached |
+| Client fetch to API | Client-side reads | Any | HTTP cache headers |

--- a/.claude/skills/next-best-practices/debug-tricks.md
+++ b/.claude/skills/next-best-practices/debug-tricks.md
@@ -1,0 +1,105 @@
+# Debug Tricks
+
+Tricks to speed up debugging Next.js applications.
+
+## MCP Endpoint (Dev Server)
+
+Next.js exposes a `/_next/mcp` endpoint in development for AI-assisted debugging via MCP (Model Context Protocol).
+
+- **Next.js 16+**: Enabled by default, use `next-devtools-mcp`
+- **Next.js < 16**: Requires `experimental.mcpServer: true` in next.config.js
+
+Reference: https://nextjs.org/docs/app/guides/mcp
+
+**Important**: Find the actual port of the running Next.js dev server (check terminal output or `package.json` scripts). Don't assume port 3000.
+
+### Request Format
+
+The endpoint uses JSON-RPC 2.0 over HTTP POST:
+
+```bash
+curl -X POST http://localhost:<port>/_next/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "tools/call",
+    "params": {
+      "name": "<tool-name>",
+      "arguments": {}
+    }
+  }'
+```
+
+### Available Tools
+
+#### `get_errors`
+Get current errors from dev server (build errors, runtime errors with source-mapped stacks):
+```json
+{ "name": "get_errors", "arguments": {} }
+```
+
+#### `get_routes`
+Discover all routes by scanning filesystem:
+```json
+{ "name": "get_routes", "arguments": {} }
+// Optional: { "name": "get_routes", "arguments": { "routerType": "app" } }
+```
+Returns: `{ "appRouter": ["/", "/api/users/[id]", ...], "pagesRouter": [...] }`
+
+#### `get_project_metadata`
+Get project path and dev server URL:
+```json
+{ "name": "get_project_metadata", "arguments": {} }
+```
+Returns: `{ "projectPath": "/path/to/project", "devServerUrl": "http://localhost:3000" }`
+
+#### `get_page_metadata`
+Get runtime metadata about current page render (requires active browser session):
+```json
+{ "name": "get_page_metadata", "arguments": {} }
+```
+Returns segment trie data showing layouts, boundaries, and page components.
+
+#### `get_logs`
+Get path to Next.js development log file:
+```json
+{ "name": "get_logs", "arguments": {} }
+```
+Returns path to `<distDir>/logs/next-development.log`
+
+#### `get_server_action_by_id`
+Locate a Server Action by ID:
+```json
+{ "name": "get_server_action_by_id", "arguments": { "actionId": "<action-id>" } }
+```
+
+### Example: Get Errors
+
+```bash
+curl -X POST http://localhost:<port>/_next/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/call","params":{"name":"get_errors","arguments":{}}}'
+```
+
+## Rebuild Specific Routes (Next.js 16+)
+
+Use `--debug-build-paths` to rebuild only specific routes instead of the entire app:
+
+```bash
+# Rebuild a specific route
+next build --debug-build-paths "/dashboard"
+
+# Rebuild routes matching a glob
+next build --debug-build-paths "/api/*"
+
+# Dynamic routes
+next build --debug-build-paths "/blog/[slug]"
+```
+
+Use this to:
+- Quickly verify a build fix without full rebuild
+- Debug static generation issues for specific pages
+- Iterate faster on build errors

--- a/.claude/skills/next-best-practices/directives.md
+++ b/.claude/skills/next-best-practices/directives.md
@@ -1,0 +1,73 @@
+# Directives
+
+## React Directives
+
+These are React directives, not Next.js specific.
+
+### `'use client'`
+
+Marks a component as a Client Component. Required for:
+- React hooks (`useState`, `useEffect`, etc.)
+- Event handlers (`onClick`, `onChange`)
+- Browser APIs (`window`, `localStorage`)
+
+```tsx
+'use client'
+
+import { useState } from 'react'
+
+export function Counter() {
+  const [count, setCount] = useState(0)
+  return <button onClick={() => setCount(count + 1)}>{count}</button>
+}
+```
+
+Reference: https://react.dev/reference/rsc/use-client
+
+### `'use server'`
+
+Marks a function as a Server Action. Can be passed to Client Components.
+
+```tsx
+'use server'
+
+export async function submitForm(formData: FormData) {
+  // Runs on server
+}
+```
+
+Or inline within a Server Component:
+
+```tsx
+export default function Page() {
+  async function submit() {
+    'use server'
+    // Runs on server
+  }
+  return <form action={submit}>...</form>
+}
+```
+
+Reference: https://react.dev/reference/rsc/use-server
+
+---
+
+## Next.js Directive
+
+### `'use cache'`
+
+Marks a function or component for caching. Part of Next.js Cache Components.
+
+```tsx
+'use cache'
+
+export async function getCachedData() {
+  return await fetchData()
+}
+```
+
+Requires `cacheComponents: true` in `next.config.ts`.
+
+For detailed usage including cache profiles, `cacheLife()`, `cacheTag()`, and `updateTag()`, see the `next-cache-components` skill.
+
+Reference: https://nextjs.org/docs/app/api-reference/directives/use-cache

--- a/.claude/skills/next-best-practices/error-handling.md
+++ b/.claude/skills/next-best-practices/error-handling.md
@@ -1,0 +1,227 @@
+# Error Handling
+
+Handle errors gracefully in Next.js applications.
+
+Reference: https://nextjs.org/docs/app/getting-started/error-handling
+
+## Error Boundaries
+
+### `error.tsx`
+
+Catches errors in a route segment and its children:
+
+```tsx
+'use client'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <div>
+      <h2>Something went wrong!</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  )
+}
+```
+
+**Important:** `error.tsx` must be a Client Component.
+
+### `global-error.tsx`
+
+Catches errors in root layout:
+
+```tsx
+'use client'
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  return (
+    <html>
+      <body>
+        <h2>Something went wrong!</h2>
+        <button onClick={() => reset()}>Try again</button>
+      </body>
+    </html>
+  )
+}
+```
+
+**Important:** Must include `<html>` and `<body>` tags.
+
+## Server Actions: Navigation API Gotcha
+
+**Do NOT wrap navigation APIs in try-catch.** They throw special errors that Next.js handles internally.
+
+Reference: https://nextjs.org/docs/app/api-reference/functions/redirect#behavior
+
+```tsx
+'use server'
+
+import { redirect } from 'next/navigation'
+import { notFound } from 'next/navigation'
+
+// Bad: try-catch catches the navigation "error"
+async function createPost(formData: FormData) {
+  try {
+    const post = await db.post.create({ ... })
+    redirect(`/posts/${post.id}`)  // This throws!
+  } catch (error) {
+    // redirect() throw is caught here - navigation fails!
+    return { error: 'Failed to create post' }
+  }
+}
+
+// Good: Call navigation APIs outside try-catch
+async function createPost(formData: FormData) {
+  let post
+  try {
+    post = await db.post.create({ ... })
+  } catch (error) {
+    return { error: 'Failed to create post' }
+  }
+  redirect(`/posts/${post.id}`)  // Outside try-catch
+}
+
+// Good: Re-throw navigation errors
+async function createPost(formData: FormData) {
+  try {
+    const post = await db.post.create({ ... })
+    redirect(`/posts/${post.id}`)
+  } catch (error) {
+    if (error instanceof Error && error.message === 'NEXT_REDIRECT') {
+      throw error  // Re-throw navigation errors
+    }
+    return { error: 'Failed to create post' }
+  }
+}
+```
+
+Same applies to:
+- `redirect()` - 307 temporary redirect
+- `permanentRedirect()` - 308 permanent redirect
+- `notFound()` - 404 not found
+- `forbidden()` - 403 forbidden
+- `unauthorized()` - 401 unauthorized
+
+Use `unstable_rethrow()` to re-throw these errors in catch blocks:
+
+```tsx
+import { unstable_rethrow } from 'next/navigation'
+
+async function action() {
+  try {
+    // ...
+    redirect('/success')
+  } catch (error) {
+    unstable_rethrow(error) // Re-throws Next.js internal errors
+    return { error: 'Something went wrong' }
+  }
+}
+```
+
+## Redirects
+
+```tsx
+import { redirect, permanentRedirect } from 'next/navigation'
+
+// 307 Temporary - use for most cases
+redirect('/new-path')
+
+// 308 Permanent - use for URL migrations (cached by browsers)
+permanentRedirect('/new-url')
+```
+
+## Auth Errors
+
+Trigger auth-related error pages:
+
+```tsx
+import { forbidden, unauthorized } from 'next/navigation'
+
+async function Page() {
+  const session = await getSession()
+
+  if (!session) {
+    unauthorized() // Renders unauthorized.tsx (401)
+  }
+
+  if (!session.hasAccess) {
+    forbidden() // Renders forbidden.tsx (403)
+  }
+
+  return <Dashboard />
+}
+```
+
+Create corresponding error pages:
+
+```tsx
+// app/forbidden.tsx
+export default function Forbidden() {
+  return <div>You don't have access to this resource</div>
+}
+
+// app/unauthorized.tsx
+export default function Unauthorized() {
+  return <div>Please log in to continue</div>
+}
+```
+
+## Not Found
+
+### `not-found.tsx`
+
+Custom 404 page for a route segment:
+
+```tsx
+export default function NotFound() {
+  return (
+    <div>
+      <h2>Not Found</h2>
+      <p>Could not find the requested resource</p>
+    </div>
+  )
+}
+```
+
+### Triggering Not Found
+
+```tsx
+import { notFound } from 'next/navigation'
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const post = await getPost(id)
+
+  if (!post) {
+    notFound()  // Renders closest not-found.tsx
+  }
+
+  return <div>{post.title}</div>
+}
+```
+
+## Error Hierarchy
+
+Errors bubble up to the nearest error boundary:
+
+```
+app/
+├── error.tsx           # Catches errors from all children
+├── blog/
+│   ├── error.tsx       # Catches errors in /blog/*
+│   └── [slug]/
+│       ├── error.tsx   # Catches errors in /blog/[slug]
+│       └── page.tsx
+└── layout.tsx          # Errors here go to global-error.tsx
+```

--- a/.claude/skills/next-best-practices/file-conventions.md
+++ b/.claude/skills/next-best-practices/file-conventions.md
@@ -1,0 +1,140 @@
+# File Conventions
+
+Next.js App Router uses file-based routing with special file conventions.
+
+## Project Structure
+
+Reference: https://nextjs.org/docs/app/getting-started/project-structure
+
+```
+app/
+├── layout.tsx          # Root layout (required)
+├── page.tsx            # Home page (/)
+├── loading.tsx         # Loading UI
+├── error.tsx           # Error UI
+├── not-found.tsx       # 404 UI
+├── global-error.tsx    # Global error UI
+├── route.ts            # API endpoint
+├── template.tsx        # Re-rendered layout
+├── default.tsx         # Parallel route fallback
+├── blog/
+│   ├── page.tsx        # /blog
+│   └── [slug]/
+│       └── page.tsx    # /blog/:slug
+└── (group)/            # Route group (no URL impact)
+    └── page.tsx
+```
+
+## Special Files
+
+| File | Purpose |
+|------|---------|
+| `page.tsx` | UI for a route segment |
+| `layout.tsx` | Shared UI for segment and children |
+| `loading.tsx` | Loading UI (Suspense boundary) |
+| `error.tsx` | Error UI (Error boundary) |
+| `not-found.tsx` | 404 UI |
+| `route.ts` | API endpoint |
+| `template.tsx` | Like layout but re-renders on navigation |
+| `default.tsx` | Fallback for parallel routes |
+
+## Route Segments
+
+```
+app/
+├── blog/               # Static segment: /blog
+├── [slug]/             # Dynamic segment: /:slug
+├── [...slug]/          # Catch-all: /a/b/c
+├── [[...slug]]/        # Optional catch-all: / or /a/b/c
+└── (marketing)/        # Route group (ignored in URL)
+```
+
+## Parallel Routes
+
+```
+app/
+├── @analytics/
+│   └── page.tsx
+├── @sidebar/
+│   └── page.tsx
+└── layout.tsx          # Receives { analytics, sidebar } as props
+```
+
+## Intercepting Routes
+
+```
+app/
+├── feed/
+│   └── page.tsx
+├── @modal/
+│   └── (.)photo/[id]/  # Intercepts /photo/[id] from /feed
+│       └── page.tsx
+└── photo/[id]/
+    └── page.tsx
+```
+
+Conventions:
+- `(.)` - same level
+- `(..)` - one level up
+- `(..)(..)` - two levels up
+- `(...)` - from root
+
+## Private Folders
+
+```
+app/
+├── _components/        # Private folder (not a route)
+│   └── Button.tsx
+└── page.tsx
+```
+
+Prefix with `_` to exclude from routing.
+
+## Middleware / Proxy
+
+### Next.js 14-15: `middleware.ts`
+
+```ts
+// middleware.ts (root of project)
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  // Auth, redirects, rewrites, etc.
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/api/:path*'],
+};
+```
+
+### Next.js 16+: `proxy.ts`
+
+Renamed for clarity - same capabilities, different names:
+
+```ts
+// proxy.ts (root of project)
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function proxy(request: NextRequest) {
+  // Same logic as middleware
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/api/:path*'],
+};
+```
+
+| Version | File | Export | Config |
+|---------|------|--------|--------|
+| v14-15 | `middleware.ts` | `middleware()` | `config` |
+| v16+ | `proxy.ts` | `proxy()` | `config` |
+
+**Migration**: Run `npx @next/codemod@latest upgrade` to auto-rename.
+
+## File Conventions Reference
+
+Reference: https://nextjs.org/docs/app/api-reference/file-conventions

--- a/.claude/skills/next-best-practices/font.md
+++ b/.claude/skills/next-best-practices/font.md
@@ -1,0 +1,245 @@
+# Font Optimization
+
+Use `next/font` for automatic font optimization with zero layout shift.
+
+## Google Fonts
+
+```tsx
+// app/layout.tsx
+import { Inter } from 'next/font/google'
+
+const inter = Inter({ subsets: ['latin'] })
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" className={inter.className}>
+      <body>{children}</body>
+    </html>
+  )
+}
+```
+
+## Multiple Fonts
+
+```tsx
+import { Inter, Roboto_Mono } from 'next/font/google'
+
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-inter',
+})
+
+const robotoMono = Roboto_Mono({
+  subsets: ['latin'],
+  variable: '--font-roboto-mono',
+})
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" className={`${inter.variable} ${robotoMono.variable}`}>
+      <body>{children}</body>
+    </html>
+  )
+}
+```
+
+Use in CSS:
+```css
+body {
+  font-family: var(--font-inter);
+}
+
+code {
+  font-family: var(--font-roboto-mono);
+}
+```
+
+## Font Weights and Styles
+
+```tsx
+// Single weight
+const inter = Inter({
+  subsets: ['latin'],
+  weight: '400',
+})
+
+// Multiple weights
+const inter = Inter({
+  subsets: ['latin'],
+  weight: ['400', '500', '700'],
+})
+
+// Variable font (recommended) - includes all weights
+const inter = Inter({
+  subsets: ['latin'],
+  // No weight needed - variable fonts support all weights
+})
+
+// With italic
+const inter = Inter({
+  subsets: ['latin'],
+  style: ['normal', 'italic'],
+})
+```
+
+## Local Fonts
+
+```tsx
+import localFont from 'next/font/local'
+
+const myFont = localFont({
+  src: './fonts/MyFont.woff2',
+})
+
+// Multiple files for different weights
+const myFont = localFont({
+  src: [
+    {
+      path: './fonts/MyFont-Regular.woff2',
+      weight: '400',
+      style: 'normal',
+    },
+    {
+      path: './fonts/MyFont-Bold.woff2',
+      weight: '700',
+      style: 'normal',
+    },
+  ],
+})
+
+// Variable font
+const myFont = localFont({
+  src: './fonts/MyFont-Variable.woff2',
+  variable: '--font-my-font',
+})
+```
+
+## Tailwind CSS Integration
+
+```tsx
+// app/layout.tsx
+import { Inter } from 'next/font/google'
+
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-inter',
+})
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en" className={inter.variable}>
+      <body>{children}</body>
+    </html>
+  )
+}
+```
+
+```js
+// tailwind.config.js
+module.exports = {
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['var(--font-inter)'],
+      },
+    },
+  },
+}
+```
+
+## Preloading Subsets
+
+Only load needed character subsets:
+
+```tsx
+// Latin only (most common)
+const inter = Inter({ subsets: ['latin'] })
+
+// Multiple subsets
+const inter = Inter({ subsets: ['latin', 'latin-ext', 'cyrillic'] })
+```
+
+## Display Strategy
+
+Control font loading behavior:
+
+```tsx
+const inter = Inter({
+  subsets: ['latin'],
+  display: 'swap', // Default - shows fallback, swaps when loaded
+})
+
+// Options:
+// 'auto' - browser decides
+// 'block' - short block period, then swap
+// 'swap' - immediate fallback, swap when ready (recommended)
+// 'fallback' - short block, short swap, then fallback
+// 'optional' - short block, no swap (use if font is optional)
+```
+
+## Don't Use Manual Font Links
+
+Always use `next/font` instead of `<link>` tags for Google Fonts.
+
+```tsx
+// Bad: Manual link tag (blocks rendering, no optimization)
+<link href="https://fonts.googleapis.com/css2?family=Inter" rel="stylesheet" />
+
+// Bad: Missing display and preconnect
+<link href="https://fonts.googleapis.com/css2?family=Inter" rel="stylesheet" />
+
+// Good: Use next/font (self-hosted, zero layout shift)
+import { Inter } from 'next/font/google'
+
+const inter = Inter({ subsets: ['latin'] })
+```
+
+## Common Mistakes
+
+```tsx
+// Bad: Importing font in every component
+// components/Button.tsx
+import { Inter } from 'next/font/google'
+const inter = Inter({ subsets: ['latin'] }) // Creates new instance each time!
+
+// Good: Import once in layout, use CSS variable
+// app/layout.tsx
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter' })
+
+// Bad: Using @import in CSS (blocks rendering)
+/* globals.css */
+@import url('https://fonts.googleapis.com/css2?family=Inter');
+
+// Good: Use next/font (self-hosted, no network request)
+import { Inter } from 'next/font/google'
+
+// Bad: Loading all weights when only using a few
+const inter = Inter({ subsets: ['latin'] }) // Loads all weights
+
+// Good: Specify only needed weights (for non-variable fonts)
+const inter = Inter({ subsets: ['latin'], weight: ['400', '700'] })
+
+// Bad: Missing subset - loads all characters
+const inter = Inter({})
+
+// Good: Always specify subset
+const inter = Inter({ subsets: ['latin'] })
+```
+
+## Font in Specific Components
+
+```tsx
+// For component-specific fonts, export from a shared file
+// lib/fonts.ts
+import { Inter, Playfair_Display } from 'next/font/google'
+
+export const inter = Inter({ subsets: ['latin'], variable: '--font-inter' })
+export const playfair = Playfair_Display({ subsets: ['latin'], variable: '--font-playfair' })
+
+// components/Heading.tsx
+import { playfair } from '@/lib/fonts'
+
+export function Heading({ children }) {
+  return <h1 className={playfair.className}>{children}</h1>
+}
+```

--- a/.claude/skills/next-best-practices/functions.md
+++ b/.claude/skills/next-best-practices/functions.md
@@ -1,0 +1,108 @@
+# Functions
+
+Next.js function APIs.
+
+Reference: https://nextjs.org/docs/app/api-reference/functions
+
+## Navigation Hooks (Client)
+
+| Hook | Purpose | Reference |
+|------|---------|-----------|
+| `useRouter` | Programmatic navigation (`push`, `replace`, `back`, `refresh`) | [Docs](https://nextjs.org/docs/app/api-reference/functions/use-router) |
+| `usePathname` | Get current pathname | [Docs](https://nextjs.org/docs/app/api-reference/functions/use-pathname) |
+| `useSearchParams` | Read URL search parameters | [Docs](https://nextjs.org/docs/app/api-reference/functions/use-search-params) |
+| `useParams` | Access dynamic route parameters | [Docs](https://nextjs.org/docs/app/api-reference/functions/use-params) |
+| `useSelectedLayoutSegment` | Active child segment (one level) | [Docs](https://nextjs.org/docs/app/api-reference/functions/use-selected-layout-segment) |
+| `useSelectedLayoutSegments` | All active segments below layout | [Docs](https://nextjs.org/docs/app/api-reference/functions/use-selected-layout-segments) |
+| `useLinkStatus` | Check link prefetch status | [Docs](https://nextjs.org/docs/app/api-reference/functions/use-link-status) |
+| `useReportWebVitals` | Report Core Web Vitals metrics | [Docs](https://nextjs.org/docs/app/api-reference/functions/use-report-web-vitals) |
+
+## Server Functions
+
+| Function | Purpose | Reference |
+|----------|---------|-----------|
+| `cookies` | Read/write cookies | [Docs](https://nextjs.org/docs/app/api-reference/functions/cookies) |
+| `headers` | Read request headers | [Docs](https://nextjs.org/docs/app/api-reference/functions/headers) |
+| `draftMode` | Enable preview of unpublished CMS content | [Docs](https://nextjs.org/docs/app/api-reference/functions/draft-mode) |
+| `after` | Run code after response finishes streaming | [Docs](https://nextjs.org/docs/app/api-reference/functions/after) |
+| `connection` | Wait for connection before dynamic rendering | [Docs](https://nextjs.org/docs/app/api-reference/functions/connection) |
+| `userAgent` | Parse User-Agent header | [Docs](https://nextjs.org/docs/app/api-reference/functions/userAgent) |
+
+## Generate Functions
+
+| Function | Purpose | Reference |
+|----------|---------|-----------|
+| `generateStaticParams` | Pre-render dynamic routes at build time | [Docs](https://nextjs.org/docs/app/api-reference/functions/generate-static-params) |
+| `generateMetadata` | Dynamic metadata | [Docs](https://nextjs.org/docs/app/api-reference/functions/generate-metadata) |
+| `generateViewport` | Dynamic viewport config | [Docs](https://nextjs.org/docs/app/api-reference/functions/generate-viewport) |
+| `generateSitemaps` | Multiple sitemaps for large sites | [Docs](https://nextjs.org/docs/app/api-reference/functions/generate-sitemaps) |
+| `generateImageMetadata` | Multiple OG images per route | [Docs](https://nextjs.org/docs/app/api-reference/functions/generate-image-metadata) |
+
+## Request/Response
+
+| Function | Purpose | Reference |
+|----------|---------|-----------|
+| `NextRequest` | Extended Request with helpers | [Docs](https://nextjs.org/docs/app/api-reference/functions/next-request) |
+| `NextResponse` | Extended Response with helpers | [Docs](https://nextjs.org/docs/app/api-reference/functions/next-response) |
+| `ImageResponse` | Generate OG images | [Docs](https://nextjs.org/docs/app/api-reference/functions/image-response) |
+
+## Common Examples
+
+### Navigation
+
+Use `next/link` for internal navigation instead of `<a>` tags.
+
+```tsx
+// Bad: Plain anchor tag
+<a href="/about">About</a>
+
+// Good: Next.js Link
+import Link from 'next/link'
+
+<Link href="/about">About</Link>
+```
+
+Active link styling:
+
+```tsx
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+export function NavLink({ href, children }) {
+  const pathname = usePathname()
+
+  return (
+    <Link href={href} className={pathname === href ? 'active' : ''}>
+      {children}
+    </Link>
+  )
+}
+```
+
+### Static Generation
+
+```tsx
+// app/blog/[slug]/page.tsx
+export async function generateStaticParams() {
+  const posts = await getPosts()
+  return posts.map((post) => ({ slug: post.slug }))
+}
+```
+
+### After Response
+
+```tsx
+import { after } from 'next/server'
+
+export async function POST(request: Request) {
+  const data = await processRequest(request)
+
+  after(async () => {
+    await logAnalytics(data)
+  })
+
+  return Response.json({ success: true })
+}
+```

--- a/.claude/skills/next-best-practices/hydration-error.md
+++ b/.claude/skills/next-best-practices/hydration-error.md
@@ -1,0 +1,91 @@
+# Hydration Errors
+
+Diagnose and fix React hydration mismatch errors.
+
+## Error Signs
+
+- "Hydration failed because the initial UI does not match"
+- "Text content does not match server-rendered HTML"
+
+## Debugging
+
+In development, click the hydration error to see the server/client diff.
+
+## Common Causes and Fixes
+
+### Browser-only APIs
+
+```tsx
+// Bad: Causes mismatch - window doesn't exist on server
+<div>{window.innerWidth}</div>
+
+// Good: Use client component with mounted check
+'use client'
+import { useState, useEffect } from 'react'
+
+export function ClientOnly({ children }: { children: React.ReactNode }) {
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => setMounted(true), [])
+  return mounted ? children : null
+}
+```
+
+### Date/Time Rendering
+
+Server and client may be in different timezones:
+
+```tsx
+// Bad: Causes mismatch
+<span>{new Date().toLocaleString()}</span>
+
+// Good: Render on client only
+'use client'
+const [time, setTime] = useState<string>()
+useEffect(() => setTime(new Date().toLocaleString()), [])
+```
+
+### Random Values or IDs
+
+```tsx
+// Bad: Random values differ between server and client
+<div id={Math.random().toString()}>
+
+// Good: Use useId hook
+import { useId } from 'react'
+
+function Input() {
+  const id = useId()
+  return <input id={id} />
+}
+```
+
+### Invalid HTML Nesting
+
+```tsx
+// Bad: Invalid - div inside p
+<p><div>Content</div></p>
+
+// Bad: Invalid - p inside p
+<p><p>Nested</p></p>
+
+// Good: Valid nesting
+<div><p>Content</p></div>
+```
+
+### Third-party Scripts
+
+Scripts that modify DOM during hydration.
+
+```tsx
+// Good: Use next/script with afterInteractive
+import Script from 'next/script'
+
+export default function Page() {
+  return (
+    <Script
+      src="https://example.com/script.js"
+      strategy="afterInteractive"
+    />
+  )
+}
+```

--- a/.claude/skills/next-best-practices/image.md
+++ b/.claude/skills/next-best-practices/image.md
@@ -1,0 +1,173 @@
+# Image Optimization
+
+Use `next/image` for automatic image optimization.
+
+## Always Use next/image
+
+```tsx
+// Bad: Avoid native img
+<img src="/hero.png" alt="Hero" />
+
+// Good: Use next/image
+import Image from 'next/image'
+<Image src="/hero.png" alt="Hero" width={800} height={400} />
+```
+
+## Required Props
+
+Images need explicit dimensions to prevent layout shift:
+
+```tsx
+// Local images - dimensions inferred automatically
+import heroImage from './hero.png'
+<Image src={heroImage} alt="Hero" />
+
+// Remote images - must specify width/height
+<Image src="https://example.com/image.jpg" alt="Hero" width={800} height={400} />
+
+// Or use fill for parent-relative sizing
+<div style={{ position: 'relative', width: '100%', height: 400 }}>
+  <Image src="/hero.png" alt="Hero" fill style={{ objectFit: 'cover' }} />
+</div>
+```
+
+## Remote Images Configuration
+
+Remote domains must be configured in `next.config.js`:
+
+```js
+// next.config.js
+module.exports = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'example.com',
+        pathname: '/images/**',
+      },
+      {
+        protocol: 'https',
+        hostname: '*.cdn.com', // Wildcard subdomain
+      },
+    ],
+  },
+}
+```
+
+## Responsive Images
+
+Use `sizes` to tell the browser which size to download:
+
+```tsx
+// Full-width hero
+<Image
+  src="/hero.png"
+  alt="Hero"
+  fill
+  sizes="100vw"
+/>
+
+// Responsive grid (3 columns on desktop, 1 on mobile)
+<Image
+  src="/card.png"
+  alt="Card"
+  fill
+  sizes="(max-width: 768px) 100vw, 33vw"
+/>
+
+// Fixed sidebar image
+<Image
+  src="/avatar.png"
+  alt="Avatar"
+  width={200}
+  height={200}
+  sizes="200px"
+/>
+```
+
+## Blur Placeholder
+
+Prevent layout shift with placeholders:
+
+```tsx
+// Local images - automatic blur hash
+import heroImage from './hero.png'
+<Image src={heroImage} alt="Hero" placeholder="blur" />
+
+// Remote images - provide blurDataURL
+<Image
+  src="https://example.com/image.jpg"
+  alt="Hero"
+  width={800}
+  height={400}
+  placeholder="blur"
+  blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRg..."
+/>
+
+// Or use color placeholder
+<Image
+  src="https://example.com/image.jpg"
+  alt="Hero"
+  width={800}
+  height={400}
+  placeholder="empty"
+  style={{ backgroundColor: '#e0e0e0' }}
+/>
+```
+
+## Priority Loading
+
+Use `priority` for above-the-fold images (LCP):
+
+```tsx
+// Hero image - loads immediately
+<Image src="/hero.png" alt="Hero" fill priority />
+
+// Below-fold images - lazy loaded by default (no priority needed)
+<Image src="/card.png" alt="Card" width={400} height={300} />
+```
+
+## Common Mistakes
+
+```tsx
+// Bad: Missing sizes with fill - downloads largest image
+<Image src="/hero.png" alt="Hero" fill />
+
+// Good: Add sizes for proper responsive behavior
+<Image src="/hero.png" alt="Hero" fill sizes="100vw" />
+
+// Bad: Using width/height for aspect ratio only
+<Image src="/hero.png" alt="Hero" width={16} height={9} />
+
+// Good: Use actual display dimensions or fill with sizes
+<Image src="/hero.png" alt="Hero" fill sizes="100vw" style={{ objectFit: 'cover' }} />
+
+// Bad: Remote image without config
+<Image src="https://untrusted.com/image.jpg" alt="Image" width={400} height={300} />
+// Error: Invalid src prop, hostname not configured
+
+// Good: Add hostname to next.config.js remotePatterns
+```
+
+## Static Export
+
+When using `output: 'export'`, use `unoptimized` or custom loader:
+
+```tsx
+// Option 1: Disable optimization
+<Image src="/hero.png" alt="Hero" width={800} height={400} unoptimized />
+
+// Option 2: Global config
+// next.config.js
+module.exports = {
+  output: 'export',
+  images: { unoptimized: true },
+}
+
+// Option 3: Custom loader (Cloudinary, Imgix, etc.)
+const cloudinaryLoader = ({ src, width, quality }) => {
+  return `https://res.cloudinary.com/demo/image/upload/w_${width},q_${quality || 75}/${src}`
+}
+
+<Image loader={cloudinaryLoader} src="sample.jpg" alt="Sample" width={800} height={400} />
+```

--- a/.claude/skills/next-best-practices/metadata.md
+++ b/.claude/skills/next-best-practices/metadata.md
@@ -1,0 +1,301 @@
+# Metadata
+
+Add SEO metadata to Next.js pages using the Metadata API.
+
+## Important: Server Components Only
+
+The `metadata` object and `generateMetadata` function are **only supported in Server Components**. They cannot be used in Client Components.
+
+If the target page has `'use client'`:
+1. Remove `'use client'` if possible, move client logic to child components
+2. Or extract metadata to a parent Server Component layout
+3. Or split the file: Server Component with metadata imports Client Components
+
+## Static Metadata
+
+```tsx
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Page Title',
+  description: 'Page description for search engines',
+}
+```
+
+## Dynamic Metadata
+
+```tsx
+import type { Metadata } from 'next'
+
+type Props = { params: Promise<{ slug: string }> }
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params
+  const post = await getPost(slug)
+  return { title: post.title, description: post.description }
+}
+```
+
+## Avoid Duplicate Fetches
+
+Use React `cache()` when the same data is needed for both metadata and page:
+
+```tsx
+import { cache } from 'react'
+
+export const getPost = cache(async (slug: string) => {
+  return await db.posts.findFirst({ where: { slug } })
+})
+```
+
+## Viewport
+
+Separate from metadata for streaming support:
+
+```tsx
+import type { Viewport } from 'next'
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  themeColor: '#000000',
+}
+
+// Or dynamic
+export function generateViewport({ params }): Viewport {
+  return { themeColor: getThemeColor(params) }
+}
+```
+
+## Title Templates
+
+In root layout for consistent naming:
+
+```tsx
+export const metadata: Metadata = {
+  title: { default: 'Site Name', template: '%s | Site Name' },
+}
+```
+
+## Metadata File Conventions
+
+Reference: https://nextjs.org/docs/app/getting-started/project-structure#metadata-file-conventions
+
+Place these files in `app/` directory (or route segments):
+
+| File | Purpose |
+|------|---------|
+| `favicon.ico` | Favicon |
+| `icon.png` / `icon.svg` | App icon |
+| `apple-icon.png` | Apple app icon |
+| `opengraph-image.png` | OG image |
+| `twitter-image.png` | Twitter card image |
+| `sitemap.ts` / `sitemap.xml` | Sitemap (use `generateSitemaps` for multiple) |
+| `robots.ts` / `robots.txt` | Robots directives |
+| `manifest.ts` / `manifest.json` | Web app manifest |
+
+## SEO Best Practice: Static Files Are Often Enough
+
+For most sites, **static metadata files provide excellent SEO coverage**:
+
+```
+app/
+├── favicon.ico
+├── opengraph-image.png     # Works for both OG and Twitter
+├── sitemap.ts
+├── robots.ts
+└── layout.tsx              # With title/description metadata
+```
+
+**Tips:**
+- A single `opengraph-image.png` covers both Open Graph and Twitter (Twitter falls back to OG)
+- Static `title` and `description` in layout metadata is sufficient for most pages
+- Only use dynamic `generateMetadata` when content varies per page
+
+---
+
+# OG Image Generation
+
+Generate dynamic Open Graph images using `next/og`.
+
+## Important Rules
+
+1. **Use `next/og`** - not `@vercel/og` (it's built into Next.js)
+2. **No searchParams** - OG images can't access search params, use route params instead
+3. **Avoid Edge runtime** - Use default Node.js runtime
+
+```tsx
+// Good
+import { ImageResponse } from 'next/og'
+
+// Bad
+// import { ImageResponse } from '@vercel/og'
+// export const runtime = 'edge'
+```
+
+## Basic OG Image
+
+```tsx
+// app/opengraph-image.tsx
+import { ImageResponse } from 'next/og'
+
+export const alt = 'Site Name'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          fontSize: 128,
+          background: 'white',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        Hello World
+      </div>
+    ),
+    { ...size }
+  )
+}
+```
+
+## Dynamic OG Image
+
+```tsx
+// app/blog/[slug]/opengraph-image.tsx
+import { ImageResponse } from 'next/og'
+
+export const alt = 'Blog Post'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+type Props = { params: Promise<{ slug: string }> }
+
+export default async function Image({ params }: Props) {
+  const { slug } = await params
+  const post = await getPost(slug)
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          fontSize: 48,
+          background: 'linear-gradient(to bottom, #1a1a1a, #333)',
+          color: 'white',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 48,
+        }}
+      >
+        <div style={{ fontSize: 64, fontWeight: 'bold' }}>{post.title}</div>
+        <div style={{ marginTop: 24, opacity: 0.8 }}>{post.description}</div>
+      </div>
+    ),
+    { ...size }
+  )
+}
+```
+
+## Custom Fonts
+
+```tsx
+import { ImageResponse } from 'next/og'
+import { join } from 'path'
+import { readFile } from 'fs/promises'
+
+export default async function Image() {
+  const fontPath = join(process.cwd(), 'assets/fonts/Inter-Bold.ttf')
+  const fontData = await readFile(fontPath)
+
+  return new ImageResponse(
+    (
+      <div style={{ fontFamily: 'Inter', fontSize: 64 }}>
+        Custom Font Text
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+      fonts: [{ name: 'Inter', data: fontData, style: 'normal' }],
+    }
+  )
+}
+```
+
+## File Naming
+
+- `opengraph-image.tsx` - Open Graph (Facebook, LinkedIn)
+- `twitter-image.tsx` - Twitter/X cards (optional, falls back to OG)
+
+## Styling Notes
+
+ImageResponse uses Flexbox layout:
+- Use `display: 'flex'`
+- No CSS Grid support
+- Styles must be inline objects
+
+## Multiple OG Images
+
+Use `generateImageMetadata` for multiple images per route:
+
+```tsx
+// app/blog/[slug]/opengraph-image.tsx
+import { ImageResponse } from 'next/og'
+
+export async function generateImageMetadata({ params }) {
+  const images = await getPostImages(params.slug)
+  return images.map((img, idx) => ({
+    id: idx,
+    alt: img.alt,
+    size: { width: 1200, height: 630 },
+    contentType: 'image/png',
+  }))
+}
+
+export default async function Image({ params, id }) {
+  const images = await getPostImages(params.slug)
+  const image = images[id]
+  return new ImageResponse(/* ... */)
+}
+```
+
+## Multiple Sitemaps
+
+Use `generateSitemaps` for large sites:
+
+```tsx
+// app/sitemap.ts
+import type { MetadataRoute } from 'next'
+
+export async function generateSitemaps() {
+  // Return array of sitemap IDs
+  return [{ id: 0 }, { id: 1 }, { id: 2 }]
+}
+
+export default async function sitemap({
+  id,
+}: {
+  id: number
+}): Promise<MetadataRoute.Sitemap> {
+  const start = id * 50000
+  const end = start + 50000
+  const products = await getProducts(start, end)
+
+  return products.map((product) => ({
+    url: `https://example.com/product/${product.id}`,
+    lastModified: product.updatedAt,
+  }))
+}
+```
+
+Generates `/sitemap/0.xml`, `/sitemap/1.xml`, etc.

--- a/.claude/skills/next-best-practices/parallel-routes.md
+++ b/.claude/skills/next-best-practices/parallel-routes.md
@@ -1,0 +1,287 @@
+# Parallel & Intercepting Routes
+
+Parallel routes render multiple pages in the same layout. Intercepting routes show a different UI when navigating from within your app vs direct URL access. Together they enable modal patterns.
+
+## File Structure
+
+```
+app/
+├── @modal/                    # Parallel route slot
+│   ├── default.tsx            # Required! Returns null
+│   ├── (.)photos/             # Intercepts /photos/*
+│   │   └── [id]/
+│   │       └── page.tsx       # Modal content
+│   └── [...]catchall/         # Optional: catch unmatched
+│       └── page.tsx
+├── photos/
+│   └── [id]/
+│       └── page.tsx           # Full page (direct access)
+├── layout.tsx                 # Renders both children and @modal
+└── page.tsx
+```
+
+## Step 1: Root Layout with Slot
+
+```tsx
+// app/layout.tsx
+export default function RootLayout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode;
+  modal: React.ReactNode;
+}) {
+  return (
+    <html>
+      <body>
+        {children}
+        {modal}
+      </body>
+    </html>
+  );
+}
+```
+
+## Step 2: Default File (Critical!)
+
+**Every parallel route slot MUST have a `default.tsx`** to prevent 404s on hard navigation.
+
+```tsx
+// app/@modal/default.tsx
+export default function Default() {
+  return null;
+}
+```
+
+Without this file, refreshing any page will 404 because Next.js can't determine what to render in the `@modal` slot.
+
+## Step 3: Intercepting Route (Modal)
+
+The `(.)` prefix intercepts routes at the same level.
+
+```tsx
+// app/@modal/(.)photos/[id]/page.tsx
+import { Modal } from '@/components/modal';
+
+export default async function PhotoModal({
+  params
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params;
+  const photo = await getPhoto(id);
+
+  return (
+    <Modal>
+      <img src={photo.url} alt={photo.title} />
+    </Modal>
+  );
+}
+```
+
+## Step 4: Full Page (Direct Access)
+
+```tsx
+// app/photos/[id]/page.tsx
+export default async function PhotoPage({
+  params
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params;
+  const photo = await getPhoto(id);
+
+  return (
+    <div className="full-page">
+      <img src={photo.url} alt={photo.title} />
+      <h1>{photo.title}</h1>
+    </div>
+  );
+}
+```
+
+## Step 5: Modal Component with Correct Closing
+
+**Critical: Use `router.back()` to close modals, NOT `router.push()` or `<Link>`.**
+
+```tsx
+// components/modal.tsx
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useRef } from 'react';
+
+export function Modal({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  // Close on escape key
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        router.back(); // Correct
+      }
+    }
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [router]);
+
+  // Close on overlay click
+  const handleOverlayClick = useCallback((e: React.MouseEvent) => {
+    if (e.target === overlayRef.current) {
+      router.back(); // Correct
+    }
+  }, [router]);
+
+  return (
+    <div
+      ref={overlayRef}
+      onClick={handleOverlayClick}
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+    >
+      <div className="bg-white rounded-lg p-6 max-w-2xl w-full mx-4">
+        <button
+          onClick={() => router.back()} // Correct!
+          className="absolute top-4 right-4"
+        >
+          Close
+        </button>
+        {children}
+      </div>
+    </div>
+  );
+}
+```
+
+### Why NOT `router.push('/')` or `<Link href="/">`?
+
+Using `push` or `Link` to "close" a modal:
+1. Adds a new history entry (back button shows modal again)
+2. Doesn't properly clear the intercepted route
+3. Can cause the modal to flash or persist unexpectedly
+
+`router.back()` correctly:
+1. Removes the intercepted route from history
+2. Returns to the previous page
+3. Properly unmounts the modal
+
+## Route Matcher Reference
+
+Matchers match **route segments**, not filesystem paths:
+
+| Matcher | Matches | Example |
+|---------|---------|---------|
+| `(.)` | Same level | `@modal/(.)photos` intercepts `/photos` |
+| `(..)` | One level up | `@modal/(..)settings` from `/dashboard/@modal` intercepts `/settings` |
+| `(..)(..)` | Two levels up | Rarely used |
+| `(...)` | From root | `@modal/(...)photos` intercepts `/photos` from anywhere |
+
+**Common mistake**: Thinking `(..)` means "parent folder" - it means "parent route segment".
+
+## Handling Hard Navigation
+
+When users directly visit `/photos/123` (bookmark, refresh, shared link):
+- The intercepting route is bypassed
+- The full `photos/[id]/page.tsx` renders
+- Modal doesn't appear (expected behavior)
+
+If you want the modal to appear on direct access too, you need additional logic:
+
+```tsx
+// app/photos/[id]/page.tsx
+import { Modal } from '@/components/modal';
+
+export default async function PhotoPage({ params }) {
+  const { id } = await params;
+  const photo = await getPhoto(id);
+
+  // Option: Render as modal on direct access too
+  return (
+    <Modal>
+      <img src={photo.url} alt={photo.title} />
+    </Modal>
+  );
+}
+```
+
+## Common Gotchas
+
+### 1. Missing `default.tsx` → 404 on Refresh
+
+Every `@slot` folder needs a `default.tsx` that returns `null` (or appropriate content).
+
+### 2. Modal Persists After Navigation
+
+You're using `router.push()` instead of `router.back()`.
+
+### 3. Nested Parallel Routes Need Defaults Too
+
+If you have `@modal` inside a route group, each level needs its own `default.tsx`:
+
+```
+app/
+├── (marketing)/
+│   ├── @modal/
+│   │   └── default.tsx     # Needed!
+│   └── layout.tsx
+└── layout.tsx
+```
+
+### 4. Intercepted Route Shows Wrong Content
+
+Check your matcher:
+- `(.)photos` intercepts `/photos` from the same route level
+- If your `@modal` is in `app/dashboard/@modal`, use `(.)photos` to intercept `/dashboard/photos`, not `/photos`
+
+### 5. TypeScript Errors with `params`
+
+In Next.js 15+, `params` is a Promise:
+
+```tsx
+// Correct
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+}
+```
+
+## Complete Example: Photo Gallery Modal
+
+```
+app/
+├── @modal/
+│   ├── default.tsx
+│   └── (.)photos/
+│       └── [id]/
+│           └── page.tsx
+├── photos/
+│   ├── page.tsx           # Gallery grid
+│   └── [id]/
+│       └── page.tsx       # Full photo page
+├── layout.tsx
+└── page.tsx
+```
+
+Links in the gallery:
+
+```tsx
+// app/photos/page.tsx
+import Link from 'next/link';
+
+export default async function Gallery() {
+  const photos = await getPhotos();
+
+  return (
+    <div className="grid grid-cols-3 gap-4">
+      {photos.map(photo => (
+        <Link key={photo.id} href={`/photos/${photo.id}`}>
+          <img src={photo.thumbnail} alt={photo.title} />
+        </Link>
+      ))}
+    </div>
+  );
+}
+```
+
+Clicking a photo → Modal opens (intercepted)
+Direct URL → Full page renders
+Refresh while modal open → Full page renders

--- a/.claude/skills/next-best-practices/route-handlers.md
+++ b/.claude/skills/next-best-practices/route-handlers.md
@@ -1,0 +1,146 @@
+# Route Handlers
+
+Create API endpoints with `route.ts` files.
+
+## Basic Usage
+
+```tsx
+// app/api/users/route.ts
+export async function GET() {
+  const users = await getUsers()
+  return Response.json(users)
+}
+
+export async function POST(request: Request) {
+  const body = await request.json()
+  const user = await createUser(body)
+  return Response.json(user, { status: 201 })
+}
+```
+
+## Supported Methods
+
+`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS`
+
+## GET Handler Conflicts with page.tsx
+
+**A `route.ts` and `page.tsx` cannot coexist in the same folder.**
+
+```
+app/
+├── api/
+│   └── users/
+│       └── route.ts    # /api/users
+└── users/
+    ├── page.tsx        # /users (page)
+    └── route.ts        # Warning: Conflicts with page.tsx!
+```
+
+If you need both a page and an API at the same path, use different paths:
+
+```
+app/
+├── users/
+│   └── page.tsx        # /users (page)
+└── api/
+    └── users/
+        └── route.ts    # /api/users (API)
+```
+
+## Environment Behavior
+
+Route handlers run in a **Server Component-like environment**:
+
+- Yes: Can use `async/await`
+- Yes: Can access `cookies()`, `headers()`
+- Yes: Can use Node.js APIs
+- No: Cannot use React hooks
+- No: Cannot use React DOM APIs
+- No: Cannot use browser APIs
+
+```tsx
+// Bad: This won't work - no React DOM in route handlers
+import { renderToString } from 'react-dom/server'
+
+export async function GET() {
+  const html = renderToString(<Component />)  // Error!
+  return new Response(html)
+}
+```
+
+## Dynamic Route Handlers
+
+```tsx
+// app/api/users/[id]/route.ts
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const user = await getUser(id)
+
+  if (!user) {
+    return Response.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  return Response.json(user)
+}
+```
+
+## Request Helpers
+
+```tsx
+export async function GET(request: Request) {
+  // URL and search params
+  const { searchParams } = new URL(request.url)
+  const query = searchParams.get('q')
+
+  // Headers
+  const authHeader = request.headers.get('authorization')
+
+  // Cookies (Next.js helper)
+  const cookieStore = await cookies()
+  const token = cookieStore.get('token')
+
+  return Response.json({ query, token })
+}
+```
+
+## Response Helpers
+
+```tsx
+// JSON response
+return Response.json({ data })
+
+// With status
+return Response.json({ error: 'Not found' }, { status: 404 })
+
+// With headers
+return Response.json(data, {
+  headers: {
+    'Cache-Control': 'max-age=3600',
+  },
+})
+
+// Redirect
+return Response.redirect(new URL('/login', request.url))
+
+// Stream
+return new Response(stream, {
+  headers: { 'Content-Type': 'text/event-stream' },
+})
+```
+
+## When to Use Route Handlers vs Server Actions
+
+| Use Case | Route Handlers | Server Actions |
+|----------|----------------|----------------|
+| Form submissions | No | Yes |
+| Data mutations from UI | No | Yes |
+| Third-party webhooks | Yes | No |
+| External API consumption | Yes | No |
+| Public REST API | Yes | No |
+| File uploads | Both work | Both work |
+
+**Prefer Server Actions** for mutations triggered from your UI.
+**Use Route Handlers** for external integrations and public APIs.

--- a/.claude/skills/next-best-practices/rsc-boundaries.md
+++ b/.claude/skills/next-best-practices/rsc-boundaries.md
@@ -1,0 +1,159 @@
+# RSC Boundaries
+
+Detect and prevent invalid patterns when crossing Server/Client component boundaries.
+
+## Detection Rules
+
+### 1. Async Client Components Are Invalid
+
+Client components **cannot** be async functions. Only Server Components can be async.
+
+**Detect:** File has `'use client'` AND component is `async function` or returns `Promise`
+
+```tsx
+// Bad: async client component
+'use client'
+export default async function UserProfile() {
+  const user = await getUser() // Cannot await in client component
+  return <div>{user.name}</div>
+}
+
+// Good: Remove async, fetch data in parent server component
+// page.tsx (server component - no 'use client')
+export default async function Page() {
+  const user = await getUser()
+  return <UserProfile user={user} />
+}
+
+// UserProfile.tsx (client component)
+'use client'
+export function UserProfile({ user }: { user: User }) {
+  return <div>{user.name}</div>
+}
+```
+
+```tsx
+// Bad: async arrow function client component
+'use client'
+const Dashboard = async () => {
+  const data = await fetchDashboard()
+  return <div>{data}</div>
+}
+
+// Good: Fetch in server component, pass data down
+```
+
+### 2. Non-Serializable Props to Client Components
+
+Props passed from Server → Client must be JSON-serializable.
+
+**Detect:** Server component passes these to a client component:
+- Functions (except Server Actions with `'use server'`)
+- `Date` objects
+- `Map`, `Set`, `WeakMap`, `WeakSet`
+- Class instances
+- `Symbol` (unless globally registered)
+- Circular references
+
+```tsx
+// Bad: Function prop
+// page.tsx (server)
+export default function Page() {
+  const handleClick = () => console.log('clicked')
+  return <ClientButton onClick={handleClick} />
+}
+
+// Good: Define function inside client component
+// ClientButton.tsx
+'use client'
+export function ClientButton() {
+  const handleClick = () => console.log('clicked')
+  return <button onClick={handleClick}>Click</button>
+}
+```
+
+```tsx
+// Bad: Date object (silently becomes string, then crashes)
+// page.tsx (server)
+export default async function Page() {
+  const post = await getPost()
+  return <PostCard createdAt={post.createdAt} /> // Date object
+}
+
+// PostCard.tsx (client) - will crash on .getFullYear()
+'use client'
+export function PostCard({ createdAt }: { createdAt: Date }) {
+  return <span>{createdAt.getFullYear()}</span> // Runtime error!
+}
+
+// Good: Serialize to string on server
+// page.tsx (server)
+export default async function Page() {
+  const post = await getPost()
+  return <PostCard createdAt={post.createdAt.toISOString()} />
+}
+
+// PostCard.tsx (client)
+'use client'
+export function PostCard({ createdAt }: { createdAt: string }) {
+  const date = new Date(createdAt)
+  return <span>{date.getFullYear()}</span>
+}
+```
+
+```tsx
+// Bad: Class instance
+const user = new UserModel(data)
+<ClientProfile user={user} /> // Methods will be stripped
+
+// Good: Pass plain object
+const user = await getUser()
+<ClientProfile user={{ id: user.id, name: user.name }} />
+```
+
+```tsx
+// Bad: Map/Set
+<ClientComponent items={new Map([['a', 1]])} />
+
+// Good: Convert to array/object
+<ClientComponent items={Object.fromEntries(map)} />
+<ClientComponent items={Array.from(set)} />
+```
+
+### 3. Server Actions Are the Exception
+
+Functions marked with `'use server'` CAN be passed to client components.
+
+```tsx
+// Valid: Server Action can be passed
+// actions.ts
+'use server'
+export async function submitForm(formData: FormData) {
+  // server-side logic
+}
+
+// page.tsx (server)
+import { submitForm } from './actions'
+export default function Page() {
+  return <ClientForm onSubmit={submitForm} /> // OK!
+}
+
+// ClientForm.tsx (client)
+'use client'
+export function ClientForm({ onSubmit }: { onSubmit: (data: FormData) => Promise<void> }) {
+  return <form action={onSubmit}>...</form>
+}
+```
+
+## Quick Reference
+
+| Pattern | Valid? | Fix |
+|---------|--------|-----|
+| `'use client'` + `async function` | No | Fetch in server parent, pass data |
+| Pass `() => {}` to client | No | Define in client or use server action |
+| Pass `new Date()` to client | No | Use `.toISOString()` |
+| Pass `new Map()` to client | No | Convert to object/array |
+| Pass class instance to client | No | Pass plain object |
+| Pass server action to client | Yes | - |
+| Pass `string/number/boolean` | Yes | - |
+| Pass plain object/array | Yes | - |

--- a/.claude/skills/next-best-practices/runtime-selection.md
+++ b/.claude/skills/next-best-practices/runtime-selection.md
@@ -1,0 +1,39 @@
+# Runtime Selection
+
+## Use Node.js Runtime by Default
+
+Use the default Node.js runtime for new routes and pages. Only use Edge runtime if the project already uses it or there's a specific requirement.
+
+```tsx
+// Good: Default - no runtime config needed (uses Node.js)
+export default function Page() { ... }
+
+// Caution: Only if already used in project or specifically required
+export const runtime = 'edge'
+```
+
+## When to Use Each
+
+### Node.js Runtime (Default)
+
+- Full Node.js API support
+- File system access (`fs`)
+- Full `crypto` support
+- Database connections
+- Most npm packages work
+
+### Edge Runtime
+
+- Only for specific edge-location latency requirements
+- Limited API (no `fs`, limited `crypto`)
+- Smaller cold start
+- Geographic distribution needs
+
+## Detection
+
+**Before adding `runtime = 'edge'`**, check:
+1. Does the project already use Edge runtime?
+2. Is there a specific latency requirement?
+3. Are all dependencies Edge-compatible?
+
+If unsure, use Node.js runtime.

--- a/.claude/skills/next-best-practices/scripts.md
+++ b/.claude/skills/next-best-practices/scripts.md
@@ -1,0 +1,141 @@
+# Scripts
+
+Loading third-party scripts in Next.js.
+
+## Use next/script
+
+Always use `next/script` instead of native `<script>` tags for better performance.
+
+```tsx
+// Bad: Native script tag
+<script src="https://example.com/script.js"></script>
+
+// Good: Next.js Script component
+import Script from 'next/script'
+
+<Script src="https://example.com/script.js" />
+```
+
+## Inline Scripts Need ID
+
+Inline scripts require an `id` attribute for Next.js to track them.
+
+```tsx
+// Bad: Missing id
+<Script dangerouslySetInnerHTML={{ __html: 'console.log("hi")' }} />
+
+// Good: Has id
+<Script id="my-script" dangerouslySetInnerHTML={{ __html: 'console.log("hi")' }} />
+
+// Good: Inline with id
+<Script id="show-banner">
+  {`document.getElementById('banner').classList.remove('hidden')`}
+</Script>
+```
+
+## Don't Put Script in Head
+
+`next/script` should not be placed inside `next/head`. It handles its own positioning.
+
+```tsx
+// Bad: Script inside Head
+import Head from 'next/head'
+import Script from 'next/script'
+
+<Head>
+  <Script src="/analytics.js" />
+</Head>
+
+// Good: Script outside Head
+<Head>
+  <title>Page</title>
+</Head>
+<Script src="/analytics.js" />
+```
+
+## Loading Strategies
+
+```tsx
+// afterInteractive (default) - Load after page is interactive
+<Script src="/analytics.js" strategy="afterInteractive" />
+
+// lazyOnload - Load during idle time
+<Script src="/widget.js" strategy="lazyOnload" />
+
+// beforeInteractive - Load before page is interactive (use sparingly)
+// Only works in app/layout.tsx or pages/_document.js
+<Script src="/critical.js" strategy="beforeInteractive" />
+
+// worker - Load in web worker (experimental)
+<Script src="/heavy.js" strategy="worker" />
+```
+
+## Google Analytics
+
+Use `@next/third-parties` instead of inline GA scripts.
+
+```tsx
+// Bad: Inline GA script
+<Script src="https://www.googletagmanager.com/gtag/js?id=G-XXXXX" />
+<Script id="ga-init">
+  {`window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-XXXXX');`}
+</Script>
+
+// Good: Next.js component
+import { GoogleAnalytics } from '@next/third-parties/google'
+
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+      <GoogleAnalytics gaId="G-XXXXX" />
+    </html>
+  )
+}
+```
+
+## Google Tag Manager
+
+```tsx
+import { GoogleTagManager } from '@next/third-parties/google'
+
+export default function Layout({ children }) {
+  return (
+    <html>
+      <GoogleTagManager gtmId="GTM-XXXXX" />
+      <body>{children}</body>
+    </html>
+  )
+}
+```
+
+## Other Third-Party Scripts
+
+```tsx
+// YouTube embed
+import { YouTubeEmbed } from '@next/third-parties/google'
+
+<YouTubeEmbed videoid="dQw4w9WgXcQ" />
+
+// Google Maps
+import { GoogleMapsEmbed } from '@next/third-parties/google'
+
+<GoogleMapsEmbed
+  apiKey="YOUR_API_KEY"
+  mode="place"
+  q="Brooklyn+Bridge,New+York,NY"
+/>
+```
+
+## Quick Reference
+
+| Pattern | Issue | Fix |
+|---------|-------|-----|
+| `<script src="...">` | No optimization | Use `next/script` |
+| `<Script>` without id | Can't track inline scripts | Add `id` attribute |
+| `<Script>` inside `<Head>` | Wrong placement | Move outside Head |
+| Inline GA/GTM scripts | No optimization | Use `@next/third-parties` |
+| `strategy="beforeInteractive"` outside layout | Won't work | Only use in root layout |

--- a/.claude/skills/next-best-practices/self-hosting.md
+++ b/.claude/skills/next-best-practices/self-hosting.md
@@ -1,0 +1,371 @@
+# Self-Hosting Next.js
+
+Deploy Next.js outside of Vercel with confidence.
+
+## Quick Start: Standalone Output
+
+For Docker or any containerized deployment, use standalone output:
+
+```js
+// next.config.js
+module.exports = {
+  output: 'standalone',
+};
+```
+
+This creates a minimal `standalone` folder with only production dependencies:
+
+```
+.next/
+├── standalone/
+│   ├── server.js          # Entry point
+│   ├── node_modules/      # Only production deps
+│   └── .next/             # Build output
+└── static/                # Must be copied separately
+```
+
+## Docker Deployment
+
+### Dockerfile
+
+```dockerfile
+FROM node:20-alpine AS base
+
+# Install dependencies
+FROM base AS deps
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+# Build
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+# Production
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Create non-root user
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+# Copy standalone output
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+
+USER nextjs
+
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["node", "server.js"]
+```
+
+### Docker Compose
+
+```yaml
+version: '3.8'
+
+services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+```
+
+## PM2 Deployment
+
+For traditional server deployments:
+
+```js
+// ecosystem.config.js
+module.exports = {
+  apps: [{
+    name: 'nextjs',
+    script: '.next/standalone/server.js',
+    instances: 'max',
+    exec_mode: 'cluster',
+    env: {
+      NODE_ENV: 'production',
+      PORT: 3000,
+    },
+  }],
+};
+```
+
+```bash
+npm run build
+pm2 start ecosystem.config.js
+```
+
+## ISR and Cache Handlers
+
+### The Problem
+
+ISR (Incremental Static Regeneration) uses filesystem caching by default. This **breaks with multiple instances**:
+
+- Instance A regenerates page → saves to its local disk
+- Instance B serves stale page → doesn't see Instance A's cache
+- Load balancer sends users to random instances → inconsistent content
+
+### Solution: Custom Cache Handler
+
+Next.js 14+ supports custom cache handlers for shared storage:
+
+```js
+// next.config.js
+module.exports = {
+  cacheHandler: require.resolve('./cache-handler.js'),
+  cacheMaxMemorySize: 0, // Disable in-memory cache
+};
+```
+
+#### Redis Cache Handler Example
+
+```js
+// cache-handler.js
+const Redis = require('ioredis');
+
+const redis = new Redis(process.env.REDIS_URL);
+const CACHE_PREFIX = 'nextjs:';
+
+module.exports = class CacheHandler {
+  constructor(options) {
+    this.options = options;
+  }
+
+  async get(key) {
+    const data = await redis.get(CACHE_PREFIX + key);
+    if (!data) return null;
+
+    const parsed = JSON.parse(data);
+    return {
+      value: parsed.value,
+      lastModified: parsed.lastModified,
+    };
+  }
+
+  async set(key, data, ctx) {
+    const cacheData = {
+      value: data,
+      lastModified: Date.now(),
+    };
+
+    // Set TTL based on revalidate option
+    if (ctx?.revalidate) {
+      await redis.setex(
+        CACHE_PREFIX + key,
+        ctx.revalidate,
+        JSON.stringify(cacheData)
+      );
+    } else {
+      await redis.set(CACHE_PREFIX + key, JSON.stringify(cacheData));
+    }
+  }
+
+  async revalidateTag(tags) {
+    // Implement tag-based invalidation
+    // This requires tracking which keys have which tags
+  }
+};
+```
+
+#### S3 Cache Handler Example
+
+```js
+// cache-handler.js
+const { S3Client, GetObjectCommand, PutObjectCommand } = require('@aws-sdk/client-s3');
+
+const s3 = new S3Client({ region: process.env.AWS_REGION });
+const BUCKET = process.env.CACHE_BUCKET;
+
+module.exports = class CacheHandler {
+  async get(key) {
+    try {
+      const response = await s3.send(new GetObjectCommand({
+        Bucket: BUCKET,
+        Key: `cache/${key}`,
+      }));
+      const body = await response.Body.transformToString();
+      return JSON.parse(body);
+    } catch (err) {
+      if (err.name === 'NoSuchKey') return null;
+      throw err;
+    }
+  }
+
+  async set(key, data, ctx) {
+    await s3.send(new PutObjectCommand({
+      Bucket: BUCKET,
+      Key: `cache/${key}`,
+      Body: JSON.stringify({
+        value: data,
+        lastModified: Date.now(),
+      }),
+      ContentType: 'application/json',
+    }));
+  }
+};
+```
+
+## What Works vs What Needs Setup
+
+| Feature | Single Instance | Multi-Instance | Notes |
+|---------|----------------|----------------|-------|
+| SSR | Yes | Yes | No special setup |
+| SSG | Yes | Yes | Built at deploy time |
+| ISR | Yes | Needs cache handler | Filesystem cache breaks |
+| Image Optimization | Yes | Yes | CPU-intensive, consider CDN |
+| Middleware | Yes | Yes | Runs on Node.js |
+| Edge Runtime | Limited | Limited | Some features Node-only |
+| `revalidatePath/Tag` | Yes | Needs cache handler | Must share cache |
+| `next/font` | Yes | Yes | Fonts bundled at build |
+| Draft Mode | Yes | Yes | Cookie-based |
+
+## Image Optimization
+
+Next.js Image Optimization works out of the box but is CPU-intensive.
+
+### Option 1: Built-in (Simple)
+
+Works automatically, but consider:
+- Set `deviceSizes` and `imageSizes` in config to limit variants
+- Use `minimumCacheTTL` to reduce regeneration
+
+```js
+// next.config.js
+module.exports = {
+  images: {
+    minimumCacheTTL: 60 * 60 * 24, // 24 hours
+    deviceSizes: [640, 750, 1080, 1920], // Limit sizes
+  },
+};
+```
+
+### Option 2: External Loader (Recommended for Scale)
+
+Offload to Cloudinary, Imgix, or similar:
+
+```js
+// next.config.js
+module.exports = {
+  images: {
+    loader: 'custom',
+    loaderFile: './lib/image-loader.js',
+  },
+};
+```
+
+```js
+// lib/image-loader.js
+export default function cloudinaryLoader({ src, width, quality }) {
+  const params = ['f_auto', 'c_limit', `w_${width}`, `q_${quality || 'auto'}`];
+  return `https://res.cloudinary.com/demo/image/upload/${params.join(',')}${src}`;
+}
+```
+
+## Environment Variables
+
+### Build-time vs Runtime
+
+```js
+// Available at build time only (baked into bundle)
+NEXT_PUBLIC_API_URL=https://api.example.com
+
+// Available at runtime (server-side only)
+DATABASE_URL=postgresql://...
+API_SECRET=...
+```
+
+### Runtime Configuration
+
+For truly dynamic config, don't use `NEXT_PUBLIC_*`. Instead:
+
+```tsx
+// app/api/config/route.ts
+export async function GET() {
+  return Response.json({
+    apiUrl: process.env.API_URL,
+    features: process.env.FEATURES?.split(','),
+  });
+}
+```
+
+## OpenNext: Serverless Without Vercel
+
+[OpenNext](https://open-next.js.org/) adapts Next.js for AWS Lambda, Cloudflare Workers, etc.
+
+```bash
+npx create-sst@latest
+# or
+npx @opennextjs/aws build
+```
+
+Supports:
+- AWS Lambda + CloudFront
+- Cloudflare Workers
+- Netlify Functions
+- Deno Deploy
+
+## Health Check Endpoint
+
+Always include a health check for load balancers:
+
+```tsx
+// app/api/health/route.ts
+export async function GET() {
+  try {
+    // Optional: check database connection
+    // await db.$queryRaw`SELECT 1`;
+
+    return Response.json({ status: 'healthy' }, { status: 200 });
+  } catch (error) {
+    return Response.json({ status: 'unhealthy' }, { status: 503 });
+  }
+}
+```
+
+## Pre-Deployment Checklist
+
+1. **Build locally first**: `npm run build` - catch errors before deploy
+2. **Test standalone output**: `node .next/standalone/server.js`
+3. **Set `output: 'standalone'`** for Docker
+4. **Configure cache handler** for multi-instance ISR
+5. **Set `HOSTNAME="0.0.0.0"`** for containers
+6. **Copy `public/` and `.next/static/`** - not included in standalone
+7. **Add health check endpoint**
+8. **Test ISR revalidation** after deployment
+9. **Monitor memory usage** - Node.js defaults may need tuning
+
+## Testing Cache Handler
+
+**Critical**: Test your cache handler on every Next.js upgrade:
+
+```bash
+# Start multiple instances
+PORT=3001 node .next/standalone/server.js &
+PORT=3002 node .next/standalone/server.js &
+
+# Trigger ISR revalidation
+curl http://localhost:3001/api/revalidate?path=/posts
+
+# Verify both instances see the update
+curl http://localhost:3001/posts
+curl http://localhost:3002/posts
+# Should return identical content
+```

--- a/.claude/skills/next-best-practices/suspense-boundaries.md
+++ b/.claude/skills/next-best-practices/suspense-boundaries.md
@@ -1,0 +1,67 @@
+# Suspense Boundaries
+
+Client hooks that cause CSR bailout without Suspense boundaries.
+
+## useSearchParams
+
+Always requires Suspense boundary in static routes. Without it, the entire page becomes client-side rendered.
+
+```tsx
+// Bad: Entire page becomes CSR
+'use client'
+
+import { useSearchParams } from 'next/navigation'
+
+export default function SearchBar() {
+  const searchParams = useSearchParams()
+  return <div>Query: {searchParams.get('q')}</div>
+}
+```
+
+```tsx
+// Good: Wrap in Suspense
+import { Suspense } from 'react'
+import SearchBar from './search-bar'
+
+export default function Page() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <SearchBar />
+    </Suspense>
+  )
+}
+```
+
+## usePathname
+
+Requires Suspense boundary when route has dynamic parameters.
+
+```tsx
+// In dynamic route [slug]
+// Bad: No Suspense
+'use client'
+import { usePathname } from 'next/navigation'
+
+export function Breadcrumb() {
+  const pathname = usePathname()
+  return <nav>{pathname}</nav>
+}
+```
+
+```tsx
+// Good: Wrap in Suspense
+<Suspense fallback={<BreadcrumbSkeleton />}>
+  <Breadcrumb />
+</Suspense>
+```
+
+If you use `generateStaticParams`, Suspense is optional.
+
+## Quick Reference
+
+| Hook | Suspense Required |
+|------|-------------------|
+| `useSearchParams()` | Yes |
+| `usePathname()` | Yes (dynamic routes) |
+| `useParams()` | No |
+| `useRouter()` | No |

--- a/.claude/skills/vercel-composition-patterns/AGENTS.md
+++ b/.claude/skills/vercel-composition-patterns/AGENTS.md
@@ -82,7 +82,7 @@ function Composer({
       )}
       <Footer onSubmit={onSubmit} />
     </form>
-  );
+  )
 }
 ```
 
@@ -102,7 +102,7 @@ function ChannelComposer() {
         <Composer.Submit />
       </Composer.Footer>
     </Composer.Frame>
-  );
+  )
 }
 
 // Thread composer - adds "also send to channel" field
@@ -118,7 +118,7 @@ function ThreadComposer({ channelId }: { channelId: string }) {
         <Composer.Submit />
       </Composer.Footer>
     </Composer.Frame>
-  );
+  )
 }
 
 // Edit composer - different footer actions
@@ -133,7 +133,7 @@ function EditComposer() {
         <Composer.SaveEdit />
       </Composer.Footer>
     </Composer.Frame>
-  );
+  )
 }
 ```
 
@@ -177,25 +177,25 @@ function Composer({
         </Footer>
       )}
     </form>
-  );
+  )
 }
 ```
 
 **Correct: compound components with shared context**
 
 ```tsx
-const ComposerContext = createContext<ComposerContextValue | null>(null);
+const ComposerContext = createContext<ComposerContextValue | null>(null)
 
 function ComposerProvider({ children, state, actions, meta }: ProviderProps) {
   return (
     <ComposerContext value={{ state, actions, meta }}>
       {children}
     </ComposerContext>
-  );
+  )
 }
 
 function ComposerFrame({ children }: { children: React.ReactNode }) {
-  return <form>{children}</form>;
+  return <form>{children}</form>
 }
 
 function ComposerInput() {
@@ -203,21 +203,21 @@ function ComposerInput() {
     state,
     actions: { update },
     meta: { inputRef },
-  } = use(ComposerContext);
+  } = use(ComposerContext)
   return (
     <TextInput
       ref={inputRef}
       value={state.input}
       onChangeText={(text) => update((s) => ({ ...s, input: text }))}
     />
-  );
+  )
 }
 
 function ComposerSubmit() {
   const {
     actions: { submit },
-  } = use(ComposerContext);
-  return <Button onPress={submit}>Send</Button>;
+  } = use(ComposerContext)
+  return <Button onPress={submit}>Send</Button>
 }
 
 // Export as compound component
@@ -231,7 +231,7 @@ const Composer = {
   Attachments: ComposerAttachments,
   Formatting: ComposerFormatting,
   Emojis: ComposerEmojis,
-};
+}
 ```
 
 **Usage:**
@@ -275,8 +275,8 @@ useState, Zustand, or a server sync.
 ```tsx
 function ChannelComposer({ channelId }: { channelId: string }) {
   // UI component knows about global state implementation
-  const state = useGlobalChannelState(channelId);
-  const { submit, updateInput } = useChannelSync(channelId);
+  const state = useGlobalChannelState(channelId)
+  const { submit, updateInput } = useChannelSync(channelId)
 
   return (
     <Composer.Frame>
@@ -286,7 +286,7 @@ function ChannelComposer({ channelId }: { channelId: string }) {
       />
       <Composer.Submit onPress={() => sync.submit()} />
     </Composer.Frame>
-  );
+  )
 }
 ```
 
@@ -298,11 +298,11 @@ function ChannelProvider({
   channelId,
   children,
 }: {
-  channelId: string;
-  children: React.ReactNode;
+  channelId: string
+  children: React.ReactNode
 }) {
-  const { state, update, submit } = useGlobalChannel(channelId);
-  const inputRef = useRef(null);
+  const { state, update, submit } = useGlobalChannel(channelId)
+  const inputRef = useRef(null)
 
   return (
     <Composer.Provider
@@ -312,7 +312,7 @@ function ChannelProvider({
     >
       {children}
     </Composer.Provider>
-  );
+  )
 }
 
 // UI component only knows about the context interface
@@ -325,7 +325,7 @@ function ChannelComposer() {
         <Composer.Submit />
       </Composer.Footer>
     </Composer.Frame>
-  );
+  )
 }
 
 // Usage
@@ -334,7 +334,7 @@ function Channel({ channelId }: { channelId: string }) {
     <ChannelProvider channelId={channelId}>
       <ChannelComposer />
     </ChannelProvider>
-  );
+  )
 }
 ```
 
@@ -343,8 +343,8 @@ function Channel({ channelId }: { channelId: string }) {
 ```tsx
 // Local state for ephemeral forms
 function ForwardMessageProvider({ children }) {
-  const [state, setState] = useState(initialState);
-  const forwardMessage = useForwardMessage();
+  const [state, setState] = useState(initialState)
+  const forwardMessage = useForwardMessage()
 
   return (
     <Composer.Provider
@@ -353,18 +353,18 @@ function ForwardMessageProvider({ children }) {
     >
       {children}
     </Composer.Provider>
-  );
+  )
 }
 
 // Global synced state for channels
 function ChannelProvider({ channelId, children }) {
-  const { state, update, submit } = useGlobalChannel(channelId);
+  const { state, update, submit } = useGlobalChannel(channelId)
 
   return (
     <Composer.Provider state={state} actions={{ update, submit }}>
       {children}
     </Composer.Provider>
-  );
+  )
 }
 ```
 
@@ -393,8 +393,8 @@ dependency-injectable.
 ```tsx
 function ComposerInput() {
   // Tightly coupled to a specific hook
-  const { input, setInput } = useChannelComposerState();
-  return <TextInput value={input} onChangeText={setInput} />;
+  const { input, setInput } = useChannelComposerState()
+  return <TextInput value={input} onChangeText={setInput} />
 }
 ```
 
@@ -403,27 +403,27 @@ function ComposerInput() {
 ```tsx
 // Define a GENERIC interface that any provider can implement
 interface ComposerState {
-  input: string;
-  attachments: Attachment[];
-  isSubmitting: boolean;
+  input: string
+  attachments: Attachment[]
+  isSubmitting: boolean
 }
 
 interface ComposerActions {
-  update: (updater: (state: ComposerState) => ComposerState) => void;
-  submit: () => void;
+  update: (updater: (state: ComposerState) => ComposerState) => void
+  submit: () => void
 }
 
 interface ComposerMeta {
-  inputRef: React.RefObject<TextInput>;
+  inputRef: React.RefObject<TextInput>
 }
 
 interface ComposerContextValue {
-  state: ComposerState;
-  actions: ComposerActions;
-  meta: ComposerMeta;
+  state: ComposerState
+  actions: ComposerActions
+  meta: ComposerMeta
 }
 
-const ComposerContext = createContext<ComposerContextValue | null>(null);
+const ComposerContext = createContext<ComposerContextValue | null>(null)
 ```
 
 **UI components consume the interface, not the implementation:**
@@ -434,7 +434,7 @@ function ComposerInput() {
     state,
     actions: { update },
     meta,
-  } = use(ComposerContext);
+  } = use(ComposerContext)
 
   // This component works with ANY provider that implements the interface
   return (
@@ -443,7 +443,7 @@ function ComposerInput() {
       value={state.input}
       onChangeText={(text) => update((s) => ({ ...s, input: text }))}
     />
-  );
+  )
 }
 ```
 
@@ -452,9 +452,9 @@ function ComposerInput() {
 ```tsx
 // Provider A: Local state for ephemeral forms
 function ForwardMessageProvider({ children }: { children: React.ReactNode }) {
-  const [state, setState] = useState(initialState);
-  const inputRef = useRef(null);
-  const submit = useForwardMessage();
+  const [state, setState] = useState(initialState)
+  const inputRef = useRef(null)
+  const submit = useForwardMessage()
 
   return (
     <ComposerContext
@@ -466,13 +466,13 @@ function ForwardMessageProvider({ children }: { children: React.ReactNode }) {
     >
       {children}
     </ComposerContext>
-  );
+  )
 }
 
 // Provider B: Global synced state for channels
 function ChannelProvider({ channelId, children }: Props) {
-  const { state, update, submit } = useGlobalChannel(channelId);
-  const inputRef = useRef(null);
+  const { state, update, submit } = useGlobalChannel(channelId)
+  const inputRef = useRef(null)
 
   return (
     <ComposerContext
@@ -484,7 +484,7 @@ function ChannelProvider({ channelId, children }: Props) {
     >
       {children}
     </ComposerContext>
-  );
+  )
 }
 ```
 
@@ -534,21 +534,21 @@ function ForwardMessageDialog() {
         </DialogActions>
       </Dialog>
     </ForwardMessageProvider>
-  );
+  )
 }
 
 // This button lives OUTSIDE Composer.Frame but can still submit based on its context!
 function ForwardButton() {
   const {
     actions: { submit },
-  } = use(ComposerContext);
-  return <Button onPress={submit}>Forward</Button>;
+  } = use(ComposerContext)
+  return <Button onPress={submit}>Forward</Button>
 }
 
 // This preview lives OUTSIDE Composer.Frame but can read composer's state!
 function MessagePreview() {
-  const { state } = use(ComposerContext);
-  return <Preview message={state.input} attachments={state.attachments} />;
+  const { state } = use(ComposerContext)
+  return <Preview message={state.input} attachments={state.attachments} />
 }
 ```
 
@@ -582,15 +582,15 @@ or awkward refs.
 
 ```tsx
 function ForwardMessageComposer() {
-  const [state, setState] = useState(initialState);
-  const forwardMessage = useForwardMessage();
+  const [state, setState] = useState(initialState)
+  const forwardMessage = useForwardMessage()
 
   return (
     <Composer.Frame>
       <Composer.Input />
       <Composer.Footer />
     </Composer.Frame>
-  );
+  )
 }
 
 // Problem: How does this button access composer state?
@@ -604,7 +604,7 @@ function ForwardMessageDialog() {
         <ForwardButton /> {/* Needs to call submit */}
       </DialogActions>
     </Dialog>
-  );
+  )
 }
 ```
 
@@ -612,20 +612,20 @@ function ForwardMessageDialog() {
 
 ```tsx
 function ForwardMessageDialog() {
-  const [input, setInput] = useState("");
+  const [input, setInput] = useState('')
   return (
     <Dialog>
       <ForwardMessageComposer onInputChange={setInput} />
       <MessagePreview input={input} />
     </Dialog>
-  );
+  )
 }
 
 function ForwardMessageComposer({ onInputChange }) {
-  const [state, setState] = useState(initialState);
+  const [state, setState] = useState(initialState)
   useEffect(() => {
-    onInputChange(state.input); // Sync on every change 😬
-  }, [state.input]);
+    onInputChange(state.input) // Sync on every change 😬
+  }, [state.input])
 }
 ```
 
@@ -633,13 +633,13 @@ function ForwardMessageComposer({ onInputChange }) {
 
 ```tsx
 function ForwardMessageDialog() {
-  const stateRef = useRef(null);
+  const stateRef = useRef(null)
   return (
     <Dialog>
       <ForwardMessageComposer stateRef={stateRef} />
       <ForwardButton onPress={() => submit(stateRef.current)} />
     </Dialog>
-  );
+  )
 }
 ```
 
@@ -647,9 +647,9 @@ function ForwardMessageDialog() {
 
 ```tsx
 function ForwardMessageProvider({ children }: { children: React.ReactNode }) {
-  const [state, setState] = useState(initialState);
-  const forwardMessage = useForwardMessage();
-  const inputRef = useRef(null);
+  const [state, setState] = useState(initialState)
+  const forwardMessage = useForwardMessage()
+  const inputRef = useRef(null)
 
   return (
     <Composer.Provider
@@ -659,7 +659,7 @@ function ForwardMessageProvider({ children }: { children: React.ReactNode }) {
     >
       {children}
     </Composer.Provider>
-  );
+  )
 }
 
 function ForwardMessageDialog() {
@@ -667,21 +667,19 @@ function ForwardMessageDialog() {
     <ForwardMessageProvider>
       <Dialog>
         <ForwardMessageComposer />
-        <MessagePreview />{" "}
-        {/* Custom components can access state and actions */}
+        <MessagePreview /> {/* Custom components can access state and actions */}
         <DialogActions>
           <CancelButton />
-          <ForwardButton />{" "}
-          {/* Custom components can access state and actions */}
+          <ForwardButton /> {/* Custom components can access state and actions */}
         </DialogActions>
       </Dialog>
     </ForwardMessageProvider>
-  );
+  )
 }
 
 function ForwardButton() {
-  const { actions } = use(Composer.Context);
-  return <Button onPress={actions.submit}>Forward</Button>;
+  const { actions } = use(Composer.Context)
+  return <Button onPress={actions.submit}>Forward</Button>
 }
 ```
 
@@ -723,7 +721,7 @@ itself.
 <Composer
   isThread
   isEditing={false}
-  channelId="abc"
+  channelId='abc'
   showAttachments
   showFormatting={false}
 />
@@ -762,7 +760,7 @@ function ThreadComposer({ channelId }: { channelId: string }) {
         </Composer.Footer>
       </Composer.Frame>
     </ThreadProvider>
-  );
+  )
 }
 
 function EditMessageComposer({ messageId }: { messageId: string }) {
@@ -778,7 +776,7 @@ function EditMessageComposer({ messageId }: { messageId: string }) {
         </Composer.Footer>
       </Composer.Frame>
     </EditMessageProvider>
-  );
+  )
 }
 
 function ForwardMessageComposer({ messageId }: { messageId: string }) {
@@ -793,7 +791,7 @@ function ForwardMessageComposer({ messageId }: { messageId: string }) {
         </Composer.Footer>
       </Composer.Frame>
     </ForwardMessageProvider>
-  );
+  )
 }
 ```
 
@@ -825,9 +823,9 @@ function Composer({
   renderFooter,
   renderActions,
 }: {
-  renderHeader?: () => React.ReactNode;
-  renderFooter?: () => React.ReactNode;
-  renderActions?: () => React.ReactNode;
+  renderHeader?: () => React.ReactNode
+  renderFooter?: () => React.ReactNode
+  renderActions?: () => React.ReactNode
 }) {
   return (
     <form>
@@ -836,7 +834,7 @@ function Composer({
       {renderFooter ? renderFooter() : <DefaultFooter />}
       {renderActions?.()}
     </form>
-  );
+  )
 }
 
 // Usage is awkward and inflexible
@@ -851,18 +849,18 @@ return (
     )}
     renderActions={() => <SubmitButton />}
   />
-);
+)
 ```
 
 **Correct: compound components with children**
 
 ```tsx
 function ComposerFrame({ children }: { children: React.ReactNode }) {
-  return <form>{children}</form>;
+  return <form>{children}</form>
 }
 
 function ComposerFooter({ children }: { children: React.ReactNode }) {
-  return <footer className="flex">{children}</footer>;
+  return <footer className='flex'>{children}</footer>
 }
 
 // Usage is flexible
@@ -876,7 +874,7 @@ return (
       <SubmitButton />
     </Composer.Footer>
   </Composer.Frame>
-);
+)
 ```
 
 **When render props are appropriate:**
@@ -913,31 +911,28 @@ In React 19, `ref` is now a regular prop (no `forwardRef` wrapper needed), and `
 
 ```tsx
 const ComposerInput = forwardRef<TextInput, Props>((props, ref) => {
-  return <TextInput ref={ref} {...props} />;
-});
+  return <TextInput ref={ref} {...props} />
+})
 ```
 
 **Correct: ref as a regular prop**
 
 ```tsx
-function ComposerInput({
-  ref,
-  ...props
-}: Props & { ref?: React.Ref<TextInput> }) {
-  return <TextInput ref={ref} {...props} />;
+function ComposerInput({ ref, ...props }: Props & { ref?: React.Ref<TextInput> }) {
+  return <TextInput ref={ref} {...props} />
 }
 ```
 
 **Incorrect: useContext in React 19**
 
 ```tsx
-const value = useContext(MyContext);
+const value = useContext(MyContext)
 ```
 
 **Correct: use instead of useContext**
 
 ```tsx
-const value = use(MyContext);
+const value = use(MyContext)
 ```
 
 `use()` can also be called conditionally, unlike `useContext()`.

--- a/.claude/skills/vercel-composition-patterns/SKILL.md
+++ b/.claude/skills/vercel-composition-patterns/SKILL.md
@@ -9,7 +9,7 @@ description:
 license: MIT
 metadata:
   author: vercel
-  version: "1.0.0"
+  version: '1.0.0'
 ---
 
 # React Composition Patterns

--- a/.claude/skills/vercel-composition-patterns/rules/architecture-avoid-boolean-props.md
+++ b/.claude/skills/vercel-composition-patterns/rules/architecture-avoid-boolean-props.md
@@ -41,7 +41,7 @@ function Composer({
       )}
       <Footer onSubmit={onSubmit} />
     </form>
-  );
+  )
 }
 ```
 
@@ -61,7 +61,7 @@ function ChannelComposer() {
         <Composer.Submit />
       </Composer.Footer>
     </Composer.Frame>
-  );
+  )
 }
 
 // Thread composer - adds "also send to channel" field
@@ -77,7 +77,7 @@ function ThreadComposer({ channelId }: { channelId: string }) {
         <Composer.Submit />
       </Composer.Footer>
     </Composer.Frame>
-  );
+  )
 }
 
 // Edit composer - different footer actions
@@ -92,7 +92,7 @@ function EditComposer() {
         <Composer.SaveEdit />
       </Composer.Footer>
     </Composer.Frame>
-  );
+  )
 }
 ```
 

--- a/.claude/skills/vercel-composition-patterns/rules/architecture-compound-components.md
+++ b/.claude/skills/vercel-composition-patterns/rules/architecture-compound-components.md
@@ -37,25 +37,25 @@ function Composer({
         </Footer>
       )}
     </form>
-  );
+  )
 }
 ```
 
 **Correct (compound components with shared context):**
 
 ```tsx
-const ComposerContext = createContext<ComposerContextValue | null>(null);
+const ComposerContext = createContext<ComposerContextValue | null>(null)
 
 function ComposerProvider({ children, state, actions, meta }: ProviderProps) {
   return (
     <ComposerContext value={{ state, actions, meta }}>
       {children}
     </ComposerContext>
-  );
+  )
 }
 
 function ComposerFrame({ children }: { children: React.ReactNode }) {
-  return <form>{children}</form>;
+  return <form>{children}</form>
 }
 
 function ComposerInput() {
@@ -63,21 +63,21 @@ function ComposerInput() {
     state,
     actions: { update },
     meta: { inputRef },
-  } = use(ComposerContext);
+  } = use(ComposerContext)
   return (
     <TextInput
       ref={inputRef}
       value={state.input}
       onChangeText={(text) => update((s) => ({ ...s, input: text }))}
     />
-  );
+  )
 }
 
 function ComposerSubmit() {
   const {
     actions: { submit },
-  } = use(ComposerContext);
-  return <Button onPress={submit}>Send</Button>;
+  } = use(ComposerContext)
+  return <Button onPress={submit}>Send</Button>
 }
 
 // Export as compound component
@@ -91,7 +91,7 @@ const Composer = {
   Attachments: ComposerAttachments,
   Formatting: ComposerFormatting,
   Emojis: ComposerEmojis,
-};
+}
 ```
 
 **Usage:**

--- a/.claude/skills/vercel-composition-patterns/rules/patterns-children-over-render-props.md
+++ b/.claude/skills/vercel-composition-patterns/rules/patterns-children-over-render-props.md
@@ -19,9 +19,9 @@ function Composer({
   renderFooter,
   renderActions,
 }: {
-  renderHeader?: () => React.ReactNode;
-  renderFooter?: () => React.ReactNode;
-  renderActions?: () => React.ReactNode;
+  renderHeader?: () => React.ReactNode
+  renderFooter?: () => React.ReactNode
+  renderActions?: () => React.ReactNode
 }) {
   return (
     <form>
@@ -30,7 +30,7 @@ function Composer({
       {renderFooter ? renderFooter() : <DefaultFooter />}
       {renderActions?.()}
     </form>
-  );
+  )
 }
 
 // Usage is awkward and inflexible
@@ -45,18 +45,18 @@ return (
     )}
     renderActions={() => <SubmitButton />}
   />
-);
+)
 ```
 
 **Correct (compound components with children):**
 
 ```tsx
 function ComposerFrame({ children }: { children: React.ReactNode }) {
-  return <form>{children}</form>;
+  return <form>{children}</form>
 }
 
 function ComposerFooter({ children }: { children: React.ReactNode }) {
-  return <footer className="flex">{children}</footer>;
+  return <footer className='flex'>{children}</footer>
 }
 
 // Usage is flexible
@@ -70,7 +70,7 @@ return (
       <SubmitButton />
     </Composer.Footer>
   </Composer.Frame>
-);
+)
 ```
 
 **When render props are appropriate:**

--- a/.claude/skills/vercel-composition-patterns/rules/patterns-explicit-variants.md
+++ b/.claude/skills/vercel-composition-patterns/rules/patterns-explicit-variants.md
@@ -18,7 +18,7 @@ itself.
 <Composer
   isThread
   isEditing={false}
-  channelId="abc"
+  channelId='abc'
   showAttachments
   showFormatting={false}
 />
@@ -56,7 +56,7 @@ function ThreadComposer({ channelId }: { channelId: string }) {
         </Composer.Footer>
       </Composer.Frame>
     </ThreadProvider>
-  );
+  )
 }
 
 function EditMessageComposer({ messageId }: { messageId: string }) {
@@ -72,7 +72,7 @@ function EditMessageComposer({ messageId }: { messageId: string }) {
         </Composer.Footer>
       </Composer.Frame>
     </EditMessageProvider>
-  );
+  )
 }
 
 function ForwardMessageComposer({ messageId }: { messageId: string }) {
@@ -87,7 +87,7 @@ function ForwardMessageComposer({ messageId }: { messageId: string }) {
         </Composer.Footer>
       </Composer.Frame>
     </ForwardMessageProvider>
-  );
+  )
 }
 ```
 

--- a/.claude/skills/vercel-composition-patterns/rules/react19-no-forwardref.md
+++ b/.claude/skills/vercel-composition-patterns/rules/react19-no-forwardref.md
@@ -15,31 +15,28 @@ In React 19, `ref` is now a regular prop (no `forwardRef` wrapper needed), and `
 
 ```tsx
 const ComposerInput = forwardRef<TextInput, Props>((props, ref) => {
-  return <TextInput ref={ref} {...props} />;
-});
+  return <TextInput ref={ref} {...props} />
+})
 ```
 
 **Correct (ref as a regular prop):**
 
 ```tsx
-function ComposerInput({
-  ref,
-  ...props
-}: Props & { ref?: React.Ref<TextInput> }) {
-  return <TextInput ref={ref} {...props} />;
+function ComposerInput({ ref, ...props }: Props & { ref?: React.Ref<TextInput> }) {
+  return <TextInput ref={ref} {...props} />
 }
 ```
 
 **Incorrect (useContext in React 19):**
 
 ```tsx
-const value = useContext(MyContext);
+const value = useContext(MyContext)
 ```
 
 **Correct (use instead of useContext):**
 
 ```tsx
-const value = use(MyContext);
+const value = use(MyContext)
 ```
 
 `use()` can also be called conditionally, unlike `useContext()`.

--- a/.claude/skills/vercel-composition-patterns/rules/state-context-interface.md
+++ b/.claude/skills/vercel-composition-patterns/rules/state-context-interface.md
@@ -20,8 +20,8 @@ dependency-injectable.
 ```tsx
 function ComposerInput() {
   // Tightly coupled to a specific hook
-  const { input, setInput } = useChannelComposerState();
-  return <TextInput value={input} onChangeText={setInput} />;
+  const { input, setInput } = useChannelComposerState()
+  return <TextInput value={input} onChangeText={setInput} />
 }
 ```
 
@@ -30,27 +30,27 @@ function ComposerInput() {
 ```tsx
 // Define a GENERIC interface that any provider can implement
 interface ComposerState {
-  input: string;
-  attachments: Attachment[];
-  isSubmitting: boolean;
+  input: string
+  attachments: Attachment[]
+  isSubmitting: boolean
 }
 
 interface ComposerActions {
-  update: (updater: (state: ComposerState) => ComposerState) => void;
-  submit: () => void;
+  update: (updater: (state: ComposerState) => ComposerState) => void
+  submit: () => void
 }
 
 interface ComposerMeta {
-  inputRef: React.RefObject<TextInput>;
+  inputRef: React.RefObject<TextInput>
 }
 
 interface ComposerContextValue {
-  state: ComposerState;
-  actions: ComposerActions;
-  meta: ComposerMeta;
+  state: ComposerState
+  actions: ComposerActions
+  meta: ComposerMeta
 }
 
-const ComposerContext = createContext<ComposerContextValue | null>(null);
+const ComposerContext = createContext<ComposerContextValue | null>(null)
 ```
 
 **UI components consume the interface, not the implementation:**
@@ -61,7 +61,7 @@ function ComposerInput() {
     state,
     actions: { update },
     meta,
-  } = use(ComposerContext);
+  } = use(ComposerContext)
 
   // This component works with ANY provider that implements the interface
   return (
@@ -70,7 +70,7 @@ function ComposerInput() {
       value={state.input}
       onChangeText={(text) => update((s) => ({ ...s, input: text }))}
     />
-  );
+  )
 }
 ```
 
@@ -79,9 +79,9 @@ function ComposerInput() {
 ```tsx
 // Provider A: Local state for ephemeral forms
 function ForwardMessageProvider({ children }: { children: React.ReactNode }) {
-  const [state, setState] = useState(initialState);
-  const inputRef = useRef(null);
-  const submit = useForwardMessage();
+  const [state, setState] = useState(initialState)
+  const inputRef = useRef(null)
+  const submit = useForwardMessage()
 
   return (
     <ComposerContext
@@ -93,13 +93,13 @@ function ForwardMessageProvider({ children }: { children: React.ReactNode }) {
     >
       {children}
     </ComposerContext>
-  );
+  )
 }
 
 // Provider B: Global synced state for channels
 function ChannelProvider({ channelId, children }: Props) {
-  const { state, update, submit } = useGlobalChannel(channelId);
-  const inputRef = useRef(null);
+  const { state, update, submit } = useGlobalChannel(channelId)
+  const inputRef = useRef(null)
 
   return (
     <ComposerContext
@@ -111,7 +111,7 @@ function ChannelProvider({ channelId, children }: Props) {
     >
       {children}
     </ComposerContext>
-  );
+  )
 }
 ```
 
@@ -165,21 +165,21 @@ function ForwardMessageDialog() {
         </DialogActions>
       </Dialog>
     </ForwardMessageProvider>
-  );
+  )
 }
 
 // This button lives OUTSIDE Composer.Frame but can still submit based on its context!
 function ForwardButton() {
   const {
     actions: { submit },
-  } = use(ComposerContext);
-  return <Button onPress={submit}>Forward</Button>;
+  } = use(ComposerContext)
+  return <Button onPress={submit}>Forward</Button>
 }
 
 // This preview lives OUTSIDE Composer.Frame but can read composer's state!
 function MessagePreview() {
-  const { state } = use(ComposerContext);
-  return <Preview message={state.input} attachments={state.attachments} />;
+  const { state } = use(ComposerContext)
+  return <Preview message={state.input} attachments={state.attachments} />
 }
 ```
 

--- a/.claude/skills/vercel-composition-patterns/rules/state-decouple-implementation.md
+++ b/.claude/skills/vercel-composition-patterns/rules/state-decouple-implementation.md
@@ -16,8 +16,8 @@ useState, Zustand, or a server sync.
 ```tsx
 function ChannelComposer({ channelId }: { channelId: string }) {
   // UI component knows about global state implementation
-  const state = useGlobalChannelState(channelId);
-  const { submit, updateInput } = useChannelSync(channelId);
+  const state = useGlobalChannelState(channelId)
+  const { submit, updateInput } = useChannelSync(channelId)
 
   return (
     <Composer.Frame>
@@ -27,7 +27,7 @@ function ChannelComposer({ channelId }: { channelId: string }) {
       />
       <Composer.Submit onPress={() => sync.submit()} />
     </Composer.Frame>
-  );
+  )
 }
 ```
 
@@ -39,11 +39,11 @@ function ChannelProvider({
   channelId,
   children,
 }: {
-  channelId: string;
-  children: React.ReactNode;
+  channelId: string
+  children: React.ReactNode
 }) {
-  const { state, update, submit } = useGlobalChannel(channelId);
-  const inputRef = useRef(null);
+  const { state, update, submit } = useGlobalChannel(channelId)
+  const inputRef = useRef(null)
 
   return (
     <Composer.Provider
@@ -53,7 +53,7 @@ function ChannelProvider({
     >
       {children}
     </Composer.Provider>
-  );
+  )
 }
 
 // UI component only knows about the context interface
@@ -66,7 +66,7 @@ function ChannelComposer() {
         <Composer.Submit />
       </Composer.Footer>
     </Composer.Frame>
-  );
+  )
 }
 
 // Usage
@@ -75,7 +75,7 @@ function Channel({ channelId }: { channelId: string }) {
     <ChannelProvider channelId={channelId}>
       <ChannelComposer />
     </ChannelProvider>
-  );
+  )
 }
 ```
 
@@ -84,8 +84,8 @@ function Channel({ channelId }: { channelId: string }) {
 ```tsx
 // Local state for ephemeral forms
 function ForwardMessageProvider({ children }) {
-  const [state, setState] = useState(initialState);
-  const forwardMessage = useForwardMessage();
+  const [state, setState] = useState(initialState)
+  const forwardMessage = useForwardMessage()
 
   return (
     <Composer.Provider
@@ -94,18 +94,18 @@ function ForwardMessageProvider({ children }) {
     >
       {children}
     </Composer.Provider>
-  );
+  )
 }
 
 // Global synced state for channels
 function ChannelProvider({ channelId, children }) {
-  const { state, update, submit } = useGlobalChannel(channelId);
+  const { state, update, submit } = useGlobalChannel(channelId)
 
   return (
     <Composer.Provider state={state} actions={{ update, submit }}>
       {children}
     </Composer.Provider>
-  );
+  )
 }
 ```
 

--- a/.claude/skills/vercel-composition-patterns/rules/state-lift-state.md
+++ b/.claude/skills/vercel-composition-patterns/rules/state-lift-state.md
@@ -15,15 +15,15 @@ or awkward refs.
 
 ```tsx
 function ForwardMessageComposer() {
-  const [state, setState] = useState(initialState);
-  const forwardMessage = useForwardMessage();
+  const [state, setState] = useState(initialState)
+  const forwardMessage = useForwardMessage()
 
   return (
     <Composer.Frame>
       <Composer.Input />
       <Composer.Footer />
     </Composer.Frame>
-  );
+  )
 }
 
 // Problem: How does this button access composer state?
@@ -37,7 +37,7 @@ function ForwardMessageDialog() {
         <ForwardButton /> {/* Needs to call submit */}
       </DialogActions>
     </Dialog>
-  );
+  )
 }
 ```
 
@@ -45,20 +45,20 @@ function ForwardMessageDialog() {
 
 ```tsx
 function ForwardMessageDialog() {
-  const [input, setInput] = useState("");
+  const [input, setInput] = useState('')
   return (
     <Dialog>
       <ForwardMessageComposer onInputChange={setInput} />
       <MessagePreview input={input} />
     </Dialog>
-  );
+  )
 }
 
 function ForwardMessageComposer({ onInputChange }) {
-  const [state, setState] = useState(initialState);
+  const [state, setState] = useState(initialState)
   useEffect(() => {
-    onInputChange(state.input); // Sync on every change 😬
-  }, [state.input]);
+    onInputChange(state.input) // Sync on every change 😬
+  }, [state.input])
 }
 ```
 
@@ -66,13 +66,13 @@ function ForwardMessageComposer({ onInputChange }) {
 
 ```tsx
 function ForwardMessageDialog() {
-  const stateRef = useRef(null);
+  const stateRef = useRef(null)
   return (
     <Dialog>
       <ForwardMessageComposer stateRef={stateRef} />
       <ForwardButton onPress={() => submit(stateRef.current)} />
     </Dialog>
-  );
+  )
 }
 ```
 
@@ -80,9 +80,9 @@ function ForwardMessageDialog() {
 
 ```tsx
 function ForwardMessageProvider({ children }: { children: React.ReactNode }) {
-  const [state, setState] = useState(initialState);
-  const forwardMessage = useForwardMessage();
-  const inputRef = useRef(null);
+  const [state, setState] = useState(initialState)
+  const forwardMessage = useForwardMessage()
+  const inputRef = useRef(null)
 
   return (
     <Composer.Provider
@@ -92,7 +92,7 @@ function ForwardMessageProvider({ children }: { children: React.ReactNode }) {
     >
       {children}
     </Composer.Provider>
-  );
+  )
 }
 
 function ForwardMessageDialog() {
@@ -100,21 +100,19 @@ function ForwardMessageDialog() {
     <ForwardMessageProvider>
       <Dialog>
         <ForwardMessageComposer />
-        <MessagePreview />{" "}
-        {/* Custom components can access state and actions */}
+        <MessagePreview /> {/* Custom components can access state and actions */}
         <DialogActions>
           <CancelButton />
-          <ForwardButton />{" "}
-          {/* Custom components can access state and actions */}
+          <ForwardButton /> {/* Custom components can access state and actions */}
         </DialogActions>
       </Dialog>
     </ForwardMessageProvider>
-  );
+  )
 }
 
 function ForwardButton() {
-  const { actions } = use(Composer.Context);
-  return <Button onPress={actions.submit}>Forward</Button>;
+  const { actions } = use(Composer.Context)
+  return <Button onPress={actions.submit}>Forward</Button>
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/AGENTS.md
+++ b/.claude/skills/vercel-react-best-practices/AGENTS.md
@@ -32,7 +32,8 @@ Comprehensive performance optimization guide for React and Next.js applications,
    - 2.2 [Conditional Module Loading](#22-conditional-module-loading)
    - 2.3 [Defer Non-Critical Third-Party Libraries](#23-defer-non-critical-third-party-libraries)
    - 2.4 [Dynamic Imports for Heavy Components](#24-dynamic-imports-for-heavy-components)
-   - 2.5 [Preload Based on User Intent](#25-preload-based-on-user-intent)
+   - 2.5 [Prefer Statically Analyzable Paths](#25-prefer-statically-analyzable-paths)
+   - 2.6 [Preload Based on User Intent](#26-preload-based-on-user-intent)
 3. [Server-Side Performance](#3-server-side-performance) — **HIGH**
    - 3.1 [Authenticate Server Actions Like API Routes](#31-authenticate-server-actions-like-api-routes)
    - 3.2 [Avoid Duplicate Serialization in RSC Props](#32-avoid-duplicate-serialization-in-rsc-props)
@@ -117,7 +118,7 @@ This is a specialization of [Defer Await Until Needed](./async-defer-await.md) f
 **Incorrect:**
 
 ```typescript
-const someFlag = await getFlag();
+const someFlag = await getFlag()
 
 if (someFlag && someCondition) {
   // ...
@@ -128,7 +129,7 @@ if (someFlag && someCondition) {
 
 ```typescript
 if (someCondition) {
-  const someFlag = await getFlag();
+  const someFlag = await getFlag()
   if (someFlag) {
     // ...
   }
@@ -149,15 +150,15 @@ Move `await` operations into the branches where they're actually used to avoid b
 
 ```typescript
 async function handleRequest(userId: string, skipProcessing: boolean) {
-  const userData = await fetchUserData(userId);
-
+  const userData = await fetchUserData(userId)
+  
   if (skipProcessing) {
     // Returns immediately but still waited for userData
-    return { skipped: true };
+    return { skipped: true }
   }
-
+  
   // Only this branch uses userData
-  return processUserData(userData);
+  return processUserData(userData)
 }
 ```
 
@@ -167,12 +168,12 @@ async function handleRequest(userId: string, skipProcessing: boolean) {
 async function handleRequest(userId: string, skipProcessing: boolean) {
   if (skipProcessing) {
     // Returns immediately without waiting
-    return { skipped: true };
+    return { skipped: true }
   }
-
+  
   // Fetch only when needed
-  const userData = await fetchUserData(userId);
-  return processUserData(userData);
+  const userData = await fetchUserData(userId)
+  return processUserData(userData)
 }
 ```
 
@@ -181,35 +182,35 @@ async function handleRequest(userId: string, skipProcessing: boolean) {
 ```typescript
 // Incorrect: always fetches permissions
 async function updateResource(resourceId: string, userId: string) {
-  const permissions = await fetchPermissions(userId);
-  const resource = await getResource(resourceId);
-
+  const permissions = await fetchPermissions(userId)
+  const resource = await getResource(resourceId)
+  
   if (!resource) {
-    return { error: "Not found" };
+    return { error: 'Not found' }
   }
-
+  
   if (!permissions.canEdit) {
-    return { error: "Forbidden" };
+    return { error: 'Forbidden' }
   }
-
-  return await updateResourceData(resource, permissions);
+  
+  return await updateResourceData(resource, permissions)
 }
 
 // Correct: fetches only when needed
 async function updateResource(resourceId: string, userId: string) {
-  const resource = await getResource(resourceId);
-
+  const resource = await getResource(resourceId)
+  
   if (!resource) {
-    return { error: "Not found" };
+    return { error: 'Not found' }
   }
-
-  const permissions = await fetchPermissions(userId);
-
+  
+  const permissions = await fetchPermissions(userId)
+  
   if (!permissions.canEdit) {
-    return { error: "Forbidden" };
+    return { error: 'Forbidden' }
   }
-
-  return await updateResourceData(resource, permissions);
+  
+  return await updateResourceData(resource, permissions)
 }
 ```
 
@@ -226,39 +227,38 @@ For operations with partial dependencies, use `better-all` to maximize paralleli
 **Incorrect: profile waits for config unnecessarily**
 
 ```typescript
-const [user, config] = await Promise.all([fetchUser(), fetchConfig()]);
-const profile = await fetchProfile(user.id);
+const [user, config] = await Promise.all([
+  fetchUser(),
+  fetchConfig()
+])
+const profile = await fetchProfile(user.id)
 ```
 
 **Correct: config and profile run in parallel**
 
 ```typescript
-import { all } from "better-all";
+import { all } from 'better-all'
 
 const { user, config, profile } = await all({
-  async user() {
-    return fetchUser();
-  },
-  async config() {
-    return fetchConfig();
-  },
+  async user() { return fetchUser() },
+  async config() { return fetchConfig() },
   async profile() {
-    return fetchProfile((await this.$.user).id);
-  },
-});
+    return fetchProfile((await this.$.user).id)
+  }
+})
 ```
 
 **Alternative without extra dependencies:**
 
 ```typescript
-const userPromise = fetchUser();
-const profilePromise = userPromise.then((user) => fetchProfile(user.id));
+const userPromise = fetchUser()
+const profilePromise = userPromise.then(user => fetchProfile(user.id))
 
 const [user, config, profile] = await Promise.all([
   userPromise,
   fetchConfig(),
-  profilePromise,
-]);
+  profilePromise
+])
 ```
 
 We can also create all the promises first, and do `Promise.all()` at the end.
@@ -275,10 +275,10 @@ In API routes and Server Actions, start independent operations immediately, even
 
 ```typescript
 export async function GET(request: Request) {
-  const session = await auth();
-  const config = await fetchConfig();
-  const data = await fetchData(session.user.id);
-  return Response.json({ data, config });
+  const session = await auth()
+  const config = await fetchConfig()
+  const data = await fetchData(session.user.id)
+  return Response.json({ data, config })
 }
 ```
 
@@ -286,14 +286,14 @@ export async function GET(request: Request) {
 
 ```typescript
 export async function GET(request: Request) {
-  const sessionPromise = auth();
-  const configPromise = fetchConfig();
-  const session = await sessionPromise;
+  const sessionPromise = auth()
+  const configPromise = fetchConfig()
+  const session = await sessionPromise
   const [config, data] = await Promise.all([
     configPromise,
-    fetchData(session.user.id),
-  ]);
-  return Response.json({ data, config });
+    fetchData(session.user.id)
+  ])
+  return Response.json({ data, config })
 }
 ```
 
@@ -308,9 +308,9 @@ When async operations have no interdependencies, execute them concurrently using
 **Incorrect: sequential execution, 3 round trips**
 
 ```typescript
-const user = await fetchUser();
-const posts = await fetchPosts();
-const comments = await fetchComments();
+const user = await fetchUser()
+const posts = await fetchPosts()
+const comments = await fetchComments()
 ```
 
 **Correct: parallel execution, 1 round trip**
@@ -319,8 +319,8 @@ const comments = await fetchComments();
 const [user, posts, comments] = await Promise.all([
   fetchUser(),
   fetchPosts(),
-  fetchComments(),
-]);
+  fetchComments()
+])
 ```
 
 ### 1.6 Strategic Suspense Boundaries
@@ -333,8 +333,8 @@ Instead of awaiting data in async components before returning JSX, use Suspense 
 
 ```tsx
 async function Page() {
-  const data = await fetchData(); // Blocks entire page
-
+  const data = await fetchData() // Blocks entire page
+  
   return (
     <div>
       <div>Sidebar</div>
@@ -344,7 +344,7 @@ async function Page() {
       </div>
       <div>Footer</div>
     </div>
-  );
+  )
 }
 ```
 
@@ -365,12 +365,12 @@ function Page() {
       </div>
       <div>Footer</div>
     </div>
-  );
+  )
 }
 
 async function DataDisplay() {
-  const data = await fetchData(); // Only blocks this component
-  return <div>{data.content}</div>;
+  const data = await fetchData() // Only blocks this component
+  return <div>{data.content}</div>
 }
 ```
 
@@ -381,8 +381,8 @@ Sidebar, Header, and Footer render immediately. Only DataDisplay waits for data.
 ```tsx
 function Page() {
   // Start fetch immediately, but don't await
-  const dataPromise = fetchData();
-
+  const dataPromise = fetchData()
+  
   return (
     <div>
       <div>Sidebar</div>
@@ -393,17 +393,17 @@ function Page() {
       </Suspense>
       <div>Footer</div>
     </div>
-  );
+  )
 }
 
 function DataDisplay({ dataPromise }: { dataPromise: Promise<Data> }) {
-  const data = use(dataPromise); // Unwraps the promise
-  return <div>{data.content}</div>;
+  const data = use(dataPromise) // Unwraps the promise
+  return <div>{data.content}</div>
 }
 
 function DataSummary({ dataPromise }: { dataPromise: Promise<Data> }) {
-  const data = use(dataPromise); // Reuses the same promise
-  return <div>{data.summary}</div>;
+  const data = use(dataPromise) // Reuses the same promise
+  return <div>{data.summary}</div>
 }
 ```
 
@@ -442,11 +442,11 @@ Popular icon and component libraries can have **up to 10,000 re-exports** in the
 **Incorrect: imports entire library**
 
 ```tsx
-import { Check, X, Menu } from "lucide-react";
+import { Check, X, Menu } from 'lucide-react'
 // Loads 1,583 modules, takes ~2.8s extra in dev
 // Runtime cost: 200-800ms on every cold start
 
-import { Button, TextField } from "@mui/material";
+import { Button, TextField } from '@mui/material'
 // Loads 2,225 modules, takes ~4.2s extra in dev
 ```
 
@@ -454,7 +454,7 @@ import { Button, TextField } from "@mui/material";
 
 ```tsx
 // Keep the standard imports - Next.js transforms them to direct imports
-import { Check, X, Menu } from "lucide-react";
+import { Check, X, Menu } from 'lucide-react'
 // Full TypeScript support, no manual path wrangling
 ```
 
@@ -463,8 +463,8 @@ This is the recommended approach because it preserves TypeScript type safety and
 **Correct - Direct imports (non-Next.js projects):**
 
 ```tsx
-import Button from "@mui/material/Button";
-import TextField from "@mui/material/TextField";
+import Button from '@mui/material/Button'
+import TextField from '@mui/material/TextField'
 // Loads only what you use
 ```
 
@@ -485,25 +485,19 @@ Load large data or modules only when a feature is activated.
 **Example: lazy-load animation frames**
 
 ```tsx
-function AnimationPlayer({
-  enabled,
-  setEnabled,
-}: {
-  enabled: boolean;
-  setEnabled: React.Dispatch<React.SetStateAction<boolean>>;
-}) {
-  const [frames, setFrames] = useState<Frame[] | null>(null);
+function AnimationPlayer({ enabled, setEnabled }: { enabled: boolean; setEnabled: React.Dispatch<React.SetStateAction<boolean>> }) {
+  const [frames, setFrames] = useState<Frame[] | null>(null)
 
   useEffect(() => {
-    if (enabled && !frames && typeof window !== "undefined") {
-      import("./animation-frames.js")
-        .then((mod) => setFrames(mod.frames))
-        .catch(() => setEnabled(false));
+    if (enabled && !frames && typeof window !== 'undefined') {
+      import('./animation-frames.js')
+        .then(mod => setFrames(mod.frames))
+        .catch(() => setEnabled(false))
     }
-  }, [enabled, frames, setEnabled]);
+  }, [enabled, frames, setEnabled])
 
-  if (!frames) return <Skeleton />;
-  return <Canvas frames={frames} />;
+  if (!frames) return <Skeleton />
+  return <Canvas frames={frames} />
 }
 ```
 
@@ -518,7 +512,7 @@ Analytics, logging, and error tracking don't block user interaction. Load them a
 **Incorrect: blocks initial bundle**
 
 ```tsx
-import { Analytics } from "@vercel/analytics/react";
+import { Analytics } from '@vercel/analytics/react'
 
 export default function RootLayout({ children }) {
   return (
@@ -528,19 +522,19 @@ export default function RootLayout({ children }) {
         <Analytics />
       </body>
     </html>
-  );
+  )
 }
 ```
 
 **Correct: loads after hydration**
 
 ```tsx
-import dynamic from "next/dynamic";
+import dynamic from 'next/dynamic'
 
 const Analytics = dynamic(
-  () => import("@vercel/analytics/react").then((m) => m.Analytics),
-  { ssr: false },
-);
+  () => import('@vercel/analytics/react').then(m => m.Analytics),
+  { ssr: false }
+)
 
 export default function RootLayout({ children }) {
   return (
@@ -550,7 +544,7 @@ export default function RootLayout({ children }) {
         <Analytics />
       </body>
     </html>
-  );
+  )
 }
 ```
 
@@ -563,29 +557,88 @@ Use `next/dynamic` to lazy-load large components not needed on initial render.
 **Incorrect: Monaco bundles with main chunk ~300KB**
 
 ```tsx
-import { MonacoEditor } from "./monaco-editor";
+import { MonacoEditor } from './monaco-editor'
 
 function CodePanel({ code }: { code: string }) {
-  return <MonacoEditor value={code} />;
+  return <MonacoEditor value={code} />
 }
 ```
 
 **Correct: Monaco loads on demand**
 
 ```tsx
-import dynamic from "next/dynamic";
+import dynamic from 'next/dynamic'
 
 const MonacoEditor = dynamic(
-  () => import("./monaco-editor").then((m) => m.MonacoEditor),
-  { ssr: false },
-);
+  () => import('./monaco-editor').then(m => m.MonacoEditor),
+  { ssr: false }
+)
 
 function CodePanel({ code }: { code: string }) {
-  return <MonacoEditor value={code} />;
+  return <MonacoEditor value={code} />
 }
 ```
 
-### 2.5 Preload Based on User Intent
+### 2.5 Prefer Statically Analyzable Paths
+
+**Impact: HIGH (avoids accidental broad bundles and file traces)**
+
+Build tools work best when import and file-system paths are obvious at build time. If you hide the real path inside a variable or compose it too dynamically, the tool either has to include a broad set of possible files, warn that it cannot analyze the import, or widen file tracing to stay safe.
+
+Prefer explicit maps or literal paths so the set of reachable files stays narrow and predictable. This is the same rule whether you are choosing modules with `import()` or reading files in server/build code.
+
+When analysis becomes too broad, the cost is real:
+
+- Larger server bundles
+
+- Slower builds
+
+- Worse cold starts
+
+- More memory use
+
+**Incorrect: the bundler cannot tell what may be imported**
+
+```ts
+const PAGE_MODULES = {
+  home: './pages/home',
+  settings: './pages/settings',
+} as const
+
+const Page = await import(PAGE_MODULES[pageName])
+```
+
+**Correct: use an explicit map of allowed modules**
+
+```ts
+const PAGE_MODULES = {
+  home: () => import('./pages/home'),
+  settings: () => import('./pages/settings'),
+} as const
+
+const Page = await PAGE_MODULES[pageName]()
+```
+
+**Incorrect: a 2-value enum still hides the final path from static analysis**
+
+```ts
+const baseDir = path.join(process.cwd(), 'content/' + contentKind)
+```
+
+**Correct: make each final path literal at the callsite**
+
+```ts
+const baseDir =
+  kind === ContentKind.Blog
+    ? path.join(process.cwd(), 'content/blog')
+    : path.join(process.cwd(), 'content/docs')
+```
+
+In Next.js server code, this matters for output file tracing too. `path.join(process.cwd(), someVar)` can widen the traced file set because Next.js statically analyze `import`, `require`, and `fs` usage.
+
+Reference: [https://nextjs.org/docs/app/api-reference/config/next-config-js/output](https://nextjs.org/docs/app/api-reference/config/next-config-js/output), [https://nextjs.org/learn/seo/dynamic-imports](https://nextjs.org/learn/seo/dynamic-imports), [https://vite.dev/guide/features.html](https://vite.dev/guide/features.html), [https://esbuild.github.io/api/](https://esbuild.github.io/api/), [https://www.npmjs.com/package/@rollup/plugin-dynamic-import-vars](https://www.npmjs.com/package/@rollup/plugin-dynamic-import-vars), [https://webpack.js.org/guides/dependency-management/](https://webpack.js.org/guides/dependency-management/)
+
+### 2.6 Preload Based on User Intent
 
 **Impact: MEDIUM (reduces perceived latency)**
 
@@ -596,16 +649,20 @@ Preload heavy bundles before they're needed to reduce perceived latency.
 ```tsx
 function EditorButton({ onClick }: { onClick: () => void }) {
   const preload = () => {
-    if (typeof window !== "undefined") {
-      void import("./monaco-editor");
+    if (typeof window !== 'undefined') {
+      void import('./monaco-editor')
     }
-  };
+  }
 
   return (
-    <button onMouseEnter={preload} onFocus={preload} onClick={onClick}>
+    <button
+      onMouseEnter={preload}
+      onFocus={preload}
+      onClick={onClick}
+    >
       Open Editor
     </button>
-  );
+  )
 }
 ```
 
@@ -614,14 +671,14 @@ function EditorButton({ onClick }: { onClick: () => void }) {
 ```tsx
 function FlagsProvider({ children, flags }: Props) {
   useEffect(() => {
-    if (flags.editorEnabled && typeof window !== "undefined") {
-      void import("./monaco-editor").then((mod) => mod.init());
+    if (flags.editorEnabled && typeof window !== 'undefined') {
+      void import('./monaco-editor').then(mod => mod.init())
     }
-  }, [flags.editorEnabled]);
+  }, [flags.editorEnabled])
 
-  return (
-    <FlagsContext.Provider value={flags}>{children}</FlagsContext.Provider>
-  );
+  return <FlagsContext.Provider value={flags}>
+    {children}
+  </FlagsContext.Provider>
 }
 ```
 
@@ -646,80 +703,80 @@ Next.js documentation explicitly states: "Treat Server Actions with the same sec
 **Incorrect: no authentication check**
 
 ```typescript
-"use server";
+'use server'
 
 export async function deleteUser(userId: string) {
   // Anyone can call this! No auth check
-  await db.user.delete({ where: { id: userId } });
-  return { success: true };
+  await db.user.delete({ where: { id: userId } })
+  return { success: true }
 }
 ```
 
 **Correct: authentication inside the action**
 
 ```typescript
-"use server";
+'use server'
 
-import { verifySession } from "@/lib/auth";
-import { unauthorized } from "@/lib/errors";
+import { verifySession } from '@/lib/auth'
+import { unauthorized } from '@/lib/errors'
 
 export async function deleteUser(userId: string) {
   // Always check auth inside the action
-  const session = await verifySession();
-
+  const session = await verifySession()
+  
   if (!session) {
-    throw unauthorized("Must be logged in");
+    throw unauthorized('Must be logged in')
   }
-
+  
   // Check authorization too
-  if (session.user.role !== "admin" && session.user.id !== userId) {
-    throw unauthorized("Cannot delete other users");
+  if (session.user.role !== 'admin' && session.user.id !== userId) {
+    throw unauthorized('Cannot delete other users')
   }
-
-  await db.user.delete({ where: { id: userId } });
-  return { success: true };
+  
+  await db.user.delete({ where: { id: userId } })
+  return { success: true }
 }
 ```
 
 **With input validation:**
 
 ```typescript
-"use server";
+'use server'
 
-import { verifySession } from "@/lib/auth";
-import { z } from "zod";
+import { verifySession } from '@/lib/auth'
+import { z } from 'zod'
 
 const updateProfileSchema = z.object({
   userId: z.string().uuid(),
   name: z.string().min(1).max(100),
-  email: z.string().email(),
-});
+  email: z.string().email()
+})
 
 export async function updateProfile(data: unknown) {
   // Validate input first
-  const validated = updateProfileSchema.parse(data);
-
+  const validated = updateProfileSchema.parse(data)
+  
   // Then authenticate
-  const session = await verifySession();
+  const session = await verifySession()
   if (!session) {
-    throw new Error("Unauthorized");
+    throw new Error('Unauthorized')
   }
-
+  
   // Then authorize
   if (session.user.id !== validated.userId) {
-    throw new Error("Can only update own profile");
+    throw new Error('Can only update own profile')
   }
-
+  
   // Finally perform the mutation
   await db.user.update({
     where: { id: validated.userId },
     data: {
       name: validated.name,
-      email: validated.email,
-    },
-  });
-
-  return { success: true };
+      email: validated.email
+    }
+  })
+  
+  return { success: true }
 }
 ```
 
@@ -742,11 +799,11 @@ RSC→client serialization deduplicates by object reference, not value. Same ref
 
 ```tsx
 // RSC: send once
-<ClientList usernames={usernames} />;
+<ClientList usernames={usernames} />
 
 // Client: transform there
-("use client");
-const sorted = useMemo(() => [...usernames].sort(), [usernames]);
+'use client'
+const sorted = useMemo(() => [...usernames].sort(), [usernames])
 ```
 
 **Nested deduplication behavior:**
@@ -797,15 +854,15 @@ Treat module scope on the server as process-wide shared memory, not request-loca
 **Incorrect: request data leaks across concurrent renders**
 
 ```tsx
-let currentUser: User | null = null;
+let currentUser: User | null = null
 
 export default async function Page() {
-  currentUser = await auth();
-  return <Dashboard />;
+  currentUser = await auth()
+  return <Dashboard />
 }
 
 async function Dashboard() {
-  return <div>{currentUser?.name}</div>;
+  return <div>{currentUser?.name}</div>
 }
 ```
 
@@ -815,12 +872,12 @@ If two requests overlap, request A can set `currentUser`, then request B overwri
 
 ```tsx
 export default async function Page() {
-  const user = await auth();
-  return <Dashboard user={user} />;
+  const user = await auth()
+  return <Dashboard user={user} />
 }
 
 function Dashboard({ user }: { user: User | null }) {
-  return <div>{user?.name}</div>;
+  return <div>{user?.name}</div>
 }
 ```
 
@@ -843,20 +900,20 @@ For static assets and config, see [Hoist Static I/O to Module Level](./server-ho
 **Implementation:**
 
 ```typescript
-import { LRUCache } from "lru-cache";
+import { LRUCache } from 'lru-cache'
 
 const cache = new LRUCache<string, any>({
   max: 1000,
-  ttl: 5 * 60 * 1000, // 5 minutes
-});
+  ttl: 5 * 60 * 1000  // 5 minutes
+})
 
 export async function getUser(id: string) {
-  const cached = cache.get(id);
-  if (cached) return cached;
+  const cached = cache.get(id)
+  if (cached) return cached
 
-  const user = await db.user.findUnique({ where: { id } });
-  cache.set(id, user);
-  return user;
+  const user = await db.user.findUnique({ where: { id } })
+  cache.set(id, user)
+  return user
 }
 
 // Request 1: DB query, result cached
@@ -963,31 +1020,35 @@ export async function GET(request: Request) {
 **Incorrect: reads config on every call**
 
 ```typescript
-import fs from "node:fs/promises";
+import fs from 'node:fs/promises'
 
 export async function processRequest(data: Data) {
-  const config = JSON.parse(await fs.readFile("./config.json", "utf-8"));
-  const template = await fs.readFile("./template.html", "utf-8");
+  const config = JSON.parse(
+    await fs.readFile('./config.json', 'utf-8')
+  )
+  const template = await fs.readFile('./template.html', 'utf-8')
 
-  return render(template, data, config);
+  return render(template, data, config)
 }
 ```
 
 **Correct: hoists config and template to module level**
 
 ```typescript
-import fs from "node:fs/promises";
+import fs from 'node:fs/promises'
 
-const configPromise = fs.readFile("./config.json", "utf-8").then(JSON.parse);
-const templatePromise = fs.readFile("./template.html", "utf-8");
+const configPromise = fs
+  .readFile('./config.json', 'utf-8')
+  .then(JSON.parse)
+const templatePromise = fs.readFile('./template.html', 'utf-8')
 
 export async function processRequest(data: Data) {
   const [config, template] = await Promise.all([
     configPromise,
     templatePromise,
-  ]);
+  ])
 
-  return render(template, data, config);
+  return render(template, data, config)
 }
 ```
 
@@ -1027,13 +1088,13 @@ The React Server/Client boundary serializes all object properties into strings a
 
 ```tsx
 async function Page() {
-  const user = await fetchUser(); // 50 fields
-  return <Profile user={user} />;
+  const user = await fetchUser()  // 50 fields
+  return <Profile user={user} />
 }
 
-("use client");
+'use client'
 function Profile({ user }: { user: User }) {
-  return <div>{user.name}</div>; // uses 1 field
+  return <div>{user.name}</div>  // uses 1 field
 }
 ```
 
@@ -1041,13 +1102,13 @@ function Profile({ user }: { user: User }) {
 
 ```tsx
 async function Page() {
-  const user = await fetchUser();
-  return <Profile name={user.name} />;
+  const user = await fetchUser()
+  return <Profile name={user.name} />
 }
 
-("use client");
+'use client'
 function Profile({ name }: { name: string }) {
-  return <div>{name}</div>;
+  return <div>{name}</div>
 }
 ```
 
@@ -1061,18 +1122,18 @@ React Server Components execute sequentially within a tree. Restructure with com
 
 ```tsx
 export default async function Page() {
-  const header = await fetchHeader();
+  const header = await fetchHeader()
   return (
     <div>
       <div>{header}</div>
       <Sidebar />
     </div>
-  );
+  )
 }
 
 async function Sidebar() {
-  const items = await fetchSidebarItems();
-  return <nav>{items.map(renderItem)}</nav>;
+  const items = await fetchSidebarItems()
+  return <nav>{items.map(renderItem)}</nav>
 }
 ```
 
@@ -1080,13 +1141,13 @@ async function Sidebar() {
 
 ```tsx
 async function Header() {
-  const data = await fetchHeader();
-  return <div>{data}</div>;
+  const data = await fetchHeader()
+  return <div>{data}</div>
 }
 
 async function Sidebar() {
-  const items = await fetchSidebarItems();
-  return <nav>{items.map(renderItem)}</nav>;
+  const items = await fetchSidebarItems()
+  return <nav>{items.map(renderItem)}</nav>
 }
 
 export default function Page() {
@@ -1095,7 +1156,7 @@ export default function Page() {
       <Header />
       <Sidebar />
     </div>
-  );
+  )
 }
 ```
 
@@ -1103,13 +1164,13 @@ export default function Page() {
 
 ```tsx
 async function Header() {
-  const data = await fetchHeader();
-  return <div>{data}</div>;
+  const data = await fetchHeader()
+  return <div>{data}</div>
 }
 
 async function Sidebar() {
-  const items = await fetchSidebarItems();
-  return <nav>{items.map(renderItem)}</nav>;
+  const items = await fetchSidebarItems()
+  return <nav>{items.map(renderItem)}</nav>
 }
 
 function Layout({ children }: { children: ReactNode }) {
@@ -1118,7 +1179,7 @@ function Layout({ children }: { children: ReactNode }) {
       <Header />
       {children}
     </div>
-  );
+  )
 }
 
 export default function Page() {
@@ -1126,7 +1187,7 @@ export default function Page() {
     <Layout>
       <Sidebar />
     </Layout>
-  );
+  )
 }
 ```
 
@@ -1139,11 +1200,13 @@ When fetching nested data in parallel, chain dependent fetches within each item'
 **Incorrect: a single slow item blocks all nested fetches**
 
 ```tsx
-const chats = await Promise.all(chatIds.map((id) => getChat(id)));
+const chats = await Promise.all(
+  chatIds.map(id => getChat(id))
+)
 
 const chatAuthors = await Promise.all(
-  chats.map((chat) => getUser(chat.author)),
-);
+  chats.map(chat => getUser(chat.author))
+)
 ```
 
 If one `getChat(id)` out of 100 is extremely slow, the authors of the other 99 chats can't start loading even though their data is ready.
@@ -1152,8 +1215,8 @@ If one `getChat(id)` out of 100 is extremely slow, the authors of the other 99 c
 
 ```tsx
 const chatAuthors = await Promise.all(
-  chatIds.map((id) => getChat(id).then((chat) => getUser(chat.author))),
-);
+  chatIds.map(id => getChat(id).then(chat => getUser(chat.author)))
+)
 ```
 
 Each item independently chains `getChat` → `getUser`, so a slow chat doesn't block author fetches for the others.
@@ -1167,15 +1230,15 @@ Use `React.cache()` for server-side request deduplication. Authentication and da
 **Usage:**
 
 ```typescript
-import { cache } from "react";
+import { cache } from 'react'
 
 export const getCurrentUser = cache(async () => {
-  const session = await auth();
-  if (!session?.user?.id) return null;
+  const session = await auth()
+  if (!session?.user?.id) return null
   return await db.user.findUnique({
-    where: { id: session.user.id },
-  });
-});
+    where: { id: session.user.id }
+  })
+})
 ```
 
 Within a single request, multiple calls to `getCurrentUser()` execute the query only once.
@@ -1188,20 +1251,20 @@ Within a single request, multiple calls to `getCurrentUser()` execute the query 
 
 ```typescript
 const getUser = cache(async (params: { uid: number }) => {
-  return await db.user.findUnique({ where: { id: params.uid } });
-});
+  return await db.user.findUnique({ where: { id: params.uid } })
+})
 
 // Each call creates new object, never hits cache
-getUser({ uid: 1 });
-getUser({ uid: 1 }); // Cache miss, runs query again
+getUser({ uid: 1 })
+getUser({ uid: 1 })  // Cache miss, runs query again
 ```
 
 **Correct: cache hit**
 
 ```typescript
-const params = { uid: 1 };
-getUser(params); // Query runs
-getUser(params); // Cache hit (same reference)
+const params = { uid: 1 }
+getUser(params)  // Query runs
+getUser(params)  // Cache hit (same reference)
 ```
 
 If you must pass objects, pass the same reference:
@@ -1233,47 +1296,46 @@ Use Next.js's `after()` to schedule work that should execute after a response is
 **Incorrect: blocks response**
 
 ```tsx
-import { logUserAction } from "@/app/utils";
+import { logUserAction } from '@/app/utils'
 
 export async function POST(request: Request) {
   // Perform mutation
-  await updateDatabase(request);
-
+  await updateDatabase(request)
+  
   // Logging blocks the response
-  const userAgent = request.headers.get("user-agent") || "unknown";
-  await logUserAction({ userAgent });
-
-  return new Response(JSON.stringify({ status: "success" }), {
+  const userAgent = request.headers.get('user-agent') || 'unknown'
+  await logUserAction({ userAgent })
+  
+  return new Response(JSON.stringify({ status: 'success' }), {
     status: 200,
-    headers: { "Content-Type": "application/json" },
-  });
+    headers: { 'Content-Type': 'application/json' }
+  })
 }
 ```
 
 **Correct: non-blocking**
 
 ```tsx
-import { after } from "next/server";
-import { headers, cookies } from "next/headers";
-import { logUserAction } from "@/app/utils";
+import { after } from 'next/server'
+import { headers, cookies } from 'next/headers'
+import { logUserAction } from '@/app/utils'
 
 export async function POST(request: Request) {
   // Perform mutation
-  await updateDatabase(request);
-
+  await updateDatabase(request)
+  
   // Log after response is sent
   after(async () => {
-    const userAgent = (await headers()).get("user-agent") || "unknown";
-    const sessionCookie =
-      (await cookies()).get("session-id")?.value || "anonymous";
-
-    logUserAction({ sessionCookie, userAgent });
-  });
-
-  return new Response(JSON.stringify({ status: "success" }), {
+    const userAgent = (await headers()).get('user-agent') || 'unknown'
+    const sessionCookie = (await cookies()).get('session-id')?.value || 'anonymous'
+    
+    logUserAction({ sessionCookie, userAgent })
+  })
+  
+  return new Response(JSON.stringify({ status: 'success' }), {
     status: 200,
-    headers: { "Content-Type": "application/json" },
-  });
+    headers: { 'Content-Type': 'application/json' }
+  })
 }
 ```
 
@@ -1320,12 +1382,12 @@ function useKeyboardShortcut(key: string, callback: () => void) {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.metaKey && e.key === key) {
-        callback();
+        callback()
       }
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [key, callback]);
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [key, callback])
 }
 ```
 
@@ -1334,49 +1396,45 @@ When using the `useKeyboardShortcut` hook multiple times, each instance will reg
 **Correct: N instances = 1 listener**
 
 ```tsx
-import useSWRSubscription from "swr/subscription";
+import useSWRSubscription from 'swr/subscription'
 
 // Module-level Map to track callbacks per key
-const keyCallbacks = new Map<string, Set<() => void>>();
+const keyCallbacks = new Map<string, Set<() => void>>()
 
 function useKeyboardShortcut(key: string, callback: () => void) {
   // Register this callback in the Map
   useEffect(() => {
     if (!keyCallbacks.has(key)) {
-      keyCallbacks.set(key, new Set());
+      keyCallbacks.set(key, new Set())
     }
-    keyCallbacks.get(key)!.add(callback);
+    keyCallbacks.get(key)!.add(callback)
 
     return () => {
-      const set = keyCallbacks.get(key);
+      const set = keyCallbacks.get(key)
       if (set) {
-        set.delete(callback);
+        set.delete(callback)
         if (set.size === 0) {
-          keyCallbacks.delete(key);
+          keyCallbacks.delete(key)
         }
       }
-    };
-  }, [key, callback]);
+    }
+  }, [key, callback])
 
-  useSWRSubscription("global-keydown", () => {
+  useSWRSubscription('global-keydown', () => {
     const handler = (e: KeyboardEvent) => {
       if (e.metaKey && keyCallbacks.has(e.key)) {
-        keyCallbacks.get(e.key)!.forEach((cb) => cb());
+        keyCallbacks.get(e.key)!.forEach(cb => cb())
       }
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  });
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  })
 }
 
 function Profile() {
   // Multiple shortcuts will share the same listener
-  useKeyboardShortcut("p", () => {
-    /* ... */
-  });
-  useKeyboardShortcut("k", () => {
-    /* ... */
-  });
+  useKeyboardShortcut('p', () => { /* ... */ }) 
+  useKeyboardShortcut('k', () => { /* ... */ })
   // ...
 }
 ```
@@ -1391,34 +1449,34 @@ Add `{ passive: true }` to touch and wheel event listeners to enable immediate s
 
 ```typescript
 useEffect(() => {
-  const handleTouch = (e: TouchEvent) => console.log(e.touches[0].clientX);
-  const handleWheel = (e: WheelEvent) => console.log(e.deltaY);
-
-  document.addEventListener("touchstart", handleTouch);
-  document.addEventListener("wheel", handleWheel);
-
+  const handleTouch = (e: TouchEvent) => console.log(e.touches[0].clientX)
+  const handleWheel = (e: WheelEvent) => console.log(e.deltaY)
+  
+  document.addEventListener('touchstart', handleTouch)
+  document.addEventListener('wheel', handleWheel)
+  
   return () => {
-    document.removeEventListener("touchstart", handleTouch);
-    document.removeEventListener("wheel", handleWheel);
-  };
-}, []);
+    document.removeEventListener('touchstart', handleTouch)
+    document.removeEventListener('wheel', handleWheel)
+  }
+}, [])
 ```
 
 **Correct:**
 
 ```typescript
 useEffect(() => {
-  const handleTouch = (e: TouchEvent) => console.log(e.touches[0].clientX);
-  const handleWheel = (e: WheelEvent) => console.log(e.deltaY);
-
-  document.addEventListener("touchstart", handleTouch, { passive: true });
-  document.addEventListener("wheel", handleWheel, { passive: true });
-
+  const handleTouch = (e: TouchEvent) => console.log(e.touches[0].clientX)
+  const handleWheel = (e: WheelEvent) => console.log(e.deltaY)
+  
+  document.addEventListener('touchstart', handleTouch, { passive: true })
+  document.addEventListener('wheel', handleWheel, { passive: true })
+  
   return () => {
-    document.removeEventListener("touchstart", handleTouch);
-    document.removeEventListener("wheel", handleWheel);
-  };
-}, []);
+    document.removeEventListener('touchstart', handleTouch)
+    document.removeEventListener('wheel', handleWheel)
+  }
+}, [])
 ```
 
 **Use passive when:** tracking/analytics, logging, any listener that doesn't call `preventDefault()`.
@@ -1435,43 +1493,43 @@ SWR enables request deduplication, caching, and revalidation across component in
 
 ```tsx
 function UserList() {
-  const [users, setUsers] = useState([]);
+  const [users, setUsers] = useState([])
   useEffect(() => {
-    fetch("/api/users")
-      .then((r) => r.json())
-      .then(setUsers);
-  }, []);
+    fetch('/api/users')
+      .then(r => r.json())
+      .then(setUsers)
+  }, [])
 }
 ```
 
 **Correct: multiple instances share one request**
 
 ```tsx
-import useSWR from "swr";
+import useSWR from 'swr'
 
 function UserList() {
-  const { data: users } = useSWR("/api/users", fetcher);
+  const { data: users } = useSWR('/api/users', fetcher)
 }
 ```
 
 **For immutable data:**
 
 ```tsx
-import { useImmutableSWR } from "@/lib/swr";
+import { useImmutableSWR } from '@/lib/swr'
 
 function StaticContent() {
-  const { data } = useImmutableSWR("/api/config", fetcher);
+  const { data } = useImmutableSWR('/api/config', fetcher)
 }
 ```
 
 **For mutations:**
 
 ```tsx
-import { useSWRMutation } from "swr/mutation";
+import { useSWRMutation } from 'swr/mutation'
 
 function UpdateButton() {
-  const { trigger } = useSWRMutation("/api/user", updateUser);
-  return <button onClick={() => trigger()}>Update</button>;
+  const { trigger } = useSWRMutation('/api/user', updateUser)
+  return <button onClick={() => trigger()}>Update</button>
 }
 ```
 
@@ -1487,18 +1545,18 @@ Add version prefix to keys and store only needed fields. Prevents schema conflic
 
 ```typescript
 // No version, stores everything, no error handling
-localStorage.setItem("userConfig", JSON.stringify(fullUserObject));
-const data = localStorage.getItem("userConfig");
+localStorage.setItem('userConfig', JSON.stringify(fullUserObject))
+const data = localStorage.getItem('userConfig')
 ```
 
 **Correct:**
 
 ```typescript
-const VERSION = "v2";
+const VERSION = 'v2'
 
 function saveConfig(config: { theme: string; language: string }) {
   try {
-    localStorage.setItem(`userConfig:${VERSION}`, JSON.stringify(config));
+    localStorage.setItem(`userConfig:${VERSION}`, JSON.stringify(config))
   } catch {
     // Throws in incognito/private browsing, quota exceeded, or disabled
   }
@@ -1506,24 +1564,21 @@ function saveConfig(config: { theme: string; language: string }) {
 
 function loadConfig() {
   try {
-    const data = localStorage.getItem(`userConfig:${VERSION}`);
-    return data ? JSON.parse(data) : null;
+    const data = localStorage.getItem(`userConfig:${VERSION}`)
+    return data ? JSON.parse(data) : null
   } catch {
-    return null;
+    return null
   }
 }
 
 // Migration from v1 to v2
 function migrate() {
   try {
-    const v1 = localStorage.getItem("userConfig:v1");
+    const v1 = localStorage.getItem('userConfig:v1')
     if (v1) {
-      const old = JSON.parse(v1);
-      saveConfig({
-        theme: old.darkMode ? "dark" : "light",
-        language: old.lang,
-      });
-      localStorage.removeItem("userConfig:v1");
+      const old = JSON.parse(v1)
+      saveConfig({ theme: old.darkMode ? 'dark' : 'light', language: old.lang })
+      localStorage.removeItem('userConfig:v1')
     }
   } catch {}
 }
@@ -1535,13 +1590,10 @@ function migrate() {
 // User object has 20+ fields, only store what UI needs
 function cachePrefs(user: FullUser) {
   try {
-    localStorage.setItem(
-      "prefs:v1",
-      JSON.stringify({
-        theme: user.preferences.theme,
-        notifications: user.preferences.notifications,
-      }),
-    );
+    localStorage.setItem('prefs:v1', JSON.stringify({
+      theme: user.preferences.theme,
+      notifications: user.preferences.notifications
+    }))
   } catch {}
 }
 ```
@@ -1568,15 +1620,15 @@ If a value can be computed from current props/state, do not store it in state or
 
 ```tsx
 function Form() {
-  const [firstName, setFirstName] = useState("First");
-  const [lastName, setLastName] = useState("Last");
-  const [fullName, setFullName] = useState("");
+  const [firstName, setFirstName] = useState('First')
+  const [lastName, setLastName] = useState('Last')
+  const [fullName, setFullName] = useState('')
 
   useEffect(() => {
-    setFullName(firstName + " " + lastName);
-  }, [firstName, lastName]);
+    setFullName(firstName + ' ' + lastName)
+  }, [firstName, lastName])
 
-  return <p>{fullName}</p>;
+  return <p>{fullName}</p>
 }
 ```
 
@@ -1584,11 +1636,11 @@ function Form() {
 
 ```tsx
 function Form() {
-  const [firstName, setFirstName] = useState("First");
-  const [lastName, setLastName] = useState("Last");
-  const fullName = firstName + " " + lastName;
+  const [firstName, setFirstName] = useState('First')
+  const [lastName, setLastName] = useState('Last')
+  const fullName = firstName + ' ' + lastName
 
-  return <p>{fullName}</p>;
+  return <p>{fullName}</p>
 }
 ```
 
@@ -1604,14 +1656,14 @@ Don't subscribe to dynamic state (searchParams, localStorage) if you only read i
 
 ```tsx
 function ShareButton({ chatId }: { chatId: string }) {
-  const searchParams = useSearchParams();
+  const searchParams = useSearchParams()
 
   const handleShare = () => {
-    const ref = searchParams.get("ref");
-    shareChat(chatId, { ref });
-  };
+    const ref = searchParams.get('ref')
+    shareChat(chatId, { ref })
+  }
 
-  return <button onClick={handleShare}>Share</button>;
+  return <button onClick={handleShare}>Share</button>
 }
 ```
 
@@ -1620,12 +1672,12 @@ function ShareButton({ chatId }: { chatId: string }) {
 ```tsx
 function ShareButton({ chatId }: { chatId: string }) {
   const handleShare = () => {
-    const params = new URLSearchParams(window.location.search);
-    const ref = params.get("ref");
-    shareChat(chatId, { ref });
-  };
+    const params = new URLSearchParams(window.location.search)
+    const ref = params.get('ref')
+    shareChat(chatId, { ref })
+  }
 
-  return <button onClick={handleShare}>Share</button>;
+  return <button onClick={handleShare}>Share</button>
 }
 ```
 
@@ -1642,10 +1694,10 @@ Calling `useMemo` and comparing hook dependencies may consume more resources tha
 ```tsx
 function Header({ user, notifications }: Props) {
   const isLoading = useMemo(() => {
-    return user.isLoading || notifications.isLoading;
-  }, [user.isLoading, notifications.isLoading]);
+    return user.isLoading || notifications.isLoading
+  }, [user.isLoading, notifications.isLoading])
 
-  if (isLoading) return <Skeleton />;
+  if (isLoading) return <Skeleton />
   // return some markup
 }
 ```
@@ -1654,9 +1706,9 @@ function Header({ user, notifications }: Props) {
 
 ```tsx
 function Header({ user, notifications }: Props) {
-  const isLoading = user.isLoading || notifications.isLoading;
+  const isLoading = user.isLoading || notifications.isLoading
 
-  if (isLoading) return <Skeleton />;
+  if (isLoading) return <Skeleton />
   // return some markup
 }
 ```
@@ -1677,9 +1729,9 @@ function UserProfile({ user, theme }) {
   const Avatar = () => (
     <img
       src={user.avatarUrl}
-      className={theme === "dark" ? "avatar-dark" : "avatar-light"}
+      className={theme === 'dark' ? 'avatar-dark' : 'avatar-light'}
     />
-  );
+  )
 
   // Defined inside to access `user` - BAD
   const Stats = () => (
@@ -1687,14 +1739,14 @@ function UserProfile({ user, theme }) {
       <span>{user.followers} followers</span>
       <span>{user.posts} posts</span>
     </div>
-  );
+  )
 
   return (
     <div>
       <Avatar />
       <Stats />
     </div>
-  );
+  )
 }
 ```
 
@@ -1707,9 +1759,9 @@ function Avatar({ src, theme }: { src: string; theme: string }) {
   return (
     <img
       src={src}
-      className={theme === "dark" ? "avatar-dark" : "avatar-light"}
+      className={theme === 'dark' ? 'avatar-dark' : 'avatar-light'}
     />
-  );
+  )
 }
 
 function Stats({ followers, posts }: { followers: number; posts: number }) {
@@ -1718,7 +1770,7 @@ function Stats({ followers, posts }: { followers: number; posts: number }) {
       <span>{followers} followers</span>
       <span>{posts} posts</span>
     </div>
-  );
+  )
 }
 
 function UserProfile({ user, theme }) {
@@ -1727,7 +1779,7 @@ function UserProfile({ user, theme }) {
       <Avatar src={user.avatarUrl} theme={theme} />
       <Stats followers={user.followers} posts={user.posts} />
     </div>
-  );
+  )
 }
 ```
 
@@ -1784,12 +1836,12 @@ Extract expensive work into memoized components to enable early returns before c
 ```tsx
 function Profile({ user, loading }: Props) {
   const avatar = useMemo(() => {
-    const id = computeAvatarId(user);
-    return <Avatar id={id} />;
-  }, [user]);
+    const id = computeAvatarId(user)
+    return <Avatar id={id} />
+  }, [user])
 
-  if (loading) return <Skeleton />;
-  return <div>{avatar}</div>;
+  if (loading) return <Skeleton />
+  return <div>{avatar}</div>
 }
 ```
 
@@ -1797,17 +1849,17 @@ function Profile({ user, loading }: Props) {
 
 ```tsx
 const UserAvatar = memo(function UserAvatar({ user }: { user: User }) {
-  const id = useMemo(() => computeAvatarId(user), [user]);
-  return <Avatar id={id} />;
-});
+  const id = useMemo(() => computeAvatarId(user), [user])
+  return <Avatar id={id} />
+})
 
 function Profile({ user, loading }: Props) {
-  if (loading) return <Skeleton />;
+  if (loading) return <Skeleton />
   return (
     <div>
       <UserAvatar user={user} />
     </div>
-  );
+  )
 }
 ```
 
@@ -1823,16 +1875,16 @@ Specify primitive dependencies instead of objects to minimize effect re-runs.
 
 ```tsx
 useEffect(() => {
-  console.log(user.id);
-}, [user]);
+  console.log(user.id)
+}, [user])
 ```
 
 **Correct: re-runs only when id changes**
 
 ```tsx
 useEffect(() => {
-  console.log(user.id);
-}, [user.id]);
+  console.log(user.id)
+}, [user.id])
 ```
 
 **For derived state, compute outside effect:**
@@ -1841,17 +1893,17 @@ useEffect(() => {
 // Incorrect: runs on width=767, 766, 765...
 useEffect(() => {
   if (width < 768) {
-    enableMobileMode();
+    enableMobileMode()
   }
-}, [width]);
+}, [width])
 
 // Correct: runs only on boolean transition
-const isMobile = width < 768;
+const isMobile = width < 768
 useEffect(() => {
   if (isMobile) {
-    enableMobileMode();
+    enableMobileMode()
   }
-}, [isMobile]);
+}, [isMobile])
 ```
 
 ### 5.8 Put Interaction Logic in Event Handlers
@@ -1864,17 +1916,17 @@ If a side effect is triggered by a specific user action (submit, click, drag), r
 
 ```tsx
 function Form() {
-  const [submitted, setSubmitted] = useState(false);
-  const theme = useContext(ThemeContext);
+  const [submitted, setSubmitted] = useState(false)
+  const theme = useContext(ThemeContext)
 
   useEffect(() => {
     if (submitted) {
-      post("/api/register");
-      showToast("Registered", theme);
+      post('/api/register')
+      showToast('Registered', theme)
     }
-  }, [submitted, theme]);
+  }, [submitted, theme])
 
-  return <button onClick={() => setSubmitted(true)}>Submit</button>;
+  return <button onClick={() => setSubmitted(true)}>Submit</button>
 }
 ```
 
@@ -1882,14 +1934,14 @@ function Form() {
 
 ```tsx
 function Form() {
-  const theme = useContext(ThemeContext);
+  const theme = useContext(ThemeContext)
 
   function handleSubmit() {
-    post("/api/register");
-    showToast("Registered", theme);
+    post('/api/register')
+    showToast('Registered', theme)
   }
 
-  return <button onClick={handleSubmit}>Submit</button>;
+  return <button onClick={handleSubmit}>Submit</button>
 }
 ```
 
@@ -1905,12 +1957,12 @@ When a hook contains multiple independent tasks with different dependencies, spl
 
 ```tsx
 const sortedProducts = useMemo(() => {
-  const filtered = products.filter((p) => p.category === category);
+  const filtered = products.filter((p) => p.category === category)
   const sorted = filtered.toSorted((a, b) =>
-    sortOrder === "asc" ? a.price - b.price : b.price - a.price,
-  );
-  return sorted;
-}, [products, category, sortOrder]);
+    sortOrder === "asc" ? a.price - b.price : b.price - a.price
+  )
+  return sorted
+}, [products, category, sortOrder])
 ```
 
 **Correct: filtering only recomputes when products or category change**
@@ -1918,16 +1970,16 @@ const sortedProducts = useMemo(() => {
 ```tsx
 const filteredProducts = useMemo(
   () => products.filter((p) => p.category === category),
-  [products, category],
-);
+  [products, category]
+)
 
 const sortedProducts = useMemo(
   () =>
     filteredProducts.toSorted((a, b) =>
-      sortOrder === "asc" ? a.price - b.price : b.price - a.price,
+      sortOrder === "asc" ? a.price - b.price : b.price - a.price
     ),
-  [filteredProducts, sortOrder],
-);
+  [filteredProducts, sortOrder]
+)
 ```
 
 This pattern also applies to `useEffect` when combining unrelated side effects:
@@ -1936,21 +1988,21 @@ This pattern also applies to `useEffect` when combining unrelated side effects:
 
 ```tsx
 useEffect(() => {
-  analytics.trackPageView(pathname);
-  document.title = `${pageTitle} | My App`;
-}, [pathname, pageTitle]);
+  analytics.trackPageView(pathname)
+  document.title = `${pageTitle} | My App`
+}, [pathname, pageTitle])
 ```
 
 **Correct: effects run independently**
 
 ```tsx
 useEffect(() => {
-  analytics.trackPageView(pathname);
-}, [pathname]);
+  analytics.trackPageView(pathname)
+}, [pathname])
 
 useEffect(() => {
-  document.title = `${pageTitle} | My App`;
-}, [pageTitle]);
+  document.title = `${pageTitle} | My App`
+}, [pageTitle])
 ```
 
 **Note:** If your project has [React Compiler](https://react.dev/learn/react-compiler) enabled, it automatically optimizes dependency tracking and may handle some of these cases for you.
@@ -1965,9 +2017,9 @@ Subscribe to derived boolean state instead of continuous values to reduce re-ren
 
 ```tsx
 function Sidebar() {
-  const width = useWindowWidth(); // updates continuously
-  const isMobile = width < 768;
-  return <nav className={isMobile ? "mobile" : "desktop"} />;
+  const width = useWindowWidth()  // updates continuously
+  const isMobile = width < 768
+  return <nav className={isMobile ? 'mobile' : 'desktop'} />
 }
 ```
 
@@ -1975,8 +2027,8 @@ function Sidebar() {
 
 ```tsx
 function Sidebar() {
-  const isMobile = useMediaQuery("(max-width: 767px)");
-  return <nav className={isMobile ? "mobile" : "desktop"} />;
+  const isMobile = useMediaQuery('(max-width: 767px)')
+  return <nav className={isMobile ? 'mobile' : 'desktop'} />
 }
 ```
 
@@ -1990,22 +2042,19 @@ When updating state based on the current state value, use the functional update 
 
 ```tsx
 function TodoList() {
-  const [items, setItems] = useState(initialItems);
-
+  const [items, setItems] = useState(initialItems)
+  
   // Callback must depend on items, recreated on every items change
-  const addItems = useCallback(
-    (newItems: Item[]) => {
-      setItems([...items, ...newItems]);
-    },
-    [items],
-  ); // ❌ items dependency causes recreations
-
+  const addItems = useCallback((newItems: Item[]) => {
+    setItems([...items, ...newItems])
+  }, [items])  // ❌ items dependency causes recreations
+  
   // Risk of stale closure if dependency is forgotten
   const removeItem = useCallback((id: string) => {
-    setItems(items.filter((item) => item.id !== id));
-  }, []); // ❌ Missing items dependency - will use stale items!
-
-  return <ItemsEditor items={items} onAdd={addItems} onRemove={removeItem} />;
+    setItems(items.filter(item => item.id !== id))
+  }, [])  // ❌ Missing items dependency - will use stale items!
+  
+  return <ItemsEditor items={items} onAdd={addItems} onRemove={removeItem} />
 }
 ```
 
@@ -2015,19 +2064,19 @@ The first callback is recreated every time `items` changes, which can cause chil
 
 ```tsx
 function TodoList() {
-  const [items, setItems] = useState(initialItems);
-
+  const [items, setItems] = useState(initialItems)
+  
   // Stable callback, never recreated
   const addItems = useCallback((newItems: Item[]) => {
-    setItems((curr) => [...curr, ...newItems]);
-  }, []); // ✅ No dependencies needed
-
+    setItems(curr => [...curr, ...newItems])
+  }, [])  // ✅ No dependencies needed
+  
   // Always uses latest state, no stale closure risk
   const removeItem = useCallback((id: string) => {
-    setItems((curr) => curr.filter((item) => item.id !== id));
-  }, []); // ✅ Safe and stable
-
-  return <ItemsEditor items={items} onAdd={addItems} onRemove={removeItem} />;
+    setItems(curr => curr.filter(item => item.id !== id))
+  }, [])  // ✅ Safe and stable
+  
+  return <ItemsEditor items={items} onAdd={addItems} onRemove={removeItem} />
 }
 ```
 
@@ -2072,20 +2121,20 @@ Pass a function to `useState` for expensive initial values. Without the function
 ```tsx
 function FilteredList({ items }: { items: Item[] }) {
   // buildSearchIndex() runs on EVERY render, even after initialization
-  const [searchIndex, setSearchIndex] = useState(buildSearchIndex(items));
-  const [query, setQuery] = useState("");
-
+  const [searchIndex, setSearchIndex] = useState(buildSearchIndex(items))
+  const [query, setQuery] = useState('')
+  
   // When query changes, buildSearchIndex runs again unnecessarily
-  return <SearchResults index={searchIndex} query={query} />;
+  return <SearchResults index={searchIndex} query={query} />
 }
 
 function UserProfile() {
   // JSON.parse runs on every render
   const [settings, setSettings] = useState(
-    JSON.parse(localStorage.getItem("settings") || "{}"),
-  );
-
-  return <SettingsForm settings={settings} onChange={setSettings} />;
+    JSON.parse(localStorage.getItem('settings') || '{}')
+  )
+  
+  return <SettingsForm settings={settings} onChange={setSettings} />
 }
 ```
 
@@ -2094,20 +2143,20 @@ function UserProfile() {
 ```tsx
 function FilteredList({ items }: { items: Item[] }) {
   // buildSearchIndex() runs ONLY on initial render
-  const [searchIndex, setSearchIndex] = useState(() => buildSearchIndex(items));
-  const [query, setQuery] = useState("");
-
-  return <SearchResults index={searchIndex} query={query} />;
+  const [searchIndex, setSearchIndex] = useState(() => buildSearchIndex(items))
+  const [query, setQuery] = useState('')
+  
+  return <SearchResults index={searchIndex} query={query} />
 }
 
 function UserProfile() {
   // JSON.parse runs only on initial render
   const [settings, setSettings] = useState(() => {
-    const stored = localStorage.getItem("settings");
-    return stored ? JSON.parse(stored) : {};
-  });
-
-  return <SettingsForm settings={settings} onChange={setSettings} />;
+    const stored = localStorage.getItem('settings')
+    return stored ? JSON.parse(stored) : {}
+  })
+  
+  return <SettingsForm settings={settings} onChange={setSettings} />
 }
 ```
 
@@ -2125,29 +2174,29 @@ Mark frequent, non-urgent state updates as transitions to maintain UI responsive
 
 ```tsx
 function ScrollTracker() {
-  const [scrollY, setScrollY] = useState(0);
+  const [scrollY, setScrollY] = useState(0)
   useEffect(() => {
-    const handler = () => setScrollY(window.scrollY);
-    window.addEventListener("scroll", handler, { passive: true });
-    return () => window.removeEventListener("scroll", handler);
-  }, []);
+    const handler = () => setScrollY(window.scrollY)
+    window.addEventListener('scroll', handler, { passive: true })
+    return () => window.removeEventListener('scroll', handler)
+  }, [])
 }
 ```
 
 **Correct: non-blocking updates**
 
 ```tsx
-import { startTransition } from "react";
+import { startTransition } from 'react'
 
 function ScrollTracker() {
-  const [scrollY, setScrollY] = useState(0);
+  const [scrollY, setScrollY] = useState(0)
   useEffect(() => {
     const handler = () => {
-      startTransition(() => setScrollY(window.scrollY));
-    };
-    window.addEventListener("scroll", handler, { passive: true });
-    return () => window.removeEventListener("scroll", handler);
-  }, []);
+      startTransition(() => setScrollY(window.scrollY))
+    }
+    window.addEventListener('scroll', handler, { passive: true })
+    return () => window.removeEventListener('scroll', handler)
+  }, [])
 }
 ```
 
@@ -2161,15 +2210,15 @@ When user input triggers expensive computations or renders, use `useDeferredValu
 
 ```tsx
 function Search({ items }: { items: Item[] }) {
-  const [query, setQuery] = useState("");
-  const filtered = items.filter((item) => fuzzyMatch(item, query));
+  const [query, setQuery] = useState('')
+  const filtered = items.filter(item => fuzzyMatch(item, query))
 
   return (
     <>
-      <input value={query} onChange={(e) => setQuery(e.target.value)} />
+      <input value={query} onChange={e => setQuery(e.target.value)} />
       <ResultsList results={filtered} />
     </>
-  );
+  )
 }
 ```
 
@@ -2177,22 +2226,22 @@ function Search({ items }: { items: Item[] }) {
 
 ```tsx
 function Search({ items }: { items: Item[] }) {
-  const [query, setQuery] = useState("");
-  const deferredQuery = useDeferredValue(query);
+  const [query, setQuery] = useState('')
+  const deferredQuery = useDeferredValue(query)
   const filtered = useMemo(
-    () => items.filter((item) => fuzzyMatch(item, deferredQuery)),
-    [items, deferredQuery],
-  );
-  const isStale = query !== deferredQuery;
+    () => items.filter(item => fuzzyMatch(item, deferredQuery)),
+    [items, deferredQuery]
+  )
+  const isStale = query !== deferredQuery
 
   return (
     <>
-      <input value={query} onChange={(e) => setQuery(e.target.value)} />
+      <input value={query} onChange={e => setQuery(e.target.value)} />
       <div style={{ opacity: isStale ? 0.7 : 1 }}>
         <ResultsList results={filtered} />
       </div>
     </>
-  );
+  )
 }
 ```
 
@@ -2218,26 +2267,26 @@ When a value changes frequently and you don't want a re-render on every update (
 
 ```tsx
 function Tracker() {
-  const [lastX, setLastX] = useState(0);
+  const [lastX, setLastX] = useState(0)
 
   useEffect(() => {
-    const onMove = (e: MouseEvent) => setLastX(e.clientX);
-    window.addEventListener("mousemove", onMove);
-    return () => window.removeEventListener("mousemove", onMove);
-  }, []);
+    const onMove = (e: MouseEvent) => setLastX(e.clientX)
+    window.addEventListener('mousemove', onMove)
+    return () => window.removeEventListener('mousemove', onMove)
+  }, [])
 
   return (
     <div
       style={{
-        position: "fixed",
+        position: 'fixed',
         top: 0,
         left: lastX,
         width: 8,
         height: 8,
-        background: "black",
+        background: 'black',
       }}
     />
-  );
+  )
 }
 ```
 
@@ -2245,35 +2294,35 @@ function Tracker() {
 
 ```tsx
 function Tracker() {
-  const lastXRef = useRef(0);
-  const dotRef = useRef<HTMLDivElement>(null);
+  const lastXRef = useRef(0)
+  const dotRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     const onMove = (e: MouseEvent) => {
-      lastXRef.current = e.clientX;
-      const node = dotRef.current;
+      lastXRef.current = e.clientX
+      const node = dotRef.current
       if (node) {
-        node.style.transform = `translateX(${e.clientX}px)`;
+        node.style.transform = `translateX(${e.clientX}px)`
       }
-    };
-    window.addEventListener("mousemove", onMove);
-    return () => window.removeEventListener("mousemove", onMove);
-  }, []);
+    }
+    window.addEventListener('mousemove', onMove)
+    return () => window.removeEventListener('mousemove', onMove)
+  }, [])
 
   return (
     <div
       ref={dotRef}
       style={{
-        position: "fixed",
+        position: 'fixed',
         top: 0,
         left: 0,
         width: 8,
         height: 8,
-        background: "black",
-        transform: "translateX(0px)",
+        background: 'black',
+        transform: 'translateX(0px)',
       }}
     />
-  );
+  )
 }
 ```
 
@@ -2296,10 +2345,15 @@ Many browsers don't have hardware acceleration for CSS3 animations on SVG elemen
 ```tsx
 function LoadingSpinner() {
   return (
-    <svg className="animate-spin" width="24" height="24" viewBox="0 0 24 24">
+    <svg 
+      className="animate-spin"
+      width="24" 
+      height="24" 
+      viewBox="0 0 24 24"
+    >
       <circle cx="12" cy="12" r="10" stroke="currentColor" />
     </svg>
-  );
+  )
 }
 ```
 
@@ -2309,11 +2363,15 @@ function LoadingSpinner() {
 function LoadingSpinner() {
   return (
     <div className="animate-spin">
-      <svg width="24" height="24" viewBox="0 0 24 24">
+      <svg 
+        width="24" 
+        height="24" 
+        viewBox="0 0 24 24"
+      >
         <circle cx="12" cy="12" r="10" stroke="currentColor" />
       </svg>
     </div>
-  );
+  )
 }
 ```
 
@@ -2340,14 +2398,14 @@ Apply `content-visibility: auto` to defer off-screen rendering.
 function MessageList({ messages }: { messages: Message[] }) {
   return (
     <div className="overflow-y-auto h-screen">
-      {messages.map((msg) => (
+      {messages.map(msg => (
         <div key={msg.id} className="message-item">
           <Avatar user={msg.author} />
           <div>{msg.content}</div>
         </div>
       ))}
     </div>
-  );
+  )
 }
 ```
 
@@ -2363,21 +2421,31 @@ Extract static JSX outside components to avoid re-creation.
 
 ```tsx
 function LoadingSkeleton() {
-  return <div className="animate-pulse h-20 bg-gray-200" />;
+  return <div className="animate-pulse h-20 bg-gray-200" />
 }
 
 function Container() {
-  return <div>{loading && <LoadingSkeleton />}</div>;
+  return (
+    <div>
+      {loading && <LoadingSkeleton />}
+    </div>
+  )
 }
 ```
 
 **Correct: reuses same element**
 
 ```tsx
-const loadingSkeleton = <div className="animate-pulse h-20 bg-gray-200" />;
+const loadingSkeleton = (
+  <div className="animate-pulse h-20 bg-gray-200" />
+)
 
 function Container() {
-  return <div>{loading && loadingSkeleton}</div>;
+  return (
+    <div>
+      {loading && loadingSkeleton}
+    </div>
+  )
 }
 ```
 
@@ -2420,9 +2488,13 @@ When rendering content that depends on client-side storage (localStorage, cookie
 ```tsx
 function ThemeWrapper({ children }: { children: ReactNode }) {
   // localStorage is not available on server - throws error
-  const theme = localStorage.getItem("theme") || "light";
-
-  return <div className={theme}>{children}</div>;
+  const theme = localStorage.getItem('theme') || 'light'
+  
+  return (
+    <div className={theme}>
+      {children}
+    </div>
+  )
 }
 ```
 
@@ -2432,17 +2504,21 @@ Server-side rendering will fail because `localStorage` is undefined.
 
 ```tsx
 function ThemeWrapper({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState("light");
-
+  const [theme, setTheme] = useState('light')
+  
   useEffect(() => {
     // Runs after hydration - causes visible flash
-    const stored = localStorage.getItem("theme");
+    const stored = localStorage.getItem('theme')
     if (stored) {
-      setTheme(stored);
+      setTheme(stored)
     }
-  }, []);
-
-  return <div className={theme}>{children}</div>;
+  }, [])
+  
+  return (
+    <div className={theme}>
+      {children}
+    </div>
+  )
 }
 ```
 
@@ -2454,7 +2530,9 @@ Component first renders with default value (`light`), then updates after hydrati
 function ThemeWrapper({ children }: { children: ReactNode }) {
   return (
     <>
-      <div id="theme-wrapper">{children}</div>
+      <div id="theme-wrapper">
+        {children}
+      </div>
       <script
         dangerouslySetInnerHTML={{
           __html: `
@@ -2469,7 +2547,7 @@ function ThemeWrapper({ children }: { children: ReactNode }) {
         }}
       />
     </>
-  );
+  )
 }
 ```
 
@@ -2481,13 +2559,13 @@ This pattern is especially useful for theme toggles, user preferences, authentic
 
 **Impact: LOW-MEDIUM (avoids noisy hydration warnings for known differences)**
 
-In SSR frameworks (e.g., Next.js), some values are intentionally different on server vs client (random IDs, dates, locale/timezone formatting). For these _expected_ mismatches, wrap the dynamic text in an element with `suppressHydrationWarning` to prevent noisy warnings. Do not use this to hide real bugs. Don’t overuse it.
+In SSR frameworks (e.g., Next.js), some values are intentionally different on server vs client (random IDs, dates, locale/timezone formatting). For these *expected* mismatches, wrap the dynamic text in an element with `suppressHydrationWarning` to prevent noisy warnings. Do not use this to hide real bugs. Don’t overuse it.
 
 **Incorrect: known mismatch warnings**
 
 ```tsx
 function Timestamp() {
-  return <span>{new Date().toLocaleString()}</span>;
+  return <span>{new Date().toLocaleString()}</span>
 }
 ```
 
@@ -2495,7 +2573,11 @@ function Timestamp() {
 
 ```tsx
 function Timestamp() {
-  return <span suppressHydrationWarning>{new Date().toLocaleString()}</span>;
+  return (
+    <span suppressHydrationWarning>
+      {new Date().toLocaleString()}
+    </span>
+  )
 }
 ```
 
@@ -2508,14 +2590,14 @@ Use React's `<Activity>` to preserve state/DOM for expensive components that fre
 **Usage:**
 
 ```tsx
-import { Activity } from "react";
+import { Activity } from 'react'
 
 function Dropdown({ isOpen }: Props) {
   return (
-    <Activity mode={isOpen ? "visible" : "hidden"}>
+    <Activity mode={isOpen ? 'visible' : 'hidden'}>
       <ExpensiveMenu />
     </Activity>
-  );
+  )
 }
 ```
 
@@ -2545,25 +2627,22 @@ export default function Document() {
       </head>
       <body>{/* content */}</body>
     </html>
-  );
+  )
 }
 ```
 
 **Correct: non-blocking**
 
 ```tsx
-import Script from "next/script";
+import Script from 'next/script'
 
 export default function Page() {
   return (
     <>
-      <Script
-        src="https://example.com/analytics.js"
-        strategy="afterInteractive"
-      />
+      <Script src="https://example.com/analytics.js" strategy="afterInteractive" />
       <Script src="/scripts/utils.js" strategy="beforeInteractive" />
     </>
-  );
+  )
 }
 ```
 
@@ -2581,7 +2660,11 @@ Use explicit ternary operators (`? :`) instead of `&&` for conditional rendering
 
 ```tsx
 function Badge({ count }: { count: number }) {
-  return <div>{count && <span className="badge">{count}</span>}</div>;
+  return (
+    <div>
+      {count && <span className="badge">{count}</span>}
+    </div>
+  )
 }
 
 // When count = 0, renders: <div>0</div>
@@ -2592,7 +2675,11 @@ function Badge({ count }: { count: number }) {
 
 ```tsx
 function Badge({ count }: { count: number }) {
-  return <div>{count > 0 ? <span className="badge">{count}</span> : null}</div>;
+  return (
+    <div>
+      {count > 0 ? <span className="badge">{count}</span> : null}
+    </div>
+  )
 }
 
 // When count = 0, renders: <div></div>
@@ -2620,49 +2707,45 @@ React DOM provides APIs to hint the browser about resources it will need. These 
 **Example: preconnect to third-party APIs**
 
 ```tsx
-import { preconnect, prefetchDNS } from "react-dom";
+import { preconnect, prefetchDNS } from 'react-dom'
 
 export default function App() {
-  prefetchDNS("https://analytics.example.com");
-  preconnect("https://api.example.com");
+  prefetchDNS('https://analytics.example.com')
+  preconnect('https://api.example.com')
 
-  return <main>{/* content */}</main>;
+  return <main>{/* content */}</main>
 }
 ```
 
 **Example: preload critical fonts and styles**
 
 ```tsx
-import { preload, preinit } from "react-dom";
+import { preload, preinit } from 'react-dom'
 
 export default function RootLayout({ children }) {
   // Preload font file
-  preload("/fonts/inter.woff2", {
-    as: "font",
-    type: "font/woff2",
-    crossOrigin: "anonymous",
-  });
+  preload('/fonts/inter.woff2', { as: 'font', type: 'font/woff2', crossOrigin: 'anonymous' })
 
   // Fetch and apply critical stylesheet immediately
-  preinit("/styles/critical.css", { as: "style" });
+  preinit('/styles/critical.css', { as: 'style' })
 
   return (
     <html>
       <body>{children}</body>
     </html>
-  );
+  )
 }
 ```
 
 **Example: preload modules for code-split routes**
 
 ```tsx
-import { preloadModule, preinitModule } from "react-dom";
+import { preloadModule, preinitModule } from 'react-dom'
 
 function Navigation() {
   const preloadDashboard = () => {
-    preloadModule("/dashboard.js", { as: "script" });
-  };
+    preloadModule('/dashboard.js', { as: 'script' })
+  }
 
   return (
     <nav>
@@ -2670,7 +2753,7 @@ function Navigation() {
         Dashboard
       </a>
     </nav>
-  );
+  )
 }
 ```
 
@@ -2704,17 +2787,17 @@ Use `useTransition` instead of manual `useState` for loading states. This provid
 
 ```tsx
 function SearchResults() {
-  const [query, setQuery] = useState("");
-  const [results, setResults] = useState([]);
-  const [isLoading, setIsLoading] = useState(false);
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState([])
+  const [isLoading, setIsLoading] = useState(false)
 
   const handleSearch = async (value: string) => {
-    setIsLoading(true);
-    setQuery(value);
-    const data = await fetchResults(value);
-    setResults(data);
-    setIsLoading(false);
-  };
+    setIsLoading(true)
+    setQuery(value)
+    const data = await fetchResults(value)
+    setResults(data)
+    setIsLoading(false)
+  }
 
   return (
     <>
@@ -2722,29 +2805,29 @@ function SearchResults() {
       {isLoading && <Spinner />}
       <ResultsList results={results} />
     </>
-  );
+  )
 }
 ```
 
 **Correct: useTransition with built-in pending state**
 
 ```tsx
-import { useTransition, useState } from "react";
+import { useTransition, useState } from 'react'
 
 function SearchResults() {
-  const [query, setQuery] = useState("");
-  const [results, setResults] = useState([]);
-  const [isPending, startTransition] = useTransition();
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState([])
+  const [isPending, startTransition] = useTransition()
 
   const handleSearch = (value: string) => {
-    setQuery(value); // Update input immediately
-
+    setQuery(value) // Update input immediately
+    
     startTransition(async () => {
       // Fetch and update results
-      const data = await fetchResults(value);
-      setResults(data);
-    });
-  };
+      const data = await fetchResults(value)
+      setResults(data)
+    })
+  }
 
   return (
     <>
@@ -2752,7 +2835,7 @@ function SearchResults() {
       {isPending && <Spinner />}
       <ResultsList results={results} />
     </>
-  );
+  )
 }
 ```
 
@@ -2787,10 +2870,10 @@ Avoid interleaving style writes with layout reads. When you read a layout proper
 ```typescript
 function updateElementStyles(element: HTMLElement) {
   // Each line invalidates style, but browser batches the recalculation
-  element.style.width = "100px";
-  element.style.height = "200px";
-  element.style.backgroundColor = "blue";
-  element.style.border = "1px solid black";
+  element.style.width = '100px'
+  element.style.height = '200px'
+  element.style.backgroundColor = 'blue'
+  element.style.border = '1px solid black'
 }
 ```
 
@@ -2798,10 +2881,10 @@ function updateElementStyles(element: HTMLElement) {
 
 ```typescript
 function layoutThrashing(element: HTMLElement) {
-  element.style.width = "100px";
-  const width = element.offsetWidth; // Forces reflow
-  element.style.height = "200px";
-  const height = element.offsetHeight; // Forces another reflow
+  element.style.width = '100px'
+  const width = element.offsetWidth  // Forces reflow
+  element.style.height = '200px'
+  const height = element.offsetHeight  // Forces another reflow
 }
 ```
 
@@ -2810,13 +2893,13 @@ function layoutThrashing(element: HTMLElement) {
 ```typescript
 function updateElementStyles(element: HTMLElement) {
   // Batch all writes together
-  element.style.width = "100px";
-  element.style.height = "200px";
-  element.style.backgroundColor = "blue";
-  element.style.border = "1px solid black";
-
+  element.style.width = '100px'
+  element.style.height = '200px'
+  element.style.backgroundColor = 'blue'
+  element.style.border = '1px solid black'
+  
   // Read after all writes are done (single reflow)
-  const { width, height } = element.getBoundingClientRect();
+  const { width, height } = element.getBoundingClientRect()
 }
 ```
 
@@ -2824,9 +2907,9 @@ function updateElementStyles(element: HTMLElement) {
 
 ```typescript
 function updateElementStyles(element: HTMLElement) {
-  element.classList.add("highlighted-box");
-
-  const { width, height } = element.getBoundingClientRect();
+  element.classList.add('highlighted-box')
+  
+  const { width, height } = element.getBoundingClientRect()
 }
 ```
 
@@ -2837,22 +2920,26 @@ function updateElementStyles(element: HTMLElement) {
 ```tsx
 // Incorrect: interleaving style changes with layout queries
 function Box({ isHighlighted }: { isHighlighted: boolean }) {
-  const ref = useRef<HTMLDivElement>(null);
-
+  const ref = useRef<HTMLDivElement>(null)
+  
   useEffect(() => {
     if (ref.current && isHighlighted) {
-      ref.current.style.width = "100px";
-      const width = ref.current.offsetWidth; // Forces layout
-      ref.current.style.height = "200px";
+      ref.current.style.width = '100px'
+      const width = ref.current.offsetWidth // Forces layout
+      ref.current.style.height = '200px'
     }
-  }, [isHighlighted]);
-
-  return <div ref={ref}>Content</div>;
+  }, [isHighlighted])
+  
+  return <div ref={ref}>Content</div>
 }
 
 // Correct: toggle class
 function Box({ isHighlighted }: { isHighlighted: boolean }) {
-  return <div className={isHighlighted ? "highlighted-box" : ""}>Content</div>;
+  return (
+    <div className={isHighlighted ? 'highlighted-box' : ''}>
+      Content
+    </div>
+  )
 }
 ```
 
@@ -2870,10 +2957,10 @@ Multiple `.find()` calls by the same key should use a Map.
 
 ```typescript
 function processOrders(orders: Order[], users: User[]) {
-  return orders.map((order) => ({
+  return orders.map(order => ({
     ...order,
-    user: users.find((u) => u.id === order.userId),
-  }));
+    user: users.find(u => u.id === order.userId)
+  }))
 }
 ```
 
@@ -2881,12 +2968,12 @@ function processOrders(orders: Order[], users: User[]) {
 
 ```typescript
 function processOrders(orders: Order[], users: User[]) {
-  const userById = new Map(users.map((u) => [u.id, u]));
+  const userById = new Map(users.map(u => [u.id, u]))
 
-  return orders.map((order) => ({
+  return orders.map(order => ({
     ...order,
-    user: userById.get(order.userId),
-  }));
+    user: userById.get(order.userId)
+  }))
 }
 ```
 
@@ -2904,17 +2991,17 @@ Cache object property lookups in hot paths.
 
 ```typescript
 for (let i = 0; i < arr.length; i++) {
-  process(obj.config.settings.value);
+  process(obj.config.settings.value)
 }
 ```
 
 **Correct: 1 lookup total**
 
 ```typescript
-const value = obj.config.settings.value;
-const len = arr.length;
+const value = obj.config.settings.value
+const len = arr.length
 for (let i = 0; i < len; i++) {
-  process(value);
+  process(value)
 }
 ```
 
@@ -2933,7 +3020,7 @@ function ProjectList({ projects }: { projects: Project[] }) {
       {projects.map(project => {
         // slugify() called 100+ times for same project names
         const slug = slugify(project.name)
-
+        
         return <ProjectCard key={project.id} slug={slug} />
       })}
     </div>
@@ -2962,7 +3049,7 @@ function ProjectList({ projects }: { projects: Project[] }) {
       {projects.map(project => {
         // Computed only once per unique project name
         const slug = cachedSlugify(project.name)
-
+        
         return <ProjectCard key={project.id} slug={slug} />
       })}
     </div>
@@ -2973,20 +3060,20 @@ function ProjectList({ projects }: { projects: Project[] }) {
 **Simpler pattern for single-value functions:**
 
 ```typescript
-let isLoggedInCache: boolean | null = null;
+let isLoggedInCache: boolean | null = null
 
 function isLoggedIn(): boolean {
   if (isLoggedInCache !== null) {
-    return isLoggedInCache;
+    return isLoggedInCache
   }
-
-  isLoggedInCache = document.cookie.includes("auth=");
-  return isLoggedInCache;
+  
+  isLoggedInCache = document.cookie.includes('auth=')
+  return isLoggedInCache
 }
 
 // Clear cache when auth changes
 function onAuthChange() {
-  isLoggedInCache = null;
+  isLoggedInCache = null
 }
 ```
 
@@ -3004,7 +3091,7 @@ Reference: [https://vercel.com/blog/how-we-made-the-vercel-dashboard-twice-as-fa
 
 ```typescript
 function getTheme() {
-  return localStorage.getItem("theme") ?? "light";
+  return localStorage.getItem('theme') ?? 'light'
 }
 // Called 10 times = 10 storage reads
 ```
@@ -3012,18 +3099,18 @@ function getTheme() {
 **Correct: Map cache**
 
 ```typescript
-const storageCache = new Map<string, string | null>();
+const storageCache = new Map<string, string | null>()
 
 function getLocalStorage(key: string) {
   if (!storageCache.has(key)) {
-    storageCache.set(key, localStorage.getItem(key));
+    storageCache.set(key, localStorage.getItem(key))
   }
-  return storageCache.get(key);
+  return storageCache.get(key)
 }
 
 function setLocalStorage(key: string, value: string) {
-  localStorage.setItem(key, value);
-  storageCache.set(key, value); // keep cache in sync
+  localStorage.setItem(key, value)
+  storageCache.set(key, value)  // keep cache in sync
 }
 ```
 
@@ -3032,30 +3119,30 @@ Use a Map (not a hook) so it works everywhere: utilities, event handlers, not ju
 **Cookie caching:**
 
 ```typescript
-let cookieCache: Record<string, string> | null = null;
+let cookieCache: Record<string, string> | null = null
 
 function getCookie(name: string) {
   if (!cookieCache) {
     cookieCache = Object.fromEntries(
-      document.cookie.split("; ").map((c) => c.split("=")),
-    );
+      document.cookie.split('; ').map(c => c.split('='))
+    )
   }
-  return cookieCache[name];
+  return cookieCache[name]
 }
 ```
 
 **Important: invalidate on external changes**
 
 ```typescript
-window.addEventListener("storage", (e) => {
-  if (e.key) storageCache.delete(e.key);
-});
+window.addEventListener('storage', (e) => {
+  if (e.key) storageCache.delete(e.key)
+})
 
-document.addEventListener("visibilitychange", () => {
-  if (document.visibilityState === "visible") {
-    storageCache.clear();
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') {
+    storageCache.clear()
   }
-});
+})
 ```
 
 If storage can change externally (another tab, server-set cookies), invalidate cache:
@@ -3069,22 +3156,22 @@ Multiple `.filter()` or `.map()` calls iterate the array multiple times. Combine
 **Incorrect: 3 iterations**
 
 ```typescript
-const admins = users.filter((u) => u.isAdmin);
-const testers = users.filter((u) => u.isTester);
-const inactive = users.filter((u) => !u.isActive);
+const admins = users.filter(u => u.isAdmin)
+const testers = users.filter(u => u.isTester)
+const inactive = users.filter(u => !u.isActive)
 ```
 
 **Correct: 1 iteration**
 
 ```typescript
-const admins: User[] = [];
-const testers: User[] = [];
-const inactive: User[] = [];
+const admins: User[] = []
+const testers: User[] = []
+const inactive: User[] = []
 
 for (const user of users) {
-  if (user.isAdmin) admins.push(user);
-  if (user.isTester) testers.push(user);
-  if (!user.isActive) inactive.push(user);
+  if (user.isAdmin) admins.push(user)
+  if (user.isTester) testers.push(user)
+  if (!user.isActive) inactive.push(user)
 }
 ```
 
@@ -3098,13 +3185,13 @@ Use `requestIdleCallback()` to schedule non-critical work during browser idle pe
 
 ```typescript
 function handleSearch(query: string) {
-  const results = searchItems(query);
-  setResults(results);
+  const results = searchItems(query)
+  setResults(results)
 
   // These block the main thread immediately
-  analytics.track("search", { query });
-  saveToRecentSearches(query);
-  prefetchTopResults(results.slice(0, 3));
+  analytics.track('search', { query })
+  saveToRecentSearches(query)
+  prefetchTopResults(results.slice(0, 3))
 }
 ```
 
@@ -3112,21 +3199,21 @@ function handleSearch(query: string) {
 
 ```typescript
 function handleSearch(query: string) {
-  const results = searchItems(query);
-  setResults(results);
+  const results = searchItems(query)
+  setResults(results)
 
   // Defer non-critical work to idle periods
   requestIdleCallback(() => {
-    analytics.track("search", { query });
-  });
+    analytics.track('search', { query })
+  })
 
   requestIdleCallback(() => {
-    saveToRecentSearches(query);
-  });
+    saveToRecentSearches(query)
+  })
 
   requestIdleCallback(() => {
-    prefetchTopResults(results.slice(0, 3));
-  });
+    prefetchTopResults(results.slice(0, 3))
+  })
 }
 ```
 
@@ -3135,43 +3222,42 @@ function handleSearch(query: string) {
 ```typescript
 // Ensure analytics fires within 2 seconds even if browser stays busy
 requestIdleCallback(
-  () => analytics.track("page_view", { path: location.pathname }),
-  { timeout: 2000 },
-);
+  () => analytics.track('page_view', { path: location.pathname }),
+  { timeout: 2000 }
+)
 ```
 
 **Chunking large tasks:**
 
 ```typescript
 function processLargeDataset(items: Item[]) {
-  let index = 0;
+  let index = 0
 
   function processChunk(deadline: IdleDeadline) {
     // Process items while we have idle time (aim for <50ms chunks)
     while (index < items.length && deadline.timeRemaining() > 0) {
-      processItem(items[index]);
-      index++;
+      processItem(items[index])
+      index++
     }
 
     // Schedule next chunk if more items remain
     if (index < items.length) {
-      requestIdleCallback(processChunk);
+      requestIdleCallback(processChunk)
     }
   }
 
-  requestIdleCallback(processChunk);
+  requestIdleCallback(processChunk)
 }
 ```
 
 **With fallback for unsupported browsers:**
 
 ```typescript
-const scheduleIdleWork =
-  window.requestIdleCallback ?? ((cb: () => void) => setTimeout(cb, 1));
+const scheduleIdleWork = window.requestIdleCallback ?? ((cb: () => void) => setTimeout(cb, 1))
 
 scheduleIdleWork(() => {
   // Non-critical work
-});
+})
 ```
 
 **When to use:**
@@ -3207,7 +3293,7 @@ In real-world applications, this optimization is especially valuable when the co
 ```typescript
 function hasChanges(current: string[], original: string[]) {
   // Always sorts and joins, even when lengths differ
-  return current.sort().join() !== original.sort().join();
+  return current.sort().join() !== original.sort().join()
 }
 ```
 
@@ -3219,17 +3305,17 @@ Two O(n log n) sorts run even when `current.length` is 5 and `original.length` i
 function hasChanges(current: string[], original: string[]) {
   // Early return if lengths differ
   if (current.length !== original.length) {
-    return true;
+    return true
   }
   // Only sort when lengths match
-  const currentSorted = current.toSorted();
-  const originalSorted = original.toSorted();
+  const currentSorted = current.toSorted()
+  const originalSorted = original.toSorted()
   for (let i = 0; i < currentSorted.length; i++) {
     if (currentSorted[i] !== originalSorted[i]) {
-      return true;
+      return true
     }
   }
-  return false;
+  return false
 }
 ```
 
@@ -3253,22 +3339,22 @@ Return early when result is determined to skip unnecessary processing.
 
 ```typescript
 function validateUsers(users: User[]) {
-  let hasError = false;
-  let errorMessage = "";
-
+  let hasError = false
+  let errorMessage = ''
+  
   for (const user of users) {
     if (!user.email) {
-      hasError = true;
-      errorMessage = "Email required";
+      hasError = true
+      errorMessage = 'Email required'
     }
     if (!user.name) {
-      hasError = true;
-      errorMessage = "Name required";
+      hasError = true
+      errorMessage = 'Name required'
     }
     // Continues checking all users even after error found
   }
-
-  return hasError ? { valid: false, error: errorMessage } : { valid: true };
+  
+  return hasError ? { valid: false, error: errorMessage } : { valid: true }
 }
 ```
 
@@ -3278,14 +3364,14 @@ function validateUsers(users: User[]) {
 function validateUsers(users: User[]) {
   for (const user of users) {
     if (!user.email) {
-      return { valid: false, error: "Email required" };
+      return { valid: false, error: 'Email required' }
     }
     if (!user.name) {
-      return { valid: false, error: "Name required" };
+      return { valid: false, error: 'Name required' }
     }
   }
 
-  return { valid: true };
+  return { valid: true }
 }
 ```
 
@@ -3323,9 +3409,9 @@ function Highlighter({ text, query }: Props) {
 **Warning: global regex has mutable state**
 
 ```typescript
-const regex = /foo/g;
-regex.test("foo"); // true, lastIndex = 3
-regex.test("foo"); // false, lastIndex = 0
+const regex = /foo/g
+regex.test('foo')  // true, lastIndex = 3
+regex.test('foo')  // false, lastIndex = 0
 ```
 
 Global regex (`/g`) has mutable `lastIndex` state:
@@ -3340,14 +3426,16 @@ Chaining `.map().filter(Boolean)` creates an intermediate array and iterates twi
 
 ```typescript
 const userNames = users
-  .map((user) => (user.isActive ? user.name : null))
-  .filter(Boolean);
+  .map(user => user.isActive ? user.name : null)
+  .filter(Boolean)
 ```
 
 **Correct: 1 iteration, no intermediate array**
 
 ```typescript
-const userNames = users.flatMap((user) => (user.isActive ? [user.name] : []));
+const userNames = users.flatMap(user =>
+  user.isActive ? [user.name] : []
+)
 ```
 
 **More examples:**
@@ -3356,21 +3444,25 @@ const userNames = users.flatMap((user) => (user.isActive ? [user.name] : []));
 // Extract valid emails from responses
 // Before
 const emails = responses
-  .map((r) => (r.success ? r.data.email : null))
-  .filter(Boolean);
+  .map(r => r.success ? r.data.email : null)
+  .filter(Boolean)
 
 // After
-const emails = responses.flatMap((r) => (r.success ? [r.data.email] : []));
+const emails = responses.flatMap(r =>
+  r.success ? [r.data.email] : []
+)
 
 // Parse and filter valid numbers
 // Before
-const numbers = strings.map((s) => parseInt(s, 10)).filter((n) => !isNaN(n));
+const numbers = strings
+  .map(s => parseInt(s, 10))
+  .filter(n => !isNaN(n))
 
 // After
-const numbers = strings.flatMap((s) => {
-  const n = parseInt(s, 10);
-  return isNaN(n) ? [] : [n];
-});
+const numbers = strings.flatMap(s => {
+  const n = parseInt(s, 10)
+  return isNaN(n) ? [] : [n]
+})
 ```
 
 **When to use:**
@@ -3391,14 +3483,14 @@ Finding the smallest or largest element only requires a single pass through the 
 
 ```typescript
 interface Project {
-  id: string;
-  name: string;
-  updatedAt: number;
+  id: string
+  name: string
+  updatedAt: number
 }
 
 function getLatestProject(projects: Project[]) {
-  const sorted = [...projects].sort((a, b) => b.updatedAt - a.updatedAt);
-  return sorted[0];
+  const sorted = [...projects].sort((a, b) => b.updatedAt - a.updatedAt)
+  return sorted[0]
 }
 ```
 
@@ -3408,8 +3500,8 @@ Sorts the entire array just to find the maximum value.
 
 ```typescript
 function getOldestAndNewest(projects: Project[]) {
-  const sorted = [...projects].sort((a, b) => a.updatedAt - b.updatedAt);
-  return { oldest: sorted[0], newest: sorted[sorted.length - 1] };
+  const sorted = [...projects].sort((a, b) => a.updatedAt - b.updatedAt)
+  return { oldest: sorted[0], newest: sorted[sorted.length - 1] }
 }
 ```
 
@@ -3419,31 +3511,31 @@ Still sorts unnecessarily when only min/max are needed.
 
 ```typescript
 function getLatestProject(projects: Project[]) {
-  if (projects.length === 0) return null;
-
-  let latest = projects[0];
-
+  if (projects.length === 0) return null
+  
+  let latest = projects[0]
+  
   for (let i = 1; i < projects.length; i++) {
     if (projects[i].updatedAt > latest.updatedAt) {
-      latest = projects[i];
+      latest = projects[i]
     }
   }
-
-  return latest;
+  
+  return latest
 }
 
 function getOldestAndNewest(projects: Project[]) {
-  if (projects.length === 0) return { oldest: null, newest: null };
-
-  let oldest = projects[0];
-  let newest = projects[0];
-
+  if (projects.length === 0) return { oldest: null, newest: null }
+  
+  let oldest = projects[0]
+  let newest = projects[0]
+  
   for (let i = 1; i < projects.length; i++) {
-    if (projects[i].updatedAt < oldest.updatedAt) oldest = projects[i];
-    if (projects[i].updatedAt > newest.updatedAt) newest = projects[i];
+    if (projects[i].updatedAt < oldest.updatedAt) oldest = projects[i]
+    if (projects[i].updatedAt > newest.updatedAt) newest = projects[i]
   }
-
-  return { oldest, newest };
+  
+  return { oldest, newest }
 }
 ```
 
@@ -3452,9 +3544,9 @@ Single pass through the array, no copying, no sorting.
 **Alternative: Math.min/Math.max for small arrays**
 
 ```typescript
-const numbers = [5, 2, 8, 1, 9];
-const min = Math.min(...numbers);
-const max = Math.max(...numbers);
+const numbers = [5, 2, 8, 1, 9]
+const min = Math.min(...numbers)
+const max = Math.max(...numbers)
 ```
 
 This works for small arrays, but can be slower or just throw an error for very large arrays due to spread operator limitations. Maximal array length is approximately 124000 in Chrome 143 and 638000 in Safari 18; exact numbers may vary - see [the fiddle](https://jsfiddle.net/qw1jabsx/4/). Use the loop approach for reliability.
@@ -3521,7 +3613,7 @@ function UserList({ users }: { users: User[] }) {
 
 ```typescript
 // Fallback for older browsers
-const sorted = [...items].sort((a, b) => a.value - b.value);
+const sorted = [...items].sort((a, b) => a.value - b.value)
 ```
 
 `.toSorted()` is available in all modern browsers (Chrome 110+, Safari 16+, Firefox 115+, Node.js 20+). For older environments, use spread operator:
@@ -3553,24 +3645,21 @@ Effect Event functions do not have a stable identity. Their identity intentional
 **Incorrect: Effect Event added as a dependency**
 
 ```tsx
-import { useEffect, useEffectEvent } from "react";
+import { useEffect, useEffectEvent } from 'react'
 
-function ChatRoom({
-  roomId,
-  onConnected,
-}: {
-  roomId: string;
-  onConnected: () => void;
+function ChatRoom({ roomId, onConnected }: {
+  roomId: string
+  onConnected: () => void
 }) {
-  const handleConnected = useEffectEvent(onConnected);
+  const handleConnected = useEffectEvent(onConnected)
 
   useEffect(() => {
-    const connection = createConnection(roomId);
-    connection.on("connected", handleConnected);
-    connection.connect();
+    const connection = createConnection(roomId)
+    connection.on('connected', handleConnected)
+    connection.connect()
 
-    return () => connection.disconnect();
-  }, [roomId, handleConnected]);
+    return () => connection.disconnect()
+  }, [roomId, handleConnected])
 }
 ```
 
@@ -3579,24 +3668,21 @@ Including the Effect Event in dependencies makes the effect re-run every render 
 **Correct: depend on reactive values, not the Effect Event**
 
 ```tsx
-import { useEffect, useEffectEvent } from "react";
+import { useEffect, useEffectEvent } from 'react'
 
-function ChatRoom({
-  roomId,
-  onConnected,
-}: {
-  roomId: string;
-  onConnected: () => void;
+function ChatRoom({ roomId, onConnected }: {
+  roomId: string
+  onConnected: () => void
 }) {
-  const handleConnected = useEffectEvent(onConnected);
+  const handleConnected = useEffectEvent(onConnected)
 
   useEffect(() => {
-    const connection = createConnection(roomId);
-    connection.on("connected", handleConnected);
-    connection.connect();
+    const connection = createConnection(roomId)
+    connection.on('connected', handleConnected)
+    connection.connect()
 
-    return () => connection.disconnect();
-  }, [roomId]);
+    return () => connection.disconnect()
+  }, [roomId])
 }
 ```
 
@@ -3613,9 +3699,9 @@ Do not put app-wide initialization that must run once per app load inside `useEf
 ```tsx
 function Comp() {
   useEffect(() => {
-    loadFromStorage();
-    checkAuthToken();
-  }, []);
+    loadFromStorage()
+    checkAuthToken()
+  }, [])
 
   // ...
 }
@@ -3624,15 +3710,15 @@ function Comp() {
 **Correct: once per app load**
 
 ```tsx
-let didInit = false;
+let didInit = false
 
 function Comp() {
   useEffect(() => {
-    if (didInit) return;
-    didInit = true;
-    loadFromStorage();
-    checkAuthToken();
-  }, []);
+    if (didInit) return
+    didInit = true
+    loadFromStorage()
+    checkAuthToken()
+  }, [])
 
   // ...
 }
@@ -3651,24 +3737,24 @@ Store callbacks in refs when used in effects that shouldn't re-subscribe on call
 ```tsx
 function useWindowEvent(event: string, handler: (e) => void) {
   useEffect(() => {
-    window.addEventListener(event, handler);
-    return () => window.removeEventListener(event, handler);
-  }, [event, handler]);
+    window.addEventListener(event, handler)
+    return () => window.removeEventListener(event, handler)
+  }, [event, handler])
 }
 ```
 
 **Correct: stable subscription**
 
 ```tsx
-import { useEffectEvent } from "react";
+import { useEffectEvent } from 'react'
 
 function useWindowEvent(event: string, handler: (e) => void) {
-  const onEvent = useEffectEvent(handler);
+  const onEvent = useEffectEvent(handler)
 
   useEffect(() => {
-    window.addEventListener(event, onEvent);
-    return () => window.removeEventListener(event, onEvent);
-  }, [event]);
+    window.addEventListener(event, onEvent)
+    return () => window.removeEventListener(event, onEvent)
+  }, [event])
 }
 ```
 
@@ -3686,28 +3772,28 @@ Access latest values in callbacks without adding them to dependency arrays. Prev
 
 ```tsx
 function SearchInput({ onSearch }: { onSearch: (q: string) => void }) {
-  const [query, setQuery] = useState("");
+  const [query, setQuery] = useState('')
 
   useEffect(() => {
-    const timeout = setTimeout(() => onSearch(query), 300);
-    return () => clearTimeout(timeout);
-  }, [query, onSearch]);
+    const timeout = setTimeout(() => onSearch(query), 300)
+    return () => clearTimeout(timeout)
+  }, [query, onSearch])
 }
 ```
 
 **Correct: using React's useEffectEvent**
 
 ```tsx
-import { useEffectEvent } from "react";
+import { useEffectEvent } from 'react';
 
 function SearchInput({ onSearch }: { onSearch: (q: string) => void }) {
-  const [query, setQuery] = useState("");
-  const onSearchEvent = useEffectEvent(onSearch);
+  const [query, setQuery] = useState('')
+  const onSearchEvent = useEffectEvent(onSearch)
 
   useEffect(() => {
-    const timeout = setTimeout(() => onSearchEvent(query), 300);
-    return () => clearTimeout(timeout);
-  }, [query]);
+    const timeout = setTimeout(() => onSearchEvent(query), 300)
+    return () => clearTimeout(timeout)
+  }, [query])
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/README.md
+++ b/.claude/skills/vercel-react-best-practices/README.md
@@ -10,25 +10,22 @@ A structured repository for creating and maintaining React Best Practices optimi
   - `area-description.md` - Individual rule files
 - `src/` - Build scripts and utilities
 - `metadata.json` - Document metadata (version, organization, abstract)
-- **`AGENTS.md`** - Compiled output (generated)
-- **`test-cases.json`** - Test cases for LLM evaluation (generated)
+- __`AGENTS.md`__ - Compiled output (generated)
+- __`test-cases.json`__ - Test cases for LLM evaluation (generated)
 
 ## Getting Started
 
 1. Install dependencies:
-
    ```bash
    pnpm install
    ```
 
 2. Build AGENTS.md from rules:
-
    ```bash
    pnpm build
    ```
 
 3. Validate rule files:
-
    ```bash
    pnpm validate
    ```
@@ -58,7 +55,7 @@ A structured repository for creating and maintaining React Best Practices optimi
 
 Each rule file should follow this structure:
 
-````markdown
+```markdown
 ---
 title: Rule Title Here
 impact: MEDIUM
@@ -75,7 +72,6 @@ Brief explanation of the rule and why it matters.
 ```typescript
 // Bad code example
 ```
-````
 
 **Correct (description of what's right):**
 

--- a/.claude/skills/vercel-react-best-practices/SKILL.md
+++ b/.claude/skills/vercel-react-best-practices/SKILL.md
@@ -9,12 +9,11 @@ metadata:
 
 # Vercel React Best Practices
 
-Comprehensive performance optimization guide for React and Next.js applications, maintained by Vercel. Contains 69 rules across 8 categories, prioritized by impact to guide automated refactoring and code generation.
+Comprehensive performance optimization guide for React and Next.js applications, maintained by Vercel. Contains 70 rules across 8 categories, prioritized by impact to guide automated refactoring and code generation.
 
 ## When to Apply
 
 Reference these guidelines when:
-
 - Writing new React components or Next.js pages
 - Implementing data fetching (client or server-side)
 - Reviewing code for performance issues
@@ -23,16 +22,16 @@ Reference these guidelines when:
 
 ## Rule Categories by Priority
 
-| Priority | Category                  | Impact      | Prefix       |
-| -------- | ------------------------- | ----------- | ------------ |
-| 1        | Eliminating Waterfalls    | CRITICAL    | `async-`     |
-| 2        | Bundle Size Optimization  | CRITICAL    | `bundle-`    |
-| 3        | Server-Side Performance   | HIGH        | `server-`    |
-| 4        | Client-Side Data Fetching | MEDIUM-HIGH | `client-`    |
-| 5        | Re-render Optimization    | MEDIUM      | `rerender-`  |
-| 6        | Rendering Performance     | MEDIUM      | `rendering-` |
-| 7        | JavaScript Performance    | LOW-MEDIUM  | `js-`        |
-| 8        | Advanced Patterns         | LOW         | `advanced-`  |
+| Priority | Category | Impact | Prefix |
+|----------|----------|--------|--------|
+| 1 | Eliminating Waterfalls | CRITICAL | `async-` |
+| 2 | Bundle Size Optimization | CRITICAL | `bundle-` |
+| 3 | Server-Side Performance | HIGH | `server-` |
+| 4 | Client-Side Data Fetching | MEDIUM-HIGH | `client-` |
+| 5 | Re-render Optimization | MEDIUM | `rerender-` |
+| 6 | Rendering Performance | MEDIUM | `rendering-` |
+| 7 | JavaScript Performance | LOW-MEDIUM | `js-` |
+| 8 | Advanced Patterns | LOW | `advanced-` |
 
 ## Quick Reference
 
@@ -48,6 +47,7 @@ Reference these guidelines when:
 ### 2. Bundle Size Optimization (CRITICAL)
 
 - `bundle-barrel-imports` - Import directly, avoid barrel files
+- `bundle-analyzable-paths` - Prefer statically analyzable import and file-system paths to avoid broad bundles and traces
 - `bundle-dynamic-imports` - Use next/dynamic for heavy components
 - `bundle-defer-third-party` - Load analytics/logging after hydration
 - `bundle-conditional` - Load modules only when feature is activated
@@ -139,7 +139,6 @@ rules/bundle-barrel-imports.md
 ```
 
 Each rule file contains:
-
 - Brief explanation of why it matters
 - Incorrect code example with explanation
 - Correct code example with explanation

--- a/.claude/skills/vercel-react-best-practices/rules/_template.md
+++ b/.claude/skills/vercel-react-best-practices/rules/_template.md
@@ -15,14 +15,14 @@ Brief explanation of the rule and why it matters. This should be clear and conci
 
 ```typescript
 // Bad code example here
-const bad = example();
+const bad = example()
 ```
 
 **Correct (description of what's right):**
 
 ```typescript
 // Good code example here
-const good = example();
+const good = example()
 ```
 
 Reference: [Link to documentation or resource](https://example.com)

--- a/.claude/skills/vercel-react-best-practices/rules/advanced-effect-event-deps.md
+++ b/.claude/skills/vercel-react-best-practices/rules/advanced-effect-event-deps.md
@@ -12,24 +12,21 @@ Effect Event functions do not have a stable identity. Their identity intentional
 **Incorrect (Effect Event added as a dependency):**
 
 ```tsx
-import { useEffect, useEffectEvent } from "react";
+import { useEffect, useEffectEvent } from 'react'
 
-function ChatRoom({
-  roomId,
-  onConnected,
-}: {
-  roomId: string;
-  onConnected: () => void;
+function ChatRoom({ roomId, onConnected }: {
+  roomId: string
+  onConnected: () => void
 }) {
-  const handleConnected = useEffectEvent(onConnected);
+  const handleConnected = useEffectEvent(onConnected)
 
   useEffect(() => {
-    const connection = createConnection(roomId);
-    connection.on("connected", handleConnected);
-    connection.connect();
+    const connection = createConnection(roomId)
+    connection.on('connected', handleConnected)
+    connection.connect()
 
-    return () => connection.disconnect();
-  }, [roomId, handleConnected]);
+    return () => connection.disconnect()
+  }, [roomId, handleConnected])
 }
 ```
 
@@ -38,24 +35,21 @@ Including the Effect Event in dependencies makes the effect re-run every render 
 **Correct (depend on reactive values, not the Effect Event):**
 
 ```tsx
-import { useEffect, useEffectEvent } from "react";
+import { useEffect, useEffectEvent } from 'react'
 
-function ChatRoom({
-  roomId,
-  onConnected,
-}: {
-  roomId: string;
-  onConnected: () => void;
+function ChatRoom({ roomId, onConnected }: {
+  roomId: string
+  onConnected: () => void
 }) {
-  const handleConnected = useEffectEvent(onConnected);
+  const handleConnected = useEffectEvent(onConnected)
 
   useEffect(() => {
-    const connection = createConnection(roomId);
-    connection.on("connected", handleConnected);
-    connection.connect();
+    const connection = createConnection(roomId)
+    connection.on('connected', handleConnected)
+    connection.connect()
 
-    return () => connection.disconnect();
-  }, [roomId]);
+    return () => connection.disconnect()
+  }, [roomId])
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/advanced-event-handler-refs.md
+++ b/.claude/skills/vercel-react-best-practices/rules/advanced-event-handler-refs.md
@@ -14,9 +14,9 @@ Store callbacks in refs when used in effects that shouldn't re-subscribe on call
 ```tsx
 function useWindowEvent(event: string, handler: (e) => void) {
   useEffect(() => {
-    window.addEventListener(event, handler);
-    return () => window.removeEventListener(event, handler);
-  }, [event, handler]);
+    window.addEventListener(event, handler)
+    return () => window.removeEventListener(event, handler)
+  }, [event, handler])
 }
 ```
 
@@ -24,31 +24,31 @@ function useWindowEvent(event: string, handler: (e) => void) {
 
 ```tsx
 function useWindowEvent(event: string, handler: (e) => void) {
-  const handlerRef = useRef(handler);
+  const handlerRef = useRef(handler)
   useEffect(() => {
-    handlerRef.current = handler;
-  }, [handler]);
+    handlerRef.current = handler
+  }, [handler])
 
   useEffect(() => {
-    const listener = (e) => handlerRef.current(e);
-    window.addEventListener(event, listener);
-    return () => window.removeEventListener(event, listener);
-  }, [event]);
+    const listener = (e) => handlerRef.current(e)
+    window.addEventListener(event, listener)
+    return () => window.removeEventListener(event, listener)
+  }, [event])
 }
 ```
 
 **Alternative: use `useEffectEvent` if you're on latest React:**
 
 ```tsx
-import { useEffectEvent } from "react";
+import { useEffectEvent } from 'react'
 
 function useWindowEvent(event: string, handler: (e) => void) {
-  const onEvent = useEffectEvent(handler);
+  const onEvent = useEffectEvent(handler)
 
   useEffect(() => {
-    window.addEventListener(event, onEvent);
-    return () => window.removeEventListener(event, onEvent);
-  }, [event]);
+    window.addEventListener(event, onEvent)
+    return () => window.removeEventListener(event, onEvent)
+  }, [event])
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/advanced-init-once.md
+++ b/.claude/skills/vercel-react-best-practices/rules/advanced-init-once.md
@@ -14,9 +14,9 @@ Do not put app-wide initialization that must run once per app load inside `useEf
 ```tsx
 function Comp() {
   useEffect(() => {
-    loadFromStorage();
-    checkAuthToken();
-  }, []);
+    loadFromStorage()
+    checkAuthToken()
+  }, [])
 
   // ...
 }
@@ -25,15 +25,15 @@ function Comp() {
 **Correct (once per app load):**
 
 ```tsx
-let didInit = false;
+let didInit = false
 
 function Comp() {
   useEffect(() => {
-    if (didInit) return;
-    didInit = true;
-    loadFromStorage();
-    checkAuthToken();
-  }, []);
+    if (didInit) return
+    didInit = true
+    loadFromStorage()
+    checkAuthToken()
+  }, [])
 
   // ...
 }

--- a/.claude/skills/vercel-react-best-practices/rules/advanced-use-latest.md
+++ b/.claude/skills/vercel-react-best-practices/rules/advanced-use-latest.md
@@ -13,27 +13,27 @@ Access latest values in callbacks without adding them to dependency arrays. Prev
 
 ```tsx
 function SearchInput({ onSearch }: { onSearch: (q: string) => void }) {
-  const [query, setQuery] = useState("");
+  const [query, setQuery] = useState('')
 
   useEffect(() => {
-    const timeout = setTimeout(() => onSearch(query), 300);
-    return () => clearTimeout(timeout);
-  }, [query, onSearch]);
+    const timeout = setTimeout(() => onSearch(query), 300)
+    return () => clearTimeout(timeout)
+  }, [query, onSearch])
 }
 ```
 
 **Correct (using React's useEffectEvent):**
 
 ```tsx
-import { useEffectEvent } from "react";
+import { useEffectEvent } from 'react';
 
 function SearchInput({ onSearch }: { onSearch: (q: string) => void }) {
-  const [query, setQuery] = useState("");
-  const onSearchEvent = useEffectEvent(onSearch);
+  const [query, setQuery] = useState('')
+  const onSearchEvent = useEffectEvent(onSearch)
 
   useEffect(() => {
-    const timeout = setTimeout(() => onSearchEvent(query), 300);
-    return () => clearTimeout(timeout);
-  }, [query]);
+    const timeout = setTimeout(() => onSearchEvent(query), 300)
+    return () => clearTimeout(timeout)
+  }, [query])
 }
 ```

--- a/.claude/skills/vercel-react-best-practices/rules/async-api-routes.md
+++ b/.claude/skills/vercel-react-best-practices/rules/async-api-routes.md
@@ -13,10 +13,10 @@ In API routes and Server Actions, start independent operations immediately, even
 
 ```typescript
 export async function GET(request: Request) {
-  const session = await auth();
-  const config = await fetchConfig();
-  const data = await fetchData(session.user.id);
-  return Response.json({ data, config });
+  const session = await auth()
+  const config = await fetchConfig()
+  const data = await fetchData(session.user.id)
+  return Response.json({ data, config })
 }
 ```
 
@@ -24,14 +24,14 @@ export async function GET(request: Request) {
 
 ```typescript
 export async function GET(request: Request) {
-  const sessionPromise = auth();
-  const configPromise = fetchConfig();
-  const session = await sessionPromise;
+  const sessionPromise = auth()
+  const configPromise = fetchConfig()
+  const session = await sessionPromise
   const [config, data] = await Promise.all([
     configPromise,
-    fetchData(session.user.id),
-  ]);
-  return Response.json({ data, config });
+    fetchData(session.user.id)
+  ])
+  return Response.json({ data, config })
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/async-cheap-condition-before-await.md
+++ b/.claude/skills/vercel-react-best-practices/rules/async-cheap-condition-before-await.md
@@ -14,7 +14,7 @@ This is a specialization of [Defer Await Until Needed](./async-defer-await.md) f
 **Incorrect:**
 
 ```typescript
-const someFlag = await getFlag();
+const someFlag = await getFlag()
 
 if (someFlag && someCondition) {
   // ...
@@ -25,7 +25,7 @@ if (someFlag && someCondition) {
 
 ```typescript
 if (someCondition) {
-  const someFlag = await getFlag();
+  const someFlag = await getFlag()
   if (someFlag) {
     // ...
   }

--- a/.claude/skills/vercel-react-best-practices/rules/async-defer-await.md
+++ b/.claude/skills/vercel-react-best-practices/rules/async-defer-await.md
@@ -13,15 +13,15 @@ Move `await` operations into the branches where they're actually used to avoid b
 
 ```typescript
 async function handleRequest(userId: string, skipProcessing: boolean) {
-  const userData = await fetchUserData(userId);
-
+  const userData = await fetchUserData(userId)
+  
   if (skipProcessing) {
     // Returns immediately but still waited for userData
-    return { skipped: true };
+    return { skipped: true }
   }
-
+  
   // Only this branch uses userData
-  return processUserData(userData);
+  return processUserData(userData)
 }
 ```
 
@@ -31,12 +31,12 @@ async function handleRequest(userId: string, skipProcessing: boolean) {
 async function handleRequest(userId: string, skipProcessing: boolean) {
   if (skipProcessing) {
     // Returns immediately without waiting
-    return { skipped: true };
+    return { skipped: true }
   }
-
+  
   // Fetch only when needed
-  const userData = await fetchUserData(userId);
-  return processUserData(userData);
+  const userData = await fetchUserData(userId)
+  return processUserData(userData)
 }
 ```
 
@@ -45,35 +45,35 @@ async function handleRequest(userId: string, skipProcessing: boolean) {
 ```typescript
 // Incorrect: always fetches permissions
 async function updateResource(resourceId: string, userId: string) {
-  const permissions = await fetchPermissions(userId);
-  const resource = await getResource(resourceId);
-
+  const permissions = await fetchPermissions(userId)
+  const resource = await getResource(resourceId)
+  
   if (!resource) {
-    return { error: "Not found" };
+    return { error: 'Not found' }
   }
-
+  
   if (!permissions.canEdit) {
-    return { error: "Forbidden" };
+    return { error: 'Forbidden' }
   }
-
-  return await updateResourceData(resource, permissions);
+  
+  return await updateResourceData(resource, permissions)
 }
 
 // Correct: fetches only when needed
 async function updateResource(resourceId: string, userId: string) {
-  const resource = await getResource(resourceId);
-
+  const resource = await getResource(resourceId)
+  
   if (!resource) {
-    return { error: "Not found" };
+    return { error: 'Not found' }
   }
-
-  const permissions = await fetchPermissions(userId);
-
+  
+  const permissions = await fetchPermissions(userId)
+  
   if (!permissions.canEdit) {
-    return { error: "Forbidden" };
+    return { error: 'Forbidden' }
   }
-
-  return await updateResourceData(resource, permissions);
+  
+  return await updateResourceData(resource, permissions)
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/async-dependencies.md
+++ b/.claude/skills/vercel-react-best-practices/rules/async-dependencies.md
@@ -12,26 +12,25 @@ For operations with partial dependencies, use `better-all` to maximize paralleli
 **Incorrect (profile waits for config unnecessarily):**
 
 ```typescript
-const [user, config] = await Promise.all([fetchUser(), fetchConfig()]);
-const profile = await fetchProfile(user.id);
+const [user, config] = await Promise.all([
+  fetchUser(),
+  fetchConfig()
+])
+const profile = await fetchProfile(user.id)
 ```
 
 **Correct (config and profile run in parallel):**
 
 ```typescript
-import { all } from "better-all";
+import { all } from 'better-all'
 
 const { user, config, profile } = await all({
-  async user() {
-    return fetchUser();
-  },
-  async config() {
-    return fetchConfig();
-  },
+  async user() { return fetchUser() },
+  async config() { return fetchConfig() },
   async profile() {
-    return fetchProfile((await this.$.user).id);
-  },
-});
+    return fetchProfile((await this.$.user).id)
+  }
+})
 ```
 
 **Alternative without extra dependencies:**
@@ -39,14 +38,14 @@ const { user, config, profile } = await all({
 We can also create all the promises first, and do `Promise.all()` at the end.
 
 ```typescript
-const userPromise = fetchUser();
-const profilePromise = userPromise.then((user) => fetchProfile(user.id));
+const userPromise = fetchUser()
+const profilePromise = userPromise.then(user => fetchProfile(user.id))
 
 const [user, config, profile] = await Promise.all([
   userPromise,
   fetchConfig(),
-  profilePromise,
-]);
+  profilePromise
+])
 ```
 
 Reference: [https://github.com/shuding/better-all](https://github.com/shuding/better-all)

--- a/.claude/skills/vercel-react-best-practices/rules/async-parallel.md
+++ b/.claude/skills/vercel-react-best-practices/rules/async-parallel.md
@@ -12,9 +12,9 @@ When async operations have no interdependencies, execute them concurrently using
 **Incorrect (sequential execution, 3 round trips):**
 
 ```typescript
-const user = await fetchUser();
-const posts = await fetchPosts();
-const comments = await fetchComments();
+const user = await fetchUser()
+const posts = await fetchPosts()
+const comments = await fetchComments()
 ```
 
 **Correct (parallel execution, 1 round trip):**
@@ -23,6 +23,6 @@ const comments = await fetchComments();
 const [user, posts, comments] = await Promise.all([
   fetchUser(),
   fetchPosts(),
-  fetchComments(),
-]);
+  fetchComments()
+])
 ```

--- a/.claude/skills/vercel-react-best-practices/rules/async-suspense-boundaries.md
+++ b/.claude/skills/vercel-react-best-practices/rules/async-suspense-boundaries.md
@@ -13,8 +13,8 @@ Instead of awaiting data in async components before returning JSX, use Suspense 
 
 ```tsx
 async function Page() {
-  const data = await fetchData(); // Blocks entire page
-
+  const data = await fetchData() // Blocks entire page
+  
   return (
     <div>
       <div>Sidebar</div>
@@ -24,7 +24,7 @@ async function Page() {
       </div>
       <div>Footer</div>
     </div>
-  );
+  )
 }
 ```
 
@@ -45,12 +45,12 @@ function Page() {
       </div>
       <div>Footer</div>
     </div>
-  );
+  )
 }
 
 async function DataDisplay() {
-  const data = await fetchData(); // Only blocks this component
-  return <div>{data.content}</div>;
+  const data = await fetchData() // Only blocks this component
+  return <div>{data.content}</div>
 }
 ```
 
@@ -61,8 +61,8 @@ Sidebar, Header, and Footer render immediately. Only DataDisplay waits for data.
 ```tsx
 function Page() {
   // Start fetch immediately, but don't await
-  const dataPromise = fetchData();
-
+  const dataPromise = fetchData()
+  
   return (
     <div>
       <div>Sidebar</div>
@@ -73,17 +73,17 @@ function Page() {
       </Suspense>
       <div>Footer</div>
     </div>
-  );
+  )
 }
 
 function DataDisplay({ dataPromise }: { dataPromise: Promise<Data> }) {
-  const data = use(dataPromise); // Unwraps the promise
-  return <div>{data.content}</div>;
+  const data = use(dataPromise) // Unwraps the promise
+  return <div>{data.content}</div>
 }
 
 function DataSummary({ dataPromise }: { dataPromise: Promise<Data> }) {
-  const data = use(dataPromise); // Reuses the same promise
-  return <div>{data.summary}</div>;
+  const data = use(dataPromise) // Reuses the same promise
+  return <div>{data.summary}</div>
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/bundle-analyzable-paths.md
+++ b/.claude/skills/vercel-react-best-practices/rules/bundle-analyzable-paths.md
@@ -1,0 +1,63 @@
+---
+title: Prefer Statically Analyzable Paths
+impact: HIGH
+impactDescription: avoids accidental broad bundles and file traces
+tags: bundle, nextjs, vite, webpack, rollup, esbuild, path
+---
+
+## Prefer Statically Analyzable Paths
+
+Build tools work best when import and file-system paths are obvious at build time. If you hide the real path inside a variable or compose it too dynamically, the tool either has to include a broad set of possible files, warn that it cannot analyze the import, or widen file tracing to stay safe.
+
+Prefer explicit maps or literal paths so the set of reachable files stays narrow and predictable. This is the same rule whether you are choosing modules with `import()` or reading files in server/build code.
+
+When analysis becomes too broad, the cost is real:
+- Larger server bundles
+- Slower builds
+- Worse cold starts
+- More memory use
+
+### Import Paths
+
+**Incorrect (the bundler cannot tell what may be imported):**
+
+```ts
+const PAGE_MODULES = {
+  home: './pages/home',
+  settings: './pages/settings',
+} as const
+
+const Page = await import(PAGE_MODULES[pageName])
+```
+
+**Correct (use an explicit map of allowed modules):**
+
+```ts
+const PAGE_MODULES = {
+  home: () => import('./pages/home'),
+  settings: () => import('./pages/settings'),
+} as const
+
+const Page = await PAGE_MODULES[pageName]()
+```
+
+### File-System Paths
+
+**Incorrect (a 2-value enum still hides the final path from static analysis):**
+
+```ts
+const baseDir = path.join(process.cwd(), 'content/' + contentKind)
+```
+
+**Correct (make each final path literal at the callsite):**
+
+```ts
+const baseDir =
+  kind === ContentKind.Blog
+    ? path.join(process.cwd(), 'content/blog')
+    : path.join(process.cwd(), 'content/docs')
+```
+
+In Next.js server code, this matters for output file tracing too. `path.join(process.cwd(), someVar)` can widen the traced file set because Next.js statically analyze `import`, `require`, and `fs` usage.
+
+Reference: [Next.js output](https://nextjs.org/docs/app/api-reference/config/next-config-js/output), [Next.js dynamic imports](https://nextjs.org/learn/seo/dynamic-imports), [Vite features](https://vite.dev/guide/features.html), [esbuild API](https://esbuild.github.io/api/), [Rollup dynamic import vars](https://www.npmjs.com/package/@rollup/plugin-dynamic-import-vars), [Webpack dependency management](https://webpack.js.org/guides/dependency-management/)

--- a/.claude/skills/vercel-react-best-practices/rules/bundle-barrel-imports.md
+++ b/.claude/skills/vercel-react-best-practices/rules/bundle-barrel-imports.md
@@ -16,11 +16,11 @@ Popular icon and component libraries can have **up to 10,000 re-exports** in the
 **Incorrect (imports entire library):**
 
 ```tsx
-import { Check, X, Menu } from "lucide-react";
+import { Check, X, Menu } from 'lucide-react'
 // Loads 1,583 modules, takes ~2.8s extra in dev
 // Runtime cost: 200-800ms on every cold start
 
-import { Button, TextField } from "@mui/material";
+import { Button, TextField } from '@mui/material'
 // Loads 2,225 modules, takes ~4.2s extra in dev
 ```
 
@@ -30,14 +30,14 @@ import { Button, TextField } from "@mui/material";
 // next.config.js - automatically optimizes barrel imports at build time
 module.exports = {
   experimental: {
-    optimizePackageImports: ["lucide-react", "@mui/material"],
-  },
-};
+    optimizePackageImports: ['lucide-react', '@mui/material']
+  }
+}
 ```
 
 ```tsx
 // Keep the standard imports - Next.js transforms them to direct imports
-import { Check, X, Menu } from "lucide-react";
+import { Check, X, Menu } from 'lucide-react'
 // Full TypeScript support, no manual path wrangling
 ```
 
@@ -46,8 +46,8 @@ This is the recommended approach because it preserves TypeScript type safety and
 **Correct - Direct imports (non-Next.js projects):**
 
 ```tsx
-import Button from "@mui/material/Button";
-import TextField from "@mui/material/TextField";
+import Button from '@mui/material/Button'
+import TextField from '@mui/material/TextField'
 // Loads only what you use
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/bundle-conditional.md
+++ b/.claude/skills/vercel-react-best-practices/rules/bundle-conditional.md
@@ -12,25 +12,19 @@ Load large data or modules only when a feature is activated.
 **Example (lazy-load animation frames):**
 
 ```tsx
-function AnimationPlayer({
-  enabled,
-  setEnabled,
-}: {
-  enabled: boolean;
-  setEnabled: React.Dispatch<React.SetStateAction<boolean>>;
-}) {
-  const [frames, setFrames] = useState<Frame[] | null>(null);
+function AnimationPlayer({ enabled, setEnabled }: { enabled: boolean; setEnabled: React.Dispatch<React.SetStateAction<boolean>> }) {
+  const [frames, setFrames] = useState<Frame[] | null>(null)
 
   useEffect(() => {
-    if (enabled && !frames && typeof window !== "undefined") {
-      import("./animation-frames.js")
-        .then((mod) => setFrames(mod.frames))
-        .catch(() => setEnabled(false));
+    if (enabled && !frames && typeof window !== 'undefined') {
+      import('./animation-frames.js')
+        .then(mod => setFrames(mod.frames))
+        .catch(() => setEnabled(false))
     }
-  }, [enabled, frames, setEnabled]);
+  }, [enabled, frames, setEnabled])
 
-  if (!frames) return <Skeleton />;
-  return <Canvas frames={frames} />;
+  if (!frames) return <Skeleton />
+  return <Canvas frames={frames} />
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/bundle-defer-third-party.md
+++ b/.claude/skills/vercel-react-best-practices/rules/bundle-defer-third-party.md
@@ -12,7 +12,7 @@ Analytics, logging, and error tracking don't block user interaction. Load them a
 **Incorrect (blocks initial bundle):**
 
 ```tsx
-import { Analytics } from "@vercel/analytics/react";
+import { Analytics } from '@vercel/analytics/react'
 
 export default function RootLayout({ children }) {
   return (
@@ -22,19 +22,19 @@ export default function RootLayout({ children }) {
         <Analytics />
       </body>
     </html>
-  );
+  )
 }
 ```
 
 **Correct (loads after hydration):**
 
 ```tsx
-import dynamic from "next/dynamic";
+import dynamic from 'next/dynamic'
 
 const Analytics = dynamic(
-  () => import("@vercel/analytics/react").then((m) => m.Analytics),
-  { ssr: false },
-);
+  () => import('@vercel/analytics/react').then(m => m.Analytics),
+  { ssr: false }
+)
 
 export default function RootLayout({ children }) {
   return (
@@ -44,6 +44,6 @@ export default function RootLayout({ children }) {
         <Analytics />
       </body>
     </html>
-  );
+  )
 }
 ```

--- a/.claude/skills/vercel-react-best-practices/rules/bundle-dynamic-imports.md
+++ b/.claude/skills/vercel-react-best-practices/rules/bundle-dynamic-imports.md
@@ -12,24 +12,24 @@ Use `next/dynamic` to lazy-load large components not needed on initial render.
 **Incorrect (Monaco bundles with main chunk ~300KB):**
 
 ```tsx
-import { MonacoEditor } from "./monaco-editor";
+import { MonacoEditor } from './monaco-editor'
 
 function CodePanel({ code }: { code: string }) {
-  return <MonacoEditor value={code} />;
+  return <MonacoEditor value={code} />
 }
 ```
 
 **Correct (Monaco loads on demand):**
 
 ```tsx
-import dynamic from "next/dynamic";
+import dynamic from 'next/dynamic'
 
 const MonacoEditor = dynamic(
-  () => import("./monaco-editor").then((m) => m.MonacoEditor),
-  { ssr: false },
-);
+  () => import('./monaco-editor').then(m => m.MonacoEditor),
+  { ssr: false }
+)
 
 function CodePanel({ code }: { code: string }) {
-  return <MonacoEditor value={code} />;
+  return <MonacoEditor value={code} />
 }
 ```

--- a/.claude/skills/vercel-react-best-practices/rules/bundle-preload.md
+++ b/.claude/skills/vercel-react-best-practices/rules/bundle-preload.md
@@ -14,16 +14,20 @@ Preload heavy bundles before they're needed to reduce perceived latency.
 ```tsx
 function EditorButton({ onClick }: { onClick: () => void }) {
   const preload = () => {
-    if (typeof window !== "undefined") {
-      void import("./monaco-editor");
+    if (typeof window !== 'undefined') {
+      void import('./monaco-editor')
     }
-  };
+  }
 
   return (
-    <button onMouseEnter={preload} onFocus={preload} onClick={onClick}>
+    <button
+      onMouseEnter={preload}
+      onFocus={preload}
+      onClick={onClick}
+    >
       Open Editor
     </button>
-  );
+  )
 }
 ```
 
@@ -32,14 +36,14 @@ function EditorButton({ onClick }: { onClick: () => void }) {
 ```tsx
 function FlagsProvider({ children, flags }: Props) {
   useEffect(() => {
-    if (flags.editorEnabled && typeof window !== "undefined") {
-      void import("./monaco-editor").then((mod) => mod.init());
+    if (flags.editorEnabled && typeof window !== 'undefined') {
+      void import('./monaco-editor').then(mod => mod.init())
     }
-  }, [flags.editorEnabled]);
+  }, [flags.editorEnabled])
 
-  return (
-    <FlagsContext.Provider value={flags}>{children}</FlagsContext.Provider>
-  );
+  return <FlagsContext.Provider value={flags}>
+    {children}
+  </FlagsContext.Provider>
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/client-event-listeners.md
+++ b/.claude/skills/vercel-react-best-practices/rules/client-event-listeners.md
@@ -16,12 +16,12 @@ function useKeyboardShortcut(key: string, callback: () => void) {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.metaKey && e.key === key) {
-        callback();
+        callback()
       }
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [key, callback]);
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [key, callback])
 }
 ```
 
@@ -30,49 +30,45 @@ When using the `useKeyboardShortcut` hook multiple times, each instance will reg
 **Correct (N instances = 1 listener):**
 
 ```tsx
-import useSWRSubscription from "swr/subscription";
+import useSWRSubscription from 'swr/subscription'
 
 // Module-level Map to track callbacks per key
-const keyCallbacks = new Map<string, Set<() => void>>();
+const keyCallbacks = new Map<string, Set<() => void>>()
 
 function useKeyboardShortcut(key: string, callback: () => void) {
   // Register this callback in the Map
   useEffect(() => {
     if (!keyCallbacks.has(key)) {
-      keyCallbacks.set(key, new Set());
+      keyCallbacks.set(key, new Set())
     }
-    keyCallbacks.get(key)!.add(callback);
+    keyCallbacks.get(key)!.add(callback)
 
     return () => {
-      const set = keyCallbacks.get(key);
+      const set = keyCallbacks.get(key)
       if (set) {
-        set.delete(callback);
+        set.delete(callback)
         if (set.size === 0) {
-          keyCallbacks.delete(key);
+          keyCallbacks.delete(key)
         }
       }
-    };
-  }, [key, callback]);
+    }
+  }, [key, callback])
 
-  useSWRSubscription("global-keydown", () => {
+  useSWRSubscription('global-keydown', () => {
     const handler = (e: KeyboardEvent) => {
       if (e.metaKey && keyCallbacks.has(e.key)) {
-        keyCallbacks.get(e.key)!.forEach((cb) => cb());
+        keyCallbacks.get(e.key)!.forEach(cb => cb())
       }
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  });
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  })
 }
 
 function Profile() {
   // Multiple shortcuts will share the same listener
-  useKeyboardShortcut("p", () => {
-    /* ... */
-  });
-  useKeyboardShortcut("k", () => {
-    /* ... */
-  });
+  useKeyboardShortcut('p', () => { /* ... */ }) 
+  useKeyboardShortcut('k', () => { /* ... */ })
   // ...
 }
 ```

--- a/.claude/skills/vercel-react-best-practices/rules/client-localstorage-schema.md
+++ b/.claude/skills/vercel-react-best-practices/rules/client-localstorage-schema.md
@@ -13,18 +13,18 @@ Add version prefix to keys and store only needed fields. Prevents schema conflic
 
 ```typescript
 // No version, stores everything, no error handling
-localStorage.setItem("userConfig", JSON.stringify(fullUserObject));
-const data = localStorage.getItem("userConfig");
+localStorage.setItem('userConfig', JSON.stringify(fullUserObject))
+const data = localStorage.getItem('userConfig')
 ```
 
 **Correct:**
 
 ```typescript
-const VERSION = "v2";
+const VERSION = 'v2'
 
 function saveConfig(config: { theme: string; language: string }) {
   try {
-    localStorage.setItem(`userConfig:${VERSION}`, JSON.stringify(config));
+    localStorage.setItem(`userConfig:${VERSION}`, JSON.stringify(config))
   } catch {
     // Throws in incognito/private browsing, quota exceeded, or disabled
   }
@@ -32,24 +32,21 @@ function saveConfig(config: { theme: string; language: string }) {
 
 function loadConfig() {
   try {
-    const data = localStorage.getItem(`userConfig:${VERSION}`);
-    return data ? JSON.parse(data) : null;
+    const data = localStorage.getItem(`userConfig:${VERSION}`)
+    return data ? JSON.parse(data) : null
   } catch {
-    return null;
+    return null
   }
 }
 
 // Migration from v1 to v2
 function migrate() {
   try {
-    const v1 = localStorage.getItem("userConfig:v1");
+    const v1 = localStorage.getItem('userConfig:v1')
     if (v1) {
-      const old = JSON.parse(v1);
-      saveConfig({
-        theme: old.darkMode ? "dark" : "light",
-        language: old.lang,
-      });
-      localStorage.removeItem("userConfig:v1");
+      const old = JSON.parse(v1)
+      saveConfig({ theme: old.darkMode ? 'dark' : 'light', language: old.lang })
+      localStorage.removeItem('userConfig:v1')
     }
   } catch {}
 }
@@ -61,13 +58,10 @@ function migrate() {
 // User object has 20+ fields, only store what UI needs
 function cachePrefs(user: FullUser) {
   try {
-    localStorage.setItem(
-      "prefs:v1",
-      JSON.stringify({
-        theme: user.preferences.theme,
-        notifications: user.preferences.notifications,
-      }),
-    );
+    localStorage.setItem('prefs:v1', JSON.stringify({
+      theme: user.preferences.theme,
+      notifications: user.preferences.notifications
+    }))
   } catch {}
 }
 ```

--- a/.claude/skills/vercel-react-best-practices/rules/client-passive-event-listeners.md
+++ b/.claude/skills/vercel-react-best-practices/rules/client-passive-event-listeners.md
@@ -13,34 +13,34 @@ Add `{ passive: true }` to touch and wheel event listeners to enable immediate s
 
 ```typescript
 useEffect(() => {
-  const handleTouch = (e: TouchEvent) => console.log(e.touches[0].clientX);
-  const handleWheel = (e: WheelEvent) => console.log(e.deltaY);
-
-  document.addEventListener("touchstart", handleTouch);
-  document.addEventListener("wheel", handleWheel);
-
+  const handleTouch = (e: TouchEvent) => console.log(e.touches[0].clientX)
+  const handleWheel = (e: WheelEvent) => console.log(e.deltaY)
+  
+  document.addEventListener('touchstart', handleTouch)
+  document.addEventListener('wheel', handleWheel)
+  
   return () => {
-    document.removeEventListener("touchstart", handleTouch);
-    document.removeEventListener("wheel", handleWheel);
-  };
-}, []);
+    document.removeEventListener('touchstart', handleTouch)
+    document.removeEventListener('wheel', handleWheel)
+  }
+}, [])
 ```
 
 **Correct:**
 
 ```typescript
 useEffect(() => {
-  const handleTouch = (e: TouchEvent) => console.log(e.touches[0].clientX);
-  const handleWheel = (e: WheelEvent) => console.log(e.deltaY);
-
-  document.addEventListener("touchstart", handleTouch, { passive: true });
-  document.addEventListener("wheel", handleWheel, { passive: true });
-
+  const handleTouch = (e: TouchEvent) => console.log(e.touches[0].clientX)
+  const handleWheel = (e: WheelEvent) => console.log(e.deltaY)
+  
+  document.addEventListener('touchstart', handleTouch, { passive: true })
+  document.addEventListener('wheel', handleWheel, { passive: true })
+  
   return () => {
-    document.removeEventListener("touchstart", handleTouch);
-    document.removeEventListener("wheel", handleWheel);
-  };
-}, []);
+    document.removeEventListener('touchstart', handleTouch)
+    document.removeEventListener('wheel', handleWheel)
+  }
+}, [])
 ```
 
 **Use passive when:** tracking/analytics, logging, any listener that doesn't call `preventDefault()`.

--- a/.claude/skills/vercel-react-best-practices/rules/client-swr-dedup.md
+++ b/.claude/skills/vercel-react-best-practices/rules/client-swr-dedup.md
@@ -13,43 +13,43 @@ SWR enables request deduplication, caching, and revalidation across component in
 
 ```tsx
 function UserList() {
-  const [users, setUsers] = useState([]);
+  const [users, setUsers] = useState([])
   useEffect(() => {
-    fetch("/api/users")
-      .then((r) => r.json())
-      .then(setUsers);
-  }, []);
+    fetch('/api/users')
+      .then(r => r.json())
+      .then(setUsers)
+  }, [])
 }
 ```
 
 **Correct (multiple instances share one request):**
 
 ```tsx
-import useSWR from "swr";
+import useSWR from 'swr'
 
 function UserList() {
-  const { data: users } = useSWR("/api/users", fetcher);
+  const { data: users } = useSWR('/api/users', fetcher)
 }
 ```
 
 **For immutable data:**
 
 ```tsx
-import { useImmutableSWR } from "@/lib/swr";
+import { useImmutableSWR } from '@/lib/swr'
 
 function StaticContent() {
-  const { data } = useImmutableSWR("/api/config", fetcher);
+  const { data } = useImmutableSWR('/api/config', fetcher)
 }
 ```
 
 **For mutations:**
 
 ```tsx
-import { useSWRMutation } from "swr/mutation";
+import { useSWRMutation } from 'swr/mutation'
 
 function UpdateButton() {
-  const { trigger } = useSWRMutation("/api/user", updateUser);
-  return <button onClick={() => trigger()}>Update</button>;
+  const { trigger } = useSWRMutation('/api/user', updateUser)
+  return <button onClick={() => trigger()}>Update</button>
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/js-batch-dom-css.md
+++ b/.claude/skills/vercel-react-best-practices/rules/js-batch-dom-css.md
@@ -10,60 +10,55 @@ tags: javascript, dom, css, performance, reflow, layout-thrashing
 Avoid interleaving style writes with layout reads. When you read a layout property (like `offsetWidth`, `getBoundingClientRect()`, or `getComputedStyle()`) between style changes, the browser is forced to trigger a synchronous reflow.
 
 **This is OK (browser batches style changes):**
-
 ```typescript
 function updateElementStyles(element: HTMLElement) {
   // Each line invalidates style, but browser batches the recalculation
-  element.style.width = "100px";
-  element.style.height = "200px";
-  element.style.backgroundColor = "blue";
-  element.style.border = "1px solid black";
+  element.style.width = '100px'
+  element.style.height = '200px'
+  element.style.backgroundColor = 'blue'
+  element.style.border = '1px solid black'
 }
 ```
 
 **Incorrect (interleaved reads and writes force reflows):**
-
 ```typescript
 function layoutThrashing(element: HTMLElement) {
-  element.style.width = "100px";
-  const width = element.offsetWidth; // Forces reflow
-  element.style.height = "200px";
-  const height = element.offsetHeight; // Forces another reflow
+  element.style.width = '100px'
+  const width = element.offsetWidth  // Forces reflow
+  element.style.height = '200px'
+  const height = element.offsetHeight  // Forces another reflow
 }
 ```
 
 **Correct (batch writes, then read once):**
-
 ```typescript
 function updateElementStyles(element: HTMLElement) {
   // Batch all writes together
-  element.style.width = "100px";
-  element.style.height = "200px";
-  element.style.backgroundColor = "blue";
-  element.style.border = "1px solid black";
-
+  element.style.width = '100px'
+  element.style.height = '200px'
+  element.style.backgroundColor = 'blue'
+  element.style.border = '1px solid black'
+  
   // Read after all writes are done (single reflow)
-  const { width, height } = element.getBoundingClientRect();
+  const { width, height } = element.getBoundingClientRect()
 }
 ```
 
 **Correct (batch reads, then writes):**
-
 ```typescript
 function avoidThrashing(element: HTMLElement) {
   // Read phase - all layout queries first
-  const rect1 = element.getBoundingClientRect();
-  const offsetWidth = element.offsetWidth;
-  const offsetHeight = element.offsetHeight;
-
+  const rect1 = element.getBoundingClientRect()
+  const offsetWidth = element.offsetWidth
+  const offsetHeight = element.offsetHeight
+  
   // Write phase - all style changes after
-  element.style.width = "100px";
-  element.style.height = "200px";
+  element.style.width = '100px'
+  element.style.height = '200px'
 }
 ```
 
 **Better: use CSS classes**
-
 ```css
 .highlighted-box {
   width: 100px;
@@ -72,36 +67,38 @@ function avoidThrashing(element: HTMLElement) {
   border: 1px solid black;
 }
 ```
-
 ```typescript
 function updateElementStyles(element: HTMLElement) {
-  element.classList.add("highlighted-box");
-
-  const { width, height } = element.getBoundingClientRect();
+  element.classList.add('highlighted-box')
+  
+  const { width, height } = element.getBoundingClientRect()
 }
 ```
 
 **React example:**
-
 ```tsx
 // Incorrect: interleaving style changes with layout queries
 function Box({ isHighlighted }: { isHighlighted: boolean }) {
-  const ref = useRef<HTMLDivElement>(null);
-
+  const ref = useRef<HTMLDivElement>(null)
+  
   useEffect(() => {
     if (ref.current && isHighlighted) {
-      ref.current.style.width = "100px";
-      const width = ref.current.offsetWidth; // Forces layout
-      ref.current.style.height = "200px";
+      ref.current.style.width = '100px'
+      const width = ref.current.offsetWidth // Forces layout
+      ref.current.style.height = '200px'
     }
-  }, [isHighlighted]);
-
-  return <div ref={ref}>Content</div>;
+  }, [isHighlighted])
+  
+  return <div ref={ref}>Content</div>
 }
 
 // Correct: toggle class
 function Box({ isHighlighted }: { isHighlighted: boolean }) {
-  return <div className={isHighlighted ? "highlighted-box" : ""}>Content</div>;
+  return (
+    <div className={isHighlighted ? 'highlighted-box' : ''}>
+      Content
+    </div>
+  )
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/js-cache-function-results.md
+++ b/.claude/skills/vercel-react-best-practices/rules/js-cache-function-results.md
@@ -18,7 +18,7 @@ function ProjectList({ projects }: { projects: Project[] }) {
       {projects.map(project => {
         // slugify() called 100+ times for same project names
         const slug = slugify(project.name)
-
+        
         return <ProjectCard key={project.id} slug={slug} />
       })}
     </div>
@@ -47,7 +47,7 @@ function ProjectList({ projects }: { projects: Project[] }) {
       {projects.map(project => {
         // Computed only once per unique project name
         const slug = cachedSlugify(project.name)
-
+        
         return <ProjectCard key={project.id} slug={slug} />
       })}
     </div>
@@ -58,20 +58,20 @@ function ProjectList({ projects }: { projects: Project[] }) {
 **Simpler pattern for single-value functions:**
 
 ```typescript
-let isLoggedInCache: boolean | null = null;
+let isLoggedInCache: boolean | null = null
 
 function isLoggedIn(): boolean {
   if (isLoggedInCache !== null) {
-    return isLoggedInCache;
+    return isLoggedInCache
   }
-
-  isLoggedInCache = document.cookie.includes("auth=");
-  return isLoggedInCache;
+  
+  isLoggedInCache = document.cookie.includes('auth=')
+  return isLoggedInCache
 }
 
 // Clear cache when auth changes
 function onAuthChange() {
-  isLoggedInCache = null;
+  isLoggedInCache = null
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/js-cache-property-access.md
+++ b/.claude/skills/vercel-react-best-practices/rules/js-cache-property-access.md
@@ -13,16 +13,16 @@ Cache object property lookups in hot paths.
 
 ```typescript
 for (let i = 0; i < arr.length; i++) {
-  process(obj.config.settings.value);
+  process(obj.config.settings.value)
 }
 ```
 
 **Correct (1 lookup total):**
 
 ```typescript
-const value = obj.config.settings.value;
-const len = arr.length;
+const value = obj.config.settings.value
+const len = arr.length
 for (let i = 0; i < len; i++) {
-  process(value);
+  process(value)
 }
 ```

--- a/.claude/skills/vercel-react-best-practices/rules/js-cache-storage.md
+++ b/.claude/skills/vercel-react-best-practices/rules/js-cache-storage.md
@@ -13,7 +13,7 @@ tags: javascript, localStorage, storage, caching, performance
 
 ```typescript
 function getTheme() {
-  return localStorage.getItem("theme") ?? "light";
+  return localStorage.getItem('theme') ?? 'light'
 }
 // Called 10 times = 10 storage reads
 ```
@@ -21,18 +21,18 @@ function getTheme() {
 **Correct (Map cache):**
 
 ```typescript
-const storageCache = new Map<string, string | null>();
+const storageCache = new Map<string, string | null>()
 
 function getLocalStorage(key: string) {
   if (!storageCache.has(key)) {
-    storageCache.set(key, localStorage.getItem(key));
+    storageCache.set(key, localStorage.getItem(key))
   }
-  return storageCache.get(key);
+  return storageCache.get(key)
 }
 
 function setLocalStorage(key: string, value: string) {
-  localStorage.setItem(key, value);
-  storageCache.set(key, value); // keep cache in sync
+  localStorage.setItem(key, value)
+  storageCache.set(key, value)  // keep cache in sync
 }
 ```
 
@@ -41,15 +41,15 @@ Use a Map (not a hook) so it works everywhere: utilities, event handlers, not ju
 **Cookie caching:**
 
 ```typescript
-let cookieCache: Record<string, string> | null = null;
+let cookieCache: Record<string, string> | null = null
 
 function getCookie(name: string) {
   if (!cookieCache) {
     cookieCache = Object.fromEntries(
-      document.cookie.split("; ").map((c) => c.split("=")),
-    );
+      document.cookie.split('; ').map(c => c.split('='))
+    )
   }
-  return cookieCache[name];
+  return cookieCache[name]
 }
 ```
 
@@ -58,13 +58,13 @@ function getCookie(name: string) {
 If storage can change externally (another tab, server-set cookies), invalidate cache:
 
 ```typescript
-window.addEventListener("storage", (e) => {
-  if (e.key) storageCache.delete(e.key);
-});
+window.addEventListener('storage', (e) => {
+  if (e.key) storageCache.delete(e.key)
+})
 
-document.addEventListener("visibilitychange", () => {
-  if (document.visibilityState === "visible") {
-    storageCache.clear();
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') {
+    storageCache.clear()
   }
-});
+})
 ```

--- a/.claude/skills/vercel-react-best-practices/rules/js-combine-iterations.md
+++ b/.claude/skills/vercel-react-best-practices/rules/js-combine-iterations.md
@@ -12,21 +12,21 @@ Multiple `.filter()` or `.map()` calls iterate the array multiple times. Combine
 **Incorrect (3 iterations):**
 
 ```typescript
-const admins = users.filter((u) => u.isAdmin);
-const testers = users.filter((u) => u.isTester);
-const inactive = users.filter((u) => !u.isActive);
+const admins = users.filter(u => u.isAdmin)
+const testers = users.filter(u => u.isTester)
+const inactive = users.filter(u => !u.isActive)
 ```
 
 **Correct (1 iteration):**
 
 ```typescript
-const admins: User[] = [];
-const testers: User[] = [];
-const inactive: User[] = [];
+const admins: User[] = []
+const testers: User[] = []
+const inactive: User[] = []
 
 for (const user of users) {
-  if (user.isAdmin) admins.push(user);
-  if (user.isTester) testers.push(user);
-  if (!user.isActive) inactive.push(user);
+  if (user.isAdmin) admins.push(user)
+  if (user.isTester) testers.push(user)
+  if (!user.isActive) inactive.push(user)
 }
 ```

--- a/.claude/skills/vercel-react-best-practices/rules/js-early-exit.md
+++ b/.claude/skills/vercel-react-best-practices/rules/js-early-exit.md
@@ -13,22 +13,22 @@ Return early when result is determined to skip unnecessary processing.
 
 ```typescript
 function validateUsers(users: User[]) {
-  let hasError = false;
-  let errorMessage = "";
-
+  let hasError = false
+  let errorMessage = ''
+  
   for (const user of users) {
     if (!user.email) {
-      hasError = true;
-      errorMessage = "Email required";
+      hasError = true
+      errorMessage = 'Email required'
     }
     if (!user.name) {
-      hasError = true;
-      errorMessage = "Name required";
+      hasError = true
+      errorMessage = 'Name required'
     }
     // Continues checking all users even after error found
   }
-
-  return hasError ? { valid: false, error: errorMessage } : { valid: true };
+  
+  return hasError ? { valid: false, error: errorMessage } : { valid: true }
 }
 ```
 
@@ -38,13 +38,13 @@ function validateUsers(users: User[]) {
 function validateUsers(users: User[]) {
   for (const user of users) {
     if (!user.email) {
-      return { valid: false, error: "Email required" };
+      return { valid: false, error: 'Email required' }
     }
     if (!user.name) {
-      return { valid: false, error: "Name required" };
+      return { valid: false, error: 'Name required' }
     }
   }
 
-  return { valid: true };
+  return { valid: true }
 }
 ```

--- a/.claude/skills/vercel-react-best-practices/rules/js-flatmap-filter.md
+++ b/.claude/skills/vercel-react-best-practices/rules/js-flatmap-filter.md
@@ -15,14 +15,16 @@ Chaining `.map().filter(Boolean)` creates an intermediate array and iterates twi
 
 ```typescript
 const userNames = users
-  .map((user) => (user.isActive ? user.name : null))
-  .filter(Boolean);
+  .map(user => user.isActive ? user.name : null)
+  .filter(Boolean)
 ```
 
 **Correct (1 iteration, no intermediate array):**
 
 ```typescript
-const userNames = users.flatMap((user) => (user.isActive ? [user.name] : []));
+const userNames = users.flatMap(user =>
+  user.isActive ? [user.name] : []
+)
 ```
 
 **More examples:**
@@ -31,25 +33,28 @@ const userNames = users.flatMap((user) => (user.isActive ? [user.name] : []));
 // Extract valid emails from responses
 // Before
 const emails = responses
-  .map((r) => (r.success ? r.data.email : null))
-  .filter(Boolean);
+  .map(r => r.success ? r.data.email : null)
+  .filter(Boolean)
 
 // After
-const emails = responses.flatMap((r) => (r.success ? [r.data.email] : []));
+const emails = responses.flatMap(r =>
+  r.success ? [r.data.email] : []
+)
 
 // Parse and filter valid numbers
 // Before
-const numbers = strings.map((s) => parseInt(s, 10)).filter((n) => !isNaN(n));
+const numbers = strings
+  .map(s => parseInt(s, 10))
+  .filter(n => !isNaN(n))
 
 // After
-const numbers = strings.flatMap((s) => {
-  const n = parseInt(s, 10);
-  return isNaN(n) ? [] : [n];
-});
+const numbers = strings.flatMap(s => {
+  const n = parseInt(s, 10)
+  return isNaN(n) ? [] : [n]
+})
 ```
 
 **When to use:**
-
 - Transforming items while filtering some out
 - Conditional mapping where some inputs produce no output
 - Parsing/validating where invalid inputs should be skipped

--- a/.claude/skills/vercel-react-best-practices/rules/js-hoist-regexp.md
+++ b/.claude/skills/vercel-react-best-practices/rules/js-hoist-regexp.md
@@ -39,7 +39,7 @@ function Highlighter({ text, query }: Props) {
 Global regex (`/g`) has mutable `lastIndex` state:
 
 ```typescript
-const regex = /foo/g;
-regex.test("foo"); // true, lastIndex = 3
-regex.test("foo"); // false, lastIndex = 0
+const regex = /foo/g
+regex.test('foo')  // true, lastIndex = 3
+regex.test('foo')  // false, lastIndex = 0
 ```

--- a/.claude/skills/vercel-react-best-practices/rules/js-index-maps.md
+++ b/.claude/skills/vercel-react-best-practices/rules/js-index-maps.md
@@ -13,10 +13,10 @@ Multiple `.find()` calls by the same key should use a Map.
 
 ```typescript
 function processOrders(orders: Order[], users: User[]) {
-  return orders.map((order) => ({
+  return orders.map(order => ({
     ...order,
-    user: users.find((u) => u.id === order.userId),
-  }));
+    user: users.find(u => u.id === order.userId)
+  }))
 }
 ```
 
@@ -24,12 +24,12 @@ function processOrders(orders: Order[], users: User[]) {
 
 ```typescript
 function processOrders(orders: Order[], users: User[]) {
-  const userById = new Map(users.map((u) => [u.id, u]));
+  const userById = new Map(users.map(u => [u.id, u]))
 
-  return orders.map((order) => ({
+  return orders.map(order => ({
     ...order,
-    user: userById.get(order.userId),
-  }));
+    user: userById.get(order.userId)
+  }))
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/js-length-check-first.md
+++ b/.claude/skills/vercel-react-best-practices/rules/js-length-check-first.md
@@ -16,7 +16,7 @@ In real-world applications, this optimization is especially valuable when the co
 ```typescript
 function hasChanges(current: string[], original: string[]) {
   // Always sorts and joins, even when lengths differ
-  return current.sort().join() !== original.sort().join();
+  return current.sort().join() !== original.sort().join()
 }
 ```
 
@@ -28,22 +28,21 @@ Two O(n log n) sorts run even when `current.length` is 5 and `original.length` i
 function hasChanges(current: string[], original: string[]) {
   // Early return if lengths differ
   if (current.length !== original.length) {
-    return true;
+    return true
   }
   // Only sort when lengths match
-  const currentSorted = current.toSorted();
-  const originalSorted = original.toSorted();
+  const currentSorted = current.toSorted()
+  const originalSorted = original.toSorted()
   for (let i = 0; i < currentSorted.length; i++) {
     if (currentSorted[i] !== originalSorted[i]) {
-      return true;
+      return true
     }
   }
-  return false;
+  return false
 }
 ```
 
 This new approach is more efficient because:
-
 - It avoids the overhead of sorting and joining the arrays when lengths differ
 - It avoids consuming memory for the joined strings (especially important for large arrays)
 - It avoids mutating the original arrays

--- a/.claude/skills/vercel-react-best-practices/rules/js-min-max-loop.md
+++ b/.claude/skills/vercel-react-best-practices/rules/js-min-max-loop.md
@@ -13,14 +13,14 @@ Finding the smallest or largest element only requires a single pass through the 
 
 ```typescript
 interface Project {
-  id: string;
-  name: string;
-  updatedAt: number;
+  id: string
+  name: string
+  updatedAt: number
 }
 
 function getLatestProject(projects: Project[]) {
-  const sorted = [...projects].sort((a, b) => b.updatedAt - a.updatedAt);
-  return sorted[0];
+  const sorted = [...projects].sort((a, b) => b.updatedAt - a.updatedAt)
+  return sorted[0]
 }
 ```
 
@@ -30,8 +30,8 @@ Sorts the entire array just to find the maximum value.
 
 ```typescript
 function getOldestAndNewest(projects: Project[]) {
-  const sorted = [...projects].sort((a, b) => a.updatedAt - b.updatedAt);
-  return { oldest: sorted[0], newest: sorted[sorted.length - 1] };
+  const sorted = [...projects].sort((a, b) => a.updatedAt - b.updatedAt)
+  return { oldest: sorted[0], newest: sorted[sorted.length - 1] }
 }
 ```
 
@@ -41,31 +41,31 @@ Still sorts unnecessarily when only min/max are needed.
 
 ```typescript
 function getLatestProject(projects: Project[]) {
-  if (projects.length === 0) return null;
-
-  let latest = projects[0];
-
+  if (projects.length === 0) return null
+  
+  let latest = projects[0]
+  
   for (let i = 1; i < projects.length; i++) {
     if (projects[i].updatedAt > latest.updatedAt) {
-      latest = projects[i];
+      latest = projects[i]
     }
   }
-
-  return latest;
+  
+  return latest
 }
 
 function getOldestAndNewest(projects: Project[]) {
-  if (projects.length === 0) return { oldest: null, newest: null };
-
-  let oldest = projects[0];
-  let newest = projects[0];
-
+  if (projects.length === 0) return { oldest: null, newest: null }
+  
+  let oldest = projects[0]
+  let newest = projects[0]
+  
   for (let i = 1; i < projects.length; i++) {
-    if (projects[i].updatedAt < oldest.updatedAt) oldest = projects[i];
-    if (projects[i].updatedAt > newest.updatedAt) newest = projects[i];
+    if (projects[i].updatedAt < oldest.updatedAt) oldest = projects[i]
+    if (projects[i].updatedAt > newest.updatedAt) newest = projects[i]
   }
-
-  return { oldest, newest };
+  
+  return { oldest, newest }
 }
 ```
 
@@ -74,9 +74,9 @@ Single pass through the array, no copying, no sorting.
 **Alternative (Math.min/Math.max for small arrays):**
 
 ```typescript
-const numbers = [5, 2, 8, 1, 9];
-const min = Math.min(...numbers);
-const max = Math.max(...numbers);
+const numbers = [5, 2, 8, 1, 9]
+const min = Math.min(...numbers)
+const max = Math.max(...numbers)
 ```
 
 This works for small arrays, but can be slower or just throw an error for very large arrays due to spread operator limitations. Maximal array length is approximately 124000 in Chrome 143 and 638000 in Safari 18; exact numbers may vary - see [the fiddle](https://jsfiddle.net/qw1jabsx/4/). Use the loop approach for reliability.

--- a/.claude/skills/vercel-react-best-practices/rules/js-request-idle-callback.md
+++ b/.claude/skills/vercel-react-best-practices/rules/js-request-idle-callback.md
@@ -15,13 +15,13 @@ Use `requestIdleCallback()` to schedule non-critical work during browser idle pe
 
 ```typescript
 function handleSearch(query: string) {
-  const results = searchItems(query);
-  setResults(results);
+  const results = searchItems(query)
+  setResults(results)
 
   // These block the main thread immediately
-  analytics.track("search", { query });
-  saveToRecentSearches(query);
-  prefetchTopResults(results.slice(0, 3));
+  analytics.track('search', { query })
+  saveToRecentSearches(query)
+  prefetchTopResults(results.slice(0, 3))
 }
 ```
 
@@ -29,21 +29,21 @@ function handleSearch(query: string) {
 
 ```typescript
 function handleSearch(query: string) {
-  const results = searchItems(query);
-  setResults(results);
+  const results = searchItems(query)
+  setResults(results)
 
   // Defer non-critical work to idle periods
   requestIdleCallback(() => {
-    analytics.track("search", { query });
-  });
+    analytics.track('search', { query })
+  })
 
   requestIdleCallback(() => {
-    saveToRecentSearches(query);
-  });
+    saveToRecentSearches(query)
+  })
 
   requestIdleCallback(() => {
-    prefetchTopResults(results.slice(0, 3));
-  });
+    prefetchTopResults(results.slice(0, 3))
+  })
 }
 ```
 
@@ -52,43 +52,42 @@ function handleSearch(query: string) {
 ```typescript
 // Ensure analytics fires within 2 seconds even if browser stays busy
 requestIdleCallback(
-  () => analytics.track("page_view", { path: location.pathname }),
-  { timeout: 2000 },
-);
+  () => analytics.track('page_view', { path: location.pathname }),
+  { timeout: 2000 }
+)
 ```
 
 **Chunking large tasks:**
 
 ```typescript
 function processLargeDataset(items: Item[]) {
-  let index = 0;
+  let index = 0
 
   function processChunk(deadline: IdleDeadline) {
     // Process items while we have idle time (aim for <50ms chunks)
     while (index < items.length && deadline.timeRemaining() > 0) {
-      processItem(items[index]);
-      index++;
+      processItem(items[index])
+      index++
     }
 
     // Schedule next chunk if more items remain
     if (index < items.length) {
-      requestIdleCallback(processChunk);
+      requestIdleCallback(processChunk)
     }
   }
 
-  requestIdleCallback(processChunk);
+  requestIdleCallback(processChunk)
 }
 ```
 
 **With fallback for unsupported browsers:**
 
 ```typescript
-const scheduleIdleWork =
-  window.requestIdleCallback ?? ((cb: () => void) => setTimeout(cb, 1));
+const scheduleIdleWork = window.requestIdleCallback ?? ((cb: () => void) => setTimeout(cb, 1))
 
 scheduleIdleWork(() => {
   // Non-critical work
-});
+})
 ```
 
 **When to use:**

--- a/.claude/skills/vercel-react-best-practices/rules/js-tosorted-immutable.md
+++ b/.claude/skills/vercel-react-best-practices/rules/js-tosorted-immutable.md
@@ -46,7 +46,7 @@ function UserList({ users }: { users: User[] }) {
 
 ```typescript
 // Fallback for older browsers
-const sorted = [...items].sort((a, b) => a.value - b.value);
+const sorted = [...items].sort((a, b) => a.value - b.value)
 ```
 
 **Other immutable array methods:**

--- a/.claude/skills/vercel-react-best-practices/rules/rendering-activity.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rendering-activity.md
@@ -12,14 +12,14 @@ Use React's `<Activity>` to preserve state/DOM for expensive components that fre
 **Usage:**
 
 ```tsx
-import { Activity } from "react";
+import { Activity } from 'react'
 
 function Dropdown({ isOpen }: Props) {
   return (
-    <Activity mode={isOpen ? "visible" : "hidden"}>
+    <Activity mode={isOpen ? 'visible' : 'hidden'}>
       <ExpensiveMenu />
     </Activity>
-  );
+  )
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/rendering-animate-svg-wrapper.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rendering-animate-svg-wrapper.md
@@ -14,10 +14,15 @@ Many browsers don't have hardware acceleration for CSS3 animations on SVG elemen
 ```tsx
 function LoadingSpinner() {
   return (
-    <svg className="animate-spin" width="24" height="24" viewBox="0 0 24 24">
+    <svg 
+      className="animate-spin"
+      width="24" 
+      height="24" 
+      viewBox="0 0 24 24"
+    >
       <circle cx="12" cy="12" r="10" stroke="currentColor" />
     </svg>
-  );
+  )
 }
 ```
 
@@ -27,11 +32,15 @@ function LoadingSpinner() {
 function LoadingSpinner() {
   return (
     <div className="animate-spin">
-      <svg width="24" height="24" viewBox="0 0 24 24">
+      <svg 
+        width="24" 
+        height="24" 
+        viewBox="0 0 24 24"
+      >
         <circle cx="12" cy="12" r="10" stroke="currentColor" />
       </svg>
     </div>
-  );
+  )
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/rendering-conditional-render.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rendering-conditional-render.md
@@ -13,7 +13,11 @@ Use explicit ternary operators (`? :`) instead of `&&` for conditional rendering
 
 ```tsx
 function Badge({ count }: { count: number }) {
-  return <div>{count && <span className="badge">{count}</span>}</div>;
+  return (
+    <div>
+      {count && <span className="badge">{count}</span>}
+    </div>
+  )
 }
 
 // When count = 0, renders: <div>0</div>
@@ -24,7 +28,11 @@ function Badge({ count }: { count: number }) {
 
 ```tsx
 function Badge({ count }: { count: number }) {
-  return <div>{count > 0 ? <span className="badge">{count}</span> : null}</div>;
+  return (
+    <div>
+      {count > 0 ? <span className="badge">{count}</span> : null}
+    </div>
+  )
 }
 
 // When count = 0, renders: <div></div>

--- a/.claude/skills/vercel-react-best-practices/rules/rendering-content-visibility.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rendering-content-visibility.md
@@ -24,14 +24,14 @@ Apply `content-visibility: auto` to defer off-screen rendering.
 function MessageList({ messages }: { messages: Message[] }) {
   return (
     <div className="overflow-y-auto h-screen">
-      {messages.map((msg) => (
+      {messages.map(msg => (
         <div key={msg.id} className="message-item">
           <Avatar user={msg.author} />
           <div>{msg.content}</div>
         </div>
       ))}
     </div>
-  );
+  )
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/rendering-hoist-jsx.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rendering-hoist-jsx.md
@@ -13,21 +13,31 @@ Extract static JSX outside components to avoid re-creation.
 
 ```tsx
 function LoadingSkeleton() {
-  return <div className="animate-pulse h-20 bg-gray-200" />;
+  return <div className="animate-pulse h-20 bg-gray-200" />
 }
 
 function Container() {
-  return <div>{loading && <LoadingSkeleton />}</div>;
+  return (
+    <div>
+      {loading && <LoadingSkeleton />}
+    </div>
+  )
 }
 ```
 
 **Correct (reuses same element):**
 
 ```tsx
-const loadingSkeleton = <div className="animate-pulse h-20 bg-gray-200" />;
+const loadingSkeleton = (
+  <div className="animate-pulse h-20 bg-gray-200" />
+)
 
 function Container() {
-  return <div>{loading && loadingSkeleton}</div>;
+  return (
+    <div>
+      {loading && loadingSkeleton}
+    </div>
+  )
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/rendering-hydration-no-flicker.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rendering-hydration-no-flicker.md
@@ -14,9 +14,13 @@ When rendering content that depends on client-side storage (localStorage, cookie
 ```tsx
 function ThemeWrapper({ children }: { children: ReactNode }) {
   // localStorage is not available on server - throws error
-  const theme = localStorage.getItem("theme") || "light";
-
-  return <div className={theme}>{children}</div>;
+  const theme = localStorage.getItem('theme') || 'light'
+  
+  return (
+    <div className={theme}>
+      {children}
+    </div>
+  )
 }
 ```
 
@@ -26,17 +30,21 @@ Server-side rendering will fail because `localStorage` is undefined.
 
 ```tsx
 function ThemeWrapper({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState("light");
-
+  const [theme, setTheme] = useState('light')
+  
   useEffect(() => {
     // Runs after hydration - causes visible flash
-    const stored = localStorage.getItem("theme");
+    const stored = localStorage.getItem('theme')
     if (stored) {
-      setTheme(stored);
+      setTheme(stored)
     }
-  }, []);
-
-  return <div className={theme}>{children}</div>;
+  }, [])
+  
+  return (
+    <div className={theme}>
+      {children}
+    </div>
+  )
 }
 ```
 
@@ -48,7 +56,9 @@ Component first renders with default value (`light`), then updates after hydrati
 function ThemeWrapper({ children }: { children: ReactNode }) {
   return (
     <>
-      <div id="theme-wrapper">{children}</div>
+      <div id="theme-wrapper">
+        {children}
+      </div>
       <script
         dangerouslySetInnerHTML={{
           __html: `
@@ -63,7 +73,7 @@ function ThemeWrapper({ children }: { children: ReactNode }) {
         }}
       />
     </>
-  );
+  )
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/rendering-hydration-suppress-warning.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rendering-hydration-suppress-warning.md
@@ -7,13 +7,13 @@ tags: rendering, hydration, ssr, nextjs
 
 ## Suppress Expected Hydration Mismatches
 
-In SSR frameworks (e.g., Next.js), some values are intentionally different on server vs client (random IDs, dates, locale/timezone formatting). For these _expected_ mismatches, wrap the dynamic text in an element with `suppressHydrationWarning` to prevent noisy warnings. Do not use this to hide real bugs. Don’t overuse it.
+In SSR frameworks (e.g., Next.js), some values are intentionally different on server vs client (random IDs, dates, locale/timezone formatting). For these *expected* mismatches, wrap the dynamic text in an element with `suppressHydrationWarning` to prevent noisy warnings. Do not use this to hide real bugs. Don’t overuse it.
 
 **Incorrect (known mismatch warnings):**
 
 ```tsx
 function Timestamp() {
-  return <span>{new Date().toLocaleString()}</span>;
+  return <span>{new Date().toLocaleString()}</span>
 }
 ```
 
@@ -21,6 +21,10 @@ function Timestamp() {
 
 ```tsx
 function Timestamp() {
-  return <span suppressHydrationWarning>{new Date().toLocaleString()}</span>;
+  return (
+    <span suppressHydrationWarning>
+      {new Date().toLocaleString()}
+    </span>
+  )
 }
 ```

--- a/.claude/skills/vercel-react-best-practices/rules/rendering-resource-hints.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rendering-resource-hints.md
@@ -21,49 +21,45 @@ React DOM provides APIs to hint the browser about resources it will need. These 
 **Example (preconnect to third-party APIs):**
 
 ```tsx
-import { preconnect, prefetchDNS } from "react-dom";
+import { preconnect, prefetchDNS } from 'react-dom'
 
 export default function App() {
-  prefetchDNS("https://analytics.example.com");
-  preconnect("https://api.example.com");
+  prefetchDNS('https://analytics.example.com')
+  preconnect('https://api.example.com')
 
-  return <main>{/* content */}</main>;
+  return <main>{/* content */}</main>
 }
 ```
 
 **Example (preload critical fonts and styles):**
 
 ```tsx
-import { preload, preinit } from "react-dom";
+import { preload, preinit } from 'react-dom'
 
 export default function RootLayout({ children }) {
   // Preload font file
-  preload("/fonts/inter.woff2", {
-    as: "font",
-    type: "font/woff2",
-    crossOrigin: "anonymous",
-  });
+  preload('/fonts/inter.woff2', { as: 'font', type: 'font/woff2', crossOrigin: 'anonymous' })
 
   // Fetch and apply critical stylesheet immediately
-  preinit("/styles/critical.css", { as: "style" });
+  preinit('/styles/critical.css', { as: 'style' })
 
   return (
     <html>
       <body>{children}</body>
     </html>
-  );
+  )
 }
 ```
 
 **Example (preload modules for code-split routes):**
 
 ```tsx
-import { preloadModule, preinitModule } from "react-dom";
+import { preloadModule, preinitModule } from 'react-dom'
 
 function Navigation() {
   const preloadDashboard = () => {
-    preloadModule("/dashboard.js", { as: "script" });
-  };
+    preloadModule('/dashboard.js', { as: 'script' })
+  }
 
   return (
     <nav>
@@ -71,19 +67,19 @@ function Navigation() {
         Dashboard
       </a>
     </nav>
-  );
+  )
 }
 ```
 
 **When to use each:**
 
-| API             | Use case                                    |
-| --------------- | ------------------------------------------- |
-| `prefetchDNS`   | Third-party domains you'll connect to later |
-| `preconnect`    | APIs or CDNs you'll fetch from immediately  |
-| `preload`       | Critical resources needed for current page  |
-| `preloadModule` | JS modules for likely next navigation       |
-| `preinit`       | Stylesheets/scripts that must execute early |
-| `preinitModule` | ES modules that must execute early          |
+| API | Use case |
+|-----|----------|
+| `prefetchDNS` | Third-party domains you'll connect to later |
+| `preconnect` | APIs or CDNs you'll fetch from immediately |
+| `preload` | Critical resources needed for current page |
+| `preloadModule` | JS modules for likely next navigation |
+| `preinit` | Stylesheets/scripts that must execute early |
+| `preinitModule` | ES modules that must execute early |
 
 Reference: [React DOM Resource Preloading APIs](https://react.dev/reference/react-dom#resource-preloading-apis)

--- a/.claude/skills/vercel-react-best-practices/rules/rendering-script-defer-async.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rendering-script-defer-async.md
@@ -28,7 +28,7 @@ export default function Document() {
       </head>
       <body>{/* content */}</body>
     </html>
-  );
+  )
 }
 ```
 
@@ -46,25 +46,22 @@ export default function Document() {
       </head>
       <body>{/* content */}</body>
     </html>
-  );
+  )
 }
 ```
 
 **Note:** In Next.js, prefer the `next/script` component with `strategy` prop instead of raw script tags:
 
 ```tsx
-import Script from "next/script";
+import Script from 'next/script'
 
 export default function Page() {
   return (
     <>
-      <Script
-        src="https://example.com/analytics.js"
-        strategy="afterInteractive"
-      />
+      <Script src="https://example.com/analytics.js" strategy="afterInteractive" />
       <Script src="/scripts/utils.js" strategy="beforeInteractive" />
     </>
-  );
+  )
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/rendering-usetransition-loading.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rendering-usetransition-loading.md
@@ -13,17 +13,17 @@ Use `useTransition` instead of manual `useState` for loading states. This provid
 
 ```tsx
 function SearchResults() {
-  const [query, setQuery] = useState("");
-  const [results, setResults] = useState([]);
-  const [isLoading, setIsLoading] = useState(false);
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState([])
+  const [isLoading, setIsLoading] = useState(false)
 
   const handleSearch = async (value: string) => {
-    setIsLoading(true);
-    setQuery(value);
-    const data = await fetchResults(value);
-    setResults(data);
-    setIsLoading(false);
-  };
+    setIsLoading(true)
+    setQuery(value)
+    const data = await fetchResults(value)
+    setResults(data)
+    setIsLoading(false)
+  }
 
   return (
     <>
@@ -31,29 +31,29 @@ function SearchResults() {
       {isLoading && <Spinner />}
       <ResultsList results={results} />
     </>
-  );
+  )
 }
 ```
 
 **Correct (useTransition with built-in pending state):**
 
 ```tsx
-import { useTransition, useState } from "react";
+import { useTransition, useState } from 'react'
 
 function SearchResults() {
-  const [query, setQuery] = useState("");
-  const [results, setResults] = useState([]);
-  const [isPending, startTransition] = useTransition();
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState([])
+  const [isPending, startTransition] = useTransition()
 
   const handleSearch = (value: string) => {
-    setQuery(value); // Update input immediately
-
+    setQuery(value) // Update input immediately
+    
     startTransition(async () => {
       // Fetch and update results
-      const data = await fetchResults(value);
-      setResults(data);
-    });
-  };
+      const data = await fetchResults(value)
+      setResults(data)
+    })
+  }
 
   return (
     <>
@@ -61,7 +61,7 @@ function SearchResults() {
       {isPending && <Spinner />}
       <ResultsList results={results} />
     </>
-  );
+  )
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/rerender-defer-reads.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rerender-defer-reads.md
@@ -13,14 +13,14 @@ Don't subscribe to dynamic state (searchParams, localStorage) if you only read i
 
 ```tsx
 function ShareButton({ chatId }: { chatId: string }) {
-  const searchParams = useSearchParams();
+  const searchParams = useSearchParams()
 
   const handleShare = () => {
-    const ref = searchParams.get("ref");
-    shareChat(chatId, { ref });
-  };
+    const ref = searchParams.get('ref')
+    shareChat(chatId, { ref })
+  }
 
-  return <button onClick={handleShare}>Share</button>;
+  return <button onClick={handleShare}>Share</button>
 }
 ```
 
@@ -29,11 +29,11 @@ function ShareButton({ chatId }: { chatId: string }) {
 ```tsx
 function ShareButton({ chatId }: { chatId: string }) {
   const handleShare = () => {
-    const params = new URLSearchParams(window.location.search);
-    const ref = params.get("ref");
-    shareChat(chatId, { ref });
-  };
+    const params = new URLSearchParams(window.location.search)
+    const ref = params.get('ref')
+    shareChat(chatId, { ref })
+  }
 
-  return <button onClick={handleShare}>Share</button>;
+  return <button onClick={handleShare}>Share</button>
 }
 ```

--- a/.claude/skills/vercel-react-best-practices/rules/rerender-dependencies.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rerender-dependencies.md
@@ -13,16 +13,16 @@ Specify primitive dependencies instead of objects to minimize effect re-runs.
 
 ```tsx
 useEffect(() => {
-  console.log(user.id);
-}, [user]);
+  console.log(user.id)
+}, [user])
 ```
 
 **Correct (re-runs only when id changes):**
 
 ```tsx
 useEffect(() => {
-  console.log(user.id);
-}, [user.id]);
+  console.log(user.id)
+}, [user.id])
 ```
 
 **For derived state, compute outside effect:**
@@ -31,15 +31,15 @@ useEffect(() => {
 // Incorrect: runs on width=767, 766, 765...
 useEffect(() => {
   if (width < 768) {
-    enableMobileMode();
+    enableMobileMode()
   }
-}, [width]);
+}, [width])
 
 // Correct: runs only on boolean transition
-const isMobile = width < 768;
+const isMobile = width < 768
 useEffect(() => {
   if (isMobile) {
-    enableMobileMode();
+    enableMobileMode()
   }
-}, [isMobile]);
+}, [isMobile])
 ```

--- a/.claude/skills/vercel-react-best-practices/rules/rerender-derived-state-no-effect.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rerender-derived-state-no-effect.md
@@ -13,15 +13,15 @@ If a value can be computed from current props/state, do not store it in state or
 
 ```tsx
 function Form() {
-  const [firstName, setFirstName] = useState("First");
-  const [lastName, setLastName] = useState("Last");
-  const [fullName, setFullName] = useState("");
+  const [firstName, setFirstName] = useState('First')
+  const [lastName, setLastName] = useState('Last')
+  const [fullName, setFullName] = useState('')
 
   useEffect(() => {
-    setFullName(firstName + " " + lastName);
-  }, [firstName, lastName]);
+    setFullName(firstName + ' ' + lastName)
+  }, [firstName, lastName])
 
-  return <p>{fullName}</p>;
+  return <p>{fullName}</p>
 }
 ```
 
@@ -29,11 +29,11 @@ function Form() {
 
 ```tsx
 function Form() {
-  const [firstName, setFirstName] = useState("First");
-  const [lastName, setLastName] = useState("Last");
-  const fullName = firstName + " " + lastName;
+  const [firstName, setFirstName] = useState('First')
+  const [lastName, setLastName] = useState('Last')
+  const fullName = firstName + ' ' + lastName
 
-  return <p>{fullName}</p>;
+  return <p>{fullName}</p>
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/rerender-derived-state.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rerender-derived-state.md
@@ -13,9 +13,9 @@ Subscribe to derived boolean state instead of continuous values to reduce re-ren
 
 ```tsx
 function Sidebar() {
-  const width = useWindowWidth(); // updates continuously
-  const isMobile = width < 768;
-  return <nav className={isMobile ? "mobile" : "desktop"} />;
+  const width = useWindowWidth()  // updates continuously
+  const isMobile = width < 768
+  return <nav className={isMobile ? 'mobile' : 'desktop'} />
 }
 ```
 
@@ -23,7 +23,7 @@ function Sidebar() {
 
 ```tsx
 function Sidebar() {
-  const isMobile = useMediaQuery("(max-width: 767px)");
-  return <nav className={isMobile ? "mobile" : "desktop"} />;
+  const isMobile = useMediaQuery('(max-width: 767px)')
+  return <nav className={isMobile ? 'mobile' : 'desktop'} />
 }
 ```

--- a/.claude/skills/vercel-react-best-practices/rules/rerender-functional-setstate.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rerender-functional-setstate.md
@@ -13,22 +13,19 @@ When updating state based on the current state value, use the functional update 
 
 ```tsx
 function TodoList() {
-  const [items, setItems] = useState(initialItems);
-
+  const [items, setItems] = useState(initialItems)
+  
   // Callback must depend on items, recreated on every items change
-  const addItems = useCallback(
-    (newItems: Item[]) => {
-      setItems([...items, ...newItems]);
-    },
-    [items],
-  ); // ❌ items dependency causes recreations
-
+  const addItems = useCallback((newItems: Item[]) => {
+    setItems([...items, ...newItems])
+  }, [items])  // ❌ items dependency causes recreations
+  
   // Risk of stale closure if dependency is forgotten
   const removeItem = useCallback((id: string) => {
-    setItems(items.filter((item) => item.id !== id));
-  }, []); // ❌ Missing items dependency - will use stale items!
-
-  return <ItemsEditor items={items} onAdd={addItems} onRemove={removeItem} />;
+    setItems(items.filter(item => item.id !== id))
+  }, [])  // ❌ Missing items dependency - will use stale items!
+  
+  return <ItemsEditor items={items} onAdd={addItems} onRemove={removeItem} />
 }
 ```
 
@@ -38,19 +35,19 @@ The first callback is recreated every time `items` changes, which can cause chil
 
 ```tsx
 function TodoList() {
-  const [items, setItems] = useState(initialItems);
-
+  const [items, setItems] = useState(initialItems)
+  
   // Stable callback, never recreated
   const addItems = useCallback((newItems: Item[]) => {
-    setItems((curr) => [...curr, ...newItems]);
-  }, []); // ✅ No dependencies needed
-
+    setItems(curr => [...curr, ...newItems])
+  }, [])  // ✅ No dependencies needed
+  
   // Always uses latest state, no stale closure risk
   const removeItem = useCallback((id: string) => {
-    setItems((curr) => curr.filter((item) => item.id !== id));
-  }, []); // ✅ Safe and stable
-
-  return <ItemsEditor items={items} onAdd={addItems} onRemove={removeItem} />;
+    setItems(curr => curr.filter(item => item.id !== id))
+  }, [])  // ✅ Safe and stable
+  
+  return <ItemsEditor items={items} onAdd={addItems} onRemove={removeItem} />
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/rerender-lazy-state-init.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rerender-lazy-state-init.md
@@ -14,20 +14,20 @@ Pass a function to `useState` for expensive initial values. Without the function
 ```tsx
 function FilteredList({ items }: { items: Item[] }) {
   // buildSearchIndex() runs on EVERY render, even after initialization
-  const [searchIndex, setSearchIndex] = useState(buildSearchIndex(items));
-  const [query, setQuery] = useState("");
-
+  const [searchIndex, setSearchIndex] = useState(buildSearchIndex(items))
+  const [query, setQuery] = useState('')
+  
   // When query changes, buildSearchIndex runs again unnecessarily
-  return <SearchResults index={searchIndex} query={query} />;
+  return <SearchResults index={searchIndex} query={query} />
 }
 
 function UserProfile() {
   // JSON.parse runs on every render
   const [settings, setSettings] = useState(
-    JSON.parse(localStorage.getItem("settings") || "{}"),
-  );
-
-  return <SettingsForm settings={settings} onChange={setSettings} />;
+    JSON.parse(localStorage.getItem('settings') || '{}')
+  )
+  
+  return <SettingsForm settings={settings} onChange={setSettings} />
 }
 ```
 
@@ -36,20 +36,20 @@ function UserProfile() {
 ```tsx
 function FilteredList({ items }: { items: Item[] }) {
   // buildSearchIndex() runs ONLY on initial render
-  const [searchIndex, setSearchIndex] = useState(() => buildSearchIndex(items));
-  const [query, setQuery] = useState("");
-
-  return <SearchResults index={searchIndex} query={query} />;
+  const [searchIndex, setSearchIndex] = useState(() => buildSearchIndex(items))
+  const [query, setQuery] = useState('')
+  
+  return <SearchResults index={searchIndex} query={query} />
 }
 
 function UserProfile() {
   // JSON.parse runs only on initial render
   const [settings, setSettings] = useState(() => {
-    const stored = localStorage.getItem("settings");
-    return stored ? JSON.parse(stored) : {};
-  });
-
-  return <SettingsForm settings={settings} onChange={setSettings} />;
+    const stored = localStorage.getItem('settings')
+    return stored ? JSON.parse(stored) : {}
+  })
+  
+  return <SettingsForm settings={settings} onChange={setSettings} />
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/rerender-memo-with-default-value.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rerender-memo-with-default-value.md
@@ -1,8 +1,10 @@
 ---
+
 title: Extract Default Non-primitive Parameter Value from Memoized Component to Constant
 impact: MEDIUM
 impactDescription: restores memoization by using a constant for default value
 tags: rerender, memo, optimization
+
 ---
 
 ## Extract Default Non-primitive Parameter Value from Memoized Component to Constant

--- a/.claude/skills/vercel-react-best-practices/rules/rerender-memo.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rerender-memo.md
@@ -14,12 +14,12 @@ Extract expensive work into memoized components to enable early returns before c
 ```tsx
 function Profile({ user, loading }: Props) {
   const avatar = useMemo(() => {
-    const id = computeAvatarId(user);
-    return <Avatar id={id} />;
-  }, [user]);
+    const id = computeAvatarId(user)
+    return <Avatar id={id} />
+  }, [user])
 
-  if (loading) return <Skeleton />;
-  return <div>{avatar}</div>;
+  if (loading) return <Skeleton />
+  return <div>{avatar}</div>
 }
 ```
 
@@ -27,17 +27,17 @@ function Profile({ user, loading }: Props) {
 
 ```tsx
 const UserAvatar = memo(function UserAvatar({ user }: { user: User }) {
-  const id = useMemo(() => computeAvatarId(user), [user]);
-  return <Avatar id={id} />;
-});
+  const id = useMemo(() => computeAvatarId(user), [user])
+  return <Avatar id={id} />
+})
 
 function Profile({ user, loading }: Props) {
-  if (loading) return <Skeleton />;
+  if (loading) return <Skeleton />
   return (
     <div>
       <UserAvatar user={user} />
     </div>
-  );
+  )
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/rerender-move-effect-to-event.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rerender-move-effect-to-event.md
@@ -13,17 +13,17 @@ If a side effect is triggered by a specific user action (submit, click, drag), r
 
 ```tsx
 function Form() {
-  const [submitted, setSubmitted] = useState(false);
-  const theme = useContext(ThemeContext);
+  const [submitted, setSubmitted] = useState(false)
+  const theme = useContext(ThemeContext)
 
   useEffect(() => {
     if (submitted) {
-      post("/api/register");
-      showToast("Registered", theme);
+      post('/api/register')
+      showToast('Registered', theme)
     }
-  }, [submitted, theme]);
+  }, [submitted, theme])
 
-  return <button onClick={() => setSubmitted(true)}>Submit</button>;
+  return <button onClick={() => setSubmitted(true)}>Submit</button>
 }
 ```
 
@@ -31,14 +31,14 @@ function Form() {
 
 ```tsx
 function Form() {
-  const theme = useContext(ThemeContext);
+  const theme = useContext(ThemeContext)
 
   function handleSubmit() {
-    post("/api/register");
-    showToast("Registered", theme);
+    post('/api/register')
+    showToast('Registered', theme)
   }
 
-  return <button onClick={handleSubmit}>Submit</button>;
+  return <button onClick={handleSubmit}>Submit</button>
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/rerender-no-inline-components.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rerender-no-inline-components.md
@@ -21,9 +21,9 @@ function UserProfile({ user, theme }) {
   const Avatar = () => (
     <img
       src={user.avatarUrl}
-      className={theme === "dark" ? "avatar-dark" : "avatar-light"}
+      className={theme === 'dark' ? 'avatar-dark' : 'avatar-light'}
     />
-  );
+  )
 
   // Defined inside to access `user` - BAD
   const Stats = () => (
@@ -31,14 +31,14 @@ function UserProfile({ user, theme }) {
       <span>{user.followers} followers</span>
       <span>{user.posts} posts</span>
     </div>
-  );
+  )
 
   return (
     <div>
       <Avatar />
       <Stats />
     </div>
-  );
+  )
 }
 ```
 
@@ -51,9 +51,9 @@ function Avatar({ src, theme }: { src: string; theme: string }) {
   return (
     <img
       src={src}
-      className={theme === "dark" ? "avatar-dark" : "avatar-light"}
+      className={theme === 'dark' ? 'avatar-dark' : 'avatar-light'}
     />
-  );
+  )
 }
 
 function Stats({ followers, posts }: { followers: number; posts: number }) {
@@ -62,7 +62,7 @@ function Stats({ followers, posts }: { followers: number; posts: number }) {
       <span>{followers} followers</span>
       <span>{posts} posts</span>
     </div>
-  );
+  )
 }
 
 function UserProfile({ user, theme }) {
@@ -71,12 +71,11 @@ function UserProfile({ user, theme }) {
       <Avatar src={user.avatarUrl} theme={theme} />
       <Stats followers={user.followers} posts={user.posts} />
     </div>
-  );
+  )
 }
 ```
 
 **Symptoms of this bug:**
-
 - Input fields lose focus on every keystroke
 - Animations restart unexpectedly
 - `useEffect` cleanup/setup runs on every parent render

--- a/.claude/skills/vercel-react-best-practices/rules/rerender-simple-expression-in-memo.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rerender-simple-expression-in-memo.md
@@ -15,10 +15,10 @@ Calling `useMemo` and comparing hook dependencies may consume more resources tha
 ```tsx
 function Header({ user, notifications }: Props) {
   const isLoading = useMemo(() => {
-    return user.isLoading || notifications.isLoading;
-  }, [user.isLoading, notifications.isLoading]);
+    return user.isLoading || notifications.isLoading
+  }, [user.isLoading, notifications.isLoading])
 
-  if (isLoading) return <Skeleton />;
+  if (isLoading) return <Skeleton />
   // return some markup
 }
 ```
@@ -27,9 +27,9 @@ function Header({ user, notifications }: Props) {
 
 ```tsx
 function Header({ user, notifications }: Props) {
-  const isLoading = user.isLoading || notifications.isLoading;
+  const isLoading = user.isLoading || notifications.isLoading
 
-  if (isLoading) return <Skeleton />;
+  if (isLoading) return <Skeleton />
   // return some markup
 }
 ```

--- a/.claude/skills/vercel-react-best-practices/rules/rerender-split-combined-hooks.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rerender-split-combined-hooks.md
@@ -13,12 +13,12 @@ When a hook contains multiple independent tasks with different dependencies, spl
 
 ```tsx
 const sortedProducts = useMemo(() => {
-  const filtered = products.filter((p) => p.category === category);
+  const filtered = products.filter((p) => p.category === category)
   const sorted = filtered.toSorted((a, b) =>
-    sortOrder === "asc" ? a.price - b.price : b.price - a.price,
-  );
-  return sorted;
-}, [products, category, sortOrder]);
+    sortOrder === "asc" ? a.price - b.price : b.price - a.price
+  )
+  return sorted
+}, [products, category, sortOrder])
 ```
 
 **Correct (filtering only recomputes when products or category change):**
@@ -26,16 +26,16 @@ const sortedProducts = useMemo(() => {
 ```tsx
 const filteredProducts = useMemo(
   () => products.filter((p) => p.category === category),
-  [products, category],
-);
+  [products, category]
+)
 
 const sortedProducts = useMemo(
   () =>
     filteredProducts.toSorted((a, b) =>
-      sortOrder === "asc" ? a.price - b.price : b.price - a.price,
+      sortOrder === "asc" ? a.price - b.price : b.price - a.price
     ),
-  [filteredProducts, sortOrder],
-);
+  [filteredProducts, sortOrder]
+)
 ```
 
 This pattern also applies to `useEffect` when combining unrelated side effects:
@@ -44,21 +44,21 @@ This pattern also applies to `useEffect` when combining unrelated side effects:
 
 ```tsx
 useEffect(() => {
-  analytics.trackPageView(pathname);
-  document.title = `${pageTitle} | My App`;
-}, [pathname, pageTitle]);
+  analytics.trackPageView(pathname)
+  document.title = `${pageTitle} | My App`
+}, [pathname, pageTitle])
 ```
 
 **Correct (effects run independently):**
 
 ```tsx
 useEffect(() => {
-  analytics.trackPageView(pathname);
-}, [pathname]);
+  analytics.trackPageView(pathname)
+}, [pathname])
 
 useEffect(() => {
-  document.title = `${pageTitle} | My App`;
-}, [pageTitle]);
+  document.title = `${pageTitle} | My App`
+}, [pageTitle])
 ```
 
 **Note:** If your project has [React Compiler](https://react.dev/learn/react-compiler) enabled, it automatically optimizes dependency tracking and may handle some of these cases for you.

--- a/.claude/skills/vercel-react-best-practices/rules/rerender-transitions.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rerender-transitions.md
@@ -13,28 +13,28 @@ Mark frequent, non-urgent state updates as transitions to maintain UI responsive
 
 ```tsx
 function ScrollTracker() {
-  const [scrollY, setScrollY] = useState(0);
+  const [scrollY, setScrollY] = useState(0)
   useEffect(() => {
-    const handler = () => setScrollY(window.scrollY);
-    window.addEventListener("scroll", handler, { passive: true });
-    return () => window.removeEventListener("scroll", handler);
-  }, []);
+    const handler = () => setScrollY(window.scrollY)
+    window.addEventListener('scroll', handler, { passive: true })
+    return () => window.removeEventListener('scroll', handler)
+  }, [])
 }
 ```
 
 **Correct (non-blocking updates):**
 
 ```tsx
-import { startTransition } from "react";
+import { startTransition } from 'react'
 
 function ScrollTracker() {
-  const [scrollY, setScrollY] = useState(0);
+  const [scrollY, setScrollY] = useState(0)
   useEffect(() => {
     const handler = () => {
-      startTransition(() => setScrollY(window.scrollY));
-    };
-    window.addEventListener("scroll", handler, { passive: true });
-    return () => window.removeEventListener("scroll", handler);
-  }, []);
+      startTransition(() => setScrollY(window.scrollY))
+    }
+    window.addEventListener('scroll', handler, { passive: true })
+    return () => window.removeEventListener('scroll', handler)
+  }, [])
 }
 ```

--- a/.claude/skills/vercel-react-best-practices/rules/rerender-use-deferred-value.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rerender-use-deferred-value.md
@@ -13,15 +13,15 @@ When user input triggers expensive computations or renders, use `useDeferredValu
 
 ```tsx
 function Search({ items }: { items: Item[] }) {
-  const [query, setQuery] = useState("");
-  const filtered = items.filter((item) => fuzzyMatch(item, query));
+  const [query, setQuery] = useState('')
+  const filtered = items.filter(item => fuzzyMatch(item, query))
 
   return (
     <>
-      <input value={query} onChange={(e) => setQuery(e.target.value)} />
+      <input value={query} onChange={e => setQuery(e.target.value)} />
       <ResultsList results={filtered} />
     </>
-  );
+  )
 }
 ```
 
@@ -29,22 +29,22 @@ function Search({ items }: { items: Item[] }) {
 
 ```tsx
 function Search({ items }: { items: Item[] }) {
-  const [query, setQuery] = useState("");
-  const deferredQuery = useDeferredValue(query);
+  const [query, setQuery] = useState('')
+  const deferredQuery = useDeferredValue(query)
   const filtered = useMemo(
-    () => items.filter((item) => fuzzyMatch(item, deferredQuery)),
-    [items, deferredQuery],
-  );
-  const isStale = query !== deferredQuery;
+    () => items.filter(item => fuzzyMatch(item, deferredQuery)),
+    [items, deferredQuery]
+  )
+  const isStale = query !== deferredQuery
 
   return (
     <>
-      <input value={query} onChange={(e) => setQuery(e.target.value)} />
+      <input value={query} onChange={e => setQuery(e.target.value)} />
       <div style={{ opacity: isStale ? 0.7 : 1 }}>
         <ResultsList results={filtered} />
       </div>
     </>
-  );
+  )
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/rerender-use-ref-transient-values.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rerender-use-ref-transient-values.md
@@ -13,26 +13,26 @@ When a value changes frequently and you don't want a re-render on every update (
 
 ```tsx
 function Tracker() {
-  const [lastX, setLastX] = useState(0);
+  const [lastX, setLastX] = useState(0)
 
   useEffect(() => {
-    const onMove = (e: MouseEvent) => setLastX(e.clientX);
-    window.addEventListener("mousemove", onMove);
-    return () => window.removeEventListener("mousemove", onMove);
-  }, []);
+    const onMove = (e: MouseEvent) => setLastX(e.clientX)
+    window.addEventListener('mousemove', onMove)
+    return () => window.removeEventListener('mousemove', onMove)
+  }, [])
 
   return (
     <div
       style={{
-        position: "fixed",
+        position: 'fixed',
         top: 0,
         left: lastX,
         width: 8,
         height: 8,
-        background: "black",
+        background: 'black',
       }}
     />
-  );
+  )
 }
 ```
 
@@ -40,34 +40,34 @@ function Tracker() {
 
 ```tsx
 function Tracker() {
-  const lastXRef = useRef(0);
-  const dotRef = useRef<HTMLDivElement>(null);
+  const lastXRef = useRef(0)
+  const dotRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     const onMove = (e: MouseEvent) => {
-      lastXRef.current = e.clientX;
-      const node = dotRef.current;
+      lastXRef.current = e.clientX
+      const node = dotRef.current
       if (node) {
-        node.style.transform = `translateX(${e.clientX}px)`;
+        node.style.transform = `translateX(${e.clientX}px)`
       }
-    };
-    window.addEventListener("mousemove", onMove);
-    return () => window.removeEventListener("mousemove", onMove);
-  }, []);
+    }
+    window.addEventListener('mousemove', onMove)
+    return () => window.removeEventListener('mousemove', onMove)
+  }, [])
 
   return (
     <div
       ref={dotRef}
       style={{
-        position: "fixed",
+        position: 'fixed',
         top: 0,
         left: 0,
         width: 8,
         height: 8,
-        background: "black",
-        transform: "translateX(0px)",
+        background: 'black',
+        transform: 'translateX(0px)',
       }}
     />
-  );
+  )
 }
 ```

--- a/.claude/skills/vercel-react-best-practices/rules/server-after-nonblocking.md
+++ b/.claude/skills/vercel-react-best-practices/rules/server-after-nonblocking.md
@@ -12,47 +12,46 @@ Use Next.js's `after()` to schedule work that should execute after a response is
 **Incorrect (blocks response):**
 
 ```tsx
-import { logUserAction } from "@/app/utils";
+import { logUserAction } from '@/app/utils'
 
 export async function POST(request: Request) {
   // Perform mutation
-  await updateDatabase(request);
-
+  await updateDatabase(request)
+  
   // Logging blocks the response
-  const userAgent = request.headers.get("user-agent") || "unknown";
-  await logUserAction({ userAgent });
-
-  return new Response(JSON.stringify({ status: "success" }), {
+  const userAgent = request.headers.get('user-agent') || 'unknown'
+  await logUserAction({ userAgent })
+  
+  return new Response(JSON.stringify({ status: 'success' }), {
     status: 200,
-    headers: { "Content-Type": "application/json" },
-  });
+    headers: { 'Content-Type': 'application/json' }
+  })
 }
 ```
 
 **Correct (non-blocking):**
 
 ```tsx
-import { after } from "next/server";
-import { headers, cookies } from "next/headers";
-import { logUserAction } from "@/app/utils";
+import { after } from 'next/server'
+import { headers, cookies } from 'next/headers'
+import { logUserAction } from '@/app/utils'
 
 export async function POST(request: Request) {
   // Perform mutation
-  await updateDatabase(request);
-
+  await updateDatabase(request)
+  
   // Log after response is sent
   after(async () => {
-    const userAgent = (await headers()).get("user-agent") || "unknown";
-    const sessionCookie =
-      (await cookies()).get("session-id")?.value || "anonymous";
-
-    logUserAction({ sessionCookie, userAgent });
-  });
-
-  return new Response(JSON.stringify({ status: "success" }), {
+    const userAgent = (await headers()).get('user-agent') || 'unknown'
+    const sessionCookie = (await cookies()).get('session-id')?.value || 'anonymous'
+    
+    logUserAction({ sessionCookie, userAgent })
+  })
+  
+  return new Response(JSON.stringify({ status: 'success' }), {
     status: 200,
-    headers: { "Content-Type": "application/json" },
-  });
+    headers: { 'Content-Type': 'application/json' }
+  })
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/server-auth-actions.md
+++ b/.claude/skills/vercel-react-best-practices/rules/server-auth-actions.md
@@ -16,80 +16,80 @@ Next.js documentation explicitly states: "Treat Server Actions with the same sec
 **Incorrect (no authentication check):**
 
 ```typescript
-"use server";
+'use server'
 
 export async function deleteUser(userId: string) {
   // Anyone can call this! No auth check
-  await db.user.delete({ where: { id: userId } });
-  return { success: true };
+  await db.user.delete({ where: { id: userId } })
+  return { success: true }
 }
 ```
 
 **Correct (authentication inside the action):**
 
 ```typescript
-"use server";
+'use server'
 
-import { verifySession } from "@/lib/auth";
-import { unauthorized } from "@/lib/errors";
+import { verifySession } from '@/lib/auth'
+import { unauthorized } from '@/lib/errors'
 
 export async function deleteUser(userId: string) {
   // Always check auth inside the action
-  const session = await verifySession();
-
+  const session = await verifySession()
+  
   if (!session) {
-    throw unauthorized("Must be logged in");
+    throw unauthorized('Must be logged in')
   }
-
+  
   // Check authorization too
-  if (session.user.role !== "admin" && session.user.id !== userId) {
-    throw unauthorized("Cannot delete other users");
+  if (session.user.role !== 'admin' && session.user.id !== userId) {
+    throw unauthorized('Cannot delete other users')
   }
-
-  await db.user.delete({ where: { id: userId } });
-  return { success: true };
+  
+  await db.user.delete({ where: { id: userId } })
+  return { success: true }
 }
 ```
 
 **With input validation:**
 
 ```typescript
-"use server";
+'use server'
 
-import { verifySession } from "@/lib/auth";
-import { z } from "zod";
+import { verifySession } from '@/lib/auth'
+import { z } from 'zod'
 
 const updateProfileSchema = z.object({
   userId: z.string().uuid(),
   name: z.string().min(1).max(100),
-  email: z.string().email(),
-});
+  email: z.string().email()
+})
 
 export async function updateProfile(data: unknown) {
   // Validate input first
-  const validated = updateProfileSchema.parse(data);
-
+  const validated = updateProfileSchema.parse(data)
+  
   // Then authenticate
-  const session = await verifySession();
+  const session = await verifySession()
   if (!session) {
-    throw new Error("Unauthorized");
+    throw new Error('Unauthorized')
   }
-
+  
   // Then authorize
   if (session.user.id !== validated.userId) {
-    throw new Error("Can only update own profile");
+    throw new Error('Can only update own profile')
   }
-
+  
   // Finally perform the mutation
   await db.user.update({
     where: { id: validated.userId },
     data: {
       name: validated.name,
-      email: validated.email,
-    },
-  });
-
-  return { success: true };
+      email: validated.email
+    }
+  })
+  
+  return { success: true }
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/server-cache-lru.md
+++ b/.claude/skills/vercel-react-best-practices/rules/server-cache-lru.md
@@ -12,20 +12,20 @@ tags: server, cache, lru, cross-request
 **Implementation:**
 
 ```typescript
-import { LRUCache } from "lru-cache";
+import { LRUCache } from 'lru-cache'
 
 const cache = new LRUCache<string, any>({
   max: 1000,
-  ttl: 5 * 60 * 1000, // 5 minutes
-});
+  ttl: 5 * 60 * 1000  // 5 minutes
+})
 
 export async function getUser(id: string) {
-  const cached = cache.get(id);
-  if (cached) return cached;
+  const cached = cache.get(id)
+  if (cached) return cached
 
-  const user = await db.user.findUnique({ where: { id } });
-  cache.set(id, user);
-  return user;
+  const user = await db.user.findUnique({ where: { id } })
+  cache.set(id, user)
+  return user
 }
 
 // Request 1: DB query, result cached

--- a/.claude/skills/vercel-react-best-practices/rules/server-cache-react.md
+++ b/.claude/skills/vercel-react-best-practices/rules/server-cache-react.md
@@ -12,15 +12,15 @@ Use `React.cache()` for server-side request deduplication. Authentication and da
 **Usage:**
 
 ```typescript
-import { cache } from "react";
+import { cache } from 'react'
 
 export const getCurrentUser = cache(async () => {
-  const session = await auth();
-  if (!session?.user?.id) return null;
+  const session = await auth()
+  if (!session?.user?.id) return null
   return await db.user.findUnique({
-    where: { id: session.user.id },
-  });
-});
+    where: { id: session.user.id }
+  })
+})
 ```
 
 Within a single request, multiple calls to `getCurrentUser()` execute the query only once.
@@ -33,32 +33,32 @@ Within a single request, multiple calls to `getCurrentUser()` execute the query 
 
 ```typescript
 const getUser = cache(async (params: { uid: number }) => {
-  return await db.user.findUnique({ where: { id: params.uid } });
-});
+  return await db.user.findUnique({ where: { id: params.uid } })
+})
 
 // Each call creates new object, never hits cache
-getUser({ uid: 1 });
-getUser({ uid: 1 }); // Cache miss, runs query again
+getUser({ uid: 1 })
+getUser({ uid: 1 })  // Cache miss, runs query again
 ```
 
 **Correct (cache hit):**
 
 ```typescript
 const getUser = cache(async (uid: number) => {
-  return await db.user.findUnique({ where: { id: uid } });
-});
+  return await db.user.findUnique({ where: { id: uid } })
+})
 
 // Primitive args use value equality
-getUser(1);
-getUser(1); // Cache hit, returns cached result
+getUser(1)
+getUser(1)  // Cache hit, returns cached result
 ```
 
 If you must pass objects, pass the same reference:
 
 ```typescript
-const params = { uid: 1 };
-getUser(params); // Query runs
-getUser(params); // Cache hit (same reference)
+const params = { uid: 1 }
+getUser(params)  // Query runs
+getUser(params)  // Cache hit (same reference)
 ```
 
 **Next.js-Specific Note:**

--- a/.claude/skills/vercel-react-best-practices/rules/server-dedup-props.md
+++ b/.claude/skills/vercel-react-best-practices/rules/server-dedup-props.md
@@ -22,11 +22,11 @@ RSC→client serialization deduplicates by object reference, not value. Same ref
 
 ```tsx
 // RSC: send once
-<ClientList usernames={usernames} />;
+<ClientList usernames={usernames} />
 
 // Client: transform there
-("use client");
-const sorted = useMemo(() => [...usernames].sort(), [usernames]);
+'use client'
+const sorted = useMemo(() => [...usernames].sort(), [usernames])
 ```
 
 **Nested deduplication behavior:**

--- a/.claude/skills/vercel-react-best-practices/rules/server-hoist-static-io.md
+++ b/.claude/skills/vercel-react-best-practices/rules/server-hoist-static-io.md
@@ -97,31 +97,35 @@ export async function GET(request: Request) {
 **Incorrect (reads config on every call):**
 
 ```typescript
-import fs from "node:fs/promises";
+import fs from 'node:fs/promises'
 
 export async function processRequest(data: Data) {
-  const config = JSON.parse(await fs.readFile("./config.json", "utf-8"));
-  const template = await fs.readFile("./template.html", "utf-8");
+  const config = JSON.parse(
+    await fs.readFile('./config.json', 'utf-8')
+  )
+  const template = await fs.readFile('./template.html', 'utf-8')
 
-  return render(template, data, config);
+  return render(template, data, config)
 }
 ```
 
 **Correct (hoists config and template to module level):**
 
 ```typescript
-import fs from "node:fs/promises";
+import fs from 'node:fs/promises'
 
-const configPromise = fs.readFile("./config.json", "utf-8").then(JSON.parse);
-const templatePromise = fs.readFile("./template.html", "utf-8");
+const configPromise = fs
+  .readFile('./config.json', 'utf-8')
+  .then(JSON.parse)
+const templatePromise = fs.readFile('./template.html', 'utf-8')
 
 export async function processRequest(data: Data) {
   const [config, template] = await Promise.all([
     configPromise,
     templatePromise,
-  ]);
+  ])
 
-  return render(template, data, config);
+  return render(template, data, config)
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/server-no-shared-module-state.md
+++ b/.claude/skills/vercel-react-best-practices/rules/server-no-shared-module-state.md
@@ -14,15 +14,15 @@ Treat module scope on the server as process-wide shared memory, not request-loca
 **Incorrect (request data leaks across concurrent renders):**
 
 ```tsx
-let currentUser: User | null = null;
+let currentUser: User | null = null
 
 export default async function Page() {
-  currentUser = await auth();
-  return <Dashboard />;
+  currentUser = await auth()
+  return <Dashboard />
 }
 
 async function Dashboard() {
-  return <div>{currentUser?.name}</div>;
+  return <div>{currentUser?.name}</div>
 }
 ```
 
@@ -32,12 +32,12 @@ If two requests overlap, request A can set `currentUser`, then request B overwri
 
 ```tsx
 export default async function Page() {
-  const user = await auth();
-  return <Dashboard user={user} />;
+  const user = await auth()
+  return <Dashboard user={user} />
 }
 
 function Dashboard({ user }: { user: User | null }) {
-  return <div>{user?.name}</div>;
+  return <div>{user?.name}</div>
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/server-parallel-fetching.md
+++ b/.claude/skills/vercel-react-best-practices/rules/server-parallel-fetching.md
@@ -13,18 +13,18 @@ React Server Components execute sequentially within a tree. Restructure with com
 
 ```tsx
 export default async function Page() {
-  const header = await fetchHeader();
+  const header = await fetchHeader()
   return (
     <div>
       <div>{header}</div>
       <Sidebar />
     </div>
-  );
+  )
 }
 
 async function Sidebar() {
-  const items = await fetchSidebarItems();
-  return <nav>{items.map(renderItem)}</nav>;
+  const items = await fetchSidebarItems()
+  return <nav>{items.map(renderItem)}</nav>
 }
 ```
 
@@ -32,13 +32,13 @@ async function Sidebar() {
 
 ```tsx
 async function Header() {
-  const data = await fetchHeader();
-  return <div>{data}</div>;
+  const data = await fetchHeader()
+  return <div>{data}</div>
 }
 
 async function Sidebar() {
-  const items = await fetchSidebarItems();
-  return <nav>{items.map(renderItem)}</nav>;
+  const items = await fetchSidebarItems()
+  return <nav>{items.map(renderItem)}</nav>
 }
 
 export default function Page() {
@@ -47,7 +47,7 @@ export default function Page() {
       <Header />
       <Sidebar />
     </div>
-  );
+  )
 }
 ```
 
@@ -55,13 +55,13 @@ export default function Page() {
 
 ```tsx
 async function Header() {
-  const data = await fetchHeader();
-  return <div>{data}</div>;
+  const data = await fetchHeader()
+  return <div>{data}</div>
 }
 
 async function Sidebar() {
-  const items = await fetchSidebarItems();
-  return <nav>{items.map(renderItem)}</nav>;
+  const items = await fetchSidebarItems()
+  return <nav>{items.map(renderItem)}</nav>
 }
 
 function Layout({ children }: { children: ReactNode }) {
@@ -70,7 +70,7 @@ function Layout({ children }: { children: ReactNode }) {
       <Header />
       {children}
     </div>
-  );
+  )
 }
 
 export default function Page() {
@@ -78,6 +78,6 @@ export default function Page() {
     <Layout>
       <Sidebar />
     </Layout>
-  );
+  )
 }
 ```

--- a/.claude/skills/vercel-react-best-practices/rules/server-parallel-nested-fetching.md
+++ b/.claude/skills/vercel-react-best-practices/rules/server-parallel-nested-fetching.md
@@ -12,11 +12,13 @@ When fetching nested data in parallel, chain dependent fetches within each item'
 **Incorrect (a single slow item blocks all nested fetches):**
 
 ```tsx
-const chats = await Promise.all(chatIds.map((id) => getChat(id)));
+const chats = await Promise.all(
+  chatIds.map(id => getChat(id))
+)
 
 const chatAuthors = await Promise.all(
-  chats.map((chat) => getUser(chat.author)),
-);
+  chats.map(chat => getUser(chat.author))
+)
 ```
 
 If one `getChat(id)` out of 100 is extremely slow, the authors of the other 99 chats can't start loading even though their data is ready.
@@ -25,8 +27,8 @@ If one `getChat(id)` out of 100 is extremely slow, the authors of the other 99 c
 
 ```tsx
 const chatAuthors = await Promise.all(
-  chatIds.map((id) => getChat(id).then((chat) => getUser(chat.author))),
-);
+  chatIds.map(id => getChat(id).then(chat => getUser(chat.author)))
+)
 ```
 
 Each item independently chains `getChat` → `getUser`, so a slow chat doesn't block author fetches for the others.

--- a/.claude/skills/vercel-react-best-practices/rules/server-serialization.md
+++ b/.claude/skills/vercel-react-best-practices/rules/server-serialization.md
@@ -13,13 +13,13 @@ The React Server/Client boundary serializes all object properties into strings a
 
 ```tsx
 async function Page() {
-  const user = await fetchUser(); // 50 fields
-  return <Profile user={user} />;
+  const user = await fetchUser()  // 50 fields
+  return <Profile user={user} />
 }
 
-("use client");
+'use client'
 function Profile({ user }: { user: User }) {
-  return <div>{user.name}</div>; // uses 1 field
+  return <div>{user.name}</div>  // uses 1 field
 }
 ```
 
@@ -27,12 +27,12 @@ function Profile({ user }: { user: User }) {
 
 ```tsx
 async function Page() {
-  const user = await fetchUser();
-  return <Profile name={user.name} />;
+  const user = await fetchUser()
+  return <Profile name={user.name} />
 }
 
-("use client");
+'use client'
 function Profile({ name }: { name: string }) {
-  return <div>{name}</div>;
+  return <div>{name}</div>
 }
 ```

--- a/.claude/skills/vercel-react-view-transitions/AGENTS.md
+++ b/.claude/skills/vercel-react-view-transitions/AGENTS.md
@@ -46,7 +46,7 @@ Guide for implementing smooth, native-feeling animations using React's View Tran
 
 ---
 
-Animate between UI states using the browser's native `document.startViewTransition`. Declare _what_ with `<ViewTransition>`, trigger _when_ with `startTransition` / `useDeferredValue` / `Suspense`, control _how_ with CSS classes. Unsupported browsers skip animations gracefully.
+Animate between UI states using the browser's native `document.startViewTransition`. Declare *what* with `<ViewTransition>`, trigger *when* with `startTransition` / `useDeferredValue` / `Suspense`, control *how* with CSS classes. Unsupported browsers skip animations gracefully.
 
 ## When to Animate
 
@@ -54,24 +54,24 @@ Every `<ViewTransition>` should communicate a spatial relationship or continuity
 
 Implement **all** applicable patterns from this list, in this order:
 
-| Priority | Pattern                            | What it communicates             |
-| -------- | ---------------------------------- | -------------------------------- |
-| 1        | **Shared element** (`name`)        | "Same thing — going deeper"      |
-| 2        | **Suspense reveal**                | "Data loaded"                    |
-| 3        | **List identity** (per-item `key`) | "Same items, new arrangement"    |
-| 4        | **State change** (`enter`/`exit`)  | "Something appeared/disappeared" |
-| 5        | **Route change** (layout-level)    | "Going to a new place"           |
+| Priority | Pattern | What it communicates |
+|----------|---------|---------------------|
+| 1 | **Shared element** (`name`) | "Same thing — going deeper" |
+| 2 | **Suspense reveal** | "Data loaded" |
+| 3 | **List identity** (per-item `key`) | "Same items, new arrangement" |
+| 4 | **State change** (`enter`/`exit`) | "Something appeared/disappeared" |
+| 5 | **Route change** (layout-level) | "Going to a new place" |
 
 This is an implementation order, not a "pick one" list. Implement every pattern that fits the app. Only skip a pattern if the app has no use case for it.
 
 ### Choosing Animation Style
 
-| Context                                 | Animation                                          | Why                          |
-| --------------------------------------- | -------------------------------------------------- | ---------------------------- |
-| Hierarchical navigation (list → detail) | Type-keyed `nav-forward` / `nav-back`              | Communicates spatial depth   |
-| Lateral navigation (tab-to-tab)         | Bare `<ViewTransition>` (fade) or `default="none"` | No depth to communicate      |
-| Suspense reveal                         | `enter`/`exit` string props                        | Content arriving             |
-| Revalidation / background refresh       | `default="none"`                                   | Silent — no animation needed |
+| Context | Animation | Why |
+|---------|-----------|-----|
+| Hierarchical navigation (list → detail) | Type-keyed `nav-forward` / `nav-back` | Communicates spatial depth |
+| Lateral navigation (tab-to-tab) | Bare `<ViewTransition>` (fade) or `default="none"` | No depth to communicate |
+| Suspense reveal | `enter`/`exit` string props | Content arriving |
+| Revalidation / background refresh | `default="none"` | Silent — no animation needed |
 
 Reserve directional slides for hierarchical navigation (list → detail) and ordered sequences (prev/next photo, carousel, paginated results). For ordered sequences, the direction communicates position: "next" slides from right, "previous" from left. Lateral/unordered navigation (tab-to-tab) should not use directional slides — it falsely implies spatial depth.
 
@@ -90,23 +90,23 @@ Reserve directional slides for hierarchical navigation (list → detail) and ord
 ### The `<ViewTransition>` Component
 
 ```jsx
-import { ViewTransition } from "react";
+import { ViewTransition } from 'react';
 
 <ViewTransition>
   <Component />
-</ViewTransition>;
+</ViewTransition>
 ```
 
 React auto-assigns a unique `view-transition-name` and calls `document.startViewTransition` behind the scenes. Never call `startViewTransition` yourself.
 
 ### Animation Triggers
 
-| Trigger    | When it fires                                                                     |
-| ---------- | --------------------------------------------------------------------------------- |
-| **enter**  | VT first inserted during a Transition                                             |
-| **exit**   | VT first removed during a Transition                                              |
+| Trigger | When it fires |
+|---------|--------------|
+| **enter** | VT first inserted during a Transition |
+| **exit** | VT first removed during a Transition |
 | **update** | DOM mutations inside a VT. With nested VTs, mutation applies to the innermost one |
-| **share**  | Named VT unmounts and another with same `name` mounts in same Transition          |
+| **share** | Named VT unmounts and another with same `name` mounts in same Transition |
 
 Only `startTransition`, `useDeferredValue`, or `Suspense` activate VTs. Regular `setState` does not animate.
 
@@ -129,12 +129,7 @@ VT only activates enter/exit if it appears **before any DOM nodes**:
 Values: `"auto"` (browser cross-fade), `"none"` (disabled), `"class-name"` (custom CSS), or `{ [type]: value }` for type-specific animations.
 
 ```jsx
-<ViewTransition
-  default="none"
-  enter="slide-in"
-  exit="slide-out"
-  share="morph"
-/>
+<ViewTransition default="none" enter="slide-in" exit="slide-out" share="morph" />
 ```
 
 If `default` is `"none"`, all triggers are off unless explicitly listed.
@@ -154,9 +149,9 @@ Tag transitions with `addTransitionType` so VTs can pick different animations. C
 
 ```jsx
 startTransition(() => {
-  addTransitionType("nav-forward");
-  addTransitionType("select-item");
-  router.push("/detail/1");
+  addTransitionType('nav-forward');
+  addTransitionType('select-item');
+  router.push('/detail/1');
 });
 ```
 
@@ -164,21 +159,9 @@ Map types to CSS classes. Works on `enter`, `exit`, **and** `share`:
 
 ```jsx
 <ViewTransition
-  enter={{
-    "nav-forward": "slide-from-right",
-    "nav-back": "slide-from-left",
-    default: "none",
-  }}
-  exit={{
-    "nav-forward": "slide-to-left",
-    "nav-back": "slide-to-right",
-    default: "none",
-  }}
-  share={{
-    "nav-forward": "morph-forward",
-    "nav-back": "morph-back",
-    default: "morph",
-  }}
+  enter={{ 'nav-forward': 'slide-from-right', 'nav-back': 'slide-from-left', default: 'none' }}
+  exit={{ 'nav-forward': 'slide-to-left', 'nav-back': 'slide-to-right', default: 'none' }}
+  share={{ 'nav-forward': 'morph-forward', 'nav-back': 'morph-back', default: 'morph' }}
   default="none"
 >
   <Page />
@@ -222,7 +205,7 @@ Same `name` on two VTs — one unmounting, one mounting — creates a shared ele
 </ViewTransition>
 ```
 
-- Only one VT with a given `name` can be mounted at a time — use unique names. Watch for reusable components: if a component with a named VT is rendered in both a modal/popover _and_ a page, both mount simultaneously and break the morph. Either make the name conditional (via a prop) or move the named VT out of the shared component into the specific consumer.
+- Only one VT with a given `name` can be mounted at a time — use unique names. Watch for reusable components: if a component with a named VT is rendered in both a modal/popover *and* a page, both mount simultaneously and break the morph. Either make the name conditional (via a prop) or move the named VT out of the shared component into the specific consumer.
 - `share` takes precedence over `enter`/`exit`. Think through each navigation path: when no pair forms, `enter`/`exit` fires instead. Consider whether the element needs a fallback animation for those paths.
 - Never use fade-out exit on pages with shared morphs — use directional slide.
 
@@ -233,25 +216,17 @@ Same `name` on two VTs — one unmounting, one mounting — creates a shared ele
 ### Enter/Exit
 
 ```jsx
-{
-  show && (
-    <ViewTransition enter="fade-in" exit="fade-out">
-      <Panel />
-    </ViewTransition>
-  );
-}
+{show && (
+  <ViewTransition enter="fade-in" exit="fade-out"><Panel /></ViewTransition>
+)}
 ```
 
 ### List Reorder
 
 ```jsx
-{
-  items.map((item) => (
-    <ViewTransition key={item.id}>
-      <ItemCard item={item} />
-    </ViewTransition>
-  ));
-}
+{items.map(item => (
+  <ViewTransition key={item.id}><ItemCard item={item} /></ViewTransition>
+))}
 ```
 
 Trigger inside `startTransition`. Avoid wrapper `<div>`s between list and VT.
@@ -261,22 +236,16 @@ Trigger inside `startTransition`. Avoid wrapper `<div>`s between list and VT.
 Shared elements and list identity are independent concerns — don't confuse one for the other. When a list item contains a shared element, use two nested `<ViewTransition>` boundaries:
 
 ```jsx
-{
-  items.map((item) => (
-    <ViewTransition key={item.id}>
-      {" "}
-      {/* list identity */}
-      <Link href={`/items/${item.id}`}>
-        <ViewTransition name={`item-image-${item.id}`} share="morph">
-          {" "}
-          {/* shared element */}
-          <Image src={item.image} />
-        </ViewTransition>
-        <p>{item.name}</p>
-      </Link>
-    </ViewTransition>
-  ));
-}
+{items.map(item => (
+  <ViewTransition key={item.id}>                                      {/* list identity */}
+    <Link href={`/items/${item.id}`}>
+      <ViewTransition name={`item-image-${item.id}`} share="morph">   {/* shared element */}
+        <Image src={item.image} />
+      </ViewTransition>
+      <p>{item.name}</p>
+    </Link>
+  </ViewTransition>
+))}
 ```
 
 The outer VT handles list reorder/enter. The inner VT handles cross-route shared element morph. Missing either layer means that animation silently doesn't happen.
@@ -294,28 +263,16 @@ The outer VT handles list reorder/enter. The inner VT handles cross-route shared
 ### Suspense Fallback to Content
 
 Simple cross-fade:
-
 ```jsx
 <ViewTransition>
-  <Suspense fallback={<Skeleton />}>
-    <Content />
-  </Suspense>
+  <Suspense fallback={<Skeleton />}><Content /></Suspense>
 </ViewTransition>
 ```
 
 Directional reveal:
-
 ```jsx
-<Suspense
-  fallback={
-    <ViewTransition exit="slide-down">
-      <Skeleton />
-    </ViewTransition>
-  }
->
-  <ViewTransition enter="slide-up" default="none">
-    <Content />
-  </ViewTransition>
+<Suspense fallback={<ViewTransition exit="slide-down"><Skeleton /></ViewTransition>}>
+  <ViewTransition enter="slide-up" default="none"><Content /></ViewTransition>
 </Suspense>
 ```
 
@@ -417,8 +374,8 @@ For `backdrop-blur`/`backdrop-filter`, use the backdrop-blur workaround instead.
 
 ```jsx
 startTransition(() => {
-  addTransitionType("nav-forward");
-  router.push("/detail/1");
+  addTransitionType('nav-forward');
+  router.push('/detail/1');
 });
 ```
 
@@ -426,16 +383,8 @@ Wrap each **page component** (not layout) in a type-keyed VT:
 
 ```jsx
 <ViewTransition
-  enter={{
-    "nav-forward": "nav-forward",
-    "nav-back": "nav-back",
-    default: "none",
-  }}
-  exit={{
-    "nav-forward": "nav-forward",
-    "nav-back": "nav-back",
-    default: "none",
-  }}
+  enter={{ "nav-forward": "nav-forward", "nav-back": "nav-back", default: "none" }}
+  exit={{ "nav-forward": "nav-forward", "nav-back": "nav-back", default: "none" }}
   default="none"
 >
   <div>...page content...</div>
@@ -463,16 +412,8 @@ export function DirectionalTransition({ children }: { children: React.ReactNode 
 ## Step 5: Add Suspense Reveals
 
 ```jsx
-<Suspense
-  fallback={
-    <ViewTransition exit="slide-down">
-      <Skeleton />
-    </ViewTransition>
-  }
->
-  <ViewTransition enter="slide-up" default="none">
-    <AsyncContent />
-  </ViewTransition>
+<Suspense fallback={<ViewTransition exit="slide-down"><Skeleton /></ViewTransition>}>
+  <ViewTransition enter="slide-up" default="none"><AsyncContent /></ViewTransition>
 </Suspense>
 ```
 
@@ -532,7 +473,7 @@ Walk through every row in the navigation map from Step 1:
 - **Type maps on Suspense reveals** — Suspense resolves have no type, use string props
 - **Raw `viewTransitionName` CSS to trigger animations** — React only starts view transitions when `<ViewTransition>` components are in the tree. Bare `viewTransitionName` is for isolating elements, not triggering animations.
 - **`update` trigger for same-route navigations** — nested VTs steal the mutation from the parent. Use `key` + `name` + `share` instead.
-- **Named VT in a reusable component** — if a component with a named VT is rendered in both a modal/popover _and_ a page, both mount simultaneously and break the morph. Make the name conditional or move it to the specific consumer.
+- **Named VT in a reusable component** — if a component with a named VT is rendered in both a modal/popover *and* a page, both mount simultaneously and break the morph. Make the name conditional or move it to the specific consumer.
 - **`router.back()` for back navigation** — `router.back()` triggers synchronous `popstate`, incompatible with view transitions. Use `router.push()` with an explicit URL.
 
 For Next.js-specific steps, see the Next.js section below.
@@ -544,20 +485,17 @@ For Next.js-specific steps, see the Next.js section below.
 ## Searchable Grid with `useDeferredValue`
 
 ```tsx
-"use client";
+'use client';
 
-import { useDeferredValue, useState, ViewTransition, Suspense } from "react";
+import { useDeferredValue, useState, ViewTransition, Suspense } from 'react';
 
 export default function SearchableGrid({ itemsPromise }) {
-  const [search, setSearch] = useState("");
+  const [search, setSearch] = useState('');
   const deferredSearch = useDeferredValue(search);
 
   return (
     <>
-      <input
-        value={search}
-        onChange={(e) => setSearch(e.currentTarget.value)}
-      />
+      <input value={search} onChange={(e) => setSearch(e.currentTarget.value)} />
       <ViewTransition>
         <Suspense fallback={<GridSkeleton />}>
           <ItemGrid itemsPromise={itemsPromise} search={deferredSearch} />
@@ -573,9 +511,9 @@ Per-item named VTs in deferred lists trigger cross-fades on every keystroke. Fix
 ## Card Expand/Collapse with `startTransition`
 
 ```tsx
-"use client";
+'use client';
 
-import { useState, useRef, startTransition, ViewTransition } from "react";
+import { useState, useRef, startTransition, ViewTransition } from 'react';
 
 export default function ItemGrid({ items }) {
   const [expandedId, setExpandedId] = useState(null);
@@ -584,22 +522,18 @@ export default function ItemGrid({ items }) {
   return expandedId ? (
     <ViewTransition enter="slide-in" name={`item-${expandedId}`}>
       <ItemDetail
-        item={items.find((i) => i.id === expandedId)}
+        item={items.find(i => i.id === expandedId)}
         onClose={() => {
           startTransition(() => {
             setExpandedId(null);
-            setTimeout(
-              () =>
-                window.scrollTo({ behavior: "smooth", top: scrollRef.current }),
-              100,
-            );
+            setTimeout(() => window.scrollTo({ behavior: 'smooth', top: scrollRef.current }), 100);
           });
         }}
       />
     </ViewTransition>
   ) : (
     <div className="grid grid-cols-3 gap-4">
-      {items.map((item) => (
+      {items.map(item => (
         <ViewTransition key={item.id} name={`item-${item.id}`}>
           <ItemCard
             item={item}
@@ -620,9 +554,7 @@ export default function ItemGrid({ items }) {
 Omit `key` to trigger update (cross-fade) instead of exit + enter. Avoids Suspense remount:
 
 ```jsx
-<ViewTransition>
-  <TabPanel tab={activeTab} />
-</ViewTransition>
+<ViewTransition><TabPanel tab={activeTab} /></ViewTransition>
 ```
 
 ## Isolate Elements from Parent Animations
@@ -634,10 +566,7 @@ Persistent elements get captured in page's transition snapshot. Fix with `viewTr
 ```
 
 ```css
-::view-transition-group(persistent-nav) {
-  animation: none;
-  z-index: 100;
-}
+::view-transition-group(persistent-nav) { animation: none; z-index: 100; }
 ```
 
 Same for floating elements (popovers, tooltips). Global fix: `::view-transition-group(*) { z-index: 100; }`
@@ -651,21 +580,15 @@ Give matching controls the same `viewTransitionName`. Don't put manual `viewTran
 ```jsx
 function AnimatedCollapse({ open, children }) {
   if (!open) return null;
-  return (
-    <ViewTransition enter="expand-in" exit="collapse-out">
-      {children}
-    </ViewTransition>
-  );
+  return <ViewTransition enter="expand-in" exit="collapse-out">{children}</ViewTransition>;
 }
 ```
 
 ## Preserve State with Activity
 
 ```jsx
-<Activity mode={isVisible ? "visible" : "hidden"}>
-  <ViewTransition enter="slide-in" exit="slide-out">
-    <Sidebar />
-  </ViewTransition>
+<Activity mode={isVisible ? 'visible' : 'hidden'}>
+  <ViewTransition enter="slide-in" exit="slide-out"><Sidebar /></ViewTransition>
 </Activity>
 ```
 
@@ -683,11 +606,8 @@ Imperative control via `onEnter`, `onExit`, `onUpdate`, `onShare`. Always return
 <ViewTransition
   onEnter={(instance, types) => {
     const anim = instance.new.animate(
-      [
-        { transform: "scale(0.8)", opacity: 0 },
-        { transform: "scale(1)", opacity: 1 },
-      ],
-      { duration: 300, easing: "ease-out" },
+      [{ transform: 'scale(0.8)', opacity: 0 }, { transform: 'scale(1)', opacity: 1 }],
+      { duration: 300, easing: 'ease-out' }
     );
     return () => anim.cancel();
   }}
@@ -702,11 +622,11 @@ Imperative control via `onEnter`, `onExit`, `onUpdate`, `onShare`. Always return
 
 ## Animation Timing
 
-| Interaction          | Duration  |
-| -------------------- | --------- |
-| Direct toggle        | 100–200ms |
-| Route transition     | 150–250ms |
-| Suspense reveal      | 200–400ms |
+| Interaction | Duration |
+|------------|----------|
+| Direct toggle | 100–200ms |
+| Route transition | 150–250ms |
+| Suspense reveal | 200–400ms |
 | Shared element morph | 300–500ms |
 
 ---
@@ -751,32 +671,18 @@ Ready-to-use CSS for `<ViewTransition>` props. Copy into global stylesheet.
 
 ```css
 @keyframes fade {
-  from {
-    filter: blur(3px);
-    opacity: 0;
-  }
-  to {
-    filter: blur(0);
-    opacity: 1;
-  }
+  from { filter: blur(3px); opacity: 0; }
+  to { filter: blur(0); opacity: 1; }
 }
 
 @keyframes slide {
-  from {
-    translate: var(--slide-offset);
-  }
-  to {
-    translate: 0;
-  }
+  from { translate: var(--slide-offset); }
+  to { translate: 0; }
 }
 
 @keyframes slide-y {
-  from {
-    transform: translateY(var(--slide-y-offset, 10px));
-  }
-  to {
-    transform: translateY(0);
-  }
+  from { transform: translateY(var(--slide-y-offset, 10px)); }
+  to { transform: translateY(0); }
 }
 ```
 
@@ -878,9 +784,7 @@ Ready-to-use CSS for `<ViewTransition>` props. Copy into global stylesheet.
   animation-name: via-blur;
 }
 @keyframes via-blur {
-  30% {
-    filter: blur(3px);
-  }
+  30% { filter: blur(3px); }
 }
 ```
 
@@ -914,24 +818,12 @@ Avoids raster scaling artifacts on text by hiding the old snapshot and showing t
   animation: var(--duration-enter) ease-out var(--duration-exit) both scale-up;
 }
 @keyframes scale-down {
-  from {
-    transform: scale(1);
-    opacity: 1;
-  }
-  to {
-    transform: scale(0.85);
-    opacity: 0;
-  }
+  from { transform: scale(1); opacity: 1; }
+  to { transform: scale(0.85); opacity: 0; }
 }
 @keyframes scale-up {
-  from {
-    transform: scale(0.85);
-    opacity: 0;
-  }
-  to {
-    transform: scale(1);
-    opacity: 1;
-  }
+  from { transform: scale(0.85); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
 }
 ```
 
@@ -947,12 +839,8 @@ Avoids raster scaling artifacts on text by hiding the old snapshot and showing t
 ### Backdrop-Blur Workaround
 
 ```css
-::view-transition-old(persistent-nav) {
-  display: none;
-}
-::view-transition-new(persistent-nav) {
-  animation: none;
-}
+::view-transition-old(persistent-nav) { display: none; }
+::view-transition-new(persistent-nav) { animation: none; }
 ```
 
 ## Reduced Motion
@@ -976,9 +864,7 @@ Avoids raster scaling artifacts on text by hiding the old snapshot and showing t
 
 ```js
 // next.config.js
-experimental: {
-  viewTransition: true;
-}
+experimental: { viewTransition: true }
 ```
 
 Wraps every `<Link>` navigation in `document.startViewTransition`. Use `default="none"` to prevent competing animations. Do **not** install `react@canary` — the App Router already bundles it.
@@ -988,7 +874,6 @@ Wraps every `<Link>` navigation in `document.startViewTransition`. Use `default=
 **After Step 2:** Enable the experimental flag.
 
 **Step 4:** Use `transitionTypes` on `<Link>` (if available — see availability note below):
-
 ```tsx
 <Link href="/photo/1" transitionTypes={["nav-forward"]}>View</Link>
 <Link href="/" transitionTypes={["nav-back"]}>Back</Link>
@@ -1003,11 +888,8 @@ Don't add a layout-level VT wrapping `{children}` if pages have their own VTs �
 ## The `transitionTypes` Prop
 
 Works in Server Components, no wrapper needed:
-
 ```tsx
-<Link href="/products/1" transitionTypes={["nav-forward"]}>
-  View
-</Link>
+<Link href="/products/1" transitionTypes={['nav-forward']}>View</Link>
 ```
 
 **Availability:** Requires `experimental.viewTransition: true`. Available in Next.js 15+ canary builds and Next.js 16+. If unavailable, use `startTransition` + `addTransitionType` + `router.push()`. To check: `grep -r "transitionTypes" node_modules/next/dist/`. Reserve manual `startTransition` for non-link interactions.
@@ -1031,16 +913,8 @@ Directional slides + Suspense reveals coexist because they fire at different mom
   default="none"
 >
   <div>
-    <Suspense
-      fallback={
-        <ViewTransition exit="slide-down">
-          <Skeleton />
-        </ViewTransition>
-      }
-    >
-      <ViewTransition enter="slide-up" default="none">
-        <Content />
-      </ViewTransition>
+    <Suspense fallback={<ViewTransition exit="slide-down"><Skeleton /></ViewTransition>}>
+      <ViewTransition enter="slide-up" default="none"><Content /></ViewTransition>
     </Suspense>
   </div>
 </ViewTransition>
@@ -1068,12 +942,7 @@ Page stays mounted on dynamic segment change — enter/exit never fire. Use `key
 
 ```tsx
 <Suspense fallback={<Skeleton />}>
-  <ViewTransition
-    key={slug}
-    name={`collection-${slug}`}
-    share="auto"
-    default="none"
-  >
+  <ViewTransition key={slug} name={`collection-${slug}`} share="auto" default="none">
     <Content slug={slug} />
   </ViewTransition>
 </Suspense>

--- a/.claude/skills/vercel-react-view-transitions/SKILL.md
+++ b/.claude/skills/vercel-react-view-transitions/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 
 # React View Transitions
 
-Animate between UI states using the browser's native `document.startViewTransition`. Declare _what_ with `<ViewTransition>`, trigger _when_ with `startTransition` / `useDeferredValue` / `Suspense`, control _how_ with CSS classes. Unsupported browsers skip animations gracefully.
+Animate between UI states using the browser's native `document.startViewTransition`. Declare *what* with `<ViewTransition>`, trigger *when* with `startTransition` / `useDeferredValue` / `Suspense`, control *how* with CSS classes. Unsupported browsers skip animations gracefully.
 
 ## When to Animate
 
@@ -17,24 +17,24 @@ Every `<ViewTransition>` should communicate a spatial relationship or continuity
 
 Implement **all** applicable patterns from this list, in this order:
 
-| Priority | Pattern                            | What it communicates             |
-| -------- | ---------------------------------- | -------------------------------- |
-| 1        | **Shared element** (`name`)        | "Same thing — going deeper"      |
-| 2        | **Suspense reveal**                | "Data loaded"                    |
-| 3        | **List identity** (per-item `key`) | "Same items, new arrangement"    |
-| 4        | **State change** (`enter`/`exit`)  | "Something appeared/disappeared" |
-| 5        | **Route change** (layout-level)    | "Going to a new place"           |
+| Priority | Pattern | What it communicates |
+|----------|---------|---------------------|
+| 1 | **Shared element** (`name`) | "Same thing — going deeper" |
+| 2 | **Suspense reveal** | "Data loaded" |
+| 3 | **List identity** (per-item `key`) | "Same items, new arrangement" |
+| 4 | **State change** (`enter`/`exit`) | "Something appeared/disappeared" |
+| 5 | **Route change** (layout-level) | "Going to a new place" |
 
 This is an implementation order, not a "pick one" list. Implement every pattern that fits the app. Only skip a pattern if the app has no use case for it.
 
 ### Choosing Animation Style
 
-| Context                                 | Animation                                          | Why                          |
-| --------------------------------------- | -------------------------------------------------- | ---------------------------- |
-| Hierarchical navigation (list → detail) | Type-keyed `nav-forward` / `nav-back`              | Communicates spatial depth   |
-| Lateral navigation (tab-to-tab)         | Bare `<ViewTransition>` (fade) or `default="none"` | No depth to communicate      |
-| Suspense reveal                         | `enter`/`exit` string props                        | Content arriving             |
-| Revalidation / background refresh       | `default="none"`                                   | Silent — no animation needed |
+| Context | Animation | Why |
+|---------|-----------|-----|
+| Hierarchical navigation (list → detail) | Type-keyed `nav-forward` / `nav-back` | Communicates spatial depth |
+| Lateral navigation (tab-to-tab) | Bare `<ViewTransition>` (fade) or `default="none"` | No depth to communicate |
+| Suspense reveal | `enter`/`exit` string props | Content arriving |
+| Revalidation / background refresh | `default="none"` | Silent — no animation needed |
 
 Reserve directional slides for hierarchical navigation (list → detail) and ordered sequences (prev/next photo, carousel, paginated results). For ordered sequences, the direction communicates position: "next" slides from right, "previous" from left. Lateral/unordered navigation (tab-to-tab) should not use directional slides — it falsely implies spatial depth.
 
@@ -59,23 +59,23 @@ When adding view transitions to an existing app, **follow `references/implementa
 ### The `<ViewTransition>` Component
 
 ```jsx
-import { ViewTransition } from "react";
+import { ViewTransition } from 'react';
 
 <ViewTransition>
   <Component />
-</ViewTransition>;
+</ViewTransition>
 ```
 
 React auto-assigns a unique `view-transition-name` and calls `document.startViewTransition` behind the scenes. Never call `startViewTransition` yourself.
 
 ### Animation Triggers
 
-| Trigger    | When it fires                                                                                     |
-| ---------- | ------------------------------------------------------------------------------------------------- |
-| **enter**  | `<ViewTransition>` first inserted during a Transition                                             |
-| **exit**   | `<ViewTransition>` first removed during a Transition                                              |
+| Trigger | When it fires |
+|---------|--------------|
+| **enter** | `<ViewTransition>` first inserted during a Transition |
+| **exit** | `<ViewTransition>` first removed during a Transition |
 | **update** | DOM mutations inside a `<ViewTransition>`. With nested VTs, mutation applies to the innermost one |
-| **share**  | Named VT unmounts and another with same `name` mounts in the same Transition                      |
+| **share** | Named VT unmounts and another with same `name` mounts in the same Transition |
 
 Only `startTransition`, `useDeferredValue`, or `Suspense` activate VTs. Regular `setState` does not animate.
 
@@ -106,12 +106,7 @@ Only `startTransition`, `useDeferredValue`, or `Suspense` activate VTs. Regular 
 Values: `"auto"` (browser cross-fade), `"none"` (disabled), `"class-name"` (custom CSS), or `{ [type]: value }` for type-specific animations.
 
 ```jsx
-<ViewTransition
-  default="none"
-  enter="slide-in"
-  exit="slide-out"
-  share="morph"
-/>
+<ViewTransition default="none" enter="slide-in" exit="slide-out" share="morph" />
 ```
 
 If `default` is `"none"`, all triggers are off unless explicitly listed.
@@ -133,9 +128,9 @@ Tag transitions with `addTransitionType` so VTs can pick different animations ba
 
 ```jsx
 startTransition(() => {
-  addTransitionType("nav-forward");
-  addTransitionType("select-item");
-  router.push("/detail/1");
+  addTransitionType('nav-forward');
+  addTransitionType('select-item');
+  router.push('/detail/1');
 });
 ```
 
@@ -143,21 +138,9 @@ Pass an object to map types to CSS classes. Works on `enter`, `exit`, **and** `s
 
 ```jsx
 <ViewTransition
-  enter={{
-    "nav-forward": "slide-from-right",
-    "nav-back": "slide-from-left",
-    default: "none",
-  }}
-  exit={{
-    "nav-forward": "slide-to-left",
-    "nav-back": "slide-to-right",
-    default: "none",
-  }}
-  share={{
-    "nav-forward": "morph-forward",
-    "nav-back": "morph-back",
-    default: "morph",
-  }}
+  enter={{ 'nav-forward': 'slide-from-right', 'nav-back': 'slide-from-left', default: 'none' }}
+  exit={{ 'nav-forward': 'slide-to-left', 'nav-back': 'slide-to-right', default: 'none' }}
+  share={{ 'nav-forward': 'morph-forward', 'nav-back': 'morph-back', default: 'morph' }}
   default="none"
 >
   <Page />
@@ -217,7 +200,7 @@ Same `name` on two VTs — one unmounting, one mounting — creates a shared ele
 </ViewTransition>
 ```
 
-- Only one VT with a given `name` can be mounted at a time — use unique names (`photo-${id}`). Watch for reusable components: if a component with a named VT is rendered in both a modal/popover _and_ a page, both mount simultaneously and break the morph. Either make the name conditional (via a prop) or move the named VT out of the shared component into the specific consumer.
+- Only one VT with a given `name` can be mounted at a time — use unique names (`photo-${id}`). Watch for reusable components: if a component with a named VT is rendered in both a modal/popover *and* a page, both mount simultaneously and break the morph. Either make the name conditional (via a prop) or move the named VT out of the shared component into the specific consumer.
 - `share` takes precedence over `enter`/`exit`. Think through each navigation path: when no matching pair forms (e.g., the target page doesn't have the same name), `enter`/`exit` fires instead. Consider whether the element needs a fallback animation for those paths.
 - Never use a fade-out exit on pages with shared morphs — use a directional slide instead.
 
@@ -228,25 +211,17 @@ Same `name` on two VTs — one unmounting, one mounting — creates a shared ele
 ### Enter/Exit
 
 ```jsx
-{
-  show && (
-    <ViewTransition enter="fade-in" exit="fade-out">
-      <Panel />
-    </ViewTransition>
-  );
-}
+{show && (
+  <ViewTransition enter="fade-in" exit="fade-out"><Panel /></ViewTransition>
+)}
 ```
 
 ### List Reorder
 
 ```jsx
-{
-  items.map((item) => (
-    <ViewTransition key={item.id}>
-      <ItemCard item={item} />
-    </ViewTransition>
-  ));
-}
+{items.map(item => (
+  <ViewTransition key={item.id}><ItemCard item={item} /></ViewTransition>
+))}
 ```
 
 Trigger inside `startTransition`. Avoid wrapper `<div>`s between list and VT.
@@ -256,22 +231,16 @@ Trigger inside `startTransition`. Avoid wrapper `<div>`s between list and VT.
 Shared elements and list identity are independent concerns — don't confuse one for the other. When a list item contains a shared element (e.g., an image that morphs into a detail view), use two nested `<ViewTransition>` boundaries:
 
 ```jsx
-{
-  items.map((item) => (
-    <ViewTransition key={item.id}>
-      {" "}
-      {/* list identity */}
-      <Link href={`/items/${item.id}`}>
-        <ViewTransition name={`item-image-${item.id}`} share="morph">
-          {" "}
-          {/* shared element */}
-          <Image src={item.image} />
-        </ViewTransition>
-        <p>{item.name}</p>
-      </Link>
-    </ViewTransition>
-  ));
-}
+{items.map(item => (
+  <ViewTransition key={item.id}>                                      {/* list identity */}
+    <Link href={`/items/${item.id}`}>
+      <ViewTransition name={`item-image-${item.id}`} share="morph">   {/* shared element */}
+        <Image src={item.image} />
+      </ViewTransition>
+      <p>{item.name}</p>
+    </Link>
+  </ViewTransition>
+))}
 ```
 
 The outer VT handles list reorder/enter animations. The inner VT handles the cross-route shared element morph. Missing either layer means that animation silently doesn't happen.
@@ -289,28 +258,16 @@ The outer VT handles list reorder/enter animations. The inner VT handles the cro
 ### Suspense Fallback to Content
 
 Simple cross-fade:
-
 ```jsx
 <ViewTransition>
-  <Suspense fallback={<Skeleton />}>
-    <Content />
-  </Suspense>
+  <Suspense fallback={<Skeleton />}><Content /></Suspense>
 </ViewTransition>
 ```
 
 Directional reveal:
-
 ```jsx
-<Suspense
-  fallback={
-    <ViewTransition exit="slide-down">
-      <Skeleton />
-    </ViewTransition>
-  }
->
-  <ViewTransition enter="slide-up" default="none">
-    <Content />
-  </ViewTransition>
+<Suspense fallback={<ViewTransition exit="slide-down"><Skeleton /></ViewTransition>}>
+  <ViewTransition enter="slide-up" default="none"><Content /></ViewTransition>
 </Suspense>
 ```
 

--- a/.claude/skills/vercel-react-view-transitions/references/css-recipes.md
+++ b/.claude/skills/vercel-react-view-transitions/references/css-recipes.md
@@ -18,32 +18,18 @@ Ready-to-use CSS for `<ViewTransition>` props. Copy into your global stylesheet.
 
 ```css
 @keyframes fade {
-  from {
-    filter: blur(3px);
-    opacity: 0;
-  }
-  to {
-    filter: blur(0);
-    opacity: 1;
-  }
+  from { filter: blur(3px); opacity: 0; }
+  to { filter: blur(0); opacity: 1; }
 }
 
 @keyframes slide {
-  from {
-    translate: var(--slide-offset);
-  }
-  to {
-    translate: 0;
-  }
+  from { translate: var(--slide-offset); }
+  to { translate: 0; }
 }
 
 @keyframes slide-y {
-  from {
-    transform: translateY(var(--slide-y-offset, 10px));
-  }
-  to {
-    transform: translateY(0);
-  }
+  from { transform: translateY(var(--slide-y-offset, 10px)); }
+  to { transform: translateY(0); }
 }
 ```
 
@@ -80,18 +66,9 @@ Usage: `<ViewTransition enter="fade-in" exit="fade-out" />`
 ```
 
 Usage:
-
 ```jsx
-<Suspense
-  fallback={
-    <ViewTransition exit="slide-down">
-      <Skeleton />
-    </ViewTransition>
-  }
->
-  <ViewTransition default="none" enter="slide-up">
-    <Content />
-  </ViewTransition>
+<Suspense fallback={<ViewTransition exit="slide-down"><Skeleton /></ViewTransition>}>
+  <ViewTransition default="none" enter="slide-up"><Content /></ViewTransition>
 </Suspense>
 ```
 
@@ -173,9 +150,7 @@ Usage:
 }
 
 @keyframes via-blur {
-  30% {
-    filter: blur(3px);
-  }
+  30% { filter: blur(3px); }
 }
 ```
 
@@ -216,24 +191,12 @@ Usage: `<ViewTransition name={`title-${id}`} share="text-morph" />`
 }
 
 @keyframes scale-down {
-  from {
-    transform: scale(1);
-    opacity: 1;
-  }
-  to {
-    transform: scale(0.85);
-    opacity: 0;
-  }
+  from { transform: scale(1); opacity: 1; }
+  to { transform: scale(0.85); opacity: 0; }
 }
 @keyframes scale-up {
-  from {
-    transform: scale(0.85);
-    opacity: 0;
-  }
-  to {
-    transform: scale(1);
-    opacity: 1;
-  }
+  from { transform: scale(0.85); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
 }
 ```
 

--- a/.claude/skills/vercel-react-view-transitions/references/implementation.md
+++ b/.claude/skills/vercel-react-view-transitions/references/implementation.md
@@ -51,8 +51,8 @@ For hierarchical navigations identified in Step 1, tag the navigation direction 
 
 ```jsx
 startTransition(() => {
-  addTransitionType("nav-forward");
-  router.push("/detail/1");
+  addTransitionType('nav-forward');
+  router.push('/detail/1');
 });
 ```
 
@@ -97,7 +97,6 @@ export function DirectionalTransition({ children }: { children: React.ReactNode 
 This also becomes the single place to adjust if you add new transition types later.
 
 **Rules:**
-
 - Always pair `enter` with `exit` — without an exit animation, the old page disappears instantly while the new one animates in.
 - Always include `default: "none"` in type map objects and `default="none"` on the component — otherwise it fires on every transition.
 - Place the directional `<ViewTransition>` in each page component, not in a layout. Layouts persist across navigations and never trigger enter/exit.
@@ -124,7 +123,6 @@ For every `<Suspense>` boundary identified in Step 1, wrap the fallback and cont
 This example uses `slide-down` / `slide-up` for directional vertical motion. For a simpler reveal, a bare `<ViewTransition>` around the `<Suspense>` gives a cross-fade with zero configuration. Choose based on the spatial meaning — consult the "Choosing the Right Animation Style" table in the main skill file.
 
 **Rules:**
-
 - Always use `default="none"` on the content `<ViewTransition>` to prevent re-animation on revalidation or unrelated transitions.
 - Use simple string props (not type maps) on Suspense `<ViewTransition>`s — Suspense resolves fire as separate transitions with no type, so type-keyed props won't match.
 
@@ -149,7 +147,6 @@ The `share="morph"` class uses the morph recipe from `css-recipes.md` (controlle
 When list items contain shared elements, compose both patterns with two nested `<ViewTransition>` layers — see "Composing Shared Elements with List Identity" in `SKILL.md`.
 
 **Rules:**
-
 - Names must be globally unique — use prefixes like `photo-${id}`.
 - Add `default="none"` on list-side shared elements to prevent per-item cross-fades on filter/search updates.
 
@@ -177,7 +174,7 @@ If any path produces no animation or competing animations, revisit the relevant 
 - **Type maps on Suspense reveals** — Suspense resolves fire as separate transitions with no type. Type-keyed props won't match — use simple string props instead.
 - **Raw `viewTransitionName` CSS to trigger animations** — React only calls `document.startViewTransition` when `<ViewTransition>` components are in the tree. A bare `viewTransitionName` style is for isolating elements from a parent's snapshot, not for triggering animations.
 - **`update` trigger for same-route navigations** — nested VTs inside the content steal the mutation from the parent, so `update` never fires on the outer VT. Use `key` + `name` + `share` instead.
-- **Named VT in a reusable component** — if a component with a named VT is rendered in both a modal/popover _and_ a page, both mount simultaneously and break the morph. Make the name conditional or move it to the specific consumer.
+- **Named VT in a reusable component** — if a component with a named VT is rendered in both a modal/popover *and* a page, both mount simultaneously and break the morph. Make the name conditional or move it to the specific consumer.
 - **`router.back()` for back navigation** — `router.back()` triggers synchronous `popstate`, incompatible with view transitions. Use `router.push()` with an explicit URL.
 
 ---

--- a/.claude/skills/vercel-react-view-transitions/references/nextjs.md
+++ b/.claude/skills/vercel-react-view-transitions/references/nextjs.md
@@ -45,9 +45,7 @@ A bare `<ViewTransition>` in layout works only if pages have **no** VTs of their
 No wrapper component needed, works in Server Components:
 
 ```tsx
-<Link href="/products/1" transitionTypes={["transition-to-detail"]}>
-  View Product
-</Link>
+<Link href="/products/1" transitionTypes={['transition-to-detail']}>View Product</Link>
 ```
 
 Replaces the manual pattern of `onNavigate` + `startTransition` + `addTransitionType` + `router.push()`. Reserve manual `startTransition` for non-link interactions (buttons, forms).
@@ -59,15 +57,15 @@ Replaces the manual pattern of `onNavigate` + `startTransition` + `addTransition
 ## Programmatic Navigation
 
 ```tsx
-"use client";
+'use client';
 
-import { useRouter } from "next/navigation";
-import { startTransition, addTransitionType } from "react";
+import { useRouter } from 'next/navigation';
+import { startTransition, addTransitionType } from 'react';
 
 function handleNavigate(href: string) {
   const router = useRouter();
   startTransition(() => {
-    addTransitionType("nav-forward");
+    addTransitionType('nav-forward');
     router.push(href);
   });
 }
@@ -80,10 +78,10 @@ function handleNavigate(href: string) {
 For search/sort/filter that re-renders on the server (via URL params), use `startTransition` + `router.replace`. VTs activate because the state update is inside `startTransition`:
 
 ```tsx
-"use client";
+'use client';
 
-import { useRouter } from "next/navigation";
-import { startTransition } from "react";
+import { useRouter } from 'next/navigation';
+import { startTransition } from 'react';
 
 function handleSort(sort: string) {
   const router = useRouter();
@@ -108,16 +106,8 @@ Directional slides + Suspense reveals coexist because they fire at different mom
   default="none"
 >
   <div>
-    <Suspense
-      fallback={
-        <ViewTransition exit="slide-down">
-          <Skeleton />
-        </ViewTransition>
-      }
-    >
-      <ViewTransition enter="slide-up" default="none">
-        <Content />
-      </ViewTransition>
+    <Suspense fallback={<ViewTransition exit="slide-down"><Skeleton /></ViewTransition>}>
+      <ViewTransition enter="slide-up" default="none"><Content /></ViewTransition>
     </Suspense>
   </div>
 </ViewTransition>
@@ -145,29 +135,18 @@ Same rules as explicit `<Suspense>`: use simple string props (not type maps) sin
 
 ```tsx
 // List page
-{
-  products.map((product) => (
-    <Link
-      key={product.id}
-      href={`/products/${product.id}`}
-      transitionTypes={["nav-forward"]}
-    >
-      <ViewTransition name={`product-${product.id}`}>
-        <Image
-          src={product.image}
-          alt={product.name}
-          width={400}
-          height={300}
-        />
-      </ViewTransition>
-    </Link>
-  ));
-}
+{products.map((product) => (
+  <Link key={product.id} href={`/products/${product.id}`} transitionTypes={['nav-forward']}>
+    <ViewTransition name={`product-${product.id}`}>
+      <Image src={product.image} alt={product.name} width={400} height={300} />
+    </ViewTransition>
+  </Link>
+))}
 
 // Detail page — same name
 <ViewTransition name={`product-${product.id}`}>
   <Image src={product.image} alt={product.name} width={800} height={600} />
-</ViewTransition>;
+</ViewTransition>
 ```
 
 ---
@@ -178,12 +157,7 @@ When navigating between dynamic segments of the same route (e.g., `/collection/[
 
 ```tsx
 <Suspense fallback={<Skeleton />}>
-  <ViewTransition
-    key={slug}
-    name={`collection-${slug}`}
-    share="auto"
-    default="none"
-  >
+  <ViewTransition key={slug} name={`collection-${slug}`} share="auto" default="none">
     <Content slug={slug} />
   </ViewTransition>
 </Suspense>

--- a/.claude/skills/vercel-react-view-transitions/references/patterns.md
+++ b/.claude/skills/vercel-react-view-transitions/references/patterns.md
@@ -5,20 +5,17 @@
 `useDeferredValue` makes filter updates a transition, activating `<ViewTransition>`:
 
 ```tsx
-"use client";
+'use client';
 
-import { useDeferredValue, useState, ViewTransition, Suspense } from "react";
+import { useDeferredValue, useState, ViewTransition, Suspense } from 'react';
 
 export default function SearchableGrid({ itemsPromise }) {
-  const [search, setSearch] = useState("");
+  const [search, setSearch] = useState('');
   const deferredSearch = useDeferredValue(search);
 
   return (
     <>
-      <input
-        value={search}
-        onChange={(e) => setSearch(e.currentTarget.value)}
-      />
+      <input value={search} onChange={(e) => setSearch(e.currentTarget.value)} />
       <ViewTransition>
         <Suspense fallback={<GridSkeleton />}>
           <ItemGrid itemsPromise={itemsPromise} search={deferredSearch} />
@@ -32,18 +29,11 @@ export default function SearchableGrid({ itemsPromise }) {
 Per-item `<ViewTransition name={...}>` inside a deferred list triggers cross-fades on every keystroke. Fix with `default="none"`:
 
 ```tsx
-{
-  filteredItems.map((item) => (
-    <ViewTransition
-      key={item.id}
-      name={`item-${item.id}`}
-      share="morph"
-      default="none"
-    >
-      <ItemCard item={item} />
-    </ViewTransition>
-  ));
-}
+{filteredItems.map(item => (
+  <ViewTransition key={item.id} name={`item-${item.id}`} share="morph" default="none">
+    <ItemCard item={item} />
+  </ViewTransition>
+))}
 ```
 
 ## Card Expand/Collapse with `startTransition`
@@ -51,9 +41,9 @@ Per-item `<ViewTransition name={...}>` inside a deferred list triggers cross-fad
 Toggle between grid and detail view with shared element morph:
 
 ```tsx
-"use client";
+'use client';
 
-import { useState, useRef, startTransition, ViewTransition } from "react";
+import { useState, useRef, startTransition, ViewTransition } from 'react';
 
 export default function ItemGrid({ items }) {
   const [expandedId, setExpandedId] = useState(null);
@@ -62,22 +52,18 @@ export default function ItemGrid({ items }) {
   return expandedId ? (
     <ViewTransition enter="slide-in" name={`item-${expandedId}`}>
       <ItemDetail
-        item={items.find((i) => i.id === expandedId)}
+        item={items.find(i => i.id === expandedId)}
         onClose={() => {
           startTransition(() => {
             setExpandedId(null);
-            setTimeout(
-              () =>
-                window.scrollTo({ behavior: "smooth", top: scrollRef.current }),
-              100,
-            );
+            setTimeout(() => window.scrollTo({ behavior: 'smooth', top: scrollRef.current }), 100);
           });
         }}
       />
     </ViewTransition>
   ) : (
     <div className="grid grid-cols-3 gap-4">
-      {items.map((item) => (
+      {items.map(item => (
         <ViewTransition key={item.id} name={`item-${item.id}`}>
           <ItemCard
             item={item}
@@ -98,38 +84,19 @@ export default function ItemGrid({ items }) {
 Use `as const` arrays and derived types to prevent ID clashes:
 
 ```tsx
-const transitionTypes = [
-  "default",
-  "transition-to-detail",
-  "transition-to-list",
-] as const;
-const animationTypes = [
-  "auto",
-  "none",
-  "animate-slide-from-left",
-  "animate-slide-from-right",
-] as const;
+const transitionTypes = ['default', 'transition-to-detail', 'transition-to-list'] as const;
+const animationTypes = ['auto', 'none', 'animate-slide-from-left', 'animate-slide-from-right'] as const;
 
 type TransitionType = (typeof transitionTypes)[number];
 type AnimationType = (typeof animationTypes)[number];
-type TransitionMap = { default: AnimationType } & Partial<
-  Record<Exclude<TransitionType, "default">, AnimationType>
->;
+type TransitionMap = { default: AnimationType } & Partial<Record<Exclude<TransitionType, 'default'>, AnimationType>>;
 
-export function HorizontalTransition({
-  children,
-  enter,
-  exit,
-}: {
+export function HorizontalTransition({ children, enter, exit }: {
   children: React.ReactNode;
   enter: TransitionMap;
   exit: TransitionMap;
 }) {
-  return (
-    <ViewTransition enter={enter} exit={exit}>
-      {children}
-    </ViewTransition>
-  );
+  return <ViewTransition enter={enter} exit={exit}>{children}</ViewTransition>;
 }
 ```
 
@@ -162,9 +129,7 @@ Then add the persistent element isolation CSS from `css-recipes.md`. For `backdr
 Give popovers/tooltips their own `viewTransitionName`:
 
 ```jsx
-<SelectPopover style={{ viewTransitionName: "popover" }}>
-  {options}
-</SelectPopover>
+<SelectPopover style={{ viewTransitionName: 'popover' }}>{options}</SelectPopover>
 ```
 
 Global fix: see persistent element isolation in `css-recipes.md`.
@@ -202,7 +167,7 @@ function AnimatedCollapse({ open, children }) {
 ## Preserve State with Activity
 
 ```jsx
-<Activity mode={isVisible ? "visible" : "hidden"}>
+<Activity mode={isVisible ? 'visible' : 'hidden'}>
   <ViewTransition enter="slide-in" exit="slide-out">
     <Sidebar />
   </ViewTransition>
@@ -214,25 +179,21 @@ function AnimatedCollapse({ open, children }) {
 `useOptimistic` values update before the transition snapshot, excluding them from animation. Use for controls (labels); use committed state for animated content:
 
 ```tsx
-const [sort, setSort] = useState("newest");
+const [sort, setSort] = useState('newest');
 const [optimisticSort, setOptimisticSort] = useOptimistic(sort);
 
 function cycleSort() {
   const nextSort = getNextSort(optimisticSort);
   startTransition(() => {
-    setOptimisticSort(nextSort); // before snapshot — no animation
-    setSort(nextSort); // between snapshots — animates
+    setOptimisticSort(nextSort);  // before snapshot — no animation
+    setSort(nextSort);            // between snapshots — animates
   });
 }
 
-<button>Sort: {LABELS[optimisticSort]}</button>;
-{
-  items.sort(comparators[sort]).map((item) => (
-    <ViewTransition key={item.id}>
-      <ItemCard item={item} />
-    </ViewTransition>
-  ));
-}
+<button>Sort: {LABELS[optimisticSort]}</button>
+{items.sort(comparators[sort]).map(item => (
+  <ViewTransition key={item.id}><ItemCard item={item} /></ViewTransition>
+))}
 ```
 
 ---
@@ -245,11 +206,8 @@ Imperative control via `onEnter`, `onExit`, `onUpdate`, `onShare`. Always return
 <ViewTransition
   onEnter={(instance, types) => {
     const anim = instance.new.animate(
-      [
-        { transform: "scale(0.8)", opacity: 0 },
-        { transform: "scale(1)", opacity: 1 },
-      ],
-      { duration: 300, easing: "ease-out" },
+      [{ transform: 'scale(0.8)', opacity: 0 }, { transform: 'scale(1)', opacity: 1 }],
+      { duration: 300, easing: 'ease-out' }
     );
     return () => anim.cancel();
   }}
@@ -266,12 +224,12 @@ The `types` array (second argument) lets you vary animation based on transition 
 
 ## Animation Timing
 
-| Interaction                          | Duration  |
-| ------------------------------------ | --------- |
-| Direct toggle (expand/collapse)      | 100–200ms |
-| Route transition (slide)             | 150–250ms |
+| Interaction | Duration |
+|------------|----------|
+| Direct toggle (expand/collapse) | 100–200ms |
+| Route transition (slide) | 150–250ms |
 | Suspense reveal (skeleton → content) | 200–400ms |
-| Shared element morph                 | 300–500ms |
+| Shared element morph | 300–500ms |
 
 ---
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -14,8 +14,16 @@ public/sw.js.map
 # Vendored third-party code (preserve upstream formatting)
 apps/web/src/vendor/
 
+# Vendored third-party agent skills installed via the `skills` CLI
+# (tracked in skills-lock.json — preserve upstream formatting)
+.claude/skills/next-best-practices/
+.claude/skills/vercel-composition-patterns/
+.claude/skills/vercel-react-best-practices/
+.claude/skills/vercel-react-view-transitions/
+
 # Lock files
 pnpm-lock.yaml
+skills-lock.json
 
 # TypeScript build info
 tsconfig.tsbuildinfo

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,19 +1,28 @@
 {
   "version": 1,
   "skills": {
+    "next-best-practices": {
+      "source": "vercel-labs/next-skills",
+      "sourceType": "github",
+      "skillPath": "skills/next-best-practices/SKILL.md",
+      "computedHash": "f4678aef4ffc10a5ea64a91e57abe5a5081af813b06d58d565caf3e8ef56e26c"
+    },
     "vercel-composition-patterns": {
       "source": "vercel-labs/agent-skills",
       "sourceType": "github",
+      "skillPath": "skills/composition-patterns/SKILL.md",
       "computedHash": "575757e3e25761c8c562d6e395d29f0b76c98b1273c0bd72d88e6ab1bc9c7d42"
     },
     "vercel-react-best-practices": {
       "source": "vercel-labs/agent-skills",
       "sourceType": "github",
-      "computedHash": "43ca6c197f8ec13055079da7053232d477068b03ca443f9ac1bc819b95cdd432"
+      "skillPath": "skills/react-best-practices/SKILL.md",
+      "computedHash": "ca7b0c0c6e5f2750043f7f0cd72d16ac4e2abc48f9b5500d047a4b77a2506212"
     },
     "vercel-react-view-transitions": {
       "source": "vercel-labs/agent-skills",
       "sourceType": "github",
+      "skillPath": "skills/react-view-transitions/SKILL.md",
       "computedHash": "c8952fc9127fa0564d0cb71dccb4215a5608ac933b5831104f09173a97a46f85"
     }
   }


### PR DESCRIPTION
## Summary

Adds the `next-best-practices` skill from `vercel-labs/next-skills` and refreshes the three vendored `vercel-labs/agent-skills` skills (`vercel-react-best-practices`, `vercel-composition-patterns`, `vercel-react-view-transitions`) to their latest upstream versions, including a new `bundle-analyzable-paths` rule.

`skills-lock.json` is updated to record the new skill and to add `skillPath` tracking plus refreshed content hashes for all four. `.prettierignore` is extended to exclude these CLI-managed third-party skill folders and `skills-lock.json`, preserving upstream formatting consistent with the existing vendored third-party code policy.

## Notes

The project's existing `data-fetching` skill was evaluated against the new `next-best-practices` skill for overlap. It documents project-specific patterns (TanStack Query, `apiRouteWrapper`, `apiRequestWrapper`, TMDB codegen) that `next-best-practices` doesn't cover and in places contradicts, so it is not redundant and was left in place.