### PR TITLE
fix(trip-planner): rework day 0 london arrival via n17

### DIFF
--- a/apps/trip-planner/src/data/itinerary.ts
+++ b/apps/trip-planner/src/data/itinerary.ts
@@ -216,31 +216,32 @@ const days: Day[] = [
         note: "地铁 / 火车约 1h15，此时还没取车",
       },
       {
-        label: "Gatwick → Chingford 酒店",
+        label: "Gatwick → N17（取车后开回家停一天）",
         from: "Gatwick Airport South Terminal",
-        to: "Holiday Inn Express London Chingford",
+        to: "N17 9LX, London",
         mode: "driving",
-        note: "取车后开车，M23 → M25 约 1h15",
+        note: "M23 → M25 约 1h15，车停 N17 附近，白天不开进市区",
       },
       {
-        label: "酒店 → Chingford 车站",
-        from: "Holiday Inn Express London Chingford",
-        to: "Chingford Station, London",
-        mode: "walking",
-        note: "步行约 10min，车停酒店免费",
-      },
-      {
-        label: "Chingford → 市区（Liverpool Street）",
-        from: "Chingford Station, London",
+        label: "N17 → 市区（Tottenham Hale → Liverpool Street）",
+        from: "Tottenham Hale Station, London",
         to: "Liverpool Street Station, London",
         mode: "transit",
-        note: "Overground 约 30min",
+        note: "Greater Anglia 直达约 13min，到 Liverpool St 换 Elizabeth 线去各处",
       },
       {
-        label: "前往 Maru · Mayfair",
+        label: "前往 Maru · Mayfair（Elizabeth 线 → Bond St）",
+        from: "Liverpool Street Station, London",
         to: "Maru, 18 Shepherd Market, London W1J 7QH",
         mode: "transit",
-        note: "Green Park 站步行 5min",
+        note: "Liverpool St 坐 Elizabeth 线到 Bond Street 约 8min，步行 10min 到 Shepherd Market",
+      },
+      {
+        label: "回 Chingford 酒店过夜（N17 取车开过去）",
+        from: "N17 9LX, London",
+        to: "Holiday Inn Express London Chingford",
+        mode: "driving",
+        note: "晚饭后坐火车回 Tottenham Hale 取车，开去 Chingford 约 15min",
       },
     ],
     timeline: [
@@ -250,7 +251,7 @@ const days: Day[] = [
       },
       {
         time: "下午",
-        text: "进城自由活动 — 博物馆 / 公园 / 南岸随意逛（见下方想去的地方）",
+        text: "把车停在 N17，从 Tottenham Hale 坐火车 / 地铁进城自由活动 — 博物馆 / 公园 / 南岸随意逛（见下方想去的地方）",
       },
       {
         time: "17:30",
@@ -258,7 +259,7 @@ const days: Day[] = [
       },
       {
         time: "晚上",
-        text: "入住 Holiday Inn Express Chingford，为明早出发休整",
+        text: "坐车回 Tottenham Hale 取车，开去入住 Holiday Inn Express Chingford，为明早出发休整",
       },
     ],
     places: [
@@ -314,7 +315,7 @@ const days: Day[] = [
     tips: [
       {
         kind: "parking",
-        text: "车停 HIE Chingford 免费，全天坐 Overground / 地铁进城，不用开车。",
+        text: "白天把车停在 N17：路段是 CPZ 就当天用 RingGo 买一张 Haringey 住户访客券（最省事，停家门附近）；有自家车道或路段不管制则免费。想要稳妥也可提前在 JustPark / YourParkingSpace 订车位（约 £6–8/天）。别贪 Tottenham Hale 零售公园的免费 3 小时（超时罚款很重）。晚上再开去 Chingford，酒店停车免费。",
       },
       {
         kind: "drive",
@@ -322,7 +323,7 @@ const days: Day[] = [
       },
       {
         kind: "money",
-        text: "全程不进 Congestion Charge Zone（Chingford / Gatwick 均在区外），省 £15/天。",
+        text: "全程不进 Congestion Charge Zone（N17 / Chingford / Gatwick 均在区外），省 £15/天。",
       },
       {
         kind: "info",


### PR DESCRIPTION
## Why

The original Day 0 plan for getting into London was physically unworkable. It routed Gatwick → drive to the Holiday Inn Express Chingford → "walk to Chingford station (~10 min)" → train into central London. That hotel→station walk is actually well over an hour on foot, so the leg simply doesn't work.

The trip owner lives in N17 (Tottenham), so the realistic plan is to drive the Sixt rental from Gatwick to N17, park near home for the day, and take the train in from Tottenham Hale. In the evening they go back to Tottenham Hale, retrieve the car, and drive to the Chingford hotel to sleep.

A second problem: the parking guidance was wrong. The earlier draft implied "free street-side parking" in N17, but N17 streets are mostly CPZ-controlled during the day (~08:00–18:30), so that advice would have led to a fine. Parking guidance is now corrected against Haringey Council / JustPark reality.

## What changes

**Day 0 routing — before vs after:**

```mermaid
graph LR
  subgraph Before["Before (broken)"]
    G1[Gatwick] -->|drive| H1[HIE Chingford]
    H1 -.->|"walk ~10min<br/>(actually 1h+)"| C1[Chingford Station]
    C1 -->|Overground ~30min| L1[Liverpool Street]
    L1 --> M1[Maru · Mayfair]
  end
  subgraph After["After (workable)"]
    G2[Gatwick] -->|"drive, park in N17 for the day"| N2[N17 / home]
    N2 -->|"Greater Anglia ~13min"| L2[Liverpool Street]
    L2 -->|"Elizabeth line → Bond St"| M2[Maru · Mayfair]
    M2 -.->|"train back to Tottenham Hale,<br/>collect car"| N3[N17]
    N3 -->|"drive ~15min"| H2[HIE Chingford · overnight]
  end
```

- **Daytime travel** is now Tottenham Hale → Liverpool Street (Greater Anglia, ~13 min), then the Elizabeth line onward. For the fixed Maru omakase dinner in Mayfair, that's Liverpool St → Bond St (~8 min) plus a short walk to Shepherd Market.
- **Car logistics** are split into two driving legs: Gatwick → N17 in the morning (park near home, don't drive into town), then N17 → Chingford in the evening after collecting the car.
- **Parking tip** now recommends, in order: a Haringey resident *visitor permit* bought day-of via RingGo (the owner is a resident, parking near home); free parking only if the road is uncontrolled or they have a driveway; a pre-booked JustPark / YourParkingSpace space (~£6–8/day) as a guaranteed backup. It explicitly warns against the Tottenham Hale Retail Park "free 3h then heavy fines" trap.
- **Congestion-Charge tip** updated — N17 is also outside the CC zone, so the "no charge anywhere on this trip" note now lists N17 alongside Chingford and Gatwick.
- **Timeline narration** updated to match the new park-in-N17 / collect-car-in-the-evening flow.

All changes are data-only, confined to `apps/trip-planner/src/data/itinerary.ts`. The N17 parking guidance was researched against Haringey Council and JustPark sources; the Day 0 nav links were visually verified to produce correct Google Maps `/maps/dir/` URLs.