### PR TITLE
feat(trip-planner): add per-day who's-involved pictography

### DIFF
--- a/apps/trip-planner/src/components/trip/day-header.tsx
+++ b/apps/trip-planner/src/components/trip/day-header.tsx
@@ -5,42 +5,44 @@ import type { Day } from "@/data/itinerary";
 
 export function DayHeader({ day, isToday }: { day: Day; isToday: boolean }) {
   return (
-    <header>
-      <div className="flex items-center gap-2 text-sm text-muted-foreground">
-        <span className="font-medium text-foreground">Day {day.n}</span>
-        <span>·</span>
-        <span>{day.dateLabel}</span>
-        <span>{day.weekday}</span>
-        {isToday ? <Badge className="ml-1">今天</Badge> : null}
+    <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <span className="font-medium text-foreground">Day {day.n}</span>
+          <span>·</span>
+          <span>{day.dateLabel}</span>
+          <span>{day.weekday}</span>
+          {isToday ? <Badge className="ml-1">今天</Badge> : null}
+        </div>
+
+        <h2 className="mt-1 text-2xl font-semibold tracking-tight text-balance">
+          {day.title}
+        </h2>
+
+        <p className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
+          <Route className="size-4 shrink-0" />
+          {day.route}
+        </p>
+
+        {day.driving || day.weather ? (
+          <div className="mt-3 flex flex-wrap gap-2">
+            {day.driving ? (
+              <Badge variant="outline">
+                <Car />
+                {day.driving}
+              </Badge>
+            ) : null}
+            {day.weather ? (
+              <Badge variant="outline">
+                <CloudSun />
+                {day.weather.temp} · {day.weather.summary}
+              </Badge>
+            ) : null}
+          </div>
+        ) : null}
       </div>
 
-      <h2 className="mt-1 text-2xl font-semibold tracking-tight text-balance">
-        {day.title}
-      </h2>
-
-      <p className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
-        <Route className="size-4 shrink-0" />
-        {day.route}
-      </p>
-
-      <DayParty dayN={day.n} className="mt-3" />
-
-      {day.driving || day.weather ? (
-        <div className="mt-3 flex flex-wrap gap-2">
-          {day.driving ? (
-            <Badge variant="outline">
-              <Car />
-              {day.driving}
-            </Badge>
-          ) : null}
-          {day.weather ? (
-            <Badge variant="outline">
-              <CloudSun />
-              {day.weather.temp} · {day.weather.summary}
-            </Badge>
-          ) : null}
-        </div>
-      ) : null}
+      <DayParty dayN={day.n} className="shrink-0 sm:justify-end" />
     </header>
   );
 }

--- a/apps/trip-planner/src/components/trip/day-header.tsx
+++ b/apps/trip-planner/src/components/trip/day-header.tsx
@@ -5,44 +5,46 @@ import type { Day } from "@/data/itinerary";
 
 export function DayHeader({ day, isToday }: { day: Day; isToday: boolean }) {
   return (
-    <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
-      <div className="min-w-0">
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <span className="font-medium text-foreground">Day {day.n}</span>
-          <span>·</span>
-          <span>{day.dateLabel}</span>
-          <span>{day.weekday}</span>
-          {isToday ? <Badge className="ml-1">今天</Badge> : null}
+    <header>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">Day {day.n}</span>
+            <span>·</span>
+            <span>{day.dateLabel}</span>
+            <span>{day.weekday}</span>
+            {isToday ? <Badge className="ml-1">今天</Badge> : null}
+          </div>
+
+          <h2 className="mt-1 text-2xl font-semibold tracking-tight text-balance">
+            {day.title}
+          </h2>
+
+          <p className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
+            <Route className="size-4 shrink-0" />
+            {day.route}
+          </p>
         </div>
 
-        <h2 className="mt-1 text-2xl font-semibold tracking-tight text-balance">
-          {day.title}
-        </h2>
-
-        <p className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
-          <Route className="size-4 shrink-0" />
-          {day.route}
-        </p>
-
-        {day.driving || day.weather ? (
-          <div className="mt-3 flex flex-wrap gap-2">
-            {day.driving ? (
-              <Badge variant="outline">
-                <Car />
-                {day.driving}
-              </Badge>
-            ) : null}
-            {day.weather ? (
-              <Badge variant="outline">
-                <CloudSun />
-                {day.weather.temp} · {day.weather.summary}
-              </Badge>
-            ) : null}
-          </div>
-        ) : null}
+        <DayParty dayN={day.n} className="shrink-0" />
       </div>
 
-      <DayParty dayN={day.n} className="shrink-0 sm:justify-end" />
+      {day.driving || day.weather ? (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {day.driving ? (
+            <Badge variant="outline">
+              <Car />
+              {day.driving}
+            </Badge>
+          ) : null}
+          {day.weather ? (
+            <Badge variant="outline">
+              <CloudSun />
+              {day.weather.temp} · {day.weather.summary}
+            </Badge>
+          ) : null}
+        </div>
+      ) : null}
     </header>
   );
 }

