### PR TITLE
feat(trip-planner): add inline route maps per day

### DIFF
--- a/apps/trip-planner/.env.example
+++ b/apps/trip-planner/.env.example
@@ -1,0 +1,12 @@
+# Copy to .env.local and fill in. None of these are required for the app to run.
+
+# Password gate for the deployed app (see src/proxy.ts). Leave blank to disable.
+SITE_PASSWORD=
+
+# Google Maps Embed API key — enables the inline route maps in the day view.
+# Setup: Google Cloud console → enable "Maps Embed API" → create an API key →
+# restrict it to your domain(s) (HTTP referrers) AND to the Maps Embed API.
+# This value is public on purpose (it ships in the iframe URL), so the referrer
+# restriction is what protects it. The Maps Embed API has no usage charge.
+# Unset → maps are hidden and the app falls back to Google Maps deep-links.
+NEXT_PUBLIC_GOOGLE_MAPS_EMBED_API_KEY=

--- a/apps/trip-planner/README.md
+++ b/apps/trip-planner/README.md
@@ -28,6 +28,24 @@ pnpm dev          # runs every app; trip-planner uses web's port + 100
 pnpm --filter trip-planner dev
 ```
 
+## Maps
+
+Each day renders an at-a-glance route map plus an expandable inline map on every
+nav leg, via the [Google Maps Embed API](https://developers.google.com/maps/documentation/embed).
+The Embed API has **no usage charge**, so this stays free.
+
+To enable it locally, set `NEXT_PUBLIC_GOOGLE_MAPS_EMBED_API_KEY` in `.env.local`
+(see `.env.example`):
+
+1. Google Cloud console → enable **Maps Embed API**.
+2. Create an API key, then restrict it to your domain(s) (HTTP referrers) **and**
+   to the Maps Embed API — the key is public (it ships in the iframe `src`), so
+   the referrer restriction is what protects it.
+3. Add the same key as an env var in the Vercel project for production.
+
+Without a key the maps are hidden and navigation falls back to Google Maps
+deep-links — no embedded preview, everything else works.
+
 ## Deploy (Vercel)
 
 This app is a second Vercel project pointing at the same Git repo:

--- a/apps/trip-planner/src/components/trip/daily-view.tsx
+++ b/apps/trip-planner/src/components/trip/daily-view.tsx
@@ -2,6 +2,7 @@ import { Clock, MapPin } from "lucide-react";
 import { ChecklistSection } from "./checklist-section";
 import { DayGlance } from "./day-glance";
 import { DayHeader } from "./day-header";
+import { DayMap } from "./day-map";
 import { DiningSection } from "./dining-section";
 import { PlacePill } from "./links";
 import { NavSection } from "./nav-section";
@@ -27,6 +28,8 @@ export function DailyView({
       {day.anchors && day.anchors.length > 0 ? (
         <DayGlance anchors={day.anchors} />
       ) : null}
+
+      <DayMap day={day} />
 
       {day.nav && day.nav.length > 0 ? <NavSection legs={day.nav} /> : null}
 

--- a/apps/trip-planner/src/components/trip/day-map.tsx
+++ b/apps/trip-planner/src/components/trip/day-map.tsx
@@ -1,0 +1,46 @@
+import { Map as MapIcon } from "lucide-react";
+import { MapEmbed } from "./map-embed";
+import { Section } from "./section";
+import type { Day } from "@/data/itinerary";
+import {
+  dayRouteMode,
+  dayRoutePoints,
+  googleMapsEmbedDirectionsUrl,
+  mapsEmbedEnabled,
+  MAX_ROUTE_WAYPOINTS,
+} from "@/lib/maps";
+
+/**
+ * An at-a-glance map of the whole day, chaining the nav legs into one route.
+ * Drawn in the day's travel mode (driving for road-trip days, walking for
+ * no-car city days) — it frames the shape of the day, while the per-leg maps
+ * below carry the exact mode for each hop. Renders nothing when no key is
+ * configured or the day has too few stops to draw a route.
+ */
+export function DayMap({ day }: { day: Day }) {
+  if (!mapsEmbedEnabled || !day.nav || day.nav.length === 0) return null;
+
+  const points = dayRoutePoints(day.nav);
+  const [origin] = points;
+  const destination = points.at(-1);
+  if (!origin || !destination) return null;
+
+  const waypoints = points.slice(1, -1).slice(0, MAX_ROUTE_WAYPOINTS);
+  // A round-trip day (origin === destination, e.g. Inverness ↔ Speyside) still
+  // draws as a meaningful loop via its waypoints; only skip when there is
+  // genuinely nothing to route between.
+  if (origin === destination && waypoints.length === 0) return null;
+
+  const src = googleMapsEmbedDirectionsUrl({
+    origin,
+    destination,
+    waypoints,
+    mode: dayRouteMode(day.nav),
+  });
+
+  return (
+    <Section icon={MapIcon} title="本日路线">
+      <MapEmbed src={src} title={`${day.title} · 本日路线地图`} />
+    </Section>
+  );
+}

--- a/apps/trip-planner/src/components/trip/map-embed.tsx
+++ b/apps/trip-planner/src/components/trip/map-embed.tsx
@@ -1,0 +1,15 @@
+/** A framed, lazily-loaded Google Maps Embed iframe with a consistent shape. */
+export function MapEmbed({ src, title }: { src: string; title: string }) {
+  return (
+    <div className="overflow-hidden rounded-xl border bg-muted">
+      <iframe
+        src={src}
+        title={title}
+        loading="lazy"
+        referrerPolicy="no-referrer-when-downgrade"
+        allowFullScreen
+        className="block aspect-[16/10] w-full border-0"
+      />
+    </div>
+  );
+}

--- a/apps/trip-planner/src/components/trip/nav-section.tsx
+++ b/apps/trip-planner/src/components/trip/nav-section.tsx
@@ -1,8 +1,24 @@
+"use client";
+
 import type { LucideIcon } from "lucide-react";
-import { Car, Footprints, Navigation, TrainFront } from "lucide-react";
+import {
+  Car,
+  ChevronDown,
+  Footprints,
+  Navigation,
+  TrainFront,
+} from "lucide-react";
+import { useId, useState } from "react";
+import { MapEmbed } from "./map-embed";
 import { Section } from "./section";
 import type { NavLeg, TravelMode } from "@/data/itinerary";
-import { googleMapsDirectionsUrl } from "@/lib/maps";
+import {
+  googleMapsDirectionsUrl,
+  googleMapsEmbedDirectionsUrl,
+  googleMapsEmbedPlaceUrl,
+  mapsEmbedEnabled,
+} from "@/lib/maps";
+import { cn } from "@/lib/utils";
 
 const modeIcon: Record<TravelMode, LucideIcon> = {
   driving: Car,
@@ -10,42 +26,91 @@ const modeIcon: Record<TravelMode, LucideIcon> = {
   walking: Footprints,
 };
 
+/**
+ * The Embed API needs a concrete origin, so legs starting from the device's
+ * current location preview the destination as a place instead of a route.
+ */
+function legEmbedSrc(leg: NavLeg) {
+  return leg.from
+    ? googleMapsEmbedDirectionsUrl({
+        origin: leg.from,
+        destination: leg.to,
+        mode: leg.mode,
+      })
+    : googleMapsEmbedPlaceUrl(leg.to);
+}
+
+/** One nav leg: a deep-link to directions plus an optional inline map preview. */
+function NavLegRow({ leg }: { leg: NavLeg }) {
+  const [open, setOpen] = useState(false);
+  const panelId = useId();
+  const Icon = modeIcon[leg.mode ?? "driving"];
+
+  return (
+    <li className="overflow-hidden rounded-xl border bg-card transition-colors hover:border-foreground/30">
+      <div className="flex items-center gap-3 p-3">
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted">
+          <Icon className="size-4 text-muted-foreground" />
+        </span>
+        <a
+          href={googleMapsDirectionsUrl({
+            origin: leg.from,
+            destination: leg.to,
+            mode: leg.mode,
+          })}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="group min-w-0 flex-1"
+        >
+          <span className="flex items-center gap-1.5 text-sm font-medium">
+            {leg.label}
+            <Navigation className="size-3.5 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground" />
+          </span>
+          {leg.note ? (
+            <span className="mt-0.5 block text-xs text-muted-foreground">
+              {leg.note}
+            </span>
+          ) : null}
+        </a>
+        {mapsEmbedEnabled ? (
+          <button
+            type="button"
+            onClick={() => {
+              setOpen((value) => !value);
+            }}
+            aria-expanded={open}
+            aria-controls={panelId}
+            className="flex shrink-0 items-center gap-1 rounded-full border bg-card px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            地图
+            <ChevronDown
+              className={cn(
+                "size-3.5 transition-transform",
+                open && "rotate-180",
+              )}
+            />
+          </button>
+        ) : null}
+      </div>
+      {open ? (
+        <div id={panelId} className="border-t p-3">
+          <MapEmbed src={legEmbedSrc(leg)} title={`${leg.label} · 路线地图`} />
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
 /** One-tap navigation legs for the day. Each row opens Google Maps directions
- *  with the route preloaded. Answers "how do I get there". */
+ *  with the route preloaded, and can expand an inline map. Answers "how do I
+ *  get there". */
 export function NavSection({ legs }: { legs: NavLeg[] }) {
   return (
     <Section icon={Navigation} title="导航">
       <ul className="space-y-2">
-        {legs.map((leg) => {
-          const Icon = modeIcon[leg.mode ?? "driving"];
-          return (
-            <li key={leg.label}>
-              <a
-                href={googleMapsDirectionsUrl({
-                  origin: leg.from,
-                  destination: leg.to,
-                  mode: leg.mode,
-                })}
-                target="_blank"
-                rel="noreferrer noopener"
-                className="group flex items-center gap-3 rounded-xl border bg-card p-3 transition-colors hover:border-foreground/30 hover:bg-accent"
-              >
-                <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted">
-                  <Icon className="size-4 text-muted-foreground" />
-                </span>
-                <span className="min-w-0 flex-1">
-                  <span className="block text-sm font-medium">{leg.label}</span>
-                  {leg.note ? (
-                    <span className="mt-0.5 block text-xs text-muted-foreground">
-                      {leg.note}
-                    </span>
-                  ) : null}
-                </span>
-                <Navigation className="size-4 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground" />
-              </a>
-            </li>
-          );
-        })}
+        {legs.map((leg) => (
+          <NavLegRow key={leg.label} leg={leg} />
+        ))}
       </ul>
     </Section>
   );

--- a/apps/trip-planner/src/data/itinerary.ts
+++ b/apps/trip-planner/src/data/itinerary.ts
@@ -721,7 +721,7 @@ const days: Day[] = [
         time: "18:30",
         label: "入住因弗内斯独栋",
         kind: "checkin",
-        query: "41 Essichs Gardens, Inverness IV2 6BW",
+        query: "41 Essich Gardens, Inverness IV2 6BW",
       },
     ],
     nav: [
@@ -749,7 +749,7 @@ const days: Day[] = [
       {
         label: "Pitlochry → 因弗内斯",
         from: "Pitlochry town centre",
-        to: "41 Essichs Gardens, Inverness IV2 6BW",
+        to: "41 Essich Gardens, Inverness IV2 6BW",
         mode: "driving",
         note: "A9 穿凯恩戈姆，layby 随时停拍",
       },
@@ -889,8 +889,8 @@ const days: Day[] = [
       lodging: [
         {
           name: "Modern 2 Bedroom Semi-detached House",
-          query: "41 Essichs Gardens Inverness IV2 6BW",
-          address: "41 Essichs Gardens, Inverness, IV2 6BW",
+          query: "41 Essich Gardens Inverness IV2 6BW",
+          address: "41 Essich Gardens, Inverness, IV2 6BW",
           checkIn: "6.21 周日 16:00",
           checkOut: "6.23 周二 10:00",
           room: "独栋 2 居室 · 连住 2 晚 · 带私人车位",
@@ -935,7 +935,7 @@ const days: Day[] = [
     nav: [
       {
         label: "因弗内斯 → Macallan 酒厂",
-        from: "41 Essichs Gardens, Inverness IV2 6BW",
+        from: "41 Essich Gardens, Inverness IV2 6BW",
         to: "The Macallan Distillery",
         mode: "driving",
         note: "A9 → A95 约 1h15；务必提前网上预约",
@@ -950,7 +950,7 @@ const days: Day[] = [
       {
         label: "Aberlour → 因弗内斯（返回）",
         from: "Aberlour Distillery",
-        to: "41 Essichs Gardens, Inverness IV2 6BW",
+        to: "41 Essich Gardens, Inverness IV2 6BW",
         mode: "driving",
         note: "A95 → A9 返程约 1h15",
       },
@@ -1074,7 +1074,7 @@ const days: Day[] = [
         time: "08:00",
         label: "出发离开因弗内斯（行程密集，早出发）",
         kind: "checkout",
-        query: "41 Essichs Gardens, Inverness IV2 6BW",
+        query: "41 Essich Gardens, Inverness IV2 6BW",
       },
       {
         time: "08:30",
@@ -1100,7 +1100,7 @@ const days: Day[] = [
     nav: [
       {
         label: "因弗内斯 → Urquhart Castle",
-        from: "41 Essichs Gardens, Inverness IV2 6BW",
+        from: "41 Essich Gardens, Inverness IV2 6BW",
         to: "Urquhart Castle car park",
         mode: "driving",
         note: "尼斯湖畔观景台，30–40min",
@@ -2116,7 +2116,11 @@ const days: Day[] = [
       },
       {
         label: "South Bank（Tate Modern / Tower Bridge）",
-        to: "Tate Modern, London",
+        // Use the Bankside area, not "Tate Modern" — the museum geocodes to a
+        // building Google can't snap as a routable waypoint, which blanks the
+        // day-overview route. The Tate Modern place-pill below still links the
+        // museum directly.
+        to: "Bankside, London",
         mode: "transit",
         note: "Tate Modern → 千禧桥 → Tower Bridge（Borough Market 周一休市）",
       },

--- a/apps/trip-planner/src/lib/maps.ts
+++ b/apps/trip-planner/src/lib/maps.ts
@@ -1,9 +1,9 @@
+import type { NavLeg, TravelMode } from "@/data/itinerary";
+
 /** Build a Google Maps search URL that opens to the given place/query. */
 export function googleMapsUrl(query: string) {
   return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`;
 }
