### PR TITLE
fix(trip-planner): persist password unlock across browser sessions

### DIFF
--- a/apps/trip-planner/src/proxy.ts
+++ b/apps/trip-planner/src/proxy.ts
@@ -8,13 +8,35 @@ export const config = {
 };
 
 const REALM = "trip";
+const COOKIE_NAME = "trip_gate";
+// Basic Auth credentials are dropped when the browser session ends, forcing a
+// re-prompt every new session. A persistent cookie survives that, so visitors
+// unlock once and stay unlocked for ~90 days.
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 90;
 
-export function proxy(req: NextRequest) {
+// Derive an unguessable cookie value from the password so the cookie cannot be
+// forged, without storing the password itself at rest.
+async function gateToken(password: string) {
+  const data = new TextEncoder().encode(`${REALM}:${password}`);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function proxy(req: NextRequest) {
   const password = process.env.SITE_PASSWORD;
 
   // Fail closed: never serve content if the gate is misconfigured.
   if (!password) {
     return new NextResponse("Auth not configured", { status: 503 });
+  }
+
+  const expected = await gateToken(password);
+
+  // Already unlocked in a previous session — skip the prompt entirely.
+  if (req.cookies.get(COOKIE_NAME)?.value === expected) {
+    return NextResponse.next();
   }
 
   const header = req.headers.get("authorization");
@@ -25,7 +47,16 @@ export function proxy(req: NextRequest) {
       const separator = decoded.indexOf(":");
       const provided = separator === -1 ? "" : decoded.slice(separator + 1);
       if (provided === password) {
-        return NextResponse.next();
+        // Remember the unlock so future browser sessions skip the prompt.
+        const res = NextResponse.next();
+        res.cookies.set(COOKIE_NAME, expected, {
+          httpOnly: true,
+          secure: req.nextUrl.protocol === "https:",
+          sameSite: "lax",
+          path: "/",
+          maxAge: COOKIE_MAX_AGE,
+        });
+        return res;
       }
     }
   }


### PR DESCRIPTION
## Why

The trip-planner is gated behind HTTP Basic Auth (in `proxy.ts`, Next.js 16's renamed middleware). Browsers discard Basic Auth credentials when the browser session ends, so every new session re-triggered the native password dialog — visitors had to retype the shared password constantly.

The goal was to stop the re-prompting **without** building a custom login UI. The native browser dialog stays exactly as-is (zero new UI); we just remember a successful unlock.

## How

On a correct password entry, the gate sets a persistent `httpOnly` cookie (90-day max-age) whose value is a SHA-256 hash of the password. Because it's a derived hash, the cookie can't be forged and the password itself is never stored at rest. On every subsequent request — including brand-new browser sessions — a matching cookie lets the request straight through, skipping the prompt.

Safety properties preserved:

- **Fail closed** — still 503s when `SITE_PASSWORD` is unset.
- **Local dev works** — the cookie is `secure` only over HTTPS, so `http://localhost` is unaffected.
- **Rotation invalidates** — changing `SITE_PASSWORD` changes the hash, so old cookies stop matching automatically.

```mermaid
flowchart TD
    A[Request] --> B{SITE_PASSWORD set?}
    B -->|no| C[503 Auth not configured]
    B -->|yes| D{cookie == hash of password?}
    D -->|yes| E[Allow — no prompt]
    D -->|no| F{Valid Basic Auth header?}
    F -->|yes| G[Allow + set 90-day cookie]
    F -->|no| H[401 — browser shows password dialog]
```