### PR TITLE
fix: guard infinite-scroll load-more on isFetchingNextPage not isFetching

### DIFF
--- a/apps/web/e2e/movie-tv-browsing.spec.ts
+++ b/apps/web/e2e/movie-tv-browsing.spec.ts
@@ -126,30 +126,52 @@ test.describe("Movie and TV Show Browsing", () => {
   });
 
   test("should load more movies when scrolling to bottom", async ({ page }) => {
-    // Wait for initial cards (cards are links containing images with aria-labels)
-    const cards = page
-      .getByRole("link")
-      .filter({ hasText: /.+/ })
-      .filter({ has: page.getByRole("img") });
+    // Cards are links wrapping a poster image. The grid is window-virtualized
+    // (react-virtuoso with `useWindowScroll`): only a sliding window of cards is
+    // mounted at any time, so neither the mounted card count nor the "last"
+    // mounted card is a reliable signal — scrolling just remounts a different
+    // window of the *same* page. The virtualization-proof signal that another
+    // page actually loaded is the document growing taller as the new page is
+    // appended to the list.
+    const cards = page.getByRole("link").filter({ has: page.getByRole("img") });
     await expect(cards.first()).toBeVisible();
+    expect(await cards.count()).toBeGreaterThan(0);
 
-    // Get the last visible card's title before scrolling
-    const initialCount = await cards.count();
-    expect(initialCount).toBeGreaterThan(5);
-    const lastCardBeforeScroll = await cards.last().getAttribute("aria-label");
+    // Let the initial load settle so the baseline height is stable before we
+    // trigger load-more.
+    await page.waitForLoadState("networkidle");
 
-    // Scroll to bottom
-    await page.evaluate(() => {
-      window.scrollTo(0, document.body.scrollHeight);
-    });
+    const pageHeight = () =>
+      page.evaluate(() => document.documentElement.scrollHeight);
+    const initialHeight = await pageHeight();
 
-    // Wait for the last card to change (new content loaded)
-    await expect(async () => {
-      const currentLastCard = await cards.last().getAttribute("aria-label");
-      expect(currentLastCard).not.toBe(lastCardBeforeScroll);
-    }).toPass({ timeout: 10000 });
+    // Drive virtuoso's scroll-based `endReached` with a top-to-bottom sweep in
+    // viewport-sized steps (a one-shot jump to `scrollHeight` pins the window at
+    // the rendered bottom without registering as the incremental scroll it
+    // needs). Re-sweep on each poll until the document has grown past its
+    // settled height — the virtualization-proof signal that another page loaded.
+    await expect
+      .poll(
+        async () => {
+          await page.evaluate(async () => {
+            const step = window.innerHeight;
+            const end = document.documentElement.scrollHeight;
+            for (let y = 0; y <= end; y += step) {
+              window.scrollTo(0, y);
+              await new Promise((resolve) =>
+                requestAnimationFrame(() => {
+                  resolve(null);
+                }),
+              );
+            }
+          });
+          return pageHeight();
+        },
+        { timeout: 10000 },
+      )
+      .toBeGreaterThan(initialHeight);
 
-    // Verify cards are still visible after scrolling
+    // The grid is still rendered after loading more.
     await expect(cards.first()).toBeVisible();
   });
 

--- a/apps/web/src/components/movie-database/media-virtuoso-grid.tsx
+++ b/apps/web/src/components/movie-database/media-virtuoso-grid.tsx
@@ -21,7 +21,12 @@ export function MediaVirtuosoGrid({
   virtuosoKey,
   notFoundLabel,
 }: MediaVirtuosoGridProps) {
-  const { data: items, fetchNextPage, hasNextPage, isFetching } = queryResult;
+  const {
+    data: items,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = queryResult;
   const height = useViewportHeight();
   const [storedInitialItemCount] = useState(items.length);
   const initialItemCount = Math.min(storedInitialItemCount, items.length);
@@ -44,7 +49,14 @@ export function MediaVirtuosoGrid({
         <MediaCard media={items[index]} allowFollow={index < 20} />
       )}
       endReached={() => {
-        if (hasNextPage && !isFetching) {
+        // Guard on `isFetchingNextPage`, not `isFetching`. Virtuoso fires
+        // `endReached` once per end index and will not re-fire until the index
+        // grows (i.e. until more data loads). `isFetching` is true during *any*
+        // fetch — including the background refetch when `staleTime` lapses — so
+        // if that one `endReached` coincided with such a refetch, the load-more
+        // was dropped and never retried, permanently wedging pagination.
+        // `isFetchingNextPage` only blocks while a load-more is already running.
+        if (hasNextPage && !isFetchingNextPage) {
           void fetchNextPage();
         }
       }}


### PR DESCRIPTION
## The bug

The E2E test "should load more movies when scrolling to bottom" was intermittently wedged — even with 25s of continuous scrolling, the test never saw page 2 load. Instrumentation confirmed that `fetchNextPage()` was simply never called in failing runs.

The root cause: react-virtuoso fires `endReached` exactly once per end index and will not re-fire until new data grows the list. The load-more guard was `if (hasNextPage && !isFetching)` — but `isFetching` is true during *any* in-flight fetch, including the still-in-progress initial page-1 fetch after hydration (the route streams HTML with the first TanStack infinite query still pending) and any background refetch when `staleTime` lapses. If `endReached` fired for page 1's last index while one of those fetches was in flight, the guard dropped the `fetchNextPage()` call and virtuoso never re-fired for that index — permanently wedging pagination.

The old test masked the real failure: it compared the last *mounted* card's `aria-label` before and after scrolling, but under windowed virtualization that signal is satisfied by the viewport remounting a *different window of page 1*, so the test could pass without page 2 ever loading.

## The fix

Two parts, each targeting a distinct root cause.

**App guard** (`media-virtuoso-grid.tsx`): Change the guard from `!isFetching` to `!isFetchingNextPage`. `isFetchingNextPage` is only true while a load-more request is already in flight — a coincident initial or background fetch can no longer swallow the one `endReached` call virtuoso will make for that index.

**Test** (`movie-tv-browsing.spec.ts`): Replace the virtualization-blind assertions (mounted card count, last mounted card's `aria-label`) with a virtualization-proof signal: `document.documentElement.scrollHeight` growing past its settled baseline. A real page append is the only thing that can grow the document; a viewport remount within page 1 cannot. The test settles the initial load with `waitForLoadState("networkidle")`, then drives `endReached` with an incremental top-to-bottom sweep in viewport-sized steps — a one-shot jump to `scrollHeight` pins the window at the rendered bottom without registering as the incremental scroll virtuoso needs — re-sweeping on each poll.

## Notes

The `!isFetchingNextPage` guard change is what closes the gap — with the guard fix in place, the target test passed 120/120 runs with retries disabled. The test-only version (correct assertion, old guard) still failed ~7/100 because the underlying drop was still possible.

The test continues to hit the real TMDB API, consistent with the rest of the suite.