### PR TITLE
fix: source flow-gradient background colour from bgCanvas token at runtime

### DIFF
--- a/apps/web/src/components/shared/flow-gradient/flow-gradient.tsx
+++ b/apps/web/src/components/shared/flow-gradient/flow-gradient.tsx
@@ -10,18 +10,35 @@ import { init, start, type ColorOptions } from "./loop";
 import fs from "./shaders/fs.glsl";
 import vs from "./shaders/vs.glsl";
 
-// Mirrors color.bgCanvas — keep in sync if the token value changes.
-const DARK_COLORS = {
-  colorBackground: [0, 0, 0],
-} satisfies ColorOptions;
+// Foreground gradient hues only. The background colour the gradient blends into
+// is NOT defined here — it is read at runtime from the canvas's resolved
+// `background-color` (color.bgCanvas, see styles.canvas) so it always matches
+// the single token the page background uses, with no second copy to drift.
+const DARK_COLORS = {} satisfies ColorOptions;
 
 const LIGHT_COLORS = {
-  colorBackground: [0xed / 0xff, 0xec / 0xff, 0xe8 / 0xff],
   colorTop: [0.6, 0.5, 0.7],
   colorBottom: [0.4, 0.4, 1],
   colorAltTop: [1, 0.3, 0.3],
   colorAltBottom: [1, 0.3, 0.3],
 } satisfies ColorOptions;