-
-type TravelMode = "driving" | "transit" | "walking";
 
 /**
  * Build a Google Maps *directions* deep-link that opens with the route
@@ -24,4 +24,85 @@ export function googleMapsDirectionsUrl({
   if (origin) params.set("origin", origin);
   params.set("destination", destination);
   return `https://www.google.com/maps/dir/?${params.toString()}`;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Embedded maps (Google Maps Embed API)                                      */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Public Embed-API key. It ships inside the iframe `src`, so it is *meant* to
+ * be public — restrict it by HTTP referrer and to the Maps Embed API in Google
+ * Cloud. When unset, embeds are disabled and the app falls back to deep-links.
+ */
+const mapsEmbedKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_EMBED_API_KEY;
+
+/** Whether inline map previews can render (a key is configured). */
+export const mapsEmbedEnabled = Boolean(mapsEmbedKey);
+
+const EMBED_BASE = "https://www.google.com/maps/embed/v1";
+
+/** Embed-API URL that previews a single place. */
+export function googleMapsEmbedPlaceUrl(query: string) {
+  const params = new URLSearchParams({ key: mapsEmbedKey ?? "", q: query });
+  return `${EMBED_BASE}/place?${params.toString()}`;
+}
+
+/**
+ * Embed-API URL that previews a route. Unlike the deep-link, the Embed API
+ * requires a concrete `origin` (no current-location) and accepts intermediate
+ * `waypoints`.
+ */
+export function googleMapsEmbedDirectionsUrl({
+  origin,
+  destination,
+  waypoints = [],
+  mode = "driving",
+}: {
+  origin: string;
+  destination: string;
+  waypoints?: string[];
+  mode?: TravelMode;
+}) {
+  const params = new URLSearchParams({
+    key: mapsEmbedKey ?? "",
+    origin,
+    destination,
+    mode,
+  });
+  if (waypoints.length > 0) params.set("waypoints", waypoints.join("|"));
+  return `${EMBED_BASE}/directions?${params.toString()}`;
+}
+
+/** The Embed API caps how many waypoints one route may carry; stay well under. */
+export const MAX_ROUTE_WAYPOINTS = 10;
+
+/**
+ * Collapse a day's single-hop legs into one ordered list of stops for an
+ * overview route. A leg whose `from` is omitted (current location) inherits the
+ * previous leg's destination, and consecutive identical points are de-duped, so
+ * a chain like N17→Gatwick, Gatwick→Cambridge becomes [N17, Gatwick, Cambridge].
+ */
+export function dayRoutePoints(legs: NavLeg[]) {
+  const points: string[] = [];
+  for (const leg of legs) {
+    const last = points.at(-1);
+    const from = leg.from ?? last;
+    if (from && from !== last) points.push(from);
+    if (leg.to !== points.at(-1)) points.push(leg.to);
+  }
+  return points;
+}
+
+/**
+ * Mode for the day-overview route. Driving whenever the day has a driving leg
+ * (the road-trip days); walking otherwise — a no-car city day is better drawn
+ * on foot. Unlike transit, walking supports the waypoints the overview chains
+ * together and routes through pedestrian-only stops (e.g. Tate Modern), which
+ * a driving route rejects.
+ */
+export function dayRouteMode(legs: NavLeg[]): TravelMode {
+  return legs.some((leg) => (leg.mode ?? "driving") === "driving")
+    ? "driving"
+    : "walking";
 }


