### PR TITLE
feat(trip-planner): add flight cards with live tracking

### DIFF
--- a/apps/trip-planner/src/components/trip/day-feed.tsx
+++ b/apps/trip-planner/src/components/trip/day-feed.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import { ChecklistCard } from "./checklist-section";
 import { DiningList } from "./dining-section";
+import { FlightCard } from "./flight-section";
 import { PlacePill } from "./links";
 import { NavLegRow } from "./nav-section";
 import { SignSheetCard } from "./road-signs";
@@ -61,6 +62,7 @@ export function DayFeed({
       {moments.map((moment, i) => {
         const isLast = i === moments.length - 1;
         const hasExtras =
+          moment.flights.length > 0 ||
           moment.checklists.length > 0 ||
           moment.signSheets.length > 0 ||
           moment.nav.length > 0 ||
@@ -102,6 +104,10 @@ export function DayFeed({
                     moment.events.length > 0 && "mt-3",
                   )}
                 >
+                  {moment.flights.map((flight) => (
+                    <FlightCard key={flight.number} flight={flight} />
+                  ))}
+
                   {moment.checklists.map((list) => (
                     <ChecklistCard
                       key={list.title}

--- a/apps/trip-planner/src/components/trip/flight-section.tsx
+++ b/apps/trip-planner/src/components/trip/flight-section.tsx
@@ -22,6 +22,11 @@ function Endpoint({
       {endpoint.time || endpoint.terminal ? (
         <span className="mt-2 text-sm font-medium tabular-nums">
           {endpoint.time}
+          {endpoint.dayOffset ? (
+            <sup className="ml-0.5 text-[10px] font-normal text-muted-foreground">
+              +{endpoint.dayOffset}
+            </sup>
+          ) : null}
           {endpoint.terminal ? (
             <span className="ml-1.5 text-xs font-normal text-muted-foreground">
               {endpoint.terminal}

--- a/apps/trip-planner/src/components/trip/flight-section.tsx
+++ b/apps/trip-planner/src/components/trip/flight-section.tsx
@@ -1,0 +1,106 @@
+import { Plane, Radar } from "lucide-react";
+import type { Flight, FlightEndpoint } from "@/data/types";
+import { cn } from "@/lib/utils";
+
+/** One end of the route: airport code, city, and the local time / terminal. */
+function Endpoint({
+  endpoint,
+  align,
+}: {
+  endpoint: FlightEndpoint;
+  align: "left" | "right";
+}) {
+  const right = align === "right";
+  return (
+    <div className={cn("flex flex-col", right ? "items-end text-right" : "")}>
+      <span className="text-2xl leading-none font-semibold tracking-tight tabular-nums">
+        {endpoint.code}
+      </span>
+      <span className="mt-1 text-xs text-muted-foreground">
+        {endpoint.city}
+      </span>
+      {endpoint.time || endpoint.terminal ? (
+        <span className="mt-2 text-sm font-medium tabular-nums">
+          {endpoint.time}
+          {endpoint.terminal ? (
+            <span className="ml-1.5 text-xs font-normal text-muted-foreground">
+              {endpoint.terminal}
+            </span>
+          ) : null}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * A flight as a boarding-pass-style card: airline + flight number up top, the
+ * FROM → TO route with local times in the middle, and a 实时追踪 button that
+ * opens a live flight tracker. Woven into the day feed at the flight's `time`.
+ */
+export function FlightCard({ flight }: { flight: Flight }) {
+  return (
+    <div className="overflow-hidden rounded-2xl border bg-card shadow-sm">
+      <div className="flex items-center gap-2.5 border-b bg-muted/40 px-4 py-2.5">
+        <Plane className="size-4 shrink-0 text-muted-foreground" />
+        <span className="text-sm font-semibold tracking-wide">
+          {flight.number}
+        </span>
+        {flight.airline ? (
+          <span className="text-xs text-muted-foreground">
+            {flight.airline}
+          </span>
+        ) : null}
+        {flight.passenger ? (
+          <span className="ml-auto rounded-full bg-foreground px-2 py-0.5 text-[11px] font-medium text-background">
+            {flight.passenger}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="flex items-start gap-4 px-4 py-4">
+        <Endpoint endpoint={flight.from} align="left" />
+        <div
+          aria-hidden
+          className="flex flex-1 items-center gap-1.5 self-center text-muted-foreground"
+        >
+          <span className="h-px flex-1 border-t border-dashed border-border" />
+          <Plane className="size-4 rotate-45" />
+          <span className="h-px flex-1 border-t border-dashed border-border" />
+        </div>
+        <Endpoint endpoint={flight.to} align="right" />
+      </div>
+
+      {flight.track || flight.note ? (
+        <div className="relative flex items-center gap-3 border-t border-dashed border-border px-4 py-2.5">
+          <span
+            aria-hidden
+            className="absolute top-0 left-0 size-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-background"
+          />
+          <span
+            aria-hidden
+            className="absolute top-0 right-0 size-3 translate-x-1/2 -translate-y-1/2 rounded-full bg-background"
+          />
+          {flight.note ? (
+            <span className="min-w-0 flex-1 text-xs text-pretty text-muted-foreground">
+              {flight.note}
+            </span>
+          ) : (
+            <span className="flex-1" />
+          )}
+          {flight.track ? (
+            <a
+              href={flight.track}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-foreground px-3 py-1.5 text-xs font-medium text-background transition-opacity hover:opacity-90"
+            >
+              <Radar className="size-3.5" />
+              实时追踪
+            </a>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/trip-planner/src/data/trips/gb.ts
+++ b/apps/trip-planner/src/data/trips/gb.ts
@@ -205,6 +205,11 @@ const days: Day[] = [
     coords: { lat: 52.9548, lon: -1.1581 }, // 诺丁汉 Nottingham
     anchors: [
       {
+        time: "06:20",
+        label: "Jim CX255 落地 Heathrow T3（国泰，自香港）",
+        kind: "flight",
+      },
+      {
         time: "07:55",
         label: "Heathrow T3 接 Jim（出关后再开进 Short Stay）",
         kind: "pickup",
@@ -268,7 +273,10 @@ const days: Day[] = [
       },
     ],
     timeline: [
-      { time: "06:30", text: "从 Chingford 出发（Jim 的航班 06:20 落地 T3）" },
+      {
+        time: "06:30",
+        text: "从 Chingford 出发（Jim 的航班 CX255 06:20 落地 T3）",
+      },
       { time: "06:55", text: "到 N17 接石头上车" },
       { time: "07:55", text: "抵达 Heathrow T3，等 Jim 出关" },
       { time: "08:30", text: "接到 Jim，三人出发，M4 → M25 → M11 北上" },
@@ -280,6 +288,18 @@ const days: Day[] = [
       { time: "15:00", text: "抵达诺丁汉，Crowne Plaza 入住" },
       { time: "16:00", text: "沃莱顿大厅 — 蝙蝠侠韦恩庄园取景地，花园散步" },
       { time: "19:00", text: "诺丁汉市区晚餐 — 下方任选一家" },
+    ],
+    flights: [
+      {
+        number: "CX255",
+        airline: "国泰航空",
+        passenger: "Jim",
+        from: { code: "HKG", city: "香港", time: "00:05" },
+        to: { code: "LHR", city: "伦敦 希思罗", time: "06:20", terminal: "T3" },
+        track: "https://www.flightradar24.com/data/flights/cx255",
+        note: "国泰直飞，落地后看下方导航接机；点「实时追踪」查实时进度与到达口。",
+        time: "06:20",
+      },
     ],
     places: [
       {
@@ -2554,7 +2574,7 @@ const days: Day[] = [
  * Single source of truth for who is on the trip and when. 石头 is the UK-based
  * host; 大雨 and Jim are guests who fly in and out; Ed drives over for a weekend.
  *   大雨 — lands Day 0 (CA851), flies home Day 12 (CA852); around the whole trip.
- *   Jim  — lands Day 1 (Heathrow), flies home Day 8; leaves first.
+ *   Jim  — lands Day 1 (CX255, Heathrow), flies home Day 8; leaves first.
  *   Ed   — drives over from Ipswich for the weekend, Day 2 (Sat) to Day 3 (Sun).
  *   石头 — heads home the night of Day 10, sits out the Day 11 solo day, then
  *          returns Day 12 to see 大雨 off at Gatwick.

--- a/apps/trip-planner/src/data/trips/gb.ts
+++ b/apps/trip-planner/src/data/trips/gb.ts
@@ -106,6 +106,23 @@ const days: Day[] = [
         text: "坐车回 Tottenham Hale 取车，开去入住 Holiday Inn Express Chingford，为明早出发休整",
       },
     ],
+    flights: [
+      {
+        number: "CA851",
+        airline: "中国国际航空",
+        passenger: "大雨",
+        from: { code: "PEK", city: "北京 首都" },
+        to: {
+          code: "LGW",
+          city: "伦敦 盖特威克",
+          time: "06:30",
+          terminal: "North",
+        },
+        track: "https://www.flightradar24.com/data/flights/ca851",
+        note: "国航直飞北京，落地 North Terminal；石头从 N17 来接，点「实时追踪」查实时进度与到达口。",
+        time: "06:30",
+      },
+    ],
     places: [
       {
         name: "大英博物馆 British Museum",
@@ -2534,6 +2551,29 @@ const days: Day[] = [
         text: "转免费航站楼列车到 North Terminal 值机托运（国航 CA 柜台）+ 过安检",
       },
       { time: "12:35", text: "CA852 起飞，再见英国 🇬🇧 → 🇨🇳" },
+    ],
+    flights: [
+      {
+        number: "CA852",
+        airline: "中国国际航空",
+        passenger: "大雨",
+        from: {
+          code: "LGW",
+          city: "伦敦 盖特威克",
+          time: "12:35",
+          terminal: "North",
+        },
+        to: {
+          code: "PEK",
+          city: "北京 首都",
+          time: "04:52",
+          terminal: "T3",
+          dayOffset: 1,
+        },
+        track: "https://www.flightradar24.com/data/flights/ca852",
+        note: "国航回北京，North Terminal 的 CA 柜台值机；次日凌晨 04:52 抵达首都 T3，点「实时追踪」看实时状态。",
+        time: "12:35",
+      },
     ],
     places: [],
     restaurants: [],

--- a/apps/trip-planner/src/data/types.ts
+++ b/apps/trip-planner/src/data/types.ts
@@ -202,6 +202,9 @@ export interface FlightEndpoint {
   time?: string;
   /** Terminal, e.g. "T3". */
   terminal?: string;
+  /** Calendar days past departure this end falls on — set to 1 for an overnight
+   *  arrival, rendered as a "+1" beside the time. */
+  dayOffset?: number;
 }
 
 /**

--- a/apps/trip-planner/src/data/types.ts
+++ b/apps/trip-planner/src/data/types.ts
@@ -192,6 +192,40 @@ export interface Tip {
   time?: string;
 }
 
+/** One end of a flight — an airport plus the local clock time there. */
+export interface FlightEndpoint {
+  /** IATA airport code, e.g. "HKG", "LHR". */
+  code: string;
+  /** City / airport name shown under the code, e.g. "香港". */
+  city: string;
+  /** Local time at this airport, "HH:MM". */
+  time?: string;
+  /** Terminal, e.g. "T3". */
+  terminal?: string;
+}
+
+/**
+ * A flight someone on the trip is taking, rendered as a boarding-pass-style
+ * card in the day feed. Carries enough to recognise the flight at a glance and
+ * a `track` link to follow it live.
+ */
+export interface Flight {
+  /** Flight number, e.g. "CX255". */
+  number: string;
+  /** Airline name, e.g. "国泰航空". */
+  airline?: string;
+  /** Who is on this flight, e.g. "Jim". */
+  passenger?: string;
+  from: FlightEndpoint;
+  to: FlightEndpoint;
+  /** Live flight-tracking URL (e.g. Flightradar24). Renders a 实时追踪 button. */
+  track?: string;
+  note?: string;
+  /** When to slot this flight into the chronological feed (usually the relevant
+   *  landing/boarding time). Omit to keep it day-level. */
+  time?: string;
+}
+
 export interface Day {
   n: number;
   /** ISO date, e.g. "2026-06-19". */
@@ -216,6 +250,9 @@ export interface Day {
   signSheets?: SignSheet[];
   places: MapPlace[];
   restaurants: Restaurant[];
+  /** Flights taken this day (arrivals / departures), shown as boarding-pass
+   *  cards woven into the feed. */
+  flights?: Flight[];
   /** Practical heads-ups (parking, fuel, driving rules). */
   tips?: Tip[];
   stay: Stay;

--- a/apps/trip-planner/src/lib/schedule.ts
+++ b/apps/trip-planner/src/lib/schedule.ts
@@ -1,6 +1,7 @@
 import type {
   Checklist,
   Day,
+  Flight,
   MapPlace,
   NavLeg,
   Restaurant,
@@ -59,6 +60,7 @@ export interface DayMoment {
   places: MapPlace[];
   checklists: Checklist[];
   signSheets: SignSheet[];
+  flights: Flight[];
 }
 
 /**
@@ -85,6 +87,7 @@ export function buildDayFeed(day: Day): DayMoment[] {
       places: [],
       checklists: [],
       signSheets: [],
+      flights: [],
     };
     moments.set(time, created);
     return created;
@@ -92,6 +95,8 @@ export function buildDayFeed(day: Day): DayMoment[] {
 
   // Timeline first so event-bearing moments keep priority on ties.
   for (const event of day.timeline) at(event.time).events.push(event);
+  for (const flight of day.flights ?? [])
+    if (flight.time) at(flight.time).flights.push(flight);
   for (const leg of day.nav ?? []) if (leg.time) at(leg.time).nav.push(leg);
   for (const tip of day.tips ?? []) if (tip.time) at(tip.time).tips.push(tip);
   for (const r of day.restaurants) if (r.time) at(r.time).dining.push(r);


### PR DESCRIPTION
## Summary

Adds a dedicated flight item type to trip-planner, rendered as a boarding-pass-style card woven into the day feed, and backfills the GB trip's three flights — Jim's inbound CX255 and 大雨's round-trip CA851/CA852 — each with a Flightradar24 实时追踪 link. Previously flight details only lived as buried timeline copy; now they read at a glance (number, airline, passenger, route, local times, terminal) with one tap to follow the flight live.

- `data/types.ts`: new `Flight` / `FlightEndpoint` types and a `Day.flights` field; `FlightEndpoint.dayOffset` renders a `+1` for overnight arrivals (e.g. CA852 landing 04:52 next day in Beijing)
- `lib/schedule.ts`: flights slot into the chronological feed by `time`, the same way nav legs, dining, and tips already do
- `components/trip/flight-section.tsx`: new `FlightCard` — header (plane, flight number, airline, passenger badge), a `FROM → TO` route with local times and terminal, and a dark 实时追踪 button, separated by a dashed ticket divider with corner perforation notches (no banned leading accent bar)
- `components/trip/day-feed.tsx`: renders flight cards within each feed moment
- `data/trips/gb.ts`: CX255 (HKG → LHR T3, Day 1), CA851 (北京首都 PEK → 伦敦盖特威克 LGW, Day 0), CA852 (LGW → PEK, Day 12); flight numbers also surfaced in the day glance anchors and timeline copy

Note: CA851's card keeps the itinerary's existing 06:30 Gatwick arrival (the whole Day 0 pickup plan is built around it) rather than silently changing it. Worth double-checking against the booking — the live mid-June 2026 schedule shows CA851 landing Gatwick closer to 09:51.

## Verification

Verified visually in headless Chromium against a running dev build: unlocked the GB trip and confirmed all three cards render correctly on their days — route, local times, terminal, the `+1` overnight indicator on CA852, and working 实时追踪 links.

`lint:changed`, `format:changed`, trip-planner's `tsc --noEmit`, and the trip-planner production build all pass. Web's `codegen:openapi` (blocked host in this sandbox) and the web unit tests fail identically on a clean tree — environmental, unrelated to this change, which touches only trip-planner.

https://claude.ai/code/session_016VyhQLcNRqWTgNTAmwAWyD

---
_Generated by [Claude Code](https://claude.ai/code/session_016VyhQLcNRqWTgNTAmwAWyD)_