### PR TITLE
fix(trip-planner): isolate trip passwords with an in-app unlock flow

### DIFF
--- a/apps/trip-planner/src/app/unlock/[trip]/actions.ts
+++ b/apps/trip-planner/src/app/unlock/[trip]/actions.ts
@@ -1,0 +1,42 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { GATE_COOKIE_MAX_AGE, gateToken, tripGate } from "@/lib/trip-gate";
+
+export interface UnlockState {
+  error?: string;
+}
+
+// Verify a trip password and, on success, set this trip's unlock cookie and
+// send the visitor back to the itinerary. The cookie is scoped to one trip, so
+// unlocking here never grants access to any other trip.
+export async function unlockTrip(
+  _prev: UnlockState,
+  formData: FormData,
+): Promise<UnlockState> {
+  const slugValue = formData.get("slug");
+  const slug = typeof slugValue === "string" ? slugValue : "";
+  const gate = tripGate(slug);
+
+  if (!gate || !gate.password) {
+    return { error: "暂时无法验证密码，请稍后再试" };
+  }
+
+  const password = formData.get("password");
+  if (typeof password !== "string" || password !== gate.password) {
+    return { error: "密码错误，请重试" };
+  }
+
+  const token = await gateToken(gate.realm, gate.password);
+  const store = await cookies();
+  store.set(gate.cookie, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: GATE_COOKIE_MAX_AGE,
+  });
+
+  redirect(`/${slug}`);
+}