### PR DESCRIPTION
## Why

The trip-planner only offered Google Maps *deep-links* — tap a nav leg and it bounces you out to the Maps app. There was no way to see the shape of a day's route or a single hop without leaving the planner. This adds embedded map previews so the route is visible in-page, while keeping the deep-links as the action.

## What changed

- **Day-overview route map (本日路线)** — per day, the day's single-hop nav legs are chained into one ordered route and previewed as a single embedded map. Adaptive mode: driving on road-trip days, walking on no-car city days (walking supports waypoints and pedestrian-only stops; driving rejects them).
- **Per-leg inline map** — every nav leg gets a 地图 toggle that lazily mounts an inline map for that hop. Legs that start from the device's current location preview the destination as a place (the Embed API requires a concrete origin), the rest preview the route.

Both use the **Google Maps Embed API**, chosen because it has no usage charge — it stays free at any traffic level.

## Graceful degradation

The key is read from `NEXT_PUBLIC_GOOGLE_MAPS_EMBED_API_KEY`. It is public on purpose (it ships in the iframe `src`), so it is protected by HTTP-referrer restriction rather than secrecy. When no key is configured, maps are hidden and the existing deep-link behaviour is unchanged.

```mermaid
flowchart LR
    K{Embed key set?} -->|yes| M[Inline map preview<br/>+ deep-link action]
    K -->|no| D[Deep-link only<br/>unchanged behaviour]
```

## Map-routing fixes

The Embed *directions* geocoder is much stricter than the search/deep-link API — a single un-routable point blanks the entire day's overview route. Found and fixed while verifying every day renders:

- **D3 blank** — data typo `Essichs Gardens` → `Essich Gardens` (the real Inverness street; the typo failed to geocode). Fixed across all 8 occurrences (D3/D4/D5 share this lodging).
- **D4 had no overview** — it is a round-trip day (Inverness ↔ Speyside, origin == destination) and was skipped entirely; the guard now still draws a loop when there are waypoints to route through.
- **D11 (all-Tube London day) blank** — (a) the overview previously forced driving mode, wrong for a car-free day and broken on pedestrian stops → mode is now adaptive; (b) `Tate Modern, London` geocodes to the museum building, not snappable as a routing waypoint → that one nav leg's destination is now `Bankside, London` (the South Bank area it covers). The dedicated Tate Modern place-pill still links the museum directly.

All 13 days' overview maps were verified rendering in-browser.

## Verification

Lint + build pass. This app has no test harness (Vitest runs only in `apps/web` / `packages/*`), so behaviour was verified visually in the browser.