### PR TITLE
style: lighten light-theme canvas and surface background tokens

### DIFF
--- a/apps/web/e2e/theme-toggle.spec.ts
+++ b/apps/web/e2e/theme-toggle.spec.ts
@@ -16,7 +16,7 @@ test.describe("Theme Toggle", () => {
     const backgroundColor = await page.evaluate(
       () => getComputedStyle(document.documentElement).backgroundColor,
     );
-    expect(backgroundColor).toBe("rgb(233, 232, 228)");
+    expect(backgroundColor).toBe("rgb(248, 246, 242)");
 
     // Verify theme toggle shows light state
     await expect(
@@ -48,7 +48,7 @@ test.describe("Theme Toggle", () => {
     // Verify initial light theme
     await expect(page.locator("html")).toHaveCSS(
       "background-color",
-      "rgb(233, 232, 228)",
+      "rgb(248, 246, 242)",
     );
     await expect(themeToggle).not.toBeChecked();
 
@@ -64,7 +64,7 @@ test.describe("Theme Toggle", () => {
     await themeToggle.click();
     await expect(page.locator("html")).toHaveCSS(
       "background-color",
-      "rgb(233, 232, 228)",
+      "rgb(248, 246, 242)",
     );
     await expect(themeToggle).not.toBeChecked();
 
@@ -134,7 +134,7 @@ test.describe("Theme Toggle", () => {
     // System is light, so background should match the light token
     await expect(page.locator("html")).toHaveCSS(
       "background-color",
-      "rgb(233, 232, 228)",
+      "rgb(248, 246, 242)",
     );
 
     // Change system preference while following system
@@ -148,7 +148,7 @@ test.describe("Theme Toggle", () => {
     await page.emulateMedia({ colorScheme: "light" });
     await expect(page.locator("html")).toHaveCSS(
       "background-color",
-      "rgb(233, 232, 228)",
+      "rgb(248, 246, 242)",
     );
 
     // Manually override again

--- a/packages/ui/src/tokens.stylex.ts
+++ b/packages/ui/src/tokens.stylex.ts
@@ -41,20 +41,20 @@ const light = {
   accentText: purple._30,
 
   // Page — app shell, scaffolding behind everything
-  bgCanvas: gray._92,
-  bgCanvasSubtle: gray._90,
+  bgCanvas: gray._97,
+  bgCanvasSubtle: gray._99,
   bgCanvasChannels: gray_rgb._92,
 
   // Surface — cards, panels, dialog bodies
-  bgSurface: gray._95,
-  bgSurfaceRaised: gray._97,
-  bgSurfaceSunken: gray._90,
+  bgSurface: gray._100,
+  bgSurfaceRaised: gray._100,
+  bgSurfaceSunken: gray._98,
   bgSurfaceBright: gray._100,
   bgSurfaceChannels: gray_rgb._95,
 
   // Interactive — shared by buttons, list rows, menu items
-  bgInteractiveRest: gray._97,
-  bgInteractiveHover: gray._100,
+  bgInteractiveRest: gray._100,
+  bgInteractiveHover: gray._97,
   bgInteractivePressed: gray._92,
   bgInteractiveSelected: gray._90,
   bgInteractiveDisabled: gray._95,
@@ -72,7 +72,7 @@ const light = {
   bgInverse: gray._20,
 
   // Overlay — popover surface + scrim behind modals
-  bgOverlay: gray._90,
+  bgOverlay: gray._100,
   bgScrim: "rgba(0, 0, 0, 0.7)",
 
   accent: purple._30,


### PR DESCRIPTION
## Why

Light mode was reading a little too dark. The page, surface, overlay, and
interactive background tokens are stepped up the gray ramp so the whole light
surface stack reads brighter and cleaner, closer to white.

Design-driven tweak, dialled in live via author mode (#2377). No specific
contrast/accessibility target was recorded — this is a visual judgement call.

## What changes

Only the `light` theme background role tokens in
`packages/ui/src/tokens.stylex.ts` move; the `dark` theme and the translucent
`*Channels` (rgba) tokens are untouched. The light-theme html background that
the theme-toggle e2e spec asserts is updated to follow the new `bgCanvas`
value (`rgb(233,232,228)` → `rgb(248,246,242)`).

| Token | Role | Before | After |
| --- | --- | --- | --- |
| `bgCanvas` | page / app shell | `gray._92` | `gray._97` |
| `bgCanvasSubtle` | page | `gray._90` | `gray._99` |
| `bgSurface` | cards / panels / dialogs | `gray._95` | `gray._100` |
| `bgSurfaceRaised` | elevated surface | `gray._97` | `gray._100` |
| `bgSurfaceSunken` | recessed surface | `gray._90` | `gray._98` |
| `bgOverlay` | popover surface / overlay body | `gray._90` | `gray._100` |
| `bgInteractiveRest` | buttons / rows / menu items | `gray._97` | `gray._100` |
| `bgInteractiveHover` | hover state | `gray._100` | `gray._97` |

## Worth a closer look

These are palette-mapping changes only, but two of them shift the *relative*
ordering the role names imply, so flagging them explicitly:

- **`bgSurface`, `bgSurfaceRaised`, and `bgOverlay` are now all `gray._100`
  (pure white).** Raised no longer steps above surface on its own, and overlays
  / popovers sit on the same pure white — elevation in light mode now leans
  entirely on shadow rather than a brightness delta.
- **Interactive rest/hover inverted.** Rest moved to `gray._100` and hover to
  `gray._97`, so hover now *darkens* a control instead of brightening it. This
  is a behavioural change in how light-mode interactive surfaces respond to the
  pointer; the motivation for the inversion (vs. just lightening both) was not
  recorded.
- `bgCanvasSubtle` (`_99`) now sits brighter than `bgCanvas` (`_97`).

Lint, unit tests, and build all pass.
