### PR TITLE
refactor: redesign sprite editor empty state and sidebar

### DIFF
--- a/apps/web/src/components/sprite-editor/animation-mode.tsx
+++ b/apps/web/src/components/sprite-editor/animation-mode.tsx
@@ -8,7 +8,12 @@ import { PlayIcon } from "@phosphor-icons/react/dist/ssr/Play";
 import { PlusIcon } from "@phosphor-icons/react/dist/ssr/Plus";
 import { TrashIcon } from "@phosphor-icons/react/dist/ssr/Trash";
 import * as stylex from "@stylexjs/stylex";
-import { border, color, font, space } from "@tuja/ui/tokens.stylex";
+import {
+  duration as motionDuration,
+  easing,
+  motionConstants,
+} from "@tuja/ui/primitives/motion.stylex";
+import { border, color, font, shadow, space } from "@tuja/ui/tokens.stylex";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "#src/components/shared/button.tsx";
 import { t } from "#src/i18n.ts";
@@ -241,6 +246,7 @@ export function AnimationMode({
               onChange={(event) => {
                 setSpeed(Number(event.target.value));
               }}
+              css={styles.range}
               data-testid="speed"
             />
             <span css={styles.speedValue}>{speed.toFixed(2)}×</span>
@@ -436,6 +442,7 @@ const styles = stylex.create({
     backgroundPosition: "0 0, 0 8px, 8px -8px, -8px 0px",
     border: `1px solid ${color.neutralBorder}`,
     borderRadius: border.radius_2,
+    boxShadow: shadow.inset,
     imageRendering: "pixelated",
     alignSelf: "center",
   },
@@ -456,8 +463,13 @@ const styles = stylex.create({
     minWidth: "3em",
     textAlign: "right",
     fontSize: font.uiBodySmall,
+    fontFamily: font.familyMono,
     color: color.textMain,
     fontVariantNumeric: "tabular-nums",
+  },
+  range: {
+    accentColor: color.brandSpriteEditor,
+    cursor: "pointer",
   },
   timelineArea: {
     display: "flex",
@@ -481,12 +493,13 @@ const styles = stylex.create({
     margin: 0,
     fontSize: font.uiBodySmall,
     fontWeight: font.weight_7,
-    color: color.textMuted,
-    textTransform: "uppercase",
-    letterSpacing: ".05em",
+    letterSpacing: font.trackingSnug,
+    color: color.textMain,
   },
   timelineCount: {
     fontWeight: font.weight_4,
+    fontVariantNumeric: "tabular-nums",
+    color: color.textMuted,
   },
   empty: {
     margin: 0,
@@ -508,10 +521,15 @@ const styles = stylex.create({
     padding: space._2,
     border: `1px solid ${color.neutralBorder}`,
     borderRadius: border.radius_2,
-    backgroundColor: color.bgSurface,
+    backgroundColor: color.bgSurfaceSunken,
+    transition: {
+      default: `border-color ${motionDuration._150} ${easing.easeOut}, background-color ${motionDuration._150} ${easing.easeOut}`,
+      [motionConstants.REDUCED_MOTION]: "none",
+    },
   },
   frameItemActive: {
-    borderColor: color.brandPixelCreatureCreator,
+    borderColor: color.brandSpriteEditor,
+    backgroundColor: color.surfaceAccentSubtle,
   },
   thumb: {
     backgroundColor: color.bgCanvas,
@@ -545,9 +563,10 @@ const styles = stylex.create({
     paddingInline: space._1,
     border: `1px solid ${color.neutralBorder}`,
     borderRadius: border.radius_2,
-    backgroundColor: color.bgSurfaceSunken,
+    backgroundColor: color.bgSurfaceRaised,
     color: color.textMain,
-    fontFamily: "inherit",
+    fontFamily: font.familyMono,
+    fontVariantNumeric: "tabular-nums",
     fontSize: font.uiBodySmall,
   },
   frameActions: {

--- a/apps/web/src/components/sprite-editor/animation-mode.tsx
+++ b/apps/web/src/components/sprite-editor/animation-mode.tsx
@@ -468,7 +468,7 @@ const styles = stylex.create({
     fontVariantNumeric: "tabular-nums",
   },
   range: {
-    accentColor: color.brandSpriteEditor,
+    accentColor: color.accent,
     cursor: "pointer",
   },
   timelineArea: {
@@ -528,7 +528,7 @@ const styles = stylex.create({
     },
   },
   frameItemActive: {
-    borderColor: color.brandSpriteEditor,
+    borderColor: color.accent,
     backgroundColor: color.surfaceAccentSubtle,
   },
   thumb: {

--- a/apps/web/src/components/sprite-editor/cell-strip.tsx
+++ b/apps/web/src/components/sprite-editor/cell-strip.tsx
@@ -205,7 +205,7 @@ const styles = stylex.create({
     },
   },
   thumbButtonActive: {
-    borderColor: color.brandSpriteEditor,
+    borderColor: color.accent,
     boxShadow: `0 0 0 2px ${color.surfaceAccentMuted}`,
   },
   thumbWrapper: {

--- a/apps/web/src/components/sprite-editor/cell-strip.tsx
+++ b/apps/web/src/components/sprite-editor/cell-strip.tsx
@@ -1,6 +1,11 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
+import {
+  duration,
+  easing,
+  motionConstants,
+} from "@tuja/ui/primitives/motion.stylex";
 import { border, color, font, space } from "@tuja/ui/tokens.stylex";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useRadioGroup } from "#src/components/pixel-creature-creator/wizard/use-radio-group.ts";
@@ -147,22 +152,24 @@ const styles = stylex.create({
   root: {
     display: "flex",
     flexDirection: "column",
-    gap: space._2,
-    padding: space._3,
+    gap: space._3,
+    padding: space._4,
     border: `1px solid ${color.neutralBorder}`,
     borderRadius: border.radius_3,
     backgroundColor: color.bgSurface,
+    flexShrink: 0,
   },
   heading: {
     margin: 0,
     fontSize: font.uiBodySmall,
     fontWeight: font.weight_7,
-    color: color.textMuted,
-    textTransform: "uppercase",
-    letterSpacing: ".05em",
+    letterSpacing: font.trackingSnug,
+    color: color.textMain,
   },
   count: {
     fontWeight: font.weight_4,
+    fontVariantNumeric: "tabular-nums",
+    color: color.textMuted,
   },
   list: {
     display: "grid",
@@ -188,9 +195,18 @@ const styles = stylex.create({
     cursor: "pointer",
     overflow: "hidden",
     display: "block",
+    borderColor: {
+      default: color.neutralBorder,
+      ":hover": color.accentBorder,
+    },
+    transition: {
+      default: `border-color ${duration._150} ${easing.easeOut}, box-shadow ${duration._150} ${easing.easeOut}`,
+      [motionConstants.REDUCED_MOTION]: "none",
+    },
   },
   thumbButtonActive: {
-    borderColor: color.brandPixelCreatureCreator,
+    borderColor: color.brandSpriteEditor,
+    boxShadow: `0 0 0 2px ${color.surfaceAccentMuted}`,
   },
   thumbWrapper: {
     position: "absolute",

--- a/apps/web/src/components/sprite-editor/grid-controls.tsx
+++ b/apps/web/src/components/sprite-editor/grid-controls.tsx
@@ -1,6 +1,11 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
+import {
+  duration,
+  easing,
+  motionConstants,
+} from "@tuja/ui/primitives/motion.stylex";
 import { border, color, font, space } from "@tuja/ui/tokens.stylex";
 import { useId } from "react";
 import { t } from "#src/i18n.ts";
@@ -22,6 +27,7 @@ interface NumberFieldProps {
   step?: number;
   onChange: (value: number) => void;
   testId?: string;
+  emphasis?: boolean;
 }
 
 function NumberField({
@@ -32,11 +38,14 @@ function NumberField({
   step = 1,
   onChange,
   testId,
+  emphasis = false,
 }: NumberFieldProps) {
   const id = useId();
   return (
     <label htmlFor={id} css={styles.field}>
-      <span css={styles.fieldLabel}>{label}</span>
+      <span css={[styles.fieldLabel, emphasis && styles.fieldLabelEmphasis]}>
+        {label}
+      </span>
       <input
         id={id}
         type="number"
@@ -44,7 +53,7 @@ function NumberField({
         min={min}
         max={max}
         step={step}
-        css={styles.input}
+        css={[styles.input, emphasis && styles.inputEmphasis]}
         onChange={(event) => {
           // Skip mid-edit blank state — `Number("")` is 0, which would
           // commit a destructive 0 (or 1, after the callsite's clamp) and
@@ -91,113 +100,130 @@ export function GridControls({
 
   return (
     <div css={styles.root}>
-      <fieldset css={styles.group}>
-        <legend css={styles.legend}>{t({ en: "Grid", zh: "网格" })}</legend>
-        <NumberField
-          label={t({ en: "Columns", zh: "列数" })}
-          value={grid.cols}
-          min={1}
-          max={64}
-          onChange={(cols) => {
-            updateColsRows(Math.max(1, cols), grid.rows);
-          }}
-          testId="grid-cols"
-        />
-        <NumberField
-          label={t({ en: "Rows", zh: "行数" })}
-          value={grid.rows}
-          min={1}
-          max={64}
-          onChange={(rows) => {
-            updateColsRows(grid.cols, Math.max(1, rows));
-          }}
-          testId="grid-rows"
-        />
-        <NumberField
-          label={t({ en: "Offset X", zh: "X 偏移" })}
-          value={grid.offsetX}
-          min={0}
-          max={source.width}
-          onChange={(offsetX) => {
-            onGridChange({ ...grid, offsetX });
-          }}
-          testId="grid-offset-x"
-        />
-        <NumberField
-          label={t({ en: "Offset Y", zh: "Y 偏移" })}
-          value={grid.offsetY}
-          min={0}
-          max={source.height}
-          onChange={(offsetY) => {
-            onGridChange({ ...grid, offsetY });
-          }}
-          testId="grid-offset-y"
-        />
-        <NumberField
-          label={t({ en: "Cell W", zh: "格宽" })}
-          value={grid.cellWidth}
-          min={1}
-          onChange={(cellWidth) => {
-            onGridChange({ ...grid, cellWidth: Math.max(1, cellWidth) });
-          }}
-          testId="grid-cell-w"
-        />
-        <NumberField
-          label={t({ en: "Cell H", zh: "格高" })}
-          value={grid.cellHeight}
-          min={1}
-          onChange={(cellHeight) => {
-            onGridChange({ ...grid, cellHeight: Math.max(1, cellHeight) });
-          }}
-          testId="grid-cell-h"
-        />
-        <NumberField
-          label={t({ en: "Gap X", zh: "X 间距" })}
-          value={grid.gapX}
-          min={0}
-          max={source.width}
-          onChange={(gapX) => {
-            onGridChange({ ...grid, gapX: Math.max(0, gapX) });
-          }}
-          testId="grid-gap-x"
-        />
-        <NumberField
-          label={t({ en: "Gap Y", zh: "Y 间距" })}
-          value={grid.gapY}
-          min={0}
-          max={source.height}
-          onChange={(gapY) => {
-            onGridChange({ ...grid, gapY: Math.max(0, gapY) });
-          }}
-          testId="grid-gap-y"
-        />
-      </fieldset>
+      <section css={styles.group}>
+        <h3 css={styles.sectionLabel}>{t({ en: "Grid", zh: "网格" })}</h3>
+        <div css={styles.primaryRow}>
+          <NumberField
+            label={t({ en: "Columns", zh: "列数" })}
+            value={grid.cols}
+            min={1}
+            max={64}
+            onChange={(cols) => {
+              updateColsRows(Math.max(1, cols), grid.rows);
+            }}
+            testId="grid-cols"
+            emphasis
+          />
+          <span css={styles.times} aria-hidden="true">
+            ×
+          </span>
+          <NumberField
+            label={t({ en: "Rows", zh: "行数" })}
+            value={grid.rows}
+            min={1}
+            max={64}
+            onChange={(rows) => {
+              updateColsRows(grid.cols, Math.max(1, rows));
+            }}
+            testId="grid-rows"
+            emphasis
+          />
+        </div>
 
-      <fieldset css={styles.group}>
-        <legend css={styles.legend}>
+        <p css={styles.subLabel}>
+          {t({ en: "Alignment & gaps", zh: "对齐与间距" })}
+        </p>
+        <div css={styles.fieldGrid}>
+          <NumberField
+            label={t({ en: "Offset X", zh: "X 偏移" })}
+            value={grid.offsetX}
+            min={0}
+            max={source.width}
+            onChange={(offsetX) => {
+              onGridChange({ ...grid, offsetX });
+            }}
+            testId="grid-offset-x"
+          />
+          <NumberField
+            label={t({ en: "Offset Y", zh: "Y 偏移" })}
+            value={grid.offsetY}
+            min={0}
+            max={source.height}
+            onChange={(offsetY) => {
+              onGridChange({ ...grid, offsetY });
+            }}
+            testId="grid-offset-y"
+          />
+          <NumberField
+            label={t({ en: "Cell W", zh: "格宽" })}
+            value={grid.cellWidth}
+            min={1}
+            onChange={(cellWidth) => {
+              onGridChange({ ...grid, cellWidth: Math.max(1, cellWidth) });
+            }}
+            testId="grid-cell-w"
+          />
+          <NumberField
+            label={t({ en: "Cell H", zh: "格高" })}
+            value={grid.cellHeight}
+            min={1}
+            onChange={(cellHeight) => {
+              onGridChange({ ...grid, cellHeight: Math.max(1, cellHeight) });
+            }}
+            testId="grid-cell-h"
+          />
+          <NumberField
+            label={t({ en: "Gap X", zh: "X 间距" })}
+            value={grid.gapX}
+            min={0}
+            max={source.width}
+            onChange={(gapX) => {
+              onGridChange({ ...grid, gapX: Math.max(0, gapX) });
+            }}
+            testId="grid-gap-x"
+          />
+          <NumberField
+            label={t({ en: "Gap Y", zh: "Y 间距" })}
+            value={grid.gapY}
+            min={0}
+            max={source.height}
+            onChange={(gapY) => {
+              onGridChange({ ...grid, gapY: Math.max(0, gapY) });
+            }}
+            testId="grid-gap-y"
+          />
+        </div>
+      </section>
+
+      <div css={styles.divider} aria-hidden="true" />
+
+      <section css={styles.group}>
+        <h3 css={styles.sectionLabel}>
           {t({ en: "Output size", zh: "输出尺寸" })}
-        </legend>
-        <NumberField
-          label={t({ en: "Width", zh: "宽" })}
-          value={output.width}
-          min={1}
-          max={1024}
-          onChange={(width) => {
-            onOutputChange({ ...output, width: Math.max(1, width) });
-          }}
-          testId="output-width"
-        />
-        <NumberField
-          label={t({ en: "Height", zh: "高" })}
-          value={output.height}
-          min={1}
-          max={1024}
-          onChange={(height) => {
-            onOutputChange({ ...output, height: Math.max(1, height) });
-          }}
-          testId="output-height"
-        />
-      </fieldset>
+        </h3>
+        <div css={styles.fieldGrid}>
+          <NumberField
+            label={t({ en: "Width", zh: "宽" })}
+            value={output.width}
+            min={1}
+            max={1024}
+            onChange={(width) => {
+              onOutputChange({ ...output, width: Math.max(1, width) });
+            }}
+            testId="output-width"
+          />
+          <NumberField
+            label={t({ en: "Height", zh: "高" })}
+            value={output.height}
+            min={1}
+            max={1024}
+            onChange={(height) => {
+              onOutputChange({ ...output, height: Math.max(1, height) });
+            }}
+            testId="output-height"
+          />
+        </div>
+      </section>
     </div>
   );
 }
@@ -209,31 +235,63 @@ const styles = stylex.create({
     gap: space._3,
   },
   group: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space._2,
+    margin: 0,
+    padding: 0,
+    border: "none",
+  },
+  sectionLabel: {
+    margin: 0,
+    fontSize: font.uiBodySmall,
+    fontWeight: font.weight_7,
+    letterSpacing: font.trackingSnug,
+    color: color.textMain,
+  },
+  divider: {
+    height: "1px",
+    backgroundColor: color.neutralBorder,
+  },
+  primaryRow: {
+    display: "grid",
+    gridTemplateColumns: "1fr auto 1fr",
+    alignItems: "end",
+    gap: space._2,
+  },
+  times: {
+    paddingBlockEnd: space._2,
+    fontSize: font.uiHeading3,
+    fontWeight: font.weight_4,
+    color: color.textSubtle,
+    fontVariantNumeric: "tabular-nums",
+  },
+  subLabel: {
+    margin: 0,
+    marginBlockStart: space._1,
+    fontSize: font.uiCaption,
+    fontWeight: font.weight_6,
+    color: color.textSubtle,
+  },
+  fieldGrid: {
     display: "grid",
     gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
     gap: space._2,
-    padding: space._3,
-    border: `1px solid ${color.neutralBorder}`,
-    borderRadius: border.radius_3,
-    backgroundColor: color.bgSurface,
-    margin: 0,
-  },
-  legend: {
-    paddingInline: space._2,
-    fontSize: font.uiBodySmall,
-    fontWeight: font.weight_7,
-    color: color.textMuted,
-    textTransform: "uppercase",
-    letterSpacing: ".05em",
   },
   field: {
     display: "flex",
     flexDirection: "column",
-    gap: space._1,
+    gap: space._0,
+    minWidth: 0,
   },
   fieldLabel: {
-    fontSize: font.uiBodySmall,
+    fontSize: font.uiCaption,
+    fontWeight: font.weight_5,
     color: color.textMuted,
+  },
+  fieldLabelEmphasis: {
+    fontSize: font.uiBodySmall,
+    color: color.textMain,
   },
   input: {
     width: "100%",
@@ -243,8 +301,28 @@ const styles = stylex.create({
     color: color.textMain,
     border: `1px solid ${color.neutralBorder}`,
     borderRadius: border.radius_2,
-    fontSize: font.uiBody,
-    fontFamily: "inherit",
+    fontSize: font.uiBodySmall,
+    fontFamily: font.familyMono,
+    fontVariantNumeric: "tabular-nums",
     boxSizing: "border-box",
+    outlineWidth: 0,
+    transition: {
+      default: `border-color ${duration._150} ${easing.easeOut}, box-shadow ${duration._150} ${easing.easeOut}`,
+      [motionConstants.REDUCED_MOTION]: "none",
+    },
+    borderColor: {
+      default: color.neutralBorder,
+      ":focus": color.brandSpriteEditor,
+    },
+    boxShadow: {
+      default: "none",
+      ":focus": `0 0 0 1px ${color.brandSpriteEditor}`,
+    },
+  },
+  inputEmphasis: {
+    paddingBlock: space._2,
+    fontSize: font.uiHeading3,
+    fontWeight: font.weight_6,
+    textAlign: "center",
   },
 });

--- a/apps/web/src/components/sprite-editor/grid-controls.tsx
+++ b/apps/web/src/components/sprite-editor/grid-controls.tsx
@@ -312,11 +312,11 @@ const styles = stylex.create({
     },
     borderColor: {
       default: color.neutralBorder,
-      ":focus": color.brandSpriteEditor,
+      ":focus": color.accent,
     },
     boxShadow: {
       default: "none",
-      ":focus": `0 0 0 1px ${color.brandSpriteEditor}`,
+      ":focus": `0 0 0 1px ${color.accent}`,
     },
   },
   inputEmphasis: {

--- a/apps/web/src/components/sprite-editor/guide-controls.tsx
+++ b/apps/web/src/components/sprite-editor/guide-controls.tsx
@@ -13,33 +13,35 @@ interface GuideControlsProps {
 
 export function GuideControls({ guides, onGuidesChange }: GuideControlsProps) {
   return (
-    <fieldset css={styles.group}>
-      <legend css={styles.legend}>{t({ en: "Guides", zh: "辅助线" })}</legend>
-      <Toggle
-        label={t({ en: "Halves", zh: "对半" })}
-        checked={guides.halves}
-        onChange={(checked) => {
-          onGuidesChange({ ...guides, halves: checked });
-        }}
-        testId="guide-halves"
-      />
-      <Toggle
-        label={t({ en: "Thirds", zh: "三等分" })}
-        checked={guides.thirds}
-        onChange={(checked) => {
-          onGuidesChange({ ...guides, thirds: checked });
-        }}
-        testId="guide-thirds"
-      />
-      <Toggle
-        label={t({ en: "Baseline", zh: "基线" })}
-        checked={guides.baseline}
-        onChange={(checked) => {
-          onGuidesChange({ ...guides, baseline: checked });
-        }}
-        testId="guide-baseline"
-      />
-    </fieldset>
+    <section css={styles.group}>
+      <h3 css={styles.sectionLabel}>{t({ en: "Guides", zh: "辅助线" })}</h3>
+      <div css={styles.toggles}>
+        <Toggle
+          label={t({ en: "Halves", zh: "对半" })}
+          checked={guides.halves}
+          onChange={(checked) => {
+            onGuidesChange({ ...guides, halves: checked });
+          }}
+          testId="guide-halves"
+        />
+        <Toggle
+          label={t({ en: "Thirds", zh: "三等分" })}
+          checked={guides.thirds}
+          onChange={(checked) => {
+            onGuidesChange({ ...guides, thirds: checked });
+          }}
+          testId="guide-thirds"
+        />
+        <Toggle
+          label={t({ en: "Baseline", zh: "基线" })}
+          checked={guides.baseline}
+          onChange={(checked) => {
+            onGuidesChange({ ...guides, baseline: checked });
+          }}
+          testId="guide-baseline"
+        />
+      </div>
+    </section>
   );
 }
 
@@ -53,7 +55,7 @@ interface ToggleProps {
 function Toggle({ label, checked, onChange, testId }: ToggleProps) {
   const id = useId();
   return (
-    <label htmlFor={id} css={styles.toggle}>
+    <label htmlFor={id} css={[styles.toggle, checked && styles.toggleChecked]}>
       <input
         id={id}
         type="checkbox"
@@ -61,6 +63,7 @@ function Toggle({ label, checked, onChange, testId }: ToggleProps) {
         onChange={(event) => {
           onChange(event.target.checked);
         }}
+        css={styles.checkbox}
         data-testid={testId}
       />
       <span>{label}</span>
@@ -71,28 +74,43 @@ function Toggle({ label, checked, onChange, testId }: ToggleProps) {
 const styles = stylex.create({
   group: {
     display: "flex",
-    flexWrap: "wrap",
-    gap: space._3,
-    padding: space._3,
-    border: `1px solid ${color.neutralBorder}`,
-    borderRadius: border.radius_3,
-    backgroundColor: color.bgSurface,
+    flexDirection: "column",
+    gap: space._2,
     margin: 0,
+    padding: 0,
+    border: "none",
   },
-  legend: {
-    paddingInline: space._2,
+  sectionLabel: {
+    margin: 0,
     fontSize: font.uiBodySmall,
     fontWeight: font.weight_7,
-    color: color.textMuted,
-    textTransform: "uppercase",
-    letterSpacing: ".05em",
+    letterSpacing: font.trackingSnug,
+    color: color.textMain,
+  },
+  toggles: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: space._1,
   },
   toggle: {
     display: "inline-flex",
     alignItems: "center",
     gap: space._1,
+    paddingBlock: space._0,
+    paddingInline: space._2,
     fontSize: font.uiBodySmall,
+    fontWeight: font.weight_5,
+    color: color.textMuted,
+    backgroundColor: color.bgSurfaceSunken,
+    borderRadius: border.radius_round,
+    cursor: "pointer",
+  },
+  toggleChecked: {
     color: color.textMain,
+    backgroundColor: color.surfaceAccentSubtle,
+  },
+  checkbox: {
+    accentColor: color.brandSpriteEditor,
     cursor: "pointer",
   },
 });

--- a/apps/web/src/components/sprite-editor/guide-controls.tsx
+++ b/apps/web/src/components/sprite-editor/guide-controls.tsx
@@ -110,7 +110,7 @@ const styles = stylex.create({
     backgroundColor: color.surfaceAccentSubtle,
   },
   checkbox: {
-    accentColor: color.brandSpriteEditor,
+    accentColor: color.accent,
     cursor: "pointer",
   },
 });

--- a/apps/web/src/components/sprite-editor/pixel-editor.tsx
+++ b/apps/web/src/components/sprite-editor/pixel-editor.tsx
@@ -176,8 +176,8 @@ export function PixelEditor({
   const gridColor = isDark ? "rgba(255,255,255,0.18)" : "rgba(0,0,0,0.18)";
   const cellBorderColor = isDark ? "rgba(255,255,255,0.4)" : "rgba(0,0,0,0.35)";
   // The selection accent painted directly on the canvas — kept in step with
-  // the `brandSpriteEditor` token (purple._40 light / purple._50 dark).
-  const accentStroke = isDark ? purple._50 : purple._40;
+  // the `accent` token (purple._30 light / purple._50 dark).
+  const accentStroke = isDark ? purple._50 : purple._30;
 
   // Canvas size tracks the container so the cell can be panned around inside
   // the wrapper at varying zoom without having to grow the canvas itself.
@@ -1277,9 +1277,9 @@ const styles = stylex.create({
     },
   },
   toolButtonActive: {
-    backgroundColor: color.brandSpriteEditor,
+    backgroundColor: color.accent,
     color: color.accentOn,
-    borderColor: color.brandSpriteEditor,
+    borderColor: color.accent,
   },
   colorRow: {
     display: "flex",
@@ -1320,11 +1320,11 @@ const styles = stylex.create({
     padding: 0,
   },
   swatchActive: {
-    outline: `2px solid ${color.brandSpriteEditor}`,
+    outline: `2px solid ${color.accent}`,
     outlineOffset: "1px",
   },
   range: {
-    accentColor: color.brandSpriteEditor,
+    accentColor: color.accent,
     cursor: "pointer",
   },
   toleranceValue: {
@@ -1399,7 +1399,7 @@ const styles = stylex.create({
   },
   selectionButtonPrimary: {
     backgroundColor: {
-      default: color.brandSpriteEditor,
+      default: color.accent,
       ":hover": color.accentHover,
     },
     color: color.accentOn,

--- a/apps/web/src/components/sprite-editor/pixel-editor.tsx
+++ b/apps/web/src/components/sprite-editor/pixel-editor.tsx
@@ -17,7 +17,13 @@ import { SelectionIcon } from "@phosphor-icons/react/dist/ssr/Selection";
 import { TrashIcon } from "@phosphor-icons/react/dist/ssr/Trash";
 import { XIcon } from "@phosphor-icons/react/dist/ssr/X";
 import * as stylex from "@stylexjs/stylex";
-import { border, color, font, space } from "@tuja/ui/tokens.stylex";
+import { purple } from "@tuja/ui/palette/purple";
+import {
+  duration,
+  easing,
+  motionConstants,
+} from "@tuja/ui/primitives/motion.stylex";
+import { border, color, font, shadow, space } from "@tuja/ui/tokens.stylex";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useResolvedTheme } from "#src/hooks/use-resolved-theme.ts";
 import { t } from "#src/i18n.ts";
@@ -169,6 +175,9 @@ export function PixelEditor({
   const isDark = useResolvedTheme() === "dark";
   const gridColor = isDark ? "rgba(255,255,255,0.18)" : "rgba(0,0,0,0.18)";
   const cellBorderColor = isDark ? "rgba(255,255,255,0.4)" : "rgba(0,0,0,0.35)";
+  // The selection accent painted directly on the canvas — kept in step with
+  // the `brandSpriteEditor` token (purple._40 light / purple._50 dark).
+  const accentStroke = isDark ? purple._50 : purple._40;
 
   // Canvas size tracks the container so the cell can be panned around inside
   // the wrapper at varying zoom without having to grow the canvas itself.
@@ -386,7 +395,7 @@ export function PixelEditor({
       const sy = panY + r.y * scale;
       const sw = r.w * scale;
       const sh = r.h * scale;
-      ctx.strokeStyle = "rgba(168, 85, 247, 0.95)";
+      ctx.strokeStyle = accentStroke;
       ctx.lineWidth = 1.5;
       ctx.setLineDash([6, 4]);
       ctx.strokeRect(Math.round(sx) + 0.5, Math.round(sy) + 0.5, sw, sh);
@@ -395,7 +404,7 @@ export function PixelEditor({
       // Resize handle at bottom-right.
       const hx = sx + sw;
       const hy = sy + sh;
-      ctx.fillStyle = "rgba(168, 85, 247, 0.95)";
+      ctx.fillStyle = accentStroke;
       ctx.fillRect(
         hx - HANDLE_SIZE / 2,
         hy - HANDLE_SIZE / 2,
@@ -421,6 +430,7 @@ export function PixelEditor({
     selection,
     gridColor,
     cellBorderColor,
+    accentStroke,
   ]);
 
   const remember = useCallback((hex: string) => {
@@ -1086,6 +1096,7 @@ export function PixelEditor({
               onChange={(event) => {
                 setTolerance(Number(event.target.value));
               }}
+              css={styles.range}
               data-testid="tolerance"
             />
             <span css={styles.toleranceValue}>{tolerance}</span>
@@ -1249,8 +1260,8 @@ const styles = stylex.create({
     display: "inline-flex",
     alignItems: "center",
     justifyContent: "center",
-    width: "32px",
-    height: "32px",
+    width: "34px",
+    height: "34px",
     border: `1px solid ${color.neutralBorder}`,
     borderRadius: border.radius_2,
     backgroundColor: {
@@ -1260,11 +1271,15 @@ const styles = stylex.create({
     color: color.textMain,
     cursor: { default: "pointer", ":disabled": "not-allowed" },
     opacity: { default: 1, ":disabled": 0.4 },
+    transition: {
+      default: `background-color ${duration._150} ${easing.easeOut}, border-color ${duration._150} ${easing.easeOut}, color ${duration._150} ${easing.easeOut}`,
+      [motionConstants.REDUCED_MOTION]: "none",
+    },
   },
   toolButtonActive: {
-    backgroundColor: color.brandPixelCreatureCreator,
+    backgroundColor: color.brandSpriteEditor,
     color: color.accentOn,
-    borderColor: color.brandPixelCreatureCreator,
+    borderColor: color.brandSpriteEditor,
   },
   colorRow: {
     display: "flex",
@@ -1305,13 +1320,18 @@ const styles = stylex.create({
     padding: 0,
   },
   swatchActive: {
-    outline: `2px solid ${color.brandPixelCreatureCreator}`,
+    outline: `2px solid ${color.brandSpriteEditor}`,
     outlineOffset: "1px",
+  },
+  range: {
+    accentColor: color.brandSpriteEditor,
+    cursor: "pointer",
   },
   toleranceValue: {
     minWidth: "2.5em",
     textAlign: "right",
     fontSize: font.uiBodySmall,
+    fontFamily: font.familyMono,
     color: color.textMain,
     fontVariantNumeric: "tabular-nums",
   },
@@ -1320,6 +1340,7 @@ const styles = stylex.create({
     backgroundColor: color.bgSurface,
     border: `1px solid ${color.neutralBorder}`,
     borderRadius: border.radius_3,
+    boxShadow: shadow.inset,
     flex: "1",
     minHeight: 0,
     overflow: "hidden",
@@ -1378,8 +1399,8 @@ const styles = stylex.create({
   },
   selectionButtonPrimary: {
     backgroundColor: {
-      default: color.brandPixelCreatureCreator,
-      ":hover": color.accent,
+      default: color.brandSpriteEditor,
+      ":hover": color.accentHover,
     },
     color: color.accentOn,
   },

--- a/apps/web/src/components/sprite-editor/source-canvas.tsx
+++ b/apps/web/src/components/sprite-editor/source-canvas.tsx
@@ -45,13 +45,13 @@ export function SourceCanvas({
   const [transform, setTransform] = useState<ViewTransform | null>(null);
   const [isPanning, setIsPanning] = useState(false);
   // Theme-aware overlay colors: grid lines stay quiet so the artwork reads,
-  // and the selection is painted in the editor's identity purple (kept in
-  // step with the `brandSpriteEditor` token: purple._40 light / ._50 dark).
+  // and the selection is painted in the accent purple (kept in step with the
+  // `accent` token: purple._30 light / purple._50 dark).
   const isDark = useResolvedTheme() === "dark";
   const gridStroke = isDark
     ? "rgba(255, 255, 255, 0.22)"
     : "rgba(0, 0, 0, 0.2)";
-  const accentStroke = isDark ? purple._50 : purple._40;
+  const accentStroke = isDark ? purple._50 : purple._30;
   const panStateRef = useRef<{
     pointerId: number;
     startCanvasX: number;

--- a/apps/web/src/components/sprite-editor/source-canvas.tsx
+++ b/apps/web/src/components/sprite-editor/source-canvas.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
-import { yellow } from "@tuja/ui/palette/yellow";
-import { border, color } from "@tuja/ui/tokens.stylex";
+import { purple } from "@tuja/ui/palette/purple";
+import { border, color, shadow } from "@tuja/ui/tokens.stylex";
 import { useEffect, useId, useRef, useState } from "react";
+import { useResolvedTheme } from "#src/hooks/use-resolved-theme.ts";
 import { t } from "#src/i18n.ts";
 import type { GridConfig, SourceImage } from "./types";
 
@@ -43,6 +44,14 @@ export function SourceCanvas({
   const [viewport, setViewport] = useState({ width: 0, height: 0 });
   const [transform, setTransform] = useState<ViewTransform | null>(null);
   const [isPanning, setIsPanning] = useState(false);
+  // Theme-aware overlay colors: grid lines stay quiet so the artwork reads,
+  // and the selection is painted in the editor's identity purple (kept in
+  // step with the `brandSpriteEditor` token: purple._40 light / ._50 dark).
+  const isDark = useResolvedTheme() === "dark";
+  const gridStroke = isDark
+    ? "rgba(255, 255, 255, 0.22)"
+    : "rgba(0, 0, 0, 0.2)";
+  const accentStroke = isDark ? purple._50 : purple._40;
   const panStateRef = useRef<{
     pointerId: number;
     startCanvasX: number;
@@ -140,7 +149,7 @@ export function SourceCanvas({
     // Grid cell outlines — each cell drawn as its own rectangle so gaps
     // between cells are visually obvious.
     ctx.lineWidth = 1;
-    ctx.strokeStyle = "rgba(168, 85, 247, 0.85)";
+    ctx.strokeStyle = gridStroke;
     const cellPitchX = grid.cellWidth + grid.gapX;
     const cellPitchY = grid.cellHeight + grid.gapY;
     for (let r = 0; r < grid.rows; r++) {
@@ -166,7 +175,7 @@ export function SourceCanvas({
       const w = grid.cellWidth * transform.scale;
       const h = grid.cellHeight * transform.scale;
       ctx.lineWidth = 2;
-      ctx.strokeStyle = yellow._60;
+      ctx.strokeStyle = accentStroke;
       ctx.strokeRect(Math.round(x0) - 1, Math.round(y0) - 1, w + 2, h + 2);
     }
 
@@ -181,6 +190,8 @@ export function SourceCanvas({
     grid,
     selectedCell,
     drawOverlay,
+    gridStroke,
+    accentStroke,
   ]);
 
   const canvasToImage = (
@@ -332,6 +343,7 @@ const styles = stylex.create({
     backgroundPosition: "0 0, 0 8px, 8px -8px, -8px 0px",
     borderRadius: border.radius_3,
     border: `1px solid ${color.neutralBorder}`,
+    boxShadow: shadow.inset,
     overflow: "hidden",
   },
   canvas: {

--- a/apps/web/src/components/sprite-editor/source-image-input.tsx
+++ b/apps/web/src/components/sprite-editor/source-image-input.tsx
@@ -243,7 +243,7 @@ const styles = stylex.create({
     },
   },
   heroDragging: {
-    borderColor: color.brandSpriteEditor,
+    borderColor: color.accent,
     backgroundColor: color.surfaceAccentSubtle,
   },
   heroIcon: {
@@ -252,7 +252,7 @@ const styles = stylex.create({
     width: "60px",
     height: "60px",
     borderRadius: border.radius_round,
-    color: color.brandSpriteEditor,
+    color: color.accent,
     backgroundColor: color.surfaceAccentSubtle,
   },
   heroTitle: {
@@ -296,7 +296,7 @@ const styles = stylex.create({
     color: color.textMuted,
   },
   capabilityIcon: {
-    color: color.brandSpriteEditor,
+    color: color.accent,
     flexShrink: 0,
   },
 

--- a/apps/web/src/components/sprite-editor/source-image-input.tsx
+++ b/apps/web/src/components/sprite-editor/source-image-input.tsx
@@ -1,7 +1,15 @@
 "use client";
 
+import { FilmStripIcon } from "@phosphor-icons/react/dist/ssr/FilmStrip";
+import { PencilSimpleIcon } from "@phosphor-icons/react/dist/ssr/PencilSimple";
+import { ScissorsIcon } from "@phosphor-icons/react/dist/ssr/Scissors";
 import { UploadSimpleIcon } from "@phosphor-icons/react/dist/ssr/UploadSimple";
 import * as stylex from "@stylexjs/stylex";
+import {
+  duration,
+  easing,
+  motionConstants,
+} from "@tuja/ui/primitives/motion.stylex";
 import { border, color, font, space } from "@tuja/ui/tokens.stylex";
 import { useRef, useState } from "react";
 import { Button } from "#src/components/shared/button.tsx";
@@ -11,11 +19,18 @@ import type { SourceImage } from "./types";
 interface SourceImageInputProps {
   source: SourceImage | null;
   onSourceChange: (source: SourceImage) => void;
+  /**
+   * `hero` is the full drop target shown in the empty stage; `compact` is the
+   * inline file row that lives in the sidebar once a sheet is loaded. The
+   * ingest/error logic is identical — only the presentation differs.
+   */
+  variant?: "hero" | "compact";
 }
 
 export function SourceImageInput({
   source,
   onSourceChange,
+  variant = "hero",
 }: SourceImageInputProps) {
   const [isDragging, setIsDragging] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -62,21 +77,87 @@ export function SourceImageInput({
     void ingest(file);
   };
 
+  const dragHandlers = {
+    onDragEnter: (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      setIsDragging(true);
+    },
+    onDragOver: (event: React.DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+    },
+    onDragLeave: () => {
+      setIsDragging(false);
+    },
+    onDrop: handleDrop,
+  };
+
+  const fileInput = (
+    <input
+      ref={inputRef}
+      type="file"
+      accept="image/*"
+      onChange={handleFile}
+      css={styles.input}
+      data-testid="source-input"
+    />
+  );
+
+  // Compact row — sidebar header once a sheet is loaded.
+  if (variant === "compact") {
+    return (
+      <div
+        css={[styles.compact, isDragging && styles.compactDragging]}
+        {...dragHandlers}
+      >
+        <button
+          type="button"
+          css={styles.compactSwap}
+          onClick={() => {
+            inputRef.current?.click();
+          }}
+          data-testid="source-pick"
+        >
+          <UploadSimpleIcon size={16} weight="bold" aria-hidden="true" />
+          {t({ en: "Replace", zh: "替换" })}
+        </button>
+        <div css={styles.compactMeta}>
+          <span css={styles.compactName} title={source?.name}>
+            {source?.name ?? ""}
+          </span>
+          <span css={styles.compactDims}>
+            {source !== null
+              ? `${String(source.width)} × ${String(source.height)} px`
+              : ""}
+          </span>
+        </div>
+        {fileInput}
+        {error !== null ? (
+          <p role="alert" css={styles.compactError}>
+            {error}
+          </p>
+        ) : null}
+      </div>
+    );
+  }
+
+  // Hero drop target — the empty stage.
   return (
     <div
-      css={[styles.root, isDragging && styles.rootActive]}
-      onDragEnter={(event) => {
-        event.preventDefault();
-        setIsDragging(true);
-      }}
-      onDragOver={(event) => {
-        event.preventDefault();
-      }}
-      onDragLeave={() => {
-        setIsDragging(false);
-      }}
-      onDrop={handleDrop}
+      css={[styles.hero, isDragging && styles.heroDragging]}
+      {...dragHandlers}
     >
+      <span css={styles.heroIcon} aria-hidden="true">
+        <UploadSimpleIcon size={28} weight="bold" />
+      </span>
+      <h2 css={styles.heroTitle}>
+        {t({ en: "Drop a sprite sheet to begin", zh: "拖入精灵表开始" })}
+      </h2>
+      <p css={styles.heroHint}>
+        {t({
+          en: "Drag a file anywhere here, or pick one. PNG, JPG and WebP are supported.",
+          zh: "将文件拖到此处，或选择一个。支持 PNG、JPG 和 WebP。",
+        })}
+      </p>
       <Button
         variant="primary"
         icon={<UploadSimpleIcon size={18} weight="bold" aria-hidden="true" />}
@@ -85,49 +166,48 @@ export function SourceImageInput({
         }}
         data-testid="source-pick"
       >
-        {source === null
-          ? t({ en: "Choose source image", zh: "选择源图" })
-          : t({ en: "Replace source image", zh: "替换源图" })}
+        {t({ en: "Choose source image", zh: "选择源图" })}
       </Button>
-      <input
-        ref={inputRef}
-        type="file"
-        accept="image/*"
-        onChange={handleFile}
-        css={styles.input}
-        data-testid="source-input"
-      />
-      <p css={styles.hint}>
-        {source === null
-          ? t({
-              en: "Drop a sprite sheet here or click to choose. PNG, JPG, WebP supported.",
-              zh: "在此拖放精灵表或点击选择。支持 PNG、JPG、WebP。",
-            })
-          : `${source.name} — ${String(source.width)}×${String(source.height)}`}
-      </p>
+      {fileInput}
       {error !== null ? (
-        <p role="alert" css={styles.error}>
+        <p role="alert" css={styles.heroError}>
           {error}
         </p>
       ) : null}
+      <ul css={styles.capabilities}>
+        <li css={styles.capability}>
+          <ScissorsIcon
+            size={18}
+            weight="bold"
+            aria-hidden="true"
+            css={styles.capabilityIcon}
+          />
+          <span>{t({ en: "Slice into cells", zh: "切分为单元格" })}</span>
+        </li>
+        <li css={styles.capability}>
+          <PencilSimpleIcon
+            size={18}
+            weight="bold"
+            aria-hidden="true"
+            css={styles.capabilityIcon}
+          />
+          <span>{t({ en: "Clean up pixels", zh: "清理像素" })}</span>
+        </li>
+        <li css={styles.capability}>
+          <FilmStripIcon
+            size={18}
+            weight="bold"
+            aria-hidden="true"
+            css={styles.capabilityIcon}
+          />
+          <span>{t({ en: "Assemble frames", zh: "组装动画帧" })}</span>
+        </li>
+      </ul>
     </div>
   );
 }
 
 const styles = stylex.create({
-  root: {
-    display: "flex",
-    flexDirection: "column",
-    gap: space._2,
-    padding: space._3,
-    border: `1px dashed ${color.neutralBorder}`,
-    borderRadius: border.radius_3,
-    backgroundColor: color.bgSurface,
-  },
-  rootActive: {
-    borderColor: color.brandPixelCreatureCreator,
-    backgroundColor: color.bgSurfaceRaised,
-  },
   input: {
     position: "absolute",
     width: "1px",
@@ -139,14 +219,150 @@ const styles = stylex.create({
     whiteSpace: "nowrap",
     borderWidth: 0,
   },
-  hint: {
+
+  // Hero ------------------------------------------------------------------
+  hero: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: space._3,
+    width: "100%",
+    height: "100%",
+    minHeight: "320px",
+    paddingBlock: space._9,
+    paddingInline: space._4,
+    textAlign: "center",
+    border: `2px dashed ${color.neutralBorder}`,
+    borderRadius: border.radius_3,
+    backgroundColor: color.bgSurface,
+    boxSizing: "border-box",
+    transition: {
+      default: `border-color ${duration._200} ${easing.easeOut}, background-color ${duration._200} ${easing.easeOut}`,
+      [motionConstants.REDUCED_MOTION]: "none",
+    },
+  },
+  heroDragging: {
+    borderColor: color.brandSpriteEditor,
+    backgroundColor: color.surfaceAccentSubtle,
+  },
+  heroIcon: {
+    display: "grid",
+    placeItems: "center",
+    width: "60px",
+    height: "60px",
+    borderRadius: border.radius_round,
+    color: color.brandSpriteEditor,
+    backgroundColor: color.surfaceAccentSubtle,
+  },
+  heroTitle: {
+    margin: 0,
+    fontSize: font.uiHeading2,
+    fontWeight: font.weight_7,
+    letterSpacing: font.trackingSnug,
+    color: color.textMain,
+    textWrap: "balance",
+  },
+  heroHint: {
+    margin: 0,
+    maxInlineSize: "42ch",
+    fontSize: font.uiBody,
+    lineHeight: font.lineHeight_4,
+    color: color.textMuted,
+    textWrap: "pretty",
+  },
+  heroError: {
     margin: 0,
     fontSize: font.uiBodySmall,
+    fontWeight: font.weight_6,
+    color: color.dangerText,
+  },
+  capabilities: {
+    display: "flex",
+    flexWrap: "wrap",
+    justifyContent: "center",
+    gap: space._5,
+    margin: 0,
+    marginBlockStart: space._2,
+    padding: 0,
+    listStyle: "none",
+  },
+  capability: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: space._1,
+    fontSize: font.uiBodySmall,
+    fontWeight: font.weight_5,
     color: color.textMuted,
   },
-  error: {
-    margin: 0,
+  capabilityIcon: {
+    color: color.brandSpriteEditor,
+    flexShrink: 0,
+  },
+
+  // Compact ---------------------------------------------------------------
+  compact: {
+    display: "flex",
+    alignItems: "center",
+    gap: space._2,
+    paddingBlock: space._1,
+    transition: {
+      default: `background-color ${duration._150} ${easing.easeOut}`,
+      [motionConstants.REDUCED_MOTION]: "none",
+    },
+  },
+  compactDragging: {
+    backgroundColor: color.surfaceAccentSubtle,
+    borderRadius: border.radius_2,
+  },
+  compactSwap: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: space._0,
+    flexShrink: 0,
+    paddingBlock: space._1,
+    paddingInline: space._2,
     fontSize: font.uiBodySmall,
-    color: color.brandBristol,
+    fontWeight: font.weight_6,
+    fontFamily: "inherit",
+    color: color.textMain,
+    backgroundColor: {
+      default: color.bgInteractiveRest,
+      ":hover": color.bgInteractiveHover,
+    },
+    border: `1px solid ${color.neutralBorder}`,
+    borderRadius: border.radius_2,
+    cursor: "pointer",
+    transition: {
+      default: `background-color ${duration._150} ${easing.easeOut}`,
+      [motionConstants.REDUCED_MOTION]: "none",
+    },
+  },
+  compactMeta: {
+    display: "flex",
+    flexDirection: "column",
+    minWidth: 0,
+    lineHeight: font.lineHeight_2,
+  },
+  compactName: {
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    fontSize: font.uiBodySmall,
+    fontWeight: font.weight_6,
+    color: color.textMain,
+  },
+  compactDims: {
+    fontSize: font.uiCaption,
+    fontFamily: font.familyMono,
+    fontVariantNumeric: "tabular-nums",
+    color: color.textMuted,
+  },
+  compactError: {
+    flexBasis: "100%",
+    margin: 0,
+    fontSize: font.uiCaption,
+    fontWeight: font.weight_6,
+    color: color.dangerText,
   },
 });

--- a/apps/web/src/components/sprite-editor/sprite-editor.tsx
+++ b/apps/web/src/components/sprite-editor/sprite-editor.tsx
@@ -242,110 +242,114 @@ export function SpriteEditor() {
       ? (cells[onionSourceCell] ?? null)
       : null;
 
+  if (source === null) {
+    return (
+      <div css={styles.emptyRoot}>
+        <SourceImageInput
+          variant="hero"
+          source={source}
+          onSourceChange={setSource}
+        />
+      </div>
+    );
+  }
+
   return (
     <div css={styles.root}>
-      <div css={styles.sidebar}>
-        <SourceImageInput source={source} onSourceChange={setSource} />
-        {source !== null ? (
-          <>
-            <GridControls
-              source={source}
-              grid={grid}
-              onGridChange={setGrid}
-              output={output}
-              onOutputChange={setOutput}
-            />
-            <GuideControls guides={guides} onGuidesChange={setGuides} />
-            <div css={styles.actions}>
-              <Button
-                icon={
-                  <DownloadSimpleIcon
-                    size={16}
-                    weight="bold"
-                    aria-hidden="true"
-                  />
-                }
-                onClick={() => {
-                  if (selectedCell === null) return;
-                  void handleDownloadCell(selectedCell);
-                }}
-                disabled={selectedCell === null}
-                data-testid="download-selected"
-              >
-                {t({ en: "Download selected", zh: "下载选中" })}
-              </Button>
-              <Button
-                icon={
-                  <DownloadSimpleIcon
-                    size={16}
-                    weight="bold"
-                    aria-hidden="true"
-                  />
-                }
-                onClick={() => {
-                  void handleDownloadAll();
-                }}
-                disabled={cells.length === 0}
-                data-testid="download-all"
-              >
-                {t({ en: "Download all", zh: "全部下载" })}
-              </Button>
-              <Button
-                icon={
-                  <PencilSimpleIcon
-                    size={16}
-                    weight="bold"
-                    aria-hidden="true"
-                  />
-                }
-                isActive={mode === "edit"}
-                onClick={() => {
-                  setMode((current) => (current === "edit" ? "slice" : "edit"));
-                }}
-                disabled={selectedCell === null}
-                data-testid="toggle-edit"
-              >
-                {mode === "edit"
-                  ? t({ en: "Back to slice view", zh: "返回切片视图" })
-                  : t({ en: "Edit selected cell", zh: "编辑选中" })}
-              </Button>
-              <Button
-                icon={
-                  <FilmStripIcon size={16} weight="bold" aria-hidden="true" />
-                }
-                isActive={mode === "animation"}
-                onClick={() => {
-                  setMode((current) =>
-                    current === "animation" ? "slice" : "animation",
-                  );
-                }}
-                data-testid="toggle-animation"
-              >
-                {mode === "animation"
-                  ? t({ en: "Back to slice view", zh: "返回切片视图" })
-                  : t({ en: "Animation", zh: "动画" })}
-              </Button>
-            </div>
-            <CellStrip
-              cells={cells}
-              selectedCell={selectedCell}
-              onSelect={setSelectedCell}
-            />
-          </>
-        ) : null}
-      </div>
+      <aside css={styles.sidebar}>
+        <div css={styles.panel}>
+          <SourceImageInput
+            variant="compact"
+            source={source}
+            onSourceChange={setSource}
+          />
+          <div css={styles.divider} aria-hidden="true" />
+          <GridControls
+            source={source}
+            grid={grid}
+            onGridChange={setGrid}
+            output={output}
+            onOutputChange={setOutput}
+          />
+          <div css={styles.divider} aria-hidden="true" />
+          <GuideControls guides={guides} onGuidesChange={setGuides} />
+          <div css={styles.divider} aria-hidden="true" />
+          <div css={styles.actions}>
+            <Button
+              icon={
+                <PencilSimpleIcon size={16} weight="bold" aria-hidden="true" />
+              }
+              isActive={mode === "edit"}
+              onClick={() => {
+                setMode((current) => (current === "edit" ? "slice" : "edit"));
+              }}
+              disabled={selectedCell === null}
+              data-testid="toggle-edit"
+            >
+              {mode === "edit"
+                ? t({ en: "Back to slice view", zh: "返回切片视图" })
+                : t({ en: "Edit selected cell", zh: "编辑选中" })}
+            </Button>
+            <Button
+              icon={
+                <FilmStripIcon size={16} weight="bold" aria-hidden="true" />
+              }
+              isActive={mode === "animation"}
+              onClick={() => {
+                setMode((current) =>
+                  current === "animation" ? "slice" : "animation",
+                );
+              }}
+              data-testid="toggle-animation"
+            >
+              {mode === "animation"
+                ? t({ en: "Back to slice view", zh: "返回切片视图" })
+                : t({ en: "Animation", zh: "动画" })}
+            </Button>
+            <Button
+              icon={
+                <DownloadSimpleIcon
+                  size={16}
+                  weight="bold"
+                  aria-hidden="true"
+                />
+              }
+              onClick={() => {
+                if (selectedCell === null) return;
+                void handleDownloadCell(selectedCell);
+              }}
+              disabled={selectedCell === null}
+              data-testid="download-selected"
+            >
+              {t({ en: "Download selected", zh: "下载选中" })}
+            </Button>
+            <Button
+              icon={
+                <DownloadSimpleIcon
+                  size={16}
+                  weight="bold"
+                  aria-hidden="true"
+                />
+              }
+              onClick={() => {
+                void handleDownloadAll();
+              }}
+              disabled={cells.length === 0}
+              data-testid="download-all"
+            >
+              {t({ en: "Download all", zh: "全部下载" })}
+            </Button>
+          </div>
+        </div>
+        <CellStrip
+          cells={cells}
+          selectedCell={selectedCell}
+          onSelect={setSelectedCell}
+        />
+      </aside>
 
       <div css={styles.canvasArea}>
-        {source === null ? (
-          <div css={styles.empty}>
-            <p>
-              {t({
-                en: "Choose a source image to start slicing.",
-                zh: "选择源图开始切分。",
-              })}
-            </p>
-          </div>
-        ) : mode === "animation" ? (
+        {mode === "animation" ? (
           <AnimationMode
             cells={cells}
             frames={animationFrames}
@@ -407,36 +411,53 @@ const styles = stylex.create({
   root: {
     display: "grid",
     gap: space._3,
-    gridTemplateColumns: { default: "1fr", [breakpoints.md]: "320px 1fr" },
+    gridTemplateColumns: { default: "1fr", [breakpoints.md]: "340px 1fr" },
     gridTemplateRows: { default: "auto 1fr", [breakpoints.md]: "1fr" },
     height: { default: "auto", [breakpoints.md]: "calc(100dvh - 96px)" },
     maxInlineSize: "1400px",
     width: "100%",
     marginInline: "auto",
   },
+  emptyRoot: {
+    display: "flex",
+    width: "100%",
+    maxInlineSize: "880px",
+    marginInline: "auto",
+    height: { default: "70dvh", [breakpoints.md]: "calc(100dvh - 96px)" },
+    minHeight: "360px",
+  },
   sidebar: {
     display: "flex",
     flexDirection: "column",
     gap: space._3,
+    minHeight: 0,
     overflowY: { default: "visible", [breakpoints.md]: "auto" },
     paddingInlineEnd: { default: 0, [breakpoints.md]: space._1 },
+  },
+  panel: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space._4,
+    padding: space._4,
+    border: `1px solid ${color.neutralBorder}`,
+    borderRadius: border.radius_3,
+    backgroundColor: color.bgSurface,
+    // Keep natural height inside the scrolling sidebar — without this the
+    // panel shrinks as a flex child and `overflow: hidden` (kept for the
+    // full-bleed dividers) would clip the lower sections.
+    flexShrink: 0,
+    overflowX: "hidden",
+  },
+  divider: {
+    height: "1px",
+    marginInline: `calc(${space._4} * -1)`,
+    backgroundColor: color.neutralBorder,
   },
   canvasArea: {
     display: "flex",
     flexDirection: "column",
     minHeight: "320px",
     height: { default: "60dvh", [breakpoints.md]: "100%" },
-  },
-  empty: {
-    display: "grid",
-    placeItems: "center",
-    width: "100%",
-    height: "100%",
-    color: color.textMuted,
-    fontSize: font.uiBody,
-    border: `1px dashed ${color.neutralBorder}`,
-    borderRadius: border.radius_3,
-    backgroundColor: color.bgSurface,
   },
   actions: {
     display: "flex",

--- a/packages/ui/src/tokens.stylex.ts
+++ b/packages/ui/src/tokens.stylex.ts
@@ -128,10 +128,6 @@ const light = {
   brandSpotify: green._60,
   brandStudentLoan: green._50,
   brandPixelCreatureCreator: purple._50,
-  // Sprite Editor owns a deeper "ink orchid" purple — kin to the playground
-  // family, deliberately distinct from the Pixel Creature Creator's lighter
-  // lavender, and dark enough that white (`accentOn`) clears contrast on it.
-  brandSpriteEditor: purple._40,
 };
 
 const dark: { [key in keyof typeof light]: string } = {
@@ -220,7 +216,6 @@ const dark: { [key in keyof typeof light]: string } = {
   brandSpotify: green._60,
   brandStudentLoan: green._60,
   brandPixelCreatureCreator: purple._70,
-  brandSpriteEditor: purple._50,
 };
 
 export const constants = stylex.defineConsts({
@@ -491,10 +486,6 @@ export const color = stylex.defineVars({
   brandPixelCreatureCreator: {
     default: light.brandPixelCreatureCreator,
     [constants.DARK]: dark.brandPixelCreatureCreator,
-  },
-  brandSpriteEditor: {
-    default: light.brandSpriteEditor,
-    [constants.DARK]: dark.brandSpriteEditor,
   },
 });
 

--- a/packages/ui/src/tokens.stylex.ts
+++ b/packages/ui/src/tokens.stylex.ts
@@ -128,6 +128,10 @@ const light = {
   brandSpotify: green._60,
   brandStudentLoan: green._50,
   brandPixelCreatureCreator: purple._50,
+  // Sprite Editor owns a deeper "ink orchid" purple — kin to the playground
+  // family, deliberately distinct from the Pixel Creature Creator's lighter
+  // lavender, and dark enough that white (`accentOn`) clears contrast on it.
+  brandSpriteEditor: purple._40,
 };
 
 const dark: { [key in keyof typeof light]: string } = {
@@ -216,6 +220,7 @@ const dark: { [key in keyof typeof light]: string } = {
   brandSpotify: green._60,
   brandStudentLoan: green._60,
   brandPixelCreatureCreator: purple._70,
+  brandSpriteEditor: purple._50,
 };
 
 export const constants = stylex.defineConsts({
@@ -486,6 +491,10 @@ export const color = stylex.defineVars({
   brandPixelCreatureCreator: {
     default: light.brandPixelCreatureCreator,
     [constants.DARK]: dark.brandPixelCreatureCreator,
+  },
+  brandSpriteEditor: {
+    default: light.brandSpriteEditor,
+    [constants.DARK]: dark.brandSpriteEditor,
   },
 });
 


### PR DESCRIPTION
## Why

This redesign was a test run of the `impeccable` skill — driving a full visual pass over the sprite editor to see how it holds up. The results are okay-ish rather than spectacular, but the sprite editor was never really well designed to begin with, so it's a net improvement and worth shipping.

The concrete cleanup it lands: the sprite editor had been borrowing the Pixel Creature Creator's brand colour (`brandPixelCreatureCreator`) for every accented surface — selection strokes, active tool buttons, focus rings, the drag-active state — which coupled the sprite editor's look to a token it doesn't own. It also shipped a thin, utilitarian empty state. This change repoints the sprite editor onto the standard design system accent and gives it a proper first-run experience, without touching any of the slicing/editing/animation behaviour.

## What changes

**Standard accent token, no bespoke brand colour.** Every accented sprite-editor surface now points at the shared `accent` design token instead of borrowing another tool's brand colour: tool buttons, swatch outlines, cell-strip selection, animation frame selection, range-input accents, focus rings, and the drag-active border. The canvas selection strokes — painted directly onto a `<canvas>`, so they can't read a CSS var — track the accent palette by hand (`purple._30` light / `purple._50` dark). An earlier iteration introduced a dedicated `brandSpriteEditor` token to give the editor its own identity; that was the wrong call, so the token has been dropped entirely and the editor now leans on the system accent like everything else.

**A real empty state.** When no source image is loaded, the editor now renders a full-bleed hero drop target — large upload affordance, title, hint, and a three-item capability list (slice into cells / clean up pixels / assemble frames) — instead of an empty canvas with a caption. The file input gains a `variant` prop (`hero` vs `compact`) so the same ingest/error logic backs both the empty-stage hero and the slim "Replace" row that sits in the sidebar once a sheet is loaded.

```mermaid
flowchart LR
  subgraph Before
    direction TB
    B1["Sidebar: Choose-image button"]
    B2["Canvas: empty + caption"]
  end
  subgraph After
    direction TB
    A{"Source image loaded?"}
    A -->|No| A1["Full-bleed hero drop target + capability list"]
    A -->|Yes| A2["Sidebar: compact file row + controls | Canvas"]
  end
```

**Sidebar polish.** The controls move into a single bordered panel with full-bleed dividers between sections. Grid controls are restructured to foreground columns × rows as large emphasised inputs with a secondary "alignment & gaps" group; fieldsets/legends are replaced with semantic `section`/heading markup. Guides become pill toggles. Numeric inputs adopt a monospace, tabular-nums treatment with an accent-coloured focus ring. Canvases and the editor surface gain an inset shadow, and motion respects `prefers-reduced-motion` throughout.

No banned vertical-accent-bar patterns were introduced; the accent is carried by token-themed surfaces, focus rings, and selection strokes.
