### PR TITLE
fix: skip page-less design-system segments in back button

### DIFF
--- a/apps/web/src/components/shared/back-button.tsx
+++ b/apps/web/src/components/shared/back-button.tsx
@@ -11,7 +11,17 @@ import { useBackOverride } from "#src/contexts/back-override-context.tsx";
 import type { SupportedLocale } from "#src/types.ts";
 import { getLocalePath, normalizePath } from "#src/utils/pathname.ts";
 
-const ignoredSegments = new Set(["experiences", "education"]);
+// Intermediate route segments that have no page of their own — detail pages
+// live beneath them (e.g. `/experiences/citadel`,
+// `/design-system/foundations/typography`). Stripping the last segment to find
+// a parent would land on these non-existent routes, so we skip them entirely
+// and step up to the next real ancestor.
+const ignoredSegments = new Set([
+  "experiences",
+  "education",
+  "foundations",
+  "components",
+]);
 
 interface BackButtonProps {
   locale: SupportedLocale;


### PR DESCRIPTION
## Why

The back button on design-system detail pages was broken. On a page like `/design-system/foundations/typography`, clicking back navigated to `/design-system/foundations` — a 404. The same happened from every detail page under `foundations/` and `components/`.

The shared `BackButton` derives the parent page by stripping the last URL segment. But the design-system detail pages live directly beneath page-less intermediate segments: there is no route at `/design-system/foundations` or `/design-system/components` (no `page.tsx`), only the leaf pages and the `/design-system` overview. Stripping one segment lands on a non-existent route.

This is the exact situation already handled for `experiences` and `education` — intermediate segments with no page of their own. The fix adds `foundations` and `components` to the existing `ignoredSegments` set, so the back button skips them and steps up to the next real ancestor.

## Before / after

```mermaid
flowchart LR
  subgraph Before
    A["/design-system/foundations/typography"] -->|strip last segment| B["/design-system/foundations — 404"]
  end
  subgraph After
    C["/design-system/foundations/typography"] -->|skip page-less 'foundations'| D["/design-system — 200"]
  end
```

Affected detail pages: `foundations/{typography,color,elevation}` and `components/{divider,badge}`. All now resolve back to the `/design-system` overview.

Verified: lint, format, test, and build all pass; browser-confirmed the back href is now `/zh/design-system` (200) instead of `/zh/design-system/foundations` (404) on both foundations and components detail pages.