### PR TITLE
style: refine danger and info semantic color tokens

### DIFF
--- a/packages/ui/src/tokens.stylex.ts
+++ b/packages/ui/src/tokens.stylex.ts
@@ -66,7 +66,7 @@ const light = {
   surfaceInfoSubtle: `rgba(${cyan_rgb._50}, 0.1)`,
   surfaceSuccessSubtle: `rgba(${green_rgb._50}, 0.1)`,
   surfaceWarningSubtle: `rgba(${orange_rgb._50}, 0.12)`,
-  surfaceDangerSubtle: `rgba(${red_rgb._40}, 0.1)`,
+  surfaceDangerSubtle: `rgba(${red_rgb._50}, 0.1)`,
 
   // Inverse — flips theme to grab attention (tooltips, snackbars)
   bgInverse: gray._20,
@@ -89,7 +89,7 @@ const light = {
   infoBorder: `rgba(${cyan_rgb._50}, 0.4)`,
   successBorder: `rgba(${green_rgb._50}, 0.4)`,
   warningBorder: `rgba(${orange_rgb._50}, 0.4)`,
-  dangerBorder: `rgba(${red_rgb._40}, 0.4)`,
+  dangerBorder: `rgba(${red_rgb._50}, 0.4)`,
   neutralBorder: gray._90,
 
   opacityActive: "0.1",
@@ -100,7 +100,7 @@ const light = {
   // Semantic colors — bold (foreground), hover (interactive lift), text, on
   info: cyan._50,
   infoHover: cyan._60,
-  infoText: cyan._40,
+  infoText: cyan._30,
   infoOn: gray._100,
   success: green._50,
   successHover: green._60,
@@ -110,8 +110,8 @@ const light = {
   warningHover: orange._60,
   warningText: orange._30,
   warningOn: gray._100,
-  danger: red._40,
-  dangerHover: red._50,
+  danger: red._50,
+  dangerHover: red._60,
   dangerText: red._20,
   dangerOn: gray._100,
 
@@ -163,7 +163,7 @@ const dark: { [key in keyof typeof light]: string } = {
   surfaceInfoSubtle: `rgba(${cyan_rgb._70}, 0.14)`,
   surfaceSuccessSubtle: `rgba(${green_rgb._70}, 0.14)`,
   surfaceWarningSubtle: `rgba(${yellow_rgb._60}, 0.16)`,
-  surfaceDangerSubtle: `rgba(${red_rgb._70}, 0.14)`,
+  surfaceDangerSubtle: `rgba(${red_rgb._80}, 0.14)`,
 
   bgInverse: gray._92,
   bgOverlay: gray._7,
@@ -181,7 +181,7 @@ const dark: { [key in keyof typeof light]: string } = {
   infoBorder: `rgba(${cyan_rgb._70}, 0.4)`,
   successBorder: `rgba(${green_rgb._70}, 0.4)`,
   warningBorder: `rgba(${yellow_rgb._60}, 0.4)`,
-  dangerBorder: `rgba(${red_rgb._70}, 0.4)`,
+  dangerBorder: `rgba(${red_rgb._60}, 0.4)`,
   neutralBorder: gray._20,
 
   opacityActive: "0.2",
@@ -203,7 +203,7 @@ const dark: { [key in keyof typeof light]: string } = {
   warningOn: orange._20,
   danger: red._60,
   dangerHover: red._70,
-  dangerText: red._80,
+  dangerText: red._70,
   dangerOn: red._7,
 
   brandTmdb: cyan._70,


### PR DESCRIPTION
## Why

The danger and info semantic color tokens were nudged to slightly different palette shades using the in-browser design-system author mode, which writes back to `packages/ui/src/tokens.stylex.ts`. The intent was to refine these semantic colors across both light and dark themes.

The author did not record a per-token rationale for each individual shade shift — see the gap noted below.

## What changed

Each affected token moves one step on the palette ramp. No new tokens, no structural changes — just the referenced shade.

**Light theme**

| Token | Before | After |
| --- | --- | --- |
| `surfaceDangerSubtle` | `red._40` | `red._50` |
| `dangerBorder` | `red._40` | `red._50` |
| `danger` | `red._40` | `red._50` |
| `dangerHover` | `red._50` | `red._60` |
| `infoText` | `cyan._40` | `cyan._30` |

**Dark theme**

| Token | Before | After |
| --- | --- | --- |
| `surfaceDangerSubtle` | `red._70` | `red._80` |
| `dangerBorder` | `red._70` | `red._60` |
| `dangerText` | `red._80` | `red._70` |

Net effect: light-theme danger reads a touch deeper/more saturated, light-theme info text gains contrast, and dark-theme danger surface/border/text are rebalanced.

## Gap to confirm

The per-token "why" was not stated. Worth confirming the design rationale, particularly the dark-theme `dangerBorder` move (`red._70` → `red._60`, a lighter border) which goes the opposite direction from the light-theme border change (`red._40` → `red._50`, a deeper border).