### PR TITLE
feat(trip-planner): show live weather with seasonal fallback

### DIFF
--- a/apps/trip-planner/src/app/page.tsx
+++ b/apps/trip-planner/src/app/page.tsx
@@ -1,14 +1,22 @@
 import { TripView } from "@/components/trip/trip-view";
 import { resolveDay } from "@/data/itinerary";
+import { getTripWeather } from "@/lib/weather";
 
 // "Current day" depends on the wall clock, so render per-request.
 export const dynamic = "force-dynamic";
 
-export default function HomePage() {
+export default async function HomePage() {
   // Per-request server component (force-dynamic): request time is the intended "now".
   // eslint-disable-next-line @eslint-react/purity
   const { index, phase, daysUntil } = resolveDay(new Date());
+  // Live forecast for the days within Open-Meteo's horizon; cached server-side.
+  const weatherByDay = await getTripWeather();
   return (
-    <TripView currentDayIndex={index} phase={phase} daysUntil={daysUntil} />
+    <TripView
+      currentDayIndex={index}
+      phase={phase}
+      daysUntil={daysUntil}
+      weatherByDay={weatherByDay}
+    />
   );
 }

--- a/apps/trip-planner/src/components/trip/daily-view.tsx
+++ b/apps/trip-planner/src/components/trip/daily-view.tsx
@@ -18,14 +18,17 @@ import {
   untimedDining,
   untimedPlaces,
 } from "@/lib/schedule";
+import type { LiveWeather } from "@/lib/wmo";
 
 export function DailyView({
   day,
   isToday,
+  liveWeather,
   onOpenDay,
 }: {
   day: Day;
   isToday: boolean;
+  liveWeather?: LiveWeather;
   onOpenDay: (index: number) => void;
 }) {
   const moments = buildDayFeed(day);
@@ -48,7 +51,7 @@ export function DailyView({
 
   return (
     <article className="space-y-6">
-      <DayHeader day={day} isToday={isToday} />
+      <DayHeader day={day} isToday={isToday} liveWeather={liveWeather} />
 
       {day.anchors && day.anchors.length > 0 ? (
         <DayGlance

--- a/apps/trip-planner/src/components/trip/day-header.tsx
+++ b/apps/trip-planner/src/components/trip/day-header.tsx
@@ -81,7 +81,7 @@ export function DayHeader({
             </Badge>
           ) : null}
           {day.weather ? (
-            <Badge variant="outline">
+            <Badge variant="outline" className="whitespace-normal">
               {liveWeather ? (
                 <WeatherIcon code={liveWeather.code} />
               ) : (
@@ -90,6 +90,9 @@ export function DayHeader({
               {liveWeather
                 ? `${liveWeather.temp} · ${liveWeather.condition}${day.weather.note ? `，${day.weather.note}` : ""}`
                 : `${day.weather.temp} · ${day.weather.summary}`}
+              <span className="text-muted-foreground">
+                {liveWeather ? `· ${liveWeather.updated}` : "· 预估"}
+              </span>
             </Badge>
           ) : null}
         </div>

--- a/apps/trip-planner/src/components/trip/day-header.tsx
+++ b/apps/trip-planner/src/components/trip/day-header.tsx
@@ -1,9 +1,52 @@
-import { Car, CloudSun, Route } from "lucide-react";
+import {
+  Car,
+  Cloud,
+  CloudDrizzle,
+  CloudFog,
+  CloudLightning,
+  CloudRain,
+  CloudSnow,
+  CloudSun,
+  Route,
+  Sun,
+} from "lucide-react";
 import { DayParty } from "./day-party";
 import { Badge } from "@/components/ui/badge";
 import type { Day } from "@/data/itinerary";
+import { type LiveWeather, wmoGroup } from "@/lib/wmo";
 
-export function DayHeader({ day, isToday }: { day: Day; isToday: boolean }) {
+/** Pick an icon that matches the day's actual condition. */
+function WeatherIcon({ code }: { code: number }) {
+  switch (wmoGroup(code)) {
+    case "clear":
+      return <Sun />;
+    case "partly":
+      return <CloudSun />;
+    case "cloud":
+      return <Cloud />;
+    case "fog":
+      return <CloudFog />;
+    case "drizzle":
+      return <CloudDrizzle />;
+    case "rain":
+    case "showers":
+      return <CloudRain />;
+    case "snow":
+      return <CloudSnow />;
+    case "thunder":
+      return <CloudLightning />;
+  }
+}
+
+export function DayHeader({
+  day,
+  isToday,
+  liveWeather,
+}: {
+  day: Day;
+  isToday: boolean;
+  liveWeather?: LiveWeather;
+}) {
   return (
     <header>
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
@@ -39,8 +82,14 @@ export function DayHeader({ day, isToday }: { day: Day; isToday: boolean }) {
           ) : null}
           {day.weather ? (
             <Badge variant="outline">
-              <CloudSun />
-              {day.weather.temp} · {day.weather.summary}
+              {liveWeather ? (
+                <WeatherIcon code={liveWeather.code} />
+              ) : (
+                <CloudSun />
+              )}
+              {liveWeather
+                ? `${liveWeather.temp} · ${liveWeather.condition}${day.weather.note ? `，${day.weather.note}` : ""}`
+                : `${day.weather.temp} · ${day.weather.summary}`}
             </Badge>
           ) : null}
         </div>

--- a/apps/trip-planner/src/components/trip/trip-view.tsx
+++ b/apps/trip-planner/src/components/trip/trip-view.tsx
@@ -6,6 +6,7 @@ import { DailyView } from "./daily-view";
 import { Overview } from "./overview";
 import { type Day, type TripPhase, trip } from "@/data/itinerary";
 import { cn } from "@/lib/utils";
+import type { LiveWeather } from "@/lib/wmo";
 
 type View = "daily" | "overview";
 
@@ -126,10 +127,12 @@ export function TripView({
   currentDayIndex,
   phase,
   daysUntil,
+  weatherByDay,
 }: {
   currentDayIndex: number;
   phase: TripPhase;
   daysUntil: number;
+  weatherByDay: Record<number, LiveWeather>;
 }) {
   const [view, setView] = useState<View>("daily");
   const [dayIndex, setDayIndex] = useState(currentDayIndex);
@@ -166,6 +169,7 @@ export function TripView({
           <DailyView
             day={trip.days[dayIndex]}
             isToday={dayIndex === todayIndex}
+            liveWeather={weatherByDay[trip.days[dayIndex].n]}
             onOpenDay={openDay}
           />
         ) : (

--- a/apps/trip-planner/src/data/itinerary.ts
+++ b/apps/trip-planner/src/data/itinerary.ts
@@ -78,8 +78,19 @@ export interface TimelineItem {
 }
 
 export interface Weather {
+  /** Hand-authored temperature range, the fallback when no live forecast exists. */
   temp: string;
+  /** Hand-authored condition + advice, the fallback when no live forecast exists. */
   summary: string;
+  /** Advice kept alongside the live condition (e.g. "注意倒时差"). Omit when
+   *  `summary` is purely a condition with no extra guidance worth preserving. */
+  note?: string;
+}
+
+/** A geographic point, used to fetch live weather for a day. */
+export interface Coords {
+  lat: number;
+  lon: number;
 }
 
 /** How a navigation deep-link should route. */
@@ -162,6 +173,9 @@ export interface Day {
   route: string;
   driving?: string;
   weather?: Weather;
+  /** Representative point (overnight base or the day's main locus) for fetching
+   *  the day's live weather. Omit on days with no weather slot. */
+  coords?: Coords;
   /** Fixed commitments surfaced in the at-a-glance card. */
   anchors?: Anchor[];
   /** One-tap navigation legs for the day. */
@@ -217,7 +231,8 @@ const days: Day[] = [
     weekday: "周四",
     title: "抵达伦敦 · 取车 · Omakase",
     route: "Gatwick 取车 → Mayfair → Chingford",
-    weather: { temp: "15–22°C", summary: "晴，注意倒时差" },
+    weather: { temp: "15–22°C", summary: "晴，注意倒时差", note: "注意倒时差" },
+    coords: { lat: 51.5074, lon: -0.1278 }, // 伦敦 London
     anchors: [
       {
         time: "06:30",
@@ -401,7 +416,8 @@ const days: Day[] = [
     title: "抵达英国 · 剑桥 · 诺丁汉",
     route: "希思罗接机 → 剑桥 → 诺丁汉",
     driving: "约 4 小时",
-    weather: { temp: "17–24°C", summary: "晴，热浪开局" },
+    weather: { temp: "17–24°C", summary: "晴，热浪开局", note: "热浪开局" },
+    coords: { lat: 52.9548, lon: -1.1581 }, // 诺丁汉 Nottingham
     anchors: [
       {
         time: "07:55",
@@ -623,7 +639,8 @@ const days: Day[] = [
     title: "诺丁汉大学 · 毕业十周年",
     route: "诺丁汉市内（无需驾车）",
     driving: "无需驾车",
-    weather: { temp: "15–28°C", summary: "晴，高温防晒" },
+    weather: { temp: "15–28°C", summary: "晴，高温防晒", note: "高温防晒" },
+    coords: { lat: 52.9548, lon: -1.1581 }, // 诺丁汉 Nottingham
     anchors: [
       {
         time: "09:30",
@@ -788,7 +805,8 @@ const days: Day[] = [
     title: "北上苏格兰 · 因弗内斯",
     route: "诺丁汉 → A9 → 因弗内斯",
     driving: "约 6.5 小时",
-    weather: { temp: "11–19°C", summary: "有阵雨，北上渐凉" },
+    weather: { temp: "11–19°C", summary: "有阵雨，北上渐凉", note: "北上渐凉" },
+    coords: { lat: 57.4778, lon: -4.2247 }, // 因弗内斯 Inverness
     anchors: [
       {
         time: "10:00",
@@ -1022,7 +1040,12 @@ const days: Day[] = [
     title: "Speyside 威士忌酒厂日",
     route: "因弗内斯 ↔ Speyside（往返）",
     driving: "约 2.5 小时",
-    weather: { temp: "10–17°C", summary: "高地有雨，室内品酒无碍" },
+    weather: {
+      temp: "10–17°C",
+      summary: "高地有雨，室内品酒无碍",
+      note: "室内品酒无碍",
+    },
+    coords: { lat: 57.4778, lon: -4.2247 }, // 因弗内斯 Inverness
     anchors: [
       {
         time: "10:30",
@@ -1196,7 +1219,12 @@ const days: Day[] = [
     title: "尼斯湖 · 天空岛",
     route: "因弗内斯 → 尼斯湖 → 天空岛 → Fort William",
     driving: "约 5 小时（分段）",
-    weather: { temp: "10–16°C", summary: "阵雨，防风防水外套必备" },
+    weather: {
+      temp: "10–16°C",
+      summary: "阵雨，防风防水外套必备",
+      note: "防风防水外套必备",
+    },
+    coords: { lat: 56.8198, lon: -5.1052 }, // 威廉堡 Fort William
     anchors: [
       {
         time: "08:00",
@@ -1489,6 +1517,7 @@ const days: Day[] = [
     route: "Fort William → 格伦科 → 温德米尔",
     driving: "约 3.5 小时",
     weather: { temp: "10–15°C", summary: "偏凉，可能小雨" },
+    coords: { lat: 54.3807, lon: -2.9063 }, // 温德米尔 Windermere
     anchors: [
       {
         time: "09:30",
@@ -1670,6 +1699,7 @@ const days: Day[] = [
     route: "湖区 → 伯明翰",
     driving: "约 2 小时",
     weather: { temp: "10–18°C", summary: "湖区偏凉有雨" },
+    coords: { lat: 52.4862, lon: -1.8904 }, // 伯明翰 Birmingham
     anchors: [
       {
         time: "09:30",
@@ -1868,6 +1898,7 @@ const days: Day[] = [
     route: "伯明翰 → 希思罗 → 布里斯托",
     driving: "约 3.5 小时",
     weather: { temp: "12–17°C", summary: "多云，偶有小雨" },
+    coords: { lat: 51.4545, lon: -2.5879 }, // 布里斯托 Bristol
     anchors: [
       {
         time: "10:00",
@@ -2043,7 +2074,12 @@ const days: Day[] = [
     title: "巴斯一日",
     route: "布里斯托 ↔ 巴斯",
     driving: "约 0.5 小时",
-    weather: { temp: "10–17°C", summary: "多云间晴，泡温泉舒适" },
+    weather: {
+      temp: "10–17°C",
+      summary: "多云间晴，泡温泉舒适",
+      note: "泡温泉舒适",
+    },
+    coords: { lat: 51.3811, lon: -2.359 }, // 巴斯 Bath
     anchors: [
       {
         time: "10:00",
@@ -2182,7 +2218,8 @@ const days: Day[] = [
     title: "科茨沃尔德 · 牛津 · 伦敦",
     route: "布里斯托 → 科茨沃尔德 → 牛津 → 伦敦",
     driving: "约 3 小时",
-    weather: { temp: "12–19°C", summary: "多云，伦敦回暖" },
+    weather: { temp: "12–19°C", summary: "多云，伦敦回暖", note: "伦敦回暖" },
+    coords: { lat: 51.752, lon: -1.2577 }, // 牛津 Oxford（当日主要户外行程）
     anchors: [
       {
         time: "09:00",
@@ -2374,6 +2411,7 @@ const days: Day[] = [
     route: "全天地铁出行（车停 Moxy）",
     driving: "无需驾车",
     weather: { temp: "15–19°C", summary: "多云间晴" },
+    coords: { lat: 51.5074, lon: -0.1278 }, // 伦敦 London
     anchors: [
       {
         time: "09:30",

--- a/apps/trip-planner/src/lib/weather.ts
+++ b/apps/trip-planner/src/lib/weather.ts
@@ -1,0 +1,151 @@
+/**
+ * Live weather for the trip, from Open-Meteo's free forecast API (no key).
+ *
+ * Server-only: imported solely by the server page. We fetch every day's
+ * representative point in a single batched request, then map each trip day to a
+ * forecast *only* when its date falls inside the forecast horizon (~16 days).
+ * Days beyond the horizon — and any fetch failure — are intentionally left out
+ * of the result so the UI falls back to the hand-authored seasonal guess. That
+ * keeps the page as unbreakable as it was when the weather was fully static.
+ */
+
+import { unstable_cache } from "next/cache";
+import { type LiveWeather, wmoCondition } from "./wmo";
+import { trip } from "@/data/itinerary";
+
+const FORECAST_URL = "https://api.open-meteo.com/v1/forecast";
+
+/** Open-Meteo's free daily forecast reaches ~16 days out. */
+const FORECAST_DAYS = 16;
+
+/** Refresh a few times a day — forecasts update roughly that often. */
+const REVALIDATE_SECONDS = 3 * 60 * 60;
+
+interface WeatherPoint {
+  n: number;
+  date: string;
+  lat: number;
+  lon: number;
+}
+
+/** Days carrying both coordinates and a weather slot — the ones we can fetch. */
+function weatherPoints(): WeatherPoint[] {
+  return trip.days.flatMap((day) =>
+    day.coords && day.weather
+      ? [{ n: day.n, date: day.date, lat: day.coords.lat, lon: day.coords.lon }]
+      : [],
+  );
+}
+
+// Open-Meteo returns `null` in the daily arrays for any day it can't resolve —
+// typically the last day or two at the edge of the forecast horizon. We must
+// accept those nulls at the array level and skip only the individual null day,
+// rather than discarding the whole location.
+function isNullableNumberArray(value: unknown): value is (number | null)[] {
+  return (
+    Array.isArray(value) &&
+    value.every((x) => x === null || typeof x === "number")
+  );
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((x) => typeof x === "string");
+}
+
+interface DailyBlock {
+  time: string[];
+  weather_code: (number | null)[];
+  temperature_2m_max: (number | null)[];
+  temperature_2m_min: (number | null)[];
+}
+
+/** Narrow one location's payload to the daily arrays we need, or give up. */
+function asDailyBlock(value: unknown): DailyBlock | undefined {
+  if (typeof value !== "object" || value === null || !("daily" in value)) {
+    return undefined;
+  }
+  const daily = value.daily;
+  if (typeof daily !== "object" || daily === null) return undefined;
+
+  const time = "time" in daily ? daily.time : undefined;
+  const code = "weather_code" in daily ? daily.weather_code : undefined;
+  const max =
+    "temperature_2m_max" in daily ? daily.temperature_2m_max : undefined;
+  const min =
+    "temperature_2m_min" in daily ? daily.temperature_2m_min : undefined;
+
+  if (
+    isStringArray(time) &&
+    isNullableNumberArray(code) &&
+    isNullableNumberArray(max) &&
+    isNullableNumberArray(min)
+  ) {
+    return {
+      time,
+      weather_code: code,
+      temperature_2m_max: max,
+      temperature_2m_min: min,
+    };
+  }
+  return undefined;
+}
+
+function readForecast(
+  daily: DailyBlock,
+  date: string,
+): LiveWeather | undefined {
+  const i = daily.time.indexOf(date);
+  if (i < 0) return undefined; // date is beyond the forecast horizon
+  const code = daily.weather_code[i];
+  const min = daily.temperature_2m_min[i];
+  const max = daily.temperature_2m_max[i];
+  // An unresolved (null) day falls back to the hand-authored seasonal guess.
+  if (code === null || min === null || max === null) return undefined;
+  return {
+    temp: `${String(Math.round(min))}–${String(Math.round(max))}°C`,
+    condition: wmoCondition(code),
+    code,
+  };
+}
+
+async function fetchTripWeather(): Promise<Record<number, LiveWeather>> {
+  const points = weatherPoints();
+  if (points.length === 0) return {};
+
+  const params = new URLSearchParams({
+    latitude: points.map((p) => String(p.lat)).join(","),
+    longitude: points.map((p) => String(p.lon)).join(","),
+    daily: "weather_code,temperature_2m_max,temperature_2m_min",
+    timezone: "Europe/London",
+    forecast_days: String(FORECAST_DAYS),
+  });
+
+  const result: Record<number, LiveWeather> = {};
+  try {
+    const response = await fetch(`${FORECAST_URL}?${params.toString()}`);
+    if (!response.ok) return result;
+    const body: unknown = await response.json();
+    // One coordinate returns a single object; many return an aligned array.
+    const blocks = Array.isArray(body) ? body : [body];
+    points.forEach((point, i) => {
+      const daily = asDailyBlock(blocks[i]);
+      if (!daily) return;
+      const live = readForecast(daily, point.date);
+      if (live) result[point.n] = live;
+    });
+  } catch {
+    return {};
+  }
+  return result;
+}
+
+/**
+ * Live weather keyed by day number, cached so we hit Open-Meteo only a few
+ * times a day rather than on every request. `unstable_cache` keeps its own
+ * revalidation independent of the page's `force-dynamic` rendering.
+ */
+export const getTripWeather = unstable_cache(
+  fetchTripWeather,
+  ["trip-weather-v1"],
+  { revalidate: REVALIDATE_SECONDS },
+);

--- a/apps/trip-planner/src/lib/weather.ts
+++ b/apps/trip-planner/src/lib/weather.ts
@@ -93,6 +93,7 @@ function asDailyBlock(value: unknown): DailyBlock | undefined {
 function readForecast(
   daily: DailyBlock,
   date: string,
+  updated: string,
 ): LiveWeather | undefined {
   const i = daily.time.indexOf(date);
   if (i < 0) return undefined; // date is beyond the forecast horizon
@@ -105,7 +106,18 @@ function readForecast(
     temp: `${String(Math.round(min))}–${String(Math.round(max))}°C`,
     condition: wmoCondition(code),
     code,
+    updated,
   };
+}
+
+/** "6/9 更新" — the London-local date the forecast was last fetched. */
+function fetchedLabel(now: Date): string {
+  const date = new Intl.DateTimeFormat("en-US", {
+    timeZone: "Europe/London",
+    month: "numeric",
+    day: "numeric",
+  }).format(now);
+  return `${date} 更新`;
 }
 
 async function fetchTripWeather(): Promise<Record<number, LiveWeather>> {
@@ -127,10 +139,13 @@ async function fetchTripWeather(): Promise<Record<number, LiveWeather>> {
     const body: unknown = await response.json();
     // One coordinate returns a single object; many return an aligned array.
     const blocks = Array.isArray(body) ? body : [body];
+    // Stamp every live day with the fetch time; `unstable_cache` freezes it
+    // until the next revalidation, so it reads as "last refreshed at".
+    const updated = fetchedLabel(new Date());
     points.forEach((point, i) => {
       const daily = asDailyBlock(blocks[i]);
       if (!daily) return;
-      const live = readForecast(daily, point.date);
+      const live = readForecast(daily, point.date, updated);
       if (live) result[point.n] = live;
     });
   } catch {

--- a/apps/trip-planner/src/lib/wmo.ts
+++ b/apps/trip-planner/src/lib/wmo.ts
@@ -28,6 +28,9 @@ export interface LiveWeather {
   condition: string;
   /** Raw WMO weather code, so the badge can pick a matching icon. */
   code: number;
+  /** When the forecast was last fetched, e.g. "6/9 更新" — marks the day as
+   *  live and shows its freshness. Identical across days (one fetch). */
+  updated: string;
 }
 
 /** Collapse a raw WMO code into one of the planner's coarse condition groups. */

--- a/apps/trip-planner/src/lib/wmo.ts
+++ b/apps/trip-planner/src/lib/wmo.ts
@@ -1,0 +1,62 @@
+/**
+ * WMO weather-interpretation codes (Open-Meteo's `weather_code`) folded into the
+ * handful of conditions the planner cares about, each with a Chinese label.
+ *
+ * Pure and isomorphic on purpose: the server fetch derives the label from a code
+ * and the client badge derives an icon from the same code, so both share one
+ * source of truth for what a code means.
+ *
+ * Code reference: https://open-meteo.com/en/docs (WMO 4677 subset).
+ */
+
+export type WmoGroup =
+  | "clear"
+  | "partly"
+  | "cloud"
+  | "fog"
+  | "drizzle"
+  | "rain"
+  | "showers"
+  | "snow"
+  | "thunder";
+
+/** Live weather for a single day, derived from Open-Meteo. */
+export interface LiveWeather {
+  /** Temperature range for the day, e.g. "12–17°C". */
+  temp: string;
+  /** Chinese condition label derived from the WMO code, e.g. "多云". */
+  condition: string;
+  /** Raw WMO weather code, so the badge can pick a matching icon. */
+  code: number;
+}
+
+/** Collapse a raw WMO code into one of the planner's coarse condition groups. */
+export function wmoGroup(code: number): WmoGroup {
+  if (code <= 0) return "clear"; // 0 clear sky
+  if (code <= 2) return "partly"; // 1–2 mainly clear / partly cloudy
+  if (code === 3) return "cloud"; // 3 overcast
+  if (code <= 48) return "fog"; // 45, 48 fog
+  if (code <= 57) return "drizzle"; // 51–57 drizzle
+  if (code <= 67) return "rain"; // 61–67 rain
+  if (code <= 77) return "snow"; // 71–77 snowfall
+  if (code <= 82) return "showers"; // 80–82 rain showers
+  if (code <= 86) return "snow"; // 85–86 snow showers
+  return "thunder"; // 95, 96, 99 thunderstorm
+}
+
+const CONDITION_ZH: Record<WmoGroup, string> = {
+  clear: "晴",
+  partly: "多云间晴",
+  cloud: "多云",
+  fog: "有雾",
+  drizzle: "小雨",
+  rain: "雨",
+  showers: "阵雨",
+  snow: "雪",
+  thunder: "雷雨",
+};
+
+/** Chinese condition label for a raw WMO code. */
+export function wmoCondition(code: number): string {
+  return CONDITION_ZH[wmoGroup(code)];
+}


### PR DESCRIPTION
## Why

The Great Britain 2026 itinerary showed hand-authored weather guesses — one `{ temp, summary }` per day, written when the itinerary was authored (e.g. `15–22°C · 晴，注意倒时差`). Those were static estimates and went stale. This swaps them for real, up-to-date forecasts.

The hard part isn't fetching weather — it's that a 13-day trip viewed ~10 days ahead is *partly beyond any reliable forecast horizon*. Forecasts only carry real skill ~7–10 days out, and no free provider reaches the whole trip when you look early. So the design is **confidence-aware** rather than all-or-nothing.

## Behaviour

- Days **inside** the forecast window show the live forecast: a temperature range and condition pulled from Open-Meteo, with an icon matched to the actual condition.
- Days **beyond** the window — plus unresolved edge days (Open-Meteo returns null at the far edge of its ~16-day horizon) and **any** fetch failure — fall back to the existing hand-authored seasonal guess. The page can never break; worst case it degrades to exactly what it showed before. As the trip approaches, days roll from fallback to live automatically.
- Because live and fallback otherwise look alike, each badge shows its **provenance** as a muted suffix: live days carry a refresh stamp (e.g. `6/9 更新`), fallback days are tagged `预估`. So it's always clear whether a number is a real forecast or the seasonal estimate.
- The hand-authored Chinese summaries blended a condition (`晴`) with human advice (`注意倒时差` / watch jet lag). No API provides that advice, so it's preserved: live data replaces only the temperature + condition, and the advice note rides alongside the live condition.

## How it's wired

- Each itinerary day with a weather slot gained a representative coordinate (overnight base or the day's main locus), so weather is looked up by lat/long rather than fuzzy place-name geocoding.
- The fetch is a single batched server-side request for every day's point, cached (`unstable_cache`, ~3h) so we hit Open-Meteo only a few times a day even though the page is `force-dynamic`. The cached fetch time doubles as the `更新` stamp.
- WMO weather codes are the single source of truth: the server derives a localized condition label from the code, the client derives a matching icon from the same code.

**Provider choice:** Open-Meteo — no API key, free, ~16-day daily forecast, and its horizon-plus-fallback shape is exactly what a partly-unforecastable trip needs.

```mermaid
flowchart TD
  A[Trip day with coords + weather slot] --> B{Date inside<br/>Open-Meteo ~16d horizon?}
  B -- no --> F["Hand-authored seasonal guess (预估)"]
  B -- yes --> C{Forecast resolved?<br/>code/min/max non-null}
  C -- no, edge day --> F
  C -- yes --> D["Live temp + WMO condition + matched icon (X/Y 更新)"]
  E[Fetch fails / non-ok] --> F
  D --> G[+ preserved advice note]
```