+
+/**
+ * Resolve the canvas's computed `background-color` (which is `color.bgCanvas`)
+ * to a normalised RGB triple for the shader's `u_colorBackground`, keeping the
+ * gradient's base colour sourced from the same token as the page background.
+ */
+function readCanvasBackground(
+  canvas: HTMLCanvasElement,
+): [number, number, number] | undefined {
+  const channels = getComputedStyle(canvas).backgroundColor.match(/[\d.]+/g);
+  if (!channels || channels.length < 3) return undefined;
+  return [
+    Number(channels[0]) / 255,
+    Number(channels[1]) / 255,
+    Number(channels[2]) / 255,
+  ];
+}
 
 export function FlowGradient() {
   const isDark = useResolvedTheme() === "dark";
@@ -33,8 +50,14 @@ export function FlowGradient() {
   const colorsRef = useRef<ColorOptions>(isDark ? DARK_COLORS : LIGHT_COLORS);
   const contextRef = useRef<ReturnType<typeof init>>(undefined);
 
+  // Re-pick the hue preset and re-read the bgCanvas value whenever the resolved
+  // theme flips. This passive effect runs after ThemeSwitch's layout effect has
+  // applied the theme class to <html>, so getComputedStyle sees the new theme.
   useEffect(() => {
-    colorsRef.current = isDark ? DARK_COLORS : LIGHT_COLORS;
+    const hues = isDark ? DARK_COLORS : LIGHT_COLORS;
+    const canvas = contextRef.current?.canvas;
+    const colorBackground = canvas ? readCanvasBackground(canvas) : undefined;
+    colorsRef.current = colorBackground ? { ...hues, colorBackground } : hues;
   }, [isDark]);
 
   useEffect(() => {

--- a/apps/web/src/components/shared/flow-gradient/loop.ts
+++ b/apps/web/src/components/shared/flow-gradient/loop.ts
@@ -183,6 +183,11 @@ export interface ColorOptions {
   colorBottom?: [number, number, number];
   colorAltTop?: [number, number, number];
   colorAltBottom?: [number, number, number];
+  /**
+   * Base colour the gradient blends into at the bottom, as normalised RGB.
+   * Sourced at runtime from the `color.bgCanvas` token (see flow-gradient.tsx)
+   * so it matches the page background — never hardcode a value here.
+   */
   colorBackground?: [number, number, number];
 }
 
@@ -250,7 +255,7 @@ export function start(
       colorBottom = [0, 0, 0.8],
       colorAltTop = [1, 0, 0],
       colorAltBottom = [1, 0, 0],
-      colorBackground = [0.953, 0.929, 0.929],
+      colorBackground,
     } = colorsRef.current;
 
     const uniforms = {
@@ -261,7 +266,9 @@ export function start(
       u_colorBottom: colorBottom,
       u_colorAltTop: colorAltTop,
       u_colorAltBottom: colorAltBottom,
-      u_colorBackground: colorBackground,
+      // Set by flow-gradient.tsx from the bgCanvas token before the first
+      // frame; omitted only if that read failed, leaving the GL default.
+      ...(colorBackground ? { u_colorBackground: colorBackground } : null),
       u_mouse: pointerState.mousePosition,
       u_rippleStrength: pointerState.rippleStrength,
       u_ripplePhase: pointerState.ripplePhase,

--- a/apps/web/src/components/shared/flow-gradient/shaders/vs.glsl
+++ b/apps/web/src/components/shared/flow-gradient/shaders/vs.glsl
@@ -128,6 +128,12 @@ void main() {
   vec3 colorAlt = u_colorAltTop + (u_colorAltBottom - u_colorAltTop) * posFactor;
   vec3 color = colorMain + (colorAlt * noiseAlt);
 
+  // Blend opaquely toward u_colorBackground at the bottom. Output stays fully
+  // opaque (alpha 1) rather than fading alpha and relying on the canvas's CSS
+  // background showing through — Safari composites a transparent WebGL canvas
+  // over white, not over the element's background-color, which would seam.
+  // u_colorBackground is fed from the color.bgCanvas token at runtime, so this
+  // bottom colour still tracks the single token the page background uses.
   float factor = posFactor * 1.1111f;
   v_color = vec4(color * clamp(1.0f - factor, 0.0f, 1.0f) + u_colorBackground * clamp(factor, 0.0f, 1.0f), 1.0f);
 


### PR DESCRIPTION
## Why

The flow gradient blends down into a "background" colour at the bottom of the canvas, where it has to match the page background behind it. That base colour was hardcoded in **three** places — a dark-mode default, a light-mode default, and a fallback in the render loop — each duplicating the `color.bgCanvas` design token instead of reading it. When the light-mode token value changed, the copies were left behind: the page rendered `rgb(233,232,228)` while the gradient still blended to `rgb(237,236,232)`, leaving a visible horizontal seam where the gradient met the page.

## What changed

The gradient now sources its base colour from a **single source of truth**: the canvas's resolved `background-color` (which already comes from `color.bgCanvas`), read at runtime via `getComputedStyle`. No copies left to drift.

```mermaid
flowchart LR
  token["color.bgCanvas token"] --> css["canvas background-color (CSS)"]
  css -->|getComputedStyle at runtime| read["readCanvasBackground()"]
  read --> uniform["u_colorBackground (shader)"]
  uniform --> blend["gradient bottom blend"]
  css --> page["page background"]
  blend -. always matches .- page
```

### Before vs after

```mermaid
flowchart TB
  subgraph Before
    t1["color.bgCanvas token"]
    d1["dark-mode default (hardcoded)"]
    l1["light-mode default (hardcoded)"]
    f1["render-loop fallback (hardcoded)"]
    t1 -. manual sync, drifted .-> d1
    t1 -. manual sync, drifted .-> l1
    t1 -. manual sync, drifted .-> f1
  end
  subgraph After
    t2["color.bgCanvas token"]
    r2["read once at runtime"]
    t2 --> r2
  end
```

### Theme switching

The base colour is re-read whenever the resolved theme flips. The effect doing the re-read runs *after* the theme class is applied to `<html>`, so `getComputedStyle` always observes the new theme's colour.

## A note on opacity (Safari)

The shader keeps its output **fully opaque** and blends explicitly toward `u_colorBackground`, rather than fading alpha and letting the canvas's CSS background show through. This is deliberate: Safari composites a transparent WebGL canvas over white rather than over the element's `background-color`, which would produce a seam. Blending opaquely in-shader avoids that while still tracking the same token.

## Safety

If the runtime read ever fails, `u_colorBackground` is simply omitted and the shader falls back to its built-in GL default — the gradient still renders.