### PR TITLE
feat: assign deterministic per-worktree dev-server port

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,10 @@
           {
             "type": "command",
             "command": "bash -c '[[ \"$CLAUDE_PROJECT_DIR\" == *\".claude/worktrees/\"* ]] || exit 0; [ -L \"$CLAUDE_PROJECT_DIR/node_modules/typescript\" ] && exit 0; cd \"$CLAUDE_PROJECT_DIR\" && pnpm install --prefer-offline'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'PORT=$(node \"$CLAUDE_PROJECT_DIR/scripts/worktree-port.mjs\"); echo \"Dev server port for this worktree: $PORT. The app runs at http://localhost:$PORT — pnpm dev and pnpm test:e2e use this port automatically. Use this URL for any Playwright or browser navigation.\"'"
           }
         ]
       }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "codegen:zod": "tsx ../../packages/tmdb-codegen/generate-selective-zod.ts && prettier 'src/_generated/tmdb-zod.ts' -w",
     "predev": "pnpm codegen:palette",
     "dev": "run-p watch:i18n dev:next",
-    "dev:next": "next dev --turbopack",
+    "dev:next": "next dev --turbopack -p $(node ../../scripts/worktree-port.mjs)",
     "build": "next build && serwist build serwist.config.mjs",
     "build:tsc": "tsc --noEmit",
     "start": "next start",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,3 +1,5 @@
+import { execFileSync } from "node:child_process";
+
 import { defineConfig, devices } from "@playwright/test";
 
 /**
@@ -7,6 +9,17 @@ import { defineConfig, devices } from "@playwright/test";
 // import dotenv from 'dotenv';
 // import path from 'path';
 // dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/* Per-worktree dev-server port (3000 in the main checkout). The port is
+ * resolved by the shared scripts/worktree-port.mjs helper, run as a
+ * subprocess rather than imported because Playwright's config loader
+ * cannot transpile a native ESM `.mjs` import. The relative path matches
+ * the dev:next script in package.json (Playwright runs from apps/web).
+ * `BASE_URL` still wins so CI and preview deployments are unaffected. */
+const port = execFileSync("node", ["../../scripts/worktree-port.mjs"], {
+  encoding: "utf8",
+}).trim();
+const baseURL = process.env.BASE_URL ?? `http://localhost:${port}`;
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -36,7 +49,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: process.env.BASE_URL || "http://localhost:3000",
+    baseURL,
 
     /* Set browser locale to English to ensure consistent behavior in CI */
     locale: "en-US",
@@ -76,7 +89,8 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: "pnpm build && pnpm start",
-    url: "http://localhost:3000",
+    url: baseURL,
+    env: { PORT: port }, // next start binds this; reuses a running dev server if present
     reuseExistingServer: !process.env.CI,
     timeout: 300 * 1000, // 5 minutes for build + server to start
   },

--- a/scripts/worktree-port.mjs
+++ b/scripts/worktree-port.mjs
@@ -1,0 +1,37 @@
+import { execSync } from "node:child_process";
+import { basename } from "node:path";
+import { pathToFileURL } from "node:url";
+
+/**
+ * Deterministic dev-server port for the current git worktree.
+ *
+ * The main checkout always keeps the standard port 3000. Each worktree
+ * created under `.claude/worktrees/<name>` gets a stable port derived from
+ * its folder name (djb2 hash mapped into 3001–3999), so the dev server,
+ * Playwright, and the agent all agree on the same port without any shared
+ * state to write or read.
+ */
+export function getWorktreePort() {
+  let root;
+  try {
+    root = execSync("git rev-parse --show-toplevel", {
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    return 3000;
+  }
+
+  if (!root.includes("/.claude/worktrees/")) return 3000;
+
+  const name = basename(root);
+  let hash = 5381;
+  for (const char of name) {
+    hash = ((hash * 33) ^ char.charCodeAt(0)) >>> 0;
+  }
+  return 3001 + (hash % 999); // 3001–3999, stable per worktree
+}
+
+// CLI mode: `node scripts/worktree-port.mjs` prints the port number.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.stdout.write(String(getWorktreePort()));
+}


### PR DESCRIPTION
## Summary

Each git worktree previously competed for port 3000 when running `pnpm dev`, making it impossible to run multiple worktrees' dev servers simultaneously and leaving agents uncertain which URL their app was on.

A new `scripts/worktree-port.mjs` helper derives a deterministic per-worktree port (3001–3999, via a djb2 hash of the worktree folder name), falling back to 3000 in the main checkout so the primary workflow is unchanged. The port is wired into three places:

- **`apps/web/package.json`** — `dev:next` appends `-p <port>` to the Next.js dev command
- **`apps/web/playwright.config.ts`** — resolves the same port via `execFileSync` (subprocess rather than import, because Playwright's config loader can't transpile a native ESM `.mjs` import) and uses it for `baseURL` and the `webServer` url/PORT env, so e2e tests target the correct server
- **`.claude/settings.json`** — a new `SessionStart` hook runs the script and prints the resolved port into the agent's context, so every `claude -w` session knows its URL

The existing `BASE_URL` env override retains precedence, so CI and preview deployments are unaffected. `scripts/` is committed (not git-ignored) so it reaches every worktree via git.

## Notes

Deterministic hashing was chosen over a free-port scan so the dev server, Playwright, and the agent always agree on the same port for a given worktree without shared state. The trade-off is a ~1-in-900 chance two simultaneously-running worktrees hash to the same port — acceptable for a solo workflow, and upgradeable to a free-port-scan fallback later if needed.