--- a/apps/trip-planner/src/components/trip/day-header.tsx
+++ b/apps/trip-planner/src/components/trip/day-header.tsx
@@ -1,4 +1,5 @@
 import { Car, CloudSun, Route } from "lucide-react";
+import { DayParty } from "./day-party";
 import { Badge } from "@/components/ui/badge";
 import type { Day } from "@/data/itinerary";
 
@@ -21,6 +22,8 @@ export function DayHeader({ day, isToday }: { day: Day; isToday: boolean }) {
         <Route className="size-4 shrink-0" />
         {day.route}
       </p>
+
+      <DayParty dayN={day.n} className="mt-3" />
 
       {day.driving || day.weather ? (
         <div className="mt-3 flex flex-wrap gap-2">

--- a/apps/trip-planner/src/components/trip/day-party.tsx
+++ b/apps/trip-planner/src/components/trip/day-party.tsx
@@ -1,0 +1,150 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  House,
+  PlaneLanding,
+  PlaneTakeoff,
+  UserRoundMinus,
+  UserRoundPlus,
+} from "lucide-react";
+import {
+  type DayPresence,
+  peopleOnDay,
+  type PresenceKind,
+  type TravelVia,
+} from "@/data/itinerary";
+import { cn } from "@/lib/utils";
+
+type Transition = Exclude<PresenceKind, "present">;
+
+const transitionVerb: Record<Transition, string> = {
+  arrive: "抵达",
+  depart: "离开",
+  home: "回家",
+};
+
+/** Pictograph per transition × travel mode. Flights use planes (大雨 / Jim);
+ *  ground arrivals use person glyphs (Ed drives over); 石头 heading home uses a
+ *  house. Keyed `${kind}-${via}` so the lookup stays a static map. */
+const transitionIcon: Record<`${Transition}-${TravelVia}`, LucideIcon> = {
+  "arrive-air": PlaneLanding,
+  "arrive-ground": UserRoundPlus,
+  "depart-air": PlaneTakeoff,
+  "depart-ground": UserRoundMinus,
+  "home-air": House,
+  "home-ground": House,
+};
+
+/**
+ * One person as an avatar medallion: their initial inside, the day's
+ * transition stamped as a corner badge. People merely around read quiet;
+ * anyone arriving, leaving, or heading home is inverted so the day's comings
+ * and goings pop out of the row.
+ */
+function PersonToken({
+  person,
+  compact,
+  index,
+}: {
+  person: DayPresence;
+  compact: boolean;
+  index: number;
+}) {
+  const transition = person.kind === "present" ? null : person.kind;
+  const Icon = transition
+    ? transitionIcon[`${transition}-${person.via}`]
+    : null;
+  const verb = transition ? transitionVerb[transition] : "同行";
+
+  return (
+    <li
+      className={cn(
+        "flex flex-col items-center gap-1.5",
+        // Staggered reveal only in the focal daily header, never in the dense
+        // overview list. Reduced-motion users get the resting (visible) state.
+        !compact &&
+          "motion-safe:animate-in motion-safe:fade-in-0 motion-safe:zoom-in-90 motion-safe:fill-mode-both",
+      )}
+      style={
+        compact ? undefined : { animationDelay: `${String(index * 70)}ms` }
+      }
+    >
+      <span
+        role="img"
+        aria-label={`${person.name} ${verb}`}
+        className="relative transition-transform duration-200 ease-out hover:-translate-y-0.5"
+      >
+        <span
+          aria-hidden
+          className={cn(
+            "grid place-items-center rounded-full font-semibold leading-none select-none",
+            compact ? "size-7 text-xs" : "size-9 text-sm",
+            transition
+              ? "bg-foreground text-background shadow-sm"
+              : "bg-muted text-foreground/75 ring-1 ring-border ring-inset",
+          )}
+        >
+          {person.initial}
+        </span>
+        {Icon ? (
+          <span
+            aria-hidden
+            className={cn(
+              "absolute -right-1 -bottom-1 grid place-items-center rounded-full bg-background text-foreground shadow-sm ring-2 ring-background",
+              compact ? "size-4" : "size-[18px]",
+            )}
+          >
+            <Icon className={compact ? "size-2.5" : "size-3"} />
+          </span>
+        ) : null}
+      </span>
+      {compact ? null : (
+        <span
+          aria-hidden
+          className={cn(
+            "max-w-16 truncate text-[11px] leading-none",
+            transition
+              ? "font-medium text-foreground"
+              : "text-muted-foreground",
+          )}
+        >
+          {person.name}
+        </span>
+      )}
+    </li>
+  );
+}
+
+/** The day's "who's involved" cast: an avatar per person, with arrivals and
+ *  departures pictographed as corner badges. `compact` drops names and motion
+ *  for dense lists (the overview). */
+export function DayParty({
+  dayN,
+  className,
+  compact = false,
+}: {
+  dayN: number;
+  className?: string;
+  compact?: boolean;
+}) {
+  const people = peopleOnDay(dayN);
+  if (people.length === 0) return null;
+
+  return (
+    <ul
+      className={cn(
+        "flex flex-wrap items-start",
+        compact ? "gap-2.5" : "gap-3",
+        className,
+      )}
+    >
+      {people.map((person, index) => (
+        <PersonToken
+          key={person.id}
+          person={person}
+          compact={compact}
+          index={index}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/apps/trip-planner/src/components/trip/overview.tsx
+++ b/apps/trip-planner/src/components/trip/overview.tsx
@@ -6,6 +6,7 @@ import {
   Users,
   Utensils,
 } from "lucide-react";
+import { DayParty } from "./day-party";
 import { Badge } from "@/components/ui/badge";
 import type { Day, Trip } from "@/data/itinerary";
 
@@ -50,6 +51,8 @@ function OverviewRow({
 
           <ChevronRight className="size-4 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground" />
         </div>
+
+        <DayParty dayN={day.n} compact className="mt-3" />
 
         <div className="mt-3 flex flex-wrap items-center gap-1.5">
           {day.driving ? (

--- a/apps/trip-planner/src/data/itinerary.ts
+++ b/apps/trip-planner/src/data/itinerary.ts
@@ -168,6 +168,31 @@ export interface Trip {
   days: Day[];
 }
 
+/** Who can appear in a day's "who's involved" chips. */
+export type PersonId = "shitou" | "dayu" | "jim" | "ed";
+
+/**
+ * How a person relates to a single day:
+ *  - `arrive` / `depart` — joins / leaves the group that day
+ *  - `home` — 石头 (the UK-based host) heads home rather than travelling on
+ *  - `present` — around that day, no transition
+ */
+export type PresenceKind = "arrive" | "depart" | "home" | "present";
+
+/** How a guest travels in and out — drives which arrive/depart glyph shows:
+ *  `air` flies (plane), `ground` drives or takes the train (person). */
+export type TravelVia = "air" | "ground";
+
+/** One person's involvement in a single day. */
+export interface DayPresence {
+  id: PersonId;
+  name: string;
+  /** Single glyph shown inside the avatar medallion (e.g. 石, 大, J, E). */
+  initial: string;
+  kind: PresenceKind;
+  via: TravelVia;
+}
+
 const days: Day[] = [
   {
     n: 0,
@@ -2419,6 +2444,79 @@ export const trip: Trip = {
   party: "3 人自驾",
   days,
 };
+
+interface PersonSchedule {
+  id: PersonId;
+  name: string;
+  /** Single glyph for the avatar medallion. */
+  initial: string;
+  /** First and last trip day (inclusive) the person is involved. */
+  range: [number, number];
+  /** How the person travels in and out; defaults to `air`. */
+  via?: TravelVia;
+  /** Days inside the range when the person is away (not involved). */
+  away?: number[];
+  /** Transition markers for specific days; unlisted in-range days are `present`. */
+  markers?: Partial<Record<number, "arrive" | "depart" | "home">>;
+}
+
+/**
+ * Single source of truth for who is on the trip and when. 石头 is the UK-based
+ * host; 大雨 and Jim are guests who fly in and out; Ed drives over for a weekend.
+ *   大雨 — lands Day 0 (CA851), flies home Day 12 (CA852); around the whole trip.
+ *   Jim  — lands Day 1 (Heathrow), flies home Day 8; leaves first.
+ *   Ed   — drives over from Ipswich for the weekend, Day 2 (Sat) to Day 3 (Sun).
+ *   石头 — heads home the night of Day 10, sits out the Day 11 solo day, then
+ *          returns Day 12 to see 大雨 off at Gatwick.
+ */
+const partySchedule: PersonSchedule[] = [
+  {
+    id: "shitou",
+    name: "石头",
+    initial: "石",
+    range: [0, 12],
+    away: [11],
+    markers: { 10: "home" },
+  },
+  {
+    id: "dayu",
+    name: "大雨",
+    initial: "雨",
+    range: [0, 12],
+    markers: { 0: "arrive", 12: "depart" },
+  },
+  {
+    id: "jim",
+    name: "Jim",
+    initial: "J",
+    range: [1, 8],
+    markers: { 1: "arrive", 8: "depart" },
+  },
+  {
+    id: "ed",
+    name: "Ed",
+    initial: "E",
+    range: [2, 3],
+    via: "ground",
+    markers: { 2: "arrive", 3: "depart" },
+  },
+];
+
+/** Who is involved on a given day, in stable host-then-guest order. */
+export function peopleOnDay(dayN: number): DayPresence[] {
+  return partySchedule
+    .filter(
+      (p) =>
+        dayN >= p.range[0] && dayN <= p.range[1] && !p.away?.includes(dayN),
+    )
+    .map((p) => ({
+      id: p.id,
+      name: p.name,
+      initial: p.initial,
+      kind: p.markers?.[dayN] ?? "present",
+      via: p.via ?? "air",
+    }));
+}
 
 export type TripPhase = "before" | "during" | "after";
 


### PR DESCRIPTION
## Why

Across the 13-day Great Britain road trip, the cast changes day to day — guests fly in and out on different days, one drives over for a weekend, and the host even peels off home for a solo day. The itinerary already laid out *what* happens each day but gave no at-a-glance read on *who* is actually around, and crucially when someone is **arriving** versus **leaving**. This adds a "who's involved" indicator to every day so the comings and goings are visible without reading the prose.

A first pass rendered these as flat tag/pills, which read as "big boring". This rebuilds them as **avatar medallions** — each person's initial in a circle, with the day's transition stamped as a corner badge — so they carry more spark while staying scannable.

## What it shows

Each day surfaces the people involved as avatars. People merely *around* read quiet (muted, ringed); anyone in transition is inverted so the day's movement pops, with a pictograph chosen by **how they travel**:

| Transition | By air | By ground |
| --- | --- | --- |
| Arrive | plane landing | person-plus |
| Depart | plane takeoff | person-minus |
| Head home (石头) | house | house |

Travel mode matters to the user, so flights (大雨, Jim) get planes while Ed's drive over from Ipswich gets person glyphs, and the host heading home gets a house.

The same component renders in two places: the **daily-view header** (full size, with name captions and a staggered entrance + hover-lift) and the **overview list rows** (compact — smaller avatars, no captions or motion — so the changing cast is scannable straight down the list). The brand is intentionally monochrome, so arrive vs leave is carried by the glyph and emphasis, not colour. Avatars expose `role="img"` labels ("石头 抵达" etc.), and the entrance animation is reduced-motion safe.

## The cast over time

A single `partySchedule` source of truth drives it — each person has a day range, optional away-days, and transition markers; `peopleOnDay(n)` resolves the rest to `present`.

```mermaid
gantt
    dateFormat X
    axisFormat Day %s
    section 石头 (host)
    around          :0, 10
    home (night)    :milestone, 10, 0
    solo day (away) :crit, 11, 12
    sees 大雨 off    :12, 13
    section 大雨 (air)
    arrive D0 → depart D12 :0, 13
    section Jim (air)
    arrive D1 → depart D8  :1, 9
    section Ed (ground)
    drives over D2–D3      :2, 4
```