### PR TITLE
refactor: hoist NODE_ENV guard to wrap useEffect in ReactGrab

### DIFF
--- a/apps/web/src/components/react-grab.tsx
+++ b/apps/web/src/components/react-grab.tsx
@@ -8,15 +8,19 @@ import { useEffect } from "react";
  * React Grab lets you hover any rendered element and press ⌘C / Ctrl+C to copy
  * its source context (file, component stack, surrounding code) for pasting into
  * a coding agent. The package self-initialises on import, so we pull it in
- * client-side via a dynamic import. The `NODE_ENV` guard is statically replaced
- * at build time, so the import is dead-code-eliminated from production bundles.
+ * client-side via a dynamic import. The `NODE_ENV` guard wraps the whole effect
+ * so SWC drops it from production builds — the import is never emitted and the
+ * library stays out of the bundle. The conditional hook call is safe because
+ * `process.env.NODE_ENV` is a build-time constant, so the branch never varies
+ * between renders; the lint rule just can't see that.
  */
 export function ReactGrab() {
-  useEffect(() => {
-    if (process.env.NODE_ENV === "development") {
+  if (process.env.NODE_ENV === "development") {
+    // eslint-disable-next-line react-hooks/rules-of-hooks, @eslint-react/rules-of-hooks
+    useEffect(() => {
       void import("react-grab");
-    }
-  }, []);
+    }, []);
+  }
 
   return null;
 }


### PR DESCRIPTION
## Summary

Moves the `process.env.NODE_ENV === "development"` guard from inside the `useEffect` callback to wrap the entire `useEffect` call, so production collapses to `return null` with no leftover effect and react-grab is fully eliminated from the bundle.

## Notes

The guard wrapping the hook is technically a conditional hook call, hence the `eslint-disable` for `react-hooks/rules-of-hooks` and `@eslint-react/rules-of-hooks`. It is safe because `process.env.NODE_ENV` is replaced with a string literal at build time — the branch is fixed for any given build and hook order never varies between renders; the lint rule just can't reason about build-time constants.

Alternative approaches that move the `import()` outside the guarded block (early-return before the hook, or a separate gated child component) leave the dynamic import in a function the bundler can't prove is dead, causing webpack to emit the chunk and ship the library to production.