--- a/apps/trip-planner/src/app/unlock/[trip]/page.tsx
+++ b/apps/trip-planner/src/app/unlock/[trip]/page.tsx
@@ -1,0 +1,62 @@
+import { Lock } from "lucide-react";
+import type { Metadata } from "next";
+import { cookies } from "next/headers";
+import { notFound, redirect } from "next/navigation";
+import { UnlockForm } from "./unlock-form";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { tripBySlug } from "@/data/trips";
+import { gateToken, tripGate } from "@/lib/trip-gate";
+
+// The unlock prompt depends on the per-request cookie, so render per-request.
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "输入行程密码",
+};
+
+interface UnlockPageProps {
+  params: Promise<{ trip: string }>;
+}
+
+export default async function UnlockPage({ params }: UnlockPageProps) {
+  const { trip: slug } = await params;
+  const trip = tripBySlug(slug);
+  if (!trip) notFound();
+
+  // Already unlocked (e.g. a bookmarked /unlock link) — skip straight to the
+  // trip rather than asking for a password the visitor has already entered.
+  const gate = tripGate(slug);
+  if (gate?.password) {
+    const token = await gateToken(gate.realm, gate.password);
+    const store = await cookies();
+    if (store.get(gate.cookie)?.value === token) {
+      redirect(`/${slug}`);
+    }
+  }
+
+  return (
+    <div className="mx-auto flex min-h-dvh max-w-md flex-col justify-center px-4 py-10">
+      <Card>
+        <CardHeader>
+          <div className="bg-muted text-muted-foreground mb-2 flex size-10 items-center justify-center rounded-full">
+            <Lock className="size-5" />
+          </div>
+          <CardTitle className="text-xl tracking-tight">{trip.title}</CardTitle>
+          <CardDescription>{trip.subtitle}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <UnlockForm slug={trip.slug} />
+          <p className="text-muted-foreground mt-4 text-center text-xs">
+            每个行程有各自的密码
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/trip-planner/src/app/unlock/[trip]/unlock-form.tsx
+++ b/apps/trip-planner/src/app/unlock/[trip]/unlock-form.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useActionState } from "react";
+import { type UnlockState, unlockTrip } from "./actions";
+import { Button } from "@/components/ui/button";
+
+const initialState: UnlockState = {};
+
+export function UnlockForm({ slug }: { slug: string }) {
+  const [state, formAction, pending] = useActionState(unlockTrip, initialState);
+
+  return (
+    <form action={formAction} className="flex flex-col gap-3">
+      <input type="hidden" name="slug" value={slug} />
+      <input
+        autoFocus
+        type="password"
+        name="password"
+        autoComplete="current-password"
+        placeholder="行程密码"
+        aria-label="行程密码"
+        aria-invalid={state.error ? true : undefined}
+        className="h-9 w-full rounded-md border bg-background px-3 text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-[3px] aria-invalid:ring-destructive/20"
+      />
+      {state.error ? (
+        <p role="alert" className="text-sm text-destructive">
+          {state.error}
+        </p>
+      ) : null}
+      <Button type="submit" disabled={pending}>
+        {pending ? "验证中…" : "进入行程"}
+      </Button>
+    </form>
+  );
+}

--- a/apps/trip-planner/src/data/trips/index.ts
+++ b/apps/trip-planner/src/data/trips/index.ts
@@ -3,7 +3,8 @@ import { gb } from "./gb";
 import { tuscany } from "./tuscany";
 
 /** Every trip the planner knows about, soonest departure first — drives the
- *  home picker. Each slug must also have a password gate in `src/proxy.ts`. */
+ *  home picker. Each slug must also have a password gate in
+ *  `src/lib/trip-gate.ts`. */
 export const trips: Trip[] = [tuscany, gb];
 
 export function tripBySlug(slug: string): Trip | undefined {

--- a/apps/trip-planner/src/data/types.ts
+++ b/apps/trip-planner/src/data/types.ts
@@ -262,7 +262,7 @@ export interface PersonSchedule {
 
 export interface Trip {
   /** URL segment the trip lives under (`/gb`), also the password-gate scope
-   *  in `src/proxy.ts` and the checklist localStorage namespace. */
+   *  in `src/lib/trip-gate.ts` and the checklist localStorage namespace. */
   slug: string;
   title: string;
   subtitle: string;

--- a/apps/trip-planner/src/lib/trip-gate.ts
+++ b/apps/trip-planner/src/lib/trip-gate.ts
@@ -1,0 +1,50 @@
+// Shared password-gate config for trips. Imported by both the proxy (edge
+// middleware) and the unlock server action (node), so this module must stay
+// runtime-agnostic: web-standard crypto and process.env only — no next/headers.
+//
+// Each trip is gated independently. Unlocking one trip never unlocks another:
+// every trip has its own cookie, and the cookie value is salted with a per-trip
+// realm, so two trips that happen to share a password still can't swap unlocks.
+
+export interface TripGate {
+  /** Cookie that records an unlock for this trip — distinct per trip. */
+  cookie: string;
+  /** Per-trip salt folded into the cookie token so hashes can't be reused
+   *  across trips even if two passwords collide. */
+  realm: string;
+  password: string | undefined;
+}
+
+// One gate per trip slug in src/data/trips. Passwords are read statically so
+// Next can inline them into the edge bundle; a trip whose variable is unset
+// fails closed until it gets one. The "gb" realm and cookie keep their
+// pre-multi-trip names so unlocks from before the multi-trip split survive.
+const gates: Record<string, TripGate | undefined> = {
+  gb: {
+    cookie: "trip_gate",
+    realm: "trip",
+    password: process.env.SITE_PASSWORD_GB,
+  },
+  tuscany: {
+    cookie: "trip_gate_tuscany",
+    realm: "trip-tuscany",
+    password: process.env.SITE_PASSWORD_TUSCANY,
+  },
+};
+
+export function tripGate(slug: string): TripGate | undefined {
+  return gates[slug];
+}
+
+// ~90 days: unlock once, stay unlocked across browser sessions.
+export const GATE_COOKIE_MAX_AGE = 60 * 60 * 24 * 90;
+
+// Derive an unguessable cookie value from the password so the cookie can't be
+// forged, without storing the password itself at rest.
+export async function gateToken(realm: string, password: string) {
+  const data = new TextEncoder().encode(`${realm}:${password}`);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/apps/trip-planner/src/proxy.ts
+++ b/apps/trip-planner/src/proxy.ts
@@ -1,58 +1,26 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { gateToken, tripGate } from "@/lib/trip-gate";
 
 // Gate each trip behind its own password so an itinerary is only readable by
 // the people on that trip. The home picker stays open — it reveals nothing
 // beyond trip titles and dates — and static assets and robots.txt stay public.
+//
+// Locked trips are sent to an in-app unlock form (`/unlock/<slug>`) instead of
+// an HTTP Basic Auth challenge. Basic Auth let the browser cache one trip's
+// credentials and re-send them to every same-origin request — which silently
+// unlocked the other trip and popped a password dialog on the public homepage
+// (where the trip links are prefetched). A form-plus-cookie flow keeps each
+// trip's unlock to itself and never prompts on a page the visitor can read.
 export const config = {
   matcher: "/((?!_next/static|_next/image|favicon.ico|robots.txt).*)",
 };
 
-// Basic Auth credentials are dropped when the browser session ends, forcing a
-// re-prompt every new session. A persistent cookie survives that, so visitors
-// unlock once and stay unlocked for ~90 days.
-const COOKIE_MAX_AGE = 60 * 60 * 24 * 90;
-
-interface TripGate {
-  /** Basic Auth realm — distinct per trip so browsers don't reuse the other
-   *  trip's saved credentials. */
-  realm: string;
-  cookie: string;
-  password: string | undefined;
-}
-
-// One gate per trip slug in src/data/trips. Passwords are read statically so
-// Next can inline them into the middleware bundle; a trip whose variable is
-// unset serves 503 (fail closed) until it gets one. The "gb" realm and cookie
-// keep their pre-multi-trip names so existing unlocks survive.
-const gates: Record<string, TripGate | undefined> = {
-  gb: {
-    realm: "trip",
-    cookie: "trip_gate",
-    password: process.env.SITE_PASSWORD_GB,
-  },
-  tuscany: {
-    realm: "trip-tuscany",
-    cookie: "trip_gate_tuscany",
-    password: process.env.SITE_PASSWORD_TUSCANY,
-  },
-};
-
-// Derive an unguessable cookie value from the password so the cookie cannot be
-// forged, without storing the password itself at rest.
-async function gateToken(realm: string, password: string) {
-  const data = new TextEncoder().encode(`${realm}:${password}`);
-  const digest = await crypto.subtle.digest("SHA-256", data);
-  return Array.from(new Uint8Array(digest))
-    .map((byte) => byte.toString(16).padStart(2, "0"))
-    .join("");
-}
-
 export async function proxy(req: NextRequest) {
   const segment = req.nextUrl.pathname.split("/")[1];
-  const gate = gates[segment];
+  const gate = tripGate(segment);
 
-  // Not a trip route (the picker, 404s…) — nothing secret to protect.
+  // Not a trip route (the picker, the unlock form, 404s…) — nothing to gate.
   if (!gate) return NextResponse.next();
 
   // Fail closed: never serve a trip if its gate is misconfigured.
@@ -62,37 +30,14 @@ export async function proxy(req: NextRequest) {
 
   const expected = await gateToken(gate.realm, gate.password);
 
-  // Already unlocked in a previous session — skip the prompt entirely.
+  // Already unlocked (this or a previous session) — let the trip through.
   if (req.cookies.get(gate.cookie)?.value === expected) {
     return NextResponse.next();
   }
 
-  const header = req.headers.get("authorization");
-  if (header) {
-    const [scheme, encoded] = header.split(" ");
-    if (scheme === "Basic" && encoded) {
-      const decoded = atob(encoded);
-      const separator = decoded.indexOf(":");
-      const provided = separator === -1 ? "" : decoded.slice(separator + 1);
-      if (provided === gate.password) {
-        // Remember the unlock so future browser sessions skip the prompt.
-        const res = NextResponse.next();
-        res.cookies.set(gate.cookie, expected, {
-          httpOnly: true,
-          secure: req.nextUrl.protocol === "https:",
-          sameSite: "lax",
-          path: "/",
-          maxAge: COOKIE_MAX_AGE,
-        });
-        return res;
-      }
-    }
-  }
-
-  return new NextResponse("Authentication required", {
-    status: 401,
-    headers: {
-      "WWW-Authenticate": `Basic realm="${gate.realm}", charset="UTF-8"`,
-    },
-  });
+  // Locked: send the visitor to this trip's unlock form. A successful unlock
+  // sets the cookie and returns them here.
+  const unlock = req.nextUrl.clone();
+  unlock.pathname = `/unlock/${segment}`;
+  return NextResponse.redirect(unlock);
 }


### PR DESCRIPTION
Replace the HTTP Basic Auth gate with a form-plus-cookie unlock flow so
each trip's password stays scoped to that trip.

Basic Auth let the browser cache one trip's credentials and re-send them
to every same-origin request. That silently unlocked the second trip once
the first was unlocked, and it popped a native password dialog on the
public homepage, where the trip links are prefetched.

The proxy now redirects a locked trip to its own `/unlock/<slug>` form
instead of returning a 401 challenge. A server action verifies the
password and sets a per-trip cookie, so an unlock never leaks across
trips and no password prompt ever fires on a page the visitor can read.
Cookie names and token derivation are unchanged, so existing unlocks
survive.

Verified against a production build: the homepage stays open, each locked
trip redirects to its own form, a correct password unlocks only that trip,
a wrong password shows an error and sets no cookie, and one trip's cookie
never unlocks another.

https://claude.ai/code/session_015t43JmqsWdCphfztpaVB41