### PR TITLE
feat(trip-planner): let today's plan drop optional stops to reclaim time

### DIFF
--- a/apps/trip-planner/package.json
+++ b/apps/trip-planner/package.json
@@ -7,7 +7,8 @@
     "build": "next build && serwist build serwist.config.mjs",
     "build:tsc": "tsc --noEmit",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.5",
@@ -34,6 +35,7 @@
     "prettier": "^3.8.4",
     "tailwindcss": "^4.3.0",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
   }
 }

--- a/apps/trip-planner/src/app/unlock/[trip]/unlock-form.tsx
+++ b/apps/trip-planner/src/app/unlock/[trip]/unlock-form.tsx
@@ -20,7 +20,9 @@ export function UnlockForm({ slug }: { slug: string }) {
         placeholder="行程密码"
         aria-label="行程密码"
         aria-invalid={state.error ? true : undefined}
-        className="h-9 w-full rounded-md border bg-background px-3 text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-[3px] aria-invalid:ring-destructive/20"
+        // `text-base` (16px) on mobile stops iOS Safari from auto-zooming when
+        // the field is focused; `sm:text-sm` keeps the tighter size on desktop.
+        className="h-9 w-full rounded-md border bg-background px-3 text-base shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-[3px] aria-invalid:ring-destructive/20 sm:text-sm"
       />
       {state.error ? (
         <p role="alert" className="text-sm text-destructive">

--- a/apps/trip-planner/src/components/trip/daily-view.tsx
+++ b/apps/trip-planner/src/components/trip/daily-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Clock, MapPin } from "lucide-react";
+import { useEffect, useState } from "react";
 import { DayFeed } from "./day-feed";
 import { DayGlance } from "./day-glance";
 import { DayHeader } from "./day-header";
@@ -10,16 +11,22 @@ import { PlaceList } from "./places-section";
 import { Section } from "./section";
 import { StaySection } from "./stay-section";
 import { TipsSection } from "./tips-section";
+import { TodayPlanner } from "./today-planner";
+import { useTodayPlan } from "./use-today-plan";
 import type { Day, Trip } from "@/data/types";
 import {
+  applyDrops,
   buildDayFeed,
   dayWideTips,
   momentDomId,
+  optionalMoments,
   untimedDining,
   untimedPlaces,
 } from "@/lib/schedule";
 import { peopleOnDay } from "@/lib/trip";
 import type { LiveWeather } from "@/lib/wmo";
+
+const NO_DROPS: ReadonlySet<string> = new Set();
 
 export function DailyView({
   trip,
@@ -35,10 +42,45 @@ export function DailyView({
   onOpenDay: (index: number) => void;
 }) {
   const moments = buildDayFeed(day);
-  const jumpableTimes = new Set(moments.map((moment) => moment.time));
+
+  // The live clock that drives the today-only planner. Read on the client so
+  // it's the user's real "now"; null on other days and until first mount, which
+  // keeps the server and first client render in sync.
+  const [nowMinutes, setNowMinutes] = useState<number | null>(null);
+  useEffect(() => {
+    if (!isToday) return;
+    const tick = () => {
+      const now = new Date();
+      setNowMinutes(now.getHours() * 60 + now.getMinutes());
+    };
+    tick();
+    const id = window.setInterval(tick, 60_000);
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [isToday]);
+
+  const { dropped, toggle, restoreAll } = useTodayPlan(trip.slug, day.n);
+  const plan = applyDrops(moments, isToday ? dropped : NO_DROPS);
+  const futureOptional =
+    isToday && nowMinutes !== null ? optionalMoments(moments, nowMinutes) : [];
+
+  // Only offer to jump to moments that are actually rendered — a dropped
+  // optional has no element to scroll to, so it must not look tappable.
+  const jumpableTimes = new Set(plan.rows.map((row) => row.moment.time));
   const extraDining = untimedDining(day);
   const extraPlaces = untimedPlaces(day);
   const generalTips = dayWideTips(day);
+
+  const planner =
+    futureOptional.length > 0 ? (
+      <TodayPlanner
+        optional={futureOptional}
+        dropped={dropped}
+        onToggle={toggle}
+        onRestoreAll={restoreAll}
+      />
+    ) : undefined;
 
   const jumpToMoment = (time: string) => {
     const target = document.getElementById(momentDomId(day.n, time));
@@ -76,7 +118,13 @@ export function DailyView({
       <DayMap day={day} />
 
       <Section icon={Clock} title="行程">
-        <DayFeed tripSlug={trip.slug} day={day} isToday={isToday} />
+        <DayFeed
+          tripSlug={trip.slug}
+          dayN={day.n}
+          rows={plan.rows}
+          nowMinutes={isToday ? nowMinutes : null}
+          planner={planner}
+        />
       </Section>
 
       {extraDining.length > 0 ? (

--- a/apps/trip-planner/src/components/trip/day-feed.tsx
+++ b/apps/trip-planner/src/components/trip/day-feed.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { Fragment, type ReactNode, useEffect, useRef } from "react";
 import { ChecklistCard } from "./checklist-section";
 import { DiningList } from "./dining-section";
 import { FlightCard } from "./flight-section";
@@ -8,18 +8,18 @@ import { PlacePill } from "./links";
 import { NavLegRow } from "./nav-section";
 import { SignSheetCard } from "./road-signs";
 import { TipRow } from "./tips-section";
-import type { Day } from "@/data/types";
-import { type DayMoment, buildDayFeed, momentDomId } from "@/lib/schedule";
+import { type PlannedMoment, momentDomId } from "@/lib/schedule";
 import { cn } from "@/lib/utils";
 
 // Only nudge the scroll on phones; on wider screens the day mostly fits.
 const MOBILE_QUERY = "(max-width: 767px)";
 
-/** Index of the moment that's "now" — the last one already started. */
-function currentMomentIndex(moments: DayMoment[], nowMinutes: number) {
-  let index = 0;
-  for (const [i, moment] of moments.entries()) {
-    if (moment.minutes <= nowMinutes) index = i;
+/** Index of the visible row that's "now" — the last one already started, or -1
+ *  when the whole day still lies ahead. */
+function currentRowIndex(rows: PlannedMoment[], nowMinutes: number) {
+  let index = -1;
+  for (const [i, row] of rows.entries()) {
+    if (row.moment.minutes <= nowMinutes) index = i;
   }
   return index;
 }
@@ -27,133 +27,196 @@ function currentMomentIndex(moments: DayMoment[], nowMinutes: number) {
 /**
  * The day as one chronological feed: every timeline moment, with its nav,
  * checklist, dining and place ideas, and heads-up tips gathered around it.
- * On phones, the initially-loaded day scrolls to the current time so "now" is
- * in view without hunting.
+ *
+ * `rows` arrives already pruned by the parent — on the current day the user's
+ * dropped optional stops are gone and the drive re-stitched around them. The
+ * `planner` control, when given, is woven in at "now" so adjusting the rest of
+ * the day is one tap away. On phones the feed scrolls to the current time so
+ * "now" is in view without hunting.
  */
 export function DayFeed({
   tripSlug,
-  day,
-  isToday,
+  dayN,
+  rows,
+  nowMinutes,
+  planner,
 }: {
   tripSlug: string;
-  day: Day;
-  isToday: boolean;
+  dayN: number;
+  rows: PlannedMoment[];
+  nowMinutes: number | null;
+  planner?: ReactNode;
 }) {
-  const moments = buildDayFeed(day);
   const didInitialScrollRef = useRef(false);
-
   useEffect(() => {
     if (didInitialScrollRef.current) return;
+    if (nowMinutes === null || rows.length === 0) return;
     didInitialScrollRef.current = true;
-    if (!isToday || moments.length === 0) return;
     if (!window.matchMedia(MOBILE_QUERY).matches) return;
 
-    const now = new Date();
-    const nowMinutes = now.getHours() * 60 + now.getMinutes();
-    const index = currentMomentIndex(moments, nowMinutes);
+    const index = Math.max(0, currentRowIndex(rows, nowMinutes));
     const target = document.getElementById(
-      momentDomId(day.n, moments[index].time),
+      momentDomId(dayN, rows[index].moment.time),
     );
     target?.scrollIntoView({ block: "start" });
-  }, [moments, isToday, day.n]);
+    // `nowMinutes` arrives null then resolves on the client, so it must be a
+    // dependency for the scroll to fire once it's known; the ref guard keeps
+    // this a one-shot despite rows/nowMinutes changing identity each render.
+  }, [rows, nowMinutes, dayN]);
+
+  // Weave the planner in right after the current moment (or at the very top
+  // when the day still lies ahead). It only renders on the current day.
+  const lastIndex = rows.length - 1;
+  const plannerAfter =
+    planner && nowMinutes !== null ? currentRowIndex(rows, nowMinutes) : null;
+  const plannerIsLast =
+    plannerAfter !== null && (rows.length === 0 || plannerAfter === lastIndex);
 
   return (
     <ol>
-      {moments.map((moment, i) => {
-        const isLast = i === moments.length - 1;
-        const hasExtras =
-          moment.flights.length > 0 ||
-          moment.checklists.length > 0 ||
-          moment.signSheets.length > 0 ||
-          moment.nav.length > 0 ||
-          moment.dining.length > 0 ||
-          moment.places.length > 0 ||
-          moment.tips.length > 0;
-
-        return (
-          <li
-            key={moment.time}
-            id={momentDomId(day.n, moment.time)}
-            className="grid scroll-mt-32 grid-cols-[3.25rem_1fr] gap-x-3"
-          >
-            <div className="pt-0.5 text-right text-sm tabular-nums text-muted-foreground">
-              {moment.time}
-            </div>
-
-            <div
-              className={cn(
-                "relative border-l pl-5",
-                isLast ? "border-l-transparent pb-1" : "pb-8",
-              )}
-            >
-              <span className="absolute top-1.5 -left-[5px] size-2.5 rounded-full bg-foreground ring-4 ring-background" />
-
-              {moment.events.map((event) => (
-                <p
-                  key={event.text}
-                  className="text-[15px] leading-snug font-medium text-pretty"
-                >
-                  {event.text}
-                </p>
-              ))}
-
-              {hasExtras ? (
-                <div
-                  className={cn(
-                    "space-y-3",
-                    moment.events.length > 0 && "mt-3",
-                  )}
-                >
-                  {moment.flights.map((flight) => (
-                    <FlightCard key={flight.number} flight={flight} />
-                  ))}
-
-                  {moment.checklists.map((list) => (
-                    <ChecklistCard
-                      key={list.title}
-                      tripSlug={tripSlug}
-                      dayN={day.n}
-                      list={list}
-                    />
-                  ))}
-
-                  {moment.signSheets.map((sheet) => (
-                    <SignSheetCard key={sheet.title} sheet={sheet} />
-                  ))}
-
-                  {moment.nav.length > 0 ? (
-                    <ul className="space-y-2">
-                      {moment.nav.map((leg) => (
-                        <NavLegRow key={leg.label} leg={leg} />
-                      ))}
-                    </ul>
-                  ) : null}
-
-                  {moment.dining.length > 0 ? (
-                    <DiningList restaurants={moment.dining} />
-                  ) : null}
-
-                  {moment.places.length > 0 ? (
-                    <div className="flex flex-wrap gap-2">
-                      {moment.places.map((place) => (
-                        <PlacePill key={place.name} place={place} />
-                      ))}
-                    </div>
-                  ) : null}
-
-                  {moment.tips.length > 0 ? (
-                    <ul className="space-y-2.5">
-                      {moment.tips.map((tip) => (
-                        <TipRow key={tip.text} tip={tip} />
-                      ))}
-                    </ul>
-                  ) : null}
-                </div>
-              ) : null}
-            </div>
-          </li>
-        );
-      })}
+      {plannerAfter === -1 ? (
+        <PlannerRow isLast={plannerIsLast}>{planner}</PlannerRow>
+      ) : null}
+      {rows.map((row, i) => (
+        <Fragment key={row.moment.time}>
+          <MomentRow
+            tripSlug={tripSlug}
+            dayN={dayN}
+            row={row}
+            isLast={i === lastIndex && !plannerIsLast}
+          />
+          {plannerAfter === i && i !== -1 ? (
+            <PlannerRow isLast={plannerIsLast}>{planner}</PlannerRow>
+          ) : null}
+        </Fragment>
+      ))}
     </ol>
+  );
+}
+
+/** The "now" row that carries the planner control, marked with a hollow node. */
+function PlannerRow({
+  isLast,
+  children,
+}: {
+  isLast: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <li className="grid grid-cols-[3.25rem_1fr] gap-x-3">
+      <div className="pt-1 text-right text-xs font-medium text-muted-foreground">
+        现在
+      </div>
+      <div
+        className={cn(
+          "relative border-l pl-5",
+          isLast ? "border-l-transparent pb-1" : "pb-8",
+        )}
+      >
+        <span className="absolute top-1.5 -left-[6px] size-3 rounded-full border-2 border-foreground bg-background ring-4 ring-background" />
+        {children}
+      </div>
+    </li>
+  );
+}
+
+/** One shown moment in the feed. */
+function MomentRow({
+  tripSlug,
+  dayN,
+  row,
+  isLast,
+}: {
+  tripSlug: string;
+  dayN: number;
+  row: PlannedMoment;
+  isLast: boolean;
+}) {
+  const { moment } = row;
+  const hasExtras =
+    moment.flights.length > 0 ||
+    moment.checklists.length > 0 ||
+    moment.signSheets.length > 0 ||
+    moment.nav.length > 0 ||
+    moment.dining.length > 0 ||
+    moment.places.length > 0 ||
+    moment.tips.length > 0;
+
+  return (
+    <li
+      id={momentDomId(dayN, moment.time)}
+      className="grid scroll-mt-32 grid-cols-[3.25rem_1fr] gap-x-3"
+    >
+      <div className="pt-0.5 text-right text-sm tabular-nums text-muted-foreground">
+        {moment.time}
+      </div>
+
+      <div
+        className={cn(
+          "relative border-l pl-5",
+          isLast ? "border-l-transparent pb-1" : "pb-8",
+        )}
+      >
+        <span className="absolute top-1.5 -left-[5px] size-2.5 rounded-full bg-foreground ring-4 ring-background" />
+
+        {moment.events.map((event) => (
+          <p
+            key={event.text}
+            className="text-[15px] leading-snug font-medium text-pretty"
+          >
+            {event.text}
+          </p>
+        ))}
+
+        {hasExtras ? (
+          <div className={cn("space-y-3", moment.events.length > 0 && "mt-3")}>
+            {moment.flights.map((flight) => (
+              <FlightCard key={flight.number} flight={flight} />
+            ))}
+
+            {moment.checklists.map((list) => (
+              <ChecklistCard
+                key={list.title}
+                tripSlug={tripSlug}
+                dayN={dayN}
+                list={list}
+              />
+            ))}
+
+            {moment.signSheets.map((sheet) => (
+              <SignSheetCard key={sheet.title} sheet={sheet} />
+            ))}
+
+            {moment.nav.length > 0 ? (
+              <ul className="space-y-2">
+                {moment.nav.map((leg) => (
+                  <NavLegRow key={leg.label} leg={leg} />
+                ))}
+              </ul>
+            ) : null}
+
+            {moment.dining.length > 0 ? (
+              <DiningList restaurants={moment.dining} />
+            ) : null}
+
+            {moment.places.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {moment.places.map((place) => (
+                  <PlacePill key={place.name} place={place} />
+                ))}
+              </div>
+            ) : null}
+
+            {moment.tips.length > 0 ? (
+              <ul className="space-y-2.5">
+                {moment.tips.map((tip) => (
+                  <TipRow key={tip.text} tip={tip} />
+                ))}
+              </ul>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </li>
   );
 }

--- a/apps/trip-planner/src/components/trip/nav-section.tsx
+++ b/apps/trip-planner/src/components/trip/nav-section.tsx
@@ -4,6 +4,7 @@ import type { LucideIcon } from "lucide-react";
 import {
   Car,
   ChevronDown,
+  CornerDownRight,
   Footprints,
   MapPin,
   Navigation,
@@ -11,13 +12,14 @@ import {
 } from "lucide-react";
 import { useId, useState } from "react";
 import { MapEmbed } from "./map-embed";
-import type { NavLeg, TravelMode } from "@/data/types";
+import type { TravelMode } from "@/data/types";
 import {
   googleMapsDirectionsUrl,
   googleMapsEmbedDirectionsUrl,
   googleMapsEmbedPlaceUrl,
   mapsEmbedEnabled,
 } from "@/lib/maps";
+import type { FeedNavLeg } from "@/lib/schedule";
 import { cn } from "@/lib/utils";
 
 const modeIcon: Record<TravelMode, LucideIcon> = {
@@ -30,7 +32,7 @@ const modeIcon: Record<TravelMode, LucideIcon> = {
  * The Embed API needs a concrete origin, so legs starting from the device's
  * current location preview the destination as a place instead of a route.
  */
-function legEmbedSrc(leg: NavLeg) {
+function legEmbedSrc(leg: FeedNavLeg) {
   // Keep the embed preview in sync with the deep-link: both route through the
   // leg's waypoints, so the inline map and the 导航 link open the same route.
   // (Every waypoint must be a name the Maps geocoder resolves, or the embed
@@ -45,14 +47,24 @@ function legEmbedSrc(leg: NavLeg) {
     : googleMapsEmbedPlaceUrl(leg.to);
 }
 
-/** One nav leg: a deep-link to directions plus an optional inline map preview. */
-export function NavLegRow({ leg }: { leg: NavLeg }) {
+/** One nav leg: a deep-link to directions plus an optional inline map preview.
+ *  When the route was re-stitched because earlier optional stops were dropped,
+ *  a small note names them, and the deep-link / embed already start from where
+ *  those stops' drive began. */
+export function NavLegRow({ leg }: { leg: FeedNavLeg }) {
   const [open, setOpen] = useState(false);
   const panelId = useId();
   const Icon = modeIcon[leg.mode ?? "driving"];
+  const skipped = leg.skipped ?? [];
 
   return (
     <li className="overflow-hidden rounded-xl border bg-card transition-colors hover:border-foreground/30">
+      {skipped.length > 0 ? (
+        <p className="flex items-center gap-1.5 border-b bg-muted/40 px-3 py-1.5 text-xs text-muted-foreground">
+          <CornerDownRight className="size-3 shrink-0" />
+          已跳过 {skipped.join("、")} · 从上一站直接前往
+        </p>
+      ) : null}
       <div className="flex items-center gap-3 p-3">
         <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted">
           <Icon className="size-4 text-muted-foreground" />

--- a/apps/trip-planner/src/components/trip/today-planner.tsx
+++ b/apps/trip-planner/src/components/trip/today-planner.tsx
@@ -28,14 +28,16 @@ function KeepSwitch({
       aria-label={`${checked ? "保留" : "已关闭"}：${label}`}
       onClick={onChange}
       className={cn(
-        "relative h-6 w-10 shrink-0 rounded-full border transition-colors",
-        checked ? "border-foreground bg-foreground" : "border-input bg-muted",
+        "relative inline-flex h-6 w-10 shrink-0 cursor-pointer appearance-none items-center rounded-full transition-colors",
+        checked ? "bg-foreground" : "bg-muted",
       )}
     >
+      {/* Positioned with explicit `left` (not a translated static position) so
+          the thumb can't drift off the track under native button rendering. */}
       <span
         className={cn(
-          "absolute top-0.5 size-4 rounded-full bg-background shadow-sm transition-transform",
-          checked ? "translate-x-[1.125rem]" : "translate-x-0.5",
+          "pointer-events-none absolute top-1/2 size-5 -translate-y-1/2 rounded-full bg-background shadow-sm ring-1 ring-foreground/10 transition-[left]",
+          checked ? "left-[calc(100%-1.375rem)]" : "left-0.5",
         )}
       />
     </button>

--- a/apps/trip-planner/src/components/trip/today-planner.tsx
+++ b/apps/trip-planner/src/components/trip/today-planner.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import {
+  ChevronDown,
+  Clock3,
+  RotateCcw,
+  SlidersHorizontal,
+} from "lucide-react";
+import { useId, useState } from "react";
+import { type DayMoment, formatDuration, momentLabel } from "@/lib/schedule";
+import { cn } from "@/lib/utils";
+
+/** An on/off switch for keeping or dropping one stop. `checked` = kept. */
+function KeepSwitch({
+  checked,
+  label,
+  onChange,
+}: {
+  checked: boolean;
+  label: string;
+  onChange: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={`${checked ? "保留" : "已关闭"}：${label}`}
+      onClick={onChange}
+      className={cn(
+        "relative h-6 w-10 shrink-0 rounded-full border transition-colors",
+        checked ? "border-foreground bg-foreground" : "border-input bg-muted",
+      )}
+    >
+      <span
+        className={cn(
+          "absolute top-0.5 size-4 rounded-full bg-background shadow-sm transition-transform",
+          checked ? "translate-x-[1.125rem]" : "translate-x-0.5",
+        )}
+      />
+    </button>
+  );
+}
+
+/**
+ * The "keep today honest" control: a single button that sits by the current
+ * moment in the feed. Open it to switch off optional stops still ahead — booked
+ * tables, travel and check-in/out are never listed, so the must-dos are safe —
+ * and the feed re-times and re-routes around what's left. Choices persist
+ * on-device via {@link useTodayPlan}.
+ */
+export function TodayPlanner({
+  optional,
+  dropped,
+  onToggle,
+  onRestoreAll,
+}: {
+  optional: DayMoment[];
+  dropped: Set<string>;
+  onToggle: (time: string) => void;
+  onRestoreAll: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const panelId = useId();
+
+  const droppedHere = optional.filter((moment) => dropped.has(moment.time));
+  const savedMinutes = droppedHere.reduce(
+    (sum, moment) => sum + moment.durationMin,
+    0,
+  );
+  const droppedCount = droppedHere.length;
+
+  const summary =
+    droppedCount > 0
+      ? `已关 ${String(droppedCount)} 项 · 省下约 ${formatDuration(savedMinutes)}`
+      : "落后于计划？关掉来不及的可选项";
+
+  return (
+    <div className="rounded-xl border border-dashed bg-card">
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={() => {
+          setOpen((value) => !value);
+        }}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left"
+      >
+        <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted">
+          <SlidersHorizontal className="size-4 text-muted-foreground" />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block text-sm font-medium">调整后续行程</span>
+          <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+            {summary}
+          </span>
+        </span>
+        {droppedCount > 0 ? (
+          <span className="flex shrink-0 items-center gap-1 rounded-full bg-foreground px-2 py-0.5 text-xs font-medium text-background tabular-nums">
+            <Clock3 className="size-3" />−{formatDuration(savedMinutes)}
+          </span>
+        ) : null}
+        <ChevronDown
+          className={cn(
+            "size-4 shrink-0 text-muted-foreground transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+
+      {open ? (
+        <div id={panelId} className="border-t px-4 py-3">
+          <p className="mb-3 text-xs leading-relaxed text-muted-foreground">
+            保留所有必到项（行程、入住退房、已订餐厅），只在下面关掉来不及的可选活动；关掉后行程与导航会自动更新。
+          </p>
+          <ul className="space-y-1">
+            {optional.map((moment) => {
+              const isKept = !dropped.has(moment.time);
+              const label = momentLabel(moment);
+              return (
+                <li
+                  key={moment.time}
+                  className="flex items-center gap-3 py-1.5"
+                >
+                  <span className="w-12 shrink-0 text-right text-sm tabular-nums text-muted-foreground">
+                    {moment.time}
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span
+                      className={cn(
+                        "block text-sm leading-snug text-pretty",
+                        !isKept && "text-muted-foreground line-through",
+                      )}
+                    >
+                      {label}
+                    </span>
+                    <span className="mt-0.5 block text-xs text-muted-foreground tabular-nums">
+                      约 {formatDuration(moment.durationMin)}
+                    </span>
+                  </span>
+                  <KeepSwitch
+                    checked={isKept}
+                    label={label}
+                    onChange={() => {
+                      onToggle(moment.time);
+                    }}
+                  />
+                </li>
+              );
+            })}
+          </ul>
+
+          {droppedCount > 0 ? (
+            <div className="mt-3 flex items-center justify-between border-t pt-3">
+              <span className="text-xs text-muted-foreground">
+                已关 {droppedCount} 项 · 预计省下约{" "}
+                {formatDuration(savedMinutes)}
+              </span>
+              <button
+                type="button"
+                onClick={onRestoreAll}
+                className="flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              >
+                <RotateCcw className="size-3" />
+                全部恢复
+              </button>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/trip-planner/src/components/trip/use-today-plan.ts
+++ b/apps/trip-planner/src/components/trip/use-today-plan.ts
@@ -1,0 +1,147 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+/**
+ * On-device record of which optional stops the user has switched off for the
+ * current day, so a slimmed-down plan survives a reload. Mirrors the checklist
+ * store: a tiny localStorage-backed store read via `useSyncExternalStore`, one
+ * per trip, SSR-safe (the server snapshot is empty) and free of
+ * setState-in-effect.
+ */
+
+const EMPTY: Record<string, boolean> = {};
+
+/** localStorage namespace per trip, alongside `${slug}-trip-checklist`. */
+function storageKeyFor(tripSlug: string) {
+  return `${tripSlug}-trip-plan`;
+}
+
+/** A dropped stop's id: the day plus the moment's (per-day unique) time. */
+function dropId(dayN: number, time: string) {
+  return `D${String(dayN)}·${time}`;
+}
+
+function isBooleanRecord(value: unknown): value is Record<string, boolean> {
+  if (typeof value !== "object" || value === null) return false;
+  return Object.values(value).every((entry) => typeof entry === "boolean");
+}
+
+function parse(raw: string | null): Record<string, boolean> {
+  if (!raw) return EMPTY;
+  try {
+    const value: unknown = JSON.parse(raw);
+    if (isBooleanRecord(value)) return value;
+  } catch {
+    // Ignore malformed storage.
+  }
+  return EMPTY;
+}
+
+interface PlanStore {
+  subscribe: (listener: () => void) => () => void;
+  getSnapshot: () => Record<string, boolean>;
+  setMany: (entries: Record<string, boolean>) => void;
+}
+
+function createStore(storageKey: string): PlanStore {
+  const listeners = new Set<() => void>();
+  let snapshot: Record<string, boolean> = EMPTY;
+  let loaded = false;
+
+  const notify = () => {
+    for (const listener of listeners) listener();
+  };
+
+  const getSnapshot = () => {
+    if (!loaded && typeof window !== "undefined") {
+      snapshot = parse(window.localStorage.getItem(storageKey));
+      loaded = true;
+    }
+    return snapshot;
+  };
+
+  const subscribe = (listener: () => void) => {
+    listeners.add(listener);
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === storageKey) {
+        snapshot = parse(event.newValue);
+        notify();
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => {
+      listeners.delete(listener);
+      window.removeEventListener("storage", onStorage);
+    };
+  };
+
+  const setMany = (entries: Record<string, boolean>) => {
+    snapshot = { ...getSnapshot(), ...entries };
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(snapshot));
+    } catch {
+      // Ignore write failures (private mode / quota).
+    }
+    notify();
+  };
+
+  return { subscribe, getSnapshot, setMany };
+}
+
+// Cached per key so subscribe/getSnapshot identities stay stable across
+// renders, as useSyncExternalStore requires.
+const stores = new Map<string, PlanStore>();
+
+function getStore(storageKey: string): PlanStore {
+  const existing = stores.get(storageKey);
+  if (existing) return existing;
+  const created = createStore(storageKey);
+  stores.set(storageKey, created);
+  return created;
+}
+
+function getServerSnapshot(): Record<string, boolean> {
+  return EMPTY;
+}
+
+/** What the planner needs to read and edit a day's dropped optional stops. */
+export interface TodayPlan {
+  /** Times of the moments currently dropped on this day. */
+  dropped: Set<string>;
+  /** Flip one moment between kept and dropped. */
+  toggle: (time: string) => void;
+  /** Restore every dropped stop on this day. */
+  restoreAll: () => void;
+}
+
+/** Read and edit which optional stops are switched off for one trip day. */
+export function useTodayPlan(tripSlug: string, dayN: number): TodayPlan {
+  const store = getStore(storageKeyFor(tripSlug));
+  const snapshot = useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    getServerSnapshot,
+  );
+
+  const prefix = `D${String(dayN)}·`;
+  const dropped = new Set(
+    Object.entries(snapshot)
+      .filter(([key, value]) => value && key.startsWith(prefix))
+      .map(([key]) => key.slice(prefix.length)),
+  );
+
+  const toggle = (time: string) => {
+    store.setMany({ [dropId(dayN, time)]: !dropped.has(time) });
+  };
+
+  const restoreAll = () => {
+    store.setMany(
+      Object.fromEntries(
+        [...dropped].map((time) => [dropId(dayN, time), false]),
+      ),
+    );
+  };
+
+  return { dropped, toggle, restoreAll };
+}

--- a/apps/trip-planner/src/data/trips/gb.test.ts
+++ b/apps/trip-planner/src/data/trips/gb.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import type { AnchorKind } from "../types";
+import { gb } from "./gb";
+import { buildDayFeed } from "@/lib/schedule";
+
+// These guard the hand-authored `optional` / `durationMin` tags against the two
+// authoring mistakes that matter: marking a must-do droppable, or leaving an
+// intended optional stop un-droppable because one of its pieces wasn't flagged.
+
+const HARD_ANCHOR_KINDS = new Set<AnchorKind>([
+  "flight",
+  "pickup",
+  "dropoff",
+  "reservation",
+  "transit",
+  "checkout",
+]);
+
+describe("GB trip optional authoring", () => {
+  it("never marks a must-do moment optional", () => {
+    for (const day of gb.days) {
+      const hardTimes = new Set(
+        (day.anchors ?? [])
+          .filter((a) => a.time && HARD_ANCHOR_KINDS.has(a.kind))
+          .map((a) => a.time),
+      );
+      for (const moment of buildDayFeed(day)) {
+        if (!moment.optional) continue;
+        const where = `D${String(day.n)} ${moment.time}`;
+        expect(moment.hard, where).toBe(false);
+        expect(
+          moment.dining.some((r) => r.status === "booked"),
+          where,
+        ).toBe(false);
+        expect(moment.flights.length, where).toBe(0);
+        expect(hardTimes.has(moment.time), where).toBe(false);
+        expect(moment.durationMin, where).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("offers droppable stops on every remaining touring day", () => {
+    const optionalCount = (dayN: number) => {
+      const day = gb.days.find((d) => d.n === dayN);
+      if (!day) throw new Error(`no day ${String(dayN)}`);
+      return buildDayFeed(day).filter((m) => m.optional).length;
+    };
+    // Days 6–11 are the trip's touring days; the final travel-home day is not.
+    for (const dayN of [6, 7, 8, 9, 10, 11])
+      expect(optionalCount(dayN), `D${String(dayN)}`).toBeGreaterThan(0);
+    expect(optionalCount(12)).toBe(0);
+  });
+
+  it("keeps the booked Henrock dinner a protected, non-optional moment", () => {
+    const day6 = gb.days.find((d) => d.n === 6);
+    if (!day6) throw new Error("no day 6");
+    const dinner = buildDayFeed(day6).find((m) =>
+      m.dining.some((r) => r.name.includes("Henrock")),
+    );
+    expect(dinner?.hard).toBe(true);
+    expect(dinner?.optional).toBe(false);
+  });
+});

--- a/apps/trip-planner/src/data/trips/gb.ts
+++ b/apps/trip-planner/src/data/trips/gb.ts
@@ -1539,7 +1539,7 @@ const days: Day[] = [
       },
       {
         time: "18:00",
-        text: "逛完回 Woodlands 梳洗、稍作休整",
+        text: "Woodlands 梳洗、稍作休整，准备去 Henrock 晚餐",
       },
       {
         time: "18:25",

--- a/apps/trip-planner/src/data/trips/gb.ts
+++ b/apps/trip-planner/src/data/trips/gb.ts
@@ -1142,6 +1142,7 @@ const days: Day[] = [
         mode: "driving",
         note: "三湖交汇经典高地城堡",
         time: "10:30",
+        optional: true,
       },
       {
         label: "Eilean Donan → Portree（午餐）",
@@ -1158,6 +1159,8 @@ const days: Day[] = [
         mode: "driving",
         note: "路边观景台拍摄 20min",
         time: "13:00",
+        optional: true,
+        durationMin: 15,
       },
       {
         label: "Old Man of Storr → Kilt Rock",
@@ -1166,6 +1169,8 @@ const days: Day[] = [
         mode: "driving",
         note: "海边悬崖瀑布 15min",
         time: "13:45",
+        optional: true,
+        durationMin: 15,
       },
       {
         label: "Kilt Rock → Quiraing",
@@ -1174,6 +1179,8 @@ const days: Day[] = [
         mode: "driving",
         note: "壮丽山脊观景 / 短途步行",
         time: "14:15",
+        optional: true,
+        durationMin: 15,
       },
       {
         label: "Quiraing → Portree 港口",
@@ -1182,6 +1189,8 @@ const days: Day[] = [
         mode: "driving",
         note: "彩色港口 + 咖啡 30min",
         time: "15:20",
+        optional: true,
+        durationMin: 20,
       },
       {
         label: "离岛南下：Portree → Fort William",
@@ -1197,23 +1206,46 @@ const days: Day[] = [
       {
         time: "08:30",
         text: "Urquhart Castle / 尼斯湖畔观景台拍照（30–40min）",
+        optional: true,
+        durationMin: 40,
       },
       {
         time: "10:30",
         text: "Eilean Donan Castle — 三湖交汇经典高地城堡（40min）",
+        optional: true,
+        durationMin: 40,
       },
       { time: "12:00", text: "过 Skye Bridge 上岛，在 Portree 午餐" },
-      { time: "13:00", text: "Old Man of Storr — 路边观景台拍摄（20min）" },
+      {
+        time: "13:00",
+        text: "Old Man of Storr — 路边观景台拍摄（20min）",
+        optional: true,
+        durationMin: 20,
+      },
       {
         time: "13:45",
         text: "Kilt Rock & Mealt Falls — 海边悬崖瀑布（15min）",
+        optional: true,
+        durationMin: 15,
       },
-      { time: "14:15", text: "Quiraing — 壮丽山脊观景 / 短途步行（30–40min）" },
+      {
+        time: "14:15",
+        text: "Quiraing — 壮丽山脊观景 / 短途步行（30–40min）",
+        optional: true,
+        durationMin: 40,
+      },
       {
         time: "15:20",
         text: "Portree 彩色港口 — 标志性彩色小屋 + 咖啡（30min）",
+        optional: true,
+        durationMin: 30,
       },
-      { time: "16:00", text: "可选 Fairy Pools 入口看一眼，或直接南下离岛" },
+      {
+        time: "16:00",
+        text: "可选 Fairy Pools 入口看一眼，或直接南下离岛",
+        optional: true,
+        durationMin: 30,
+      },
       {
         time: "17:00",
         text: "离开天空岛 → 经 A87 / A82 直达 Fort William（无需渡轮）",
@@ -1228,33 +1260,44 @@ const days: Day[] = [
         name: "Urquhart Castle / 尼斯湖",
         query: "Urquhart Castle Loch Ness",
         time: "08:30",
+        optional: true,
       },
       {
         name: "Eilean Donan Castle",
         query: "Eilean Donan Castle",
         time: "10:30",
+        optional: true,
       },
       {
         name: "Old Man of Storr",
         query: "Old Man of Storr, Isle of Skye",
         time: "13:00",
+        optional: true,
       },
       {
         name: "Kilt Rock & Mealt Falls",
         query: "Kilt Rock and Mealt Falls",
         time: "13:45",
+        optional: true,
       },
-      { name: "Quiraing", query: "Quiraing, Isle of Skye", time: "14:15" },
+      {
+        name: "Quiraing",
+        query: "Quiraing, Isle of Skye",
+        time: "14:15",
+        optional: true,
+      },
       {
         name: "Portree 彩色港口",
         query: "Portree, Isle of Skye",
         time: "15:20",
+        optional: true,
       },
       {
         name: "Fairy Pools",
         query: "Fairy Pools, Isle of Skye",
         note: "可选",
         time: "16:00",
+        optional: true,
       },
     ],
     restaurants: [
@@ -1357,6 +1400,7 @@ const days: Day[] = [
         kind: "parking",
         text: "Old Man of Storr 停车约 £5，Quiraing 免费。",
         time: "13:00",
+        optional: true,
       },
       {
         kind: "warn",
@@ -1472,6 +1516,8 @@ const days: Day[] = [
       {
         time: "10:35",
         text: "格伦科 Glencoe — 007《天幕杀机》取景地，Three Sisters 快速拍照（约 20–25min，不久留）",
+        optional: true,
+        durationMin: 25,
       },
       {
         time: "11:00",
@@ -1488,6 +1534,8 @@ const days: Day[] = [
       {
         time: "16:45",
         text: "Bowness 逛礼品店（Jim 最爱）+ Windermere 的 Lakeland 旗舰店 — 晚饭前的重点，先把礼品店逛够",
+        optional: true,
+        durationMin: 60,
       },
       {
         time: "18:00",
@@ -1511,6 +1559,7 @@ const days: Day[] = [
         name: "格伦科 Three Sisters 观景点",
         query: "Three Sisters Glencoe",
         time: "10:35",
+        optional: true,
       },
       {
         name: "Tebay Services（午餐 / 休息）",
@@ -1523,12 +1572,14 @@ const days: Day[] = [
         query: "Lakeland, Alexandra Buildings, Windermere LA23 1BQ",
         note: "Lakeland 家居总店，Jim 逛礼品",
         time: "16:45",
+        optional: true,
       },
       {
         name: "Bowness 湖边礼品店",
         query: "Lake Road, Bowness-on-Windermere",
         note: "纪念品 / 礼品店集中，Jim 慢慢逛",
         time: "16:45",
+        optional: true,
       },
     ],
     restaurants: [
@@ -1601,6 +1652,7 @@ const days: Day[] = [
         kind: "parking",
         text: "格伦科路边免费 / NTS 停车场 £5；Woodlands B&B 免费停车。",
         time: "10:35",
+        optional: true,
       },
       {
         kind: "drive",
@@ -1681,6 +1733,8 @@ const days: Day[] = [
         mode: "driving",
         note: "华兹华斯故居 + 姜饼店",
         time: "14:30",
+        optional: true,
+        durationMin: 25,
       },
       {
         label: "Grasmere → 伯明翰",
@@ -1693,11 +1747,18 @@ const days: Day[] = [
     ],
     timeline: [
       { time: "09:30", text: "温德米尔湖蒸汽游船 Bowness → Ambleside" },
-      { time: "11:30", text: "彼得兔世界 或 Hill Top 农场（作者故居）" },
+      {
+        time: "11:30",
+        text: "彼得兔世界 或 Hill Top 农场（作者故居）",
+        optional: true,
+        durationMin: 60,
+      },
       { time: "13:00", text: "午餐" },
       {
         time: "14:30",
         text: "Grasmere — 华兹华斯故居 + Sarah Nelson's 姜饼店",
+        optional: true,
+        durationMin: 60,
       },
       { time: "16:30", text: "出发前往伯明翰" },
       {
@@ -1710,11 +1771,13 @@ const days: Day[] = [
         name: "Hill Top 彼得兔故居",
         query: "Hill Top Beatrix Potter Near Sawrey",
         time: "11:30",
+        optional: true,
       },
       {
         name: "Grasmere 华兹华斯故居",
         query: "Dove Cottage, Grasmere",
         time: "14:30",
+        optional: true,
       },
       {
         name: "Ambleside（游船终点）",
@@ -1814,6 +1877,7 @@ const days: Day[] = [
         kind: "info",
         text: "Grasmere 别错过 Sarah Nelson's 1854 年姜饼店。",
         time: "14:30",
+        optional: true,
       },
     ],
     stay: {
@@ -1889,7 +1953,12 @@ const days: Day[] = [
       },
       { time: "12:30", text: "离开机场，M4 西行" },
       { time: "14:30", text: "抵达布里斯托，入住休息" },
-      { time: "16:00", text: "克利夫顿悬索桥 — Clifton Village 散步喝咖啡" },
+      {
+        time: "16:00",
+        text: "克利夫顿悬索桥 — Clifton Village 散步喝咖啡",
+        optional: true,
+        durationMin: 90,
+      },
       { time: "19:00", text: "Harbourside 晚餐" },
     ],
     places: [
@@ -1897,11 +1966,13 @@ const days: Day[] = [
         name: "克利夫顿悬索桥",
         query: "Clifton Suspension Bridge",
         time: "16:00",
+        optional: true,
       },
       {
         name: "Clifton Village",
         query: "Clifton Village, Bristol",
         time: "16:00",
+        optional: true,
       },
       {
         name: "Bristol Harbourside",
@@ -2067,11 +2138,18 @@ const days: Day[] = [
     timeline: [
       { time: "09:30", text: "前往巴斯（约 30 分钟）" },
       { time: "10:00", text: "古罗马浴场 — 2000 年温泉遗址，语音导览精彩" },
-      { time: "12:00", text: "皇家新月楼 Royal Crescent — 乔治亚建筑典范" },
+      {
+        time: "12:00",
+        text: "皇家新月楼 Royal Crescent — 乔治亚建筑典范",
+        optional: true,
+        durationMin: 45,
+      },
       { time: "13:00", text: "午餐" },
       {
         time: "14:30",
         text: "Thermae Bath Spa（可选）— 天然温泉屋顶泳池，俯瞰巴斯天际线",
+        optional: true,
+        durationMin: 90,
       },
       { time: "17:00", text: "返回布里斯托 或 继续逛巴斯" },
     ],
@@ -2085,12 +2163,14 @@ const days: Day[] = [
         name: "皇家新月楼 Royal Crescent",
         query: "Royal Crescent, Bath",
         time: "12:00",
+        optional: true,
       },
       {
         name: "Thermae Bath Spa",
         query: "Thermae Bath Spa",
         note: "可选",
         time: "14:30",
+        optional: true,
       },
     ],
     restaurants: [
@@ -2199,6 +2279,7 @@ const days: Day[] = [
         mode: "driving",
         note: "进入科茨沃尔德，“科茨沃尔德威尼斯”",
         time: "10:00",
+        optional: true,
       },
       {
         label: "Bourton → 拜伯里 Bibury",
@@ -2207,6 +2288,7 @@ const days: Day[] = [
         mode: "driving",
         note: "Arlington Row 蜜色石屋排",
         time: "11:30",
+        optional: true,
       },
       {
         label: "Bibury → 牛津 Oxford",
@@ -2230,10 +2312,14 @@ const days: Day[] = [
       {
         time: "10:00",
         text: "水上伯顿 Bourton-on-the-Water — “科茨沃尔德威尼斯”",
+        optional: true,
+        durationMin: 45,
       },
       {
         time: "11:30",
         text: "拜伯里 Bibury — Arlington Row 蜜色石屋排，最美村庄",
+        optional: true,
+        durationMin: 45,
       },
       { time: "13:00", text: "Cotswolds 村庄午餐" },
       {
@@ -2247,11 +2333,13 @@ const days: Day[] = [
         name: "水上伯顿 Bourton-on-the-Water",
         query: "Bourton-on-the-Water",
         time: "10:00",
+        optional: true,
       },
       {
         name: "拜伯里 Arlington Row",
         query: "Arlington Row, Bibury",
         time: "11:30",
+        optional: true,
       },
       {
         name: "牛津 基督教会学院",
@@ -2318,6 +2406,7 @@ const days: Day[] = [
         kind: "parking",
         text: "Cotswolds 村庄停车免费；Oxford 用 Westgate / Park & Ride（£3–5）。",
         time: "10:00",
+        optional: true,
       },
       {
         kind: "parking",
@@ -2379,6 +2468,7 @@ const days: Day[] = [
         mode: "transit",
         note: "Elizabeth Line → Liverpool Street 出",
         time: "10:00",
+        optional: true,
       },
       {
         label: "South Bank（Tate Modern / Tower Bridge）",
@@ -2390,6 +2480,7 @@ const days: Day[] = [
         mode: "transit",
         note: "Tate Modern → 千禧桥 → Tower Bridge（Borough Market 周一休市）",
         time: "12:00",
+        optional: true,
       },
       {
         label: "West End（Oxford St / Covent Garden）",
@@ -2397,6 +2488,7 @@ const days: Day[] = [
         mode: "transit",
         note: "Tottenham Court Road 下，步行 10min",
         time: "14:00",
+        optional: true,
       },
       {
         label: "Harrods · 骑士桥",
@@ -2404,6 +2496,7 @@ const days: Day[] = [
         mode: "transit",
         note: "Food Hall 买手信好",
         time: "14:00",
+        optional: true,
       },
     ],
     timeline: [
@@ -2414,18 +2507,26 @@ const days: Day[] = [
       {
         time: "10:00",
         text: "Shoreditch / Brick Lane — 街头艺术、vintage 市集、咖喱一条街",
+        optional: true,
+        durationMin: 90,
       },
       {
         time: "12:00",
         text: "South Bank 漫步 — Tate Modern（免费）→ 千禧桥 → Tower Bridge（Borough Market 周一休市，午餐另选）",
+        optional: true,
+        durationMin: 90,
       },
       {
         time: "14:00",
         text: "West End — Oxford Street / Soho / Chinatown / Covent Garden 逛街扫货",
+        optional: true,
+        durationMin: 120,
       },
       {
         time: "17:00",
         text: "可选 Camden Market（朋克 / 潮流 / street food）",
+        optional: true,
+        durationMin: 60,
       },
       {
         time: "19:00",
@@ -2438,36 +2539,42 @@ const days: Day[] = [
         query: "Brick Lane, London",
         note: "潮牌 / vintage",
         time: "10:00",
+        optional: true,
       },
       {
         name: "South Bank · Tate Modern",
         query: "Tate Modern, London",
         note: "免费 · 河岸漫步（Borough Market 周一休市）",
         time: "12:00",
+        optional: true,
       },
       {
         name: "Covent Garden · Seven Dials",
         query: "Covent Garden, London",
         note: "英伦品牌",
         time: "14:00",
+        optional: true,
       },
       {
         name: "牛津街 Oxford Street",
         query: "Oxford Street, London",
         note: "扫货",
         time: "14:00",
+        optional: true,
       },
       {
         name: "Harrods · 骑士桥",
         query: "Harrods, London",
         note: "顶奢 · Food Hall 手信",
         time: "14:00",
+        optional: true,
       },
       {
         name: "Camden Market",
         query: "Camden Market, London",
         note: "可选",
         time: "17:00",
+        optional: true,
       },
     ],
     restaurants: [

--- a/apps/trip-planner/src/data/types.ts
+++ b/apps/trip-planner/src/data/types.ts
@@ -26,6 +26,12 @@ export interface MapPlace {
   /** Short trigger for dropping to this option, e.g. "没约到就" or "不想开车".
    *  Shown as a chip beside the option in the ladder. */
   when?: string;
+  /** A "nice to have" stop the group can cut when the day runs late, rather than
+   *  protected backbone — see {@link TimelineItem.optional}. */
+  optional?: boolean;
+  /** Rough minutes spent here, the time reclaimed by skipping it — see
+   *  {@link TimelineItem.durationMin}. */
+  durationMin?: number;
 }
 
 /** A confirmed booking attached to a restaurant. */
@@ -58,6 +64,13 @@ export interface Restaurant {
    *  dinner), used to weave dining into the chronological feed at the right
    *  time. Omit to keep it as a day-level option. */
   time?: string;
+  /** A skippable meal rather than protected backbone — see
+   *  {@link TimelineItem.optional}. A `booked` restaurant is always treated as
+   *  backbone regardless of this flag. */
+  optional?: boolean;
+  /** Rough minutes at the table, the time reclaimed by skipping it — see
+   *  {@link TimelineItem.durationMin}. */
+  durationMin?: number;
 }
 
 export interface Lodging {
@@ -87,6 +100,15 @@ export interface Stay {
 export interface TimelineItem {
   time: string;
   text: string;
+  /** A "nice to have" step (a sightseeing stop, shopping, an unbooked meal)
+   *  rather than the day's protected backbone (travel, check-in/out, booked
+   *  tables). On the current day these can be toggled off near "now" to claw
+   *  back time when the day is running behind; the choice persists on-device. */
+  optional?: boolean;
+  /** Rough minutes this step needs — the time reclaimed by skipping it, summed
+   *  into the planner's "saved" estimate. Optional steps without one default to
+   *  30min. */
+  durationMin?: number;
 }
 
 export interface Weather {
@@ -130,6 +152,13 @@ export interface NavLeg {
   /** Departure time for this hop, used to slot the leg into the day's
    *  chronological feed at the moment you set off. */
   time?: string;
+  /** An optional detour — the drive to a skippable stop — rather than a
+   *  mandatory hop. When its stop is dropped, this leg drops with it and the
+   *  next kept drive re-routes from this leg's origin. See
+   *  {@link TimelineItem.optional}. */
+  optional?: boolean;
+  /** Rough driving minutes for this hop. */
+  durationMin?: number;
 }
 
 /** A tick-through checklist (e.g. 入境流程, 还车检查). State lives client-side. */
@@ -209,6 +238,9 @@ export interface Tip {
   /** When this heads-up is relevant, used to weave it into the feed next to
    *  the moment it serves. Omit for day-wide notes (shown in 今日须知). */
   time?: string;
+  /** Tie this heads-up to an optional stop so it drops away with it, rather
+   *  than keeping a moment alive on its own — see {@link TimelineItem.optional}. */
+  optional?: boolean;
 }
 
 /** One end of a flight — an airport plus the local clock time there. */

--- a/apps/trip-planner/src/lib/schedule.test.ts
+++ b/apps/trip-planner/src/lib/schedule.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyDrops,
+  buildDayFeed,
+  formatDuration,
+  optionalMoments,
+} from "./schedule";
+import type { Day } from "@/data/types";
+
+/** A minimal day with the required scaffolding; pass the fields a test cares
+ *  about. Keeps each case focused on the scheduling behaviour under test. */
+function makeDay(partial: Partial<Day>): Day {
+  return {
+    n: 1,
+    date: "2026-06-24",
+    dateLabel: "6月24日",
+    weekday: "周三",
+    title: "Test day",
+    route: "A → B",
+    timeline: [],
+    places: [],
+    restaurants: [],
+    stay: { summary: "Stay", lodging: [] },
+    ...partial,
+  };
+}
+
+/** A clean drive chain: depart → optional A → optional B → booked lunch →
+ *  arrive, with each optional stop owning its inbound drive so drops re-stitch. */
+function chainDay(): Day {
+  return makeDay({
+    anchors: [{ time: "13:00", label: "Arrive", kind: "checkin" }],
+    timeline: [
+      { time: "09:00", text: "Depart" },
+      { time: "10:00", text: "Stop A", optional: true, durationMin: 30 },
+      { time: "11:00", text: "Stop B", optional: true, durationMin: 45 },
+      { time: "12:00", text: "Lunch" },
+      { time: "13:00", text: "Arrive" },
+    ],
+    nav: [
+      {
+        label: "Home→A",
+        from: "Home",
+        to: "A",
+        time: "10:00",
+        optional: true,
+        durationMin: 20,
+      },
+      {
+        label: "A→B",
+        from: "A",
+        to: "B",
+        time: "11:00",
+        optional: true,
+        durationMin: 25,
+      },
+      { label: "B→Lunch", from: "B", to: "Lunch", time: "12:00" },
+    ],
+    places: [
+      { name: "A", query: "A", time: "10:00", optional: true },
+      { name: "B", query: "B", time: "11:00", optional: true },
+    ],
+    restaurants: [
+      {
+        name: "Table",
+        query: "Table",
+        time: "12:00",
+        status: "booked",
+        tag: "set",
+        description: "booked table",
+      },
+    ],
+  });
+}
+
+const at = (moments: ReturnType<typeof buildDayFeed>, time: string) =>
+  moments.find((moment) => moment.time === time);
+
+describe("buildDayFeed classification", () => {
+  it("marks a fully-optional stop optional and sums its dwell", () => {
+    const moments = buildDayFeed(chainDay());
+    const a = at(moments, "10:00");
+    expect(a?.optional).toBe(true);
+    expect(a?.hard).toBe(false);
+    // max over the stop's pieces: dwell 30 beats the 20min inbound drive.
+    expect(a?.durationMin).toBe(30);
+  });
+
+  it("treats a booked table as a hard, non-optional moment", () => {
+    const moments = buildDayFeed(chainDay());
+    const lunch = at(moments, "12:00");
+    expect(lunch?.hard).toBe(true);
+    expect(lunch?.optional).toBe(false);
+  });
+
+  it("keeps a moment with any backbone piece non-optional", () => {
+    // Depart carries a plain (non-optional) timeline step.
+    const moments = buildDayFeed(chainDay());
+    expect(at(moments, "09:00")?.optional).toBe(false);
+  });
+
+  it("treats a checkout anchor's time as a hard deadline", () => {
+    const day = makeDay({
+      anchors: [{ time: "10:00", label: "Check out", kind: "checkout" }],
+      timeline: [
+        { time: "10:00", text: "Leave", optional: true, durationMin: 15 },
+      ],
+    });
+    const moment = at(buildDayFeed(day), "10:00");
+    expect(moment?.hard).toBe(true);
+    expect(moment?.optional).toBe(false);
+  });
+
+  it("defaults an optional stop with no stated duration to 30 minutes", () => {
+    const day = makeDay({
+      timeline: [{ time: "10:00", text: "Wander", optional: true }],
+      places: [{ name: "Wander", query: "W", time: "10:00", optional: true }],
+    });
+    expect(at(buildDayFeed(day), "10:00")?.durationMin).toBe(30);
+  });
+
+  it("does not flag a flight moment optional", () => {
+    const day = makeDay({
+      timeline: [{ time: "08:00", text: "Land", optional: true }],
+      flights: [
+        {
+          number: "CX255",
+          from: { code: "HKG", city: "HK" },
+          to: { code: "LHR", city: "London" },
+          time: "08:00",
+        },
+      ],
+    });
+    const moment = at(buildDayFeed(day), "08:00");
+    expect(moment?.hard).toBe(true);
+    expect(moment?.optional).toBe(false);
+  });
+});
+
+describe("optionalMoments", () => {
+  it("returns optional stops in time order", () => {
+    const optionals = optionalMoments(buildDayFeed(chainDay()));
+    expect(optionals.map((moment) => moment.time)).toEqual(["10:00", "11:00"]);
+  });
+
+  it("keeps only stops still ahead of the given clock", () => {
+    const optionals = optionalMoments(buildDayFeed(chainDay()), 10 * 60 + 30);
+    expect(optionals.map((moment) => moment.time)).toEqual(["11:00"]);
+  });
+});
+
+describe("applyDrops", () => {
+  it("returns the full feed and zero saved when nothing is dropped", () => {
+    const moments = buildDayFeed(chainDay());
+    const plan = applyDrops(moments, new Set());
+    expect(plan.rows).toHaveLength(moments.length);
+    expect(plan.savedMinutes).toBe(0);
+    expect(plan.droppedLabels).toEqual([]);
+  });
+
+  it("removes a dropped stop and re-routes the next drive from its origin", () => {
+    const moments = buildDayFeed(chainDay());
+    const plan = applyDrops(moments, new Set(["10:00"]));
+
+    expect(plan.rows.map((row) => row.moment.time)).toEqual([
+      "09:00",
+      "11:00",
+      "12:00",
+      "13:00",
+    ]);
+    expect(plan.savedMinutes).toBe(30);
+    expect(plan.droppedLabels).toEqual(["A"]);
+
+    const stopB = plan.rows.find((row) => row.moment.time === "11:00");
+    const drive = stopB?.moment.nav[0];
+    expect(drive?.from).toBe("Home"); // re-stitched past the skipped stop
+    expect(drive?.skipped).toEqual(["A"]);
+    expect(stopB?.skippedBefore).toEqual(["A"]);
+  });
+
+  it("carries the original origin across consecutive drops", () => {
+    const moments = buildDayFeed(chainDay());
+    const plan = applyDrops(moments, new Set(["10:00", "11:00"]));
+
+    expect(plan.rows.map((row) => row.moment.time)).toEqual([
+      "09:00",
+      "12:00",
+      "13:00",
+    ]);
+    expect(plan.savedMinutes).toBe(75);
+
+    const lunch = plan.rows.find((row) => row.moment.time === "12:00");
+    expect(lunch?.moment.nav[0]?.from).toBe("Home");
+    expect(lunch?.moment.nav[0]?.skipped).toEqual(["A", "B"]);
+  });
+
+  it("never drops a backbone moment, even if its time is in the set", () => {
+    const moments = buildDayFeed(chainDay());
+    const plan = applyDrops(moments, new Set(["12:00"]));
+    expect(plan.rows.map((row) => row.moment.time)).toContain("12:00");
+    expect(plan.savedMinutes).toBe(0);
+  });
+
+  it("does not mutate the input moments", () => {
+    const moments = buildDayFeed(chainDay());
+    const before = at(moments, "11:00")?.nav[0]?.from;
+    applyDrops(moments, new Set(["10:00"]));
+    expect(at(moments, "11:00")?.nav[0]?.from).toBe(before);
+  });
+});
+
+describe("formatDuration", () => {
+  it.each([
+    [30, "30 分钟"],
+    [60, "1 小时"],
+    [75, "1 小时 15 分钟"],
+    [90, "1 小时 30 分钟"],
+  ])("formats %i minutes as %s", (minutes, expected) => {
+    expect(formatDuration(minutes)).toBe(expected);
+  });
+});

--- a/apps/trip-planner/src/lib/schedule.ts
+++ b/apps/trip-planner/src/lib/schedule.ts
@@ -1,4 +1,5 @@
 import type {
+  AnchorKind,
   Checklist,
   Day,
   Flight,
@@ -61,7 +62,31 @@ export interface DayMoment {
   checklists: Checklist[];
   signSheets: SignSheet[];
   flights: Flight[];
+  /** Every piece here is a "nice to have" and nothing fixed sits in it — the
+   *  user can toggle the whole moment off near "now" to reclaim its time. */
+  optional: boolean;
+  /** A fixed commitment whose time is sacred (a booked table, a flight, a hard
+   *  anchor like a checkout deadline). Never offered as droppable. */
+  hard: boolean;
+  /** Rough minutes this moment occupies — for an optional stop, the time
+   *  reclaimed by dropping it. Feeds the planner's "saved" estimate. */
+  durationMin: number;
 }
+
+/** Anchor kinds with a sacred clock time: miss them and the day breaks. A
+ *  `checkin` is flexible (arrive whenever) and a `drive` is just a waypoint, so
+ *  neither bounds the plan. */
+const HARD_ANCHOR_KINDS = new Set<AnchorKind>([
+  "flight",
+  "pickup",
+  "dropoff",
+  "reservation",
+  "transit",
+  "checkout",
+]);
+
+/** Minutes assumed reclaimed by an optional stop that states no `durationMin`. */
+const DEFAULT_OPTIONAL_MINUTES = 30;
 
 /**
  * Weave a day's parallel arrays into one chronological feed. Every timeline
@@ -88,6 +113,9 @@ export function buildDayFeed(day: Day): DayMoment[] {
       checklists: [],
       signSheets: [],
       flights: [],
+      optional: false,
+      hard: false,
+      durationMin: 0,
     };
     moments.set(time, created);
     return created;
@@ -107,7 +135,169 @@ export function buildDayFeed(day: Day): DayMoment[] {
   for (const sheet of day.signSheets ?? [])
     if (sheet.time) at(sheet.time).signSheets.push(sheet);
 
+  const hardAnchorTimes = new Set(
+    (day.anchors ?? [])
+      .filter((anchor) => anchor.time && HARD_ANCHOR_KINDS.has(anchor.kind))
+      .map((anchor) => anchor.time),
+  );
+  for (const moment of moments.values())
+    classifyMoment(moment, hardAnchorTimes.has(moment.time));
+
   return [...moments.values()].sort((a, b) => a.minutes - b.minutes);
+}
+
+/** Fill in a moment's `optional` / `hard` / `durationMin` from its contents. A
+ *  moment is optional only when it carries content and *every* piece of it is
+ *  flagged optional — and nothing fixed (a booked table, a flight, a checklist,
+ *  a sign sheet, a hard anchor time) sits in it. Those make it a sacred
+ *  commitment instead. */
+function classifyMoment(moment: DayMoment, onHardAnchor: boolean): void {
+  const bookedTable = moment.dining.some((r) => r.status === "booked");
+  const hasFlight = moment.flights.length > 0;
+  const hasChecklist = moment.checklists.length > 0;
+  const hasSignSheet = moment.signSheets.length > 0;
+
+  const pieces = [
+    ...moment.events,
+    ...moment.nav,
+    ...moment.tips,
+    ...moment.dining,
+    ...moment.places,
+  ];
+  const everyPieceOptional =
+    pieces.length > 0 && pieces.every((piece) => piece.optional === true);
+
+  moment.hard = onHardAnchor || bookedTable || hasFlight;
+  moment.optional =
+    everyPieceOptional && !moment.hard && !hasChecklist && !hasSignSheet;
+
+  const stated = pieces.reduce((max, piece) => {
+    const value = "durationMin" in piece ? piece.durationMin : undefined;
+    return typeof value === "number" && value > max ? value : max;
+  }, 0);
+  moment.durationMin =
+    stated > 0 ? stated : moment.optional ? DEFAULT_OPTIONAL_MINUTES : 0;
+}
+
+/** A short name for a moment — its lead place, meal, step or leg — used by the
+ *  planner toggles and the "skipped" reroute note. */
+export function momentLabel(moment: DayMoment): string {
+  if (moment.places.length > 0) return moment.places[0].name;
+  if (moment.dining.length > 0) return moment.dining[0].name;
+  if (moment.events.length > 0) return moment.events[0].text;
+  if (moment.nav.length > 0) return moment.nav[0].label;
+  return moment.time;
+}
+
+/** The optional moments of a day, in time order — the stops the planner can
+ *  offer to drop. Pass `fromMinutes` to keep only those still ahead of "now",
+ *  since the planner edits the *future* of the day. */
+export function optionalMoments(
+  moments: DayMoment[],
+  fromMinutes?: number,
+): DayMoment[] {
+  return moments.filter(
+    (moment) =>
+      moment.optional &&
+      (fromMinutes === undefined || moment.minutes >= fromMinutes),
+  );
+}
+
+/** A nav leg as rendered in the feed: the authored leg, plus the names of any
+ *  optional stops dropped just before it, when the route was re-stitched to
+ *  start from where those stops' drive began. */
+export interface FeedNavLeg extends NavLeg {
+  skipped?: string[];
+}
+
+/** A moment as it appears once the user's drops are applied: the (possibly
+ *  re-routed) moment, plus any optional stops collapsed away right before it. */
+export interface PlannedMoment {
+  moment: Omit<DayMoment, "nav"> & { nav: FeedNavLeg[] };
+  /** Names of optional stops dropped immediately before this moment, attached
+   *  to its re-routed drive so the change reads honestly. */
+  skippedBefore: string[];
+}
+
+/** The day's feed with the user's dropped optionals removed. */
+export interface DayPlan {
+  /** Visible moments in time order, with navigation re-stitched around drops. */
+  rows: PlannedMoment[];
+  /** Minutes reclaimed by the current drops — the headline "saved" estimate. */
+  savedMinutes: number;
+  /** Names of every dropped stop, for the summary line. */
+  droppedLabels: string[];
+}
+
+/** Is this leg a drive (the default mode) we can re-stitch a route through? */
+function isDrivingLeg(leg: NavLeg): boolean {
+  return (leg.mode ?? "driving") === "driving";
+}
+
+/**
+ * Remove the user-dropped optional moments from a day's feed and re-stitch the
+ * drive around them: a dropped stop takes its inbound detour with it, and the
+ * next kept drive picks up from where that detour began — so the route stays
+ * honest (origin → next kept stop) instead of routing through a place you
+ * skipped. Backbone moments are never dropped, even if their `time` is in the
+ * set, so a stale entry can't strand a must-do.
+ *
+ * Pure: `dropped` is a set of moment `time`s (each unique within a day).
+ */
+export function applyDrops(
+  moments: DayMoment[],
+  dropped: ReadonlySet<string>,
+): DayPlan {
+  const rows: PlannedMoment[] = [];
+  const droppedLabels: string[] = [];
+  let savedMinutes = 0;
+
+  // Carried across a run of drops: where the skipped detour set off from, and
+  // the names of the stops skipped, to re-point and annotate the next drive.
+  let carryFrom: string | undefined;
+  let carrySkipped: string[] = [];
+
+  for (const moment of moments) {
+    if (moment.optional && dropped.has(moment.time)) {
+      savedMinutes += moment.durationMin;
+      droppedLabels.push(momentLabel(moment));
+      carrySkipped.push(momentLabel(moment));
+      const detour = moment.nav.find((leg) => isDrivingLeg(leg) && leg.from);
+      if (carryFrom === undefined && detour?.from) carryFrom = detour.from;
+      continue;
+    }
+
+    if (carryFrom !== undefined) {
+      const idx = moment.nav.findIndex(isDrivingLeg);
+      if (idx >= 0) {
+        const nav: FeedNavLeg[] = moment.nav.map((leg, i) =>
+          i === idx ? { ...leg, from: carryFrom, skipped: carrySkipped } : leg,
+        );
+        rows.push({
+          moment: { ...moment, nav },
+          skippedBefore: carrySkipped,
+        });
+        carryFrom = undefined;
+        carrySkipped = [];
+        continue;
+      }
+      // No drive here to graft onto yet — keep carrying to a later moment.
+    }
+
+    rows.push({ moment: { ...moment, nav: moment.nav }, skippedBefore: [] });
+  }
+
+  return { rows, savedMinutes, droppedLabels };
+}
+
+/** Format reclaimed minutes as concise Chinese, e.g. "1 小时 5 分钟" / "45 分钟". */
+export function formatDuration(minutes: number): string {
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  if (hours > 0 && mins > 0)
+    return `${String(hours)} 小时 ${String(mins)} 分钟`;
+  if (hours > 0) return `${String(hours)} 小时`;
+  return `${String(mins)} 分钟`;
 }
 
 /** A stable DOM id for a moment, shared by the feed (sets it) and the glance

--- a/apps/trip-planner/vitest.config.ts
+++ b/apps/trip-planner/vitest.config.ts
@@ -1,0 +1,18 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// The trip-planner's unit tests cover pure scheduling logic only, so a plain
+// node environment (no jsdom / StyleX / babel) keeps this config minimal.
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(dirname, "./src"),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   apps/web:
     dependencies:


### PR DESCRIPTION
## Why

On a touring day the plan rarely survives contact with reality: a museum runs long, lunch drags, and suddenly the back half of the day is over-scheduled. Until now the itinerary stayed rigid — the traveller had to mentally work out which stops to skip, how much time that buys back, and where the next drive should actually start from. This makes the **today** view honest about what's still doable: drop the optional stops you no longer have time for, keep every must-do, and watch the time reclaimed and the route adjust.

## What it does

A single **调整后续行程** control sits by the **现在** marker in today's feed. Open it and you get a switch-list of the day's *future* optional stops — each showing its rough duration — that you can toggle off. As you do:

- The feed re-times around what's left and the headline shows the time reclaimed (省下约 …).
- When a dropped stop owned its inbound drive, the next kept drive re-routes from where that detour began. Both the Google Maps deep-link and the inline embed are corrected, and the leg carries a 已跳过 X · 从上一站直接前往 note so the change reads honestly.
- Choices persist on-device (localStorage, one record per trip) so a slimmed-down plan survives a reload.

Two guarantees hold throughout:

- **Must-dos are untouchable.** A moment is only droppable when every piece in it is optional *and* nothing fixed sits there — a booked table, a flight, a checklist/sign-sheet, or a hard anchor (checkout, flight, reservation, transit, pickup, dropoff). Flexible check-ins and plain waypoints don't pin a moment.
- **The editor only appears on the real current day**, and only lists optional stops still ahead of "now" — it edits the future of the day, never the past.

The feature is data-driven: `optional` / `durationMin` were authored on the GB trip's remaining touring days (Day 6 through Day 11). Past days were intentionally left un-authored since the planner only renders on the day that is "today".

## How the re-stitch works

When a dropped stop took the inbound drive with it, the route can't keep pointing through a place you skipped — so the origin is carried forward to the next kept drive:

```mermaid
flowchart LR
  A[Origin] -->|drive| B["Optional stop (dropped)"]
  B -->|drive| C[Next kept stop]
  A -.->|re-stitched drive · 已跳过 B| C
```

`applyDrops` carries the dropped detour's origin and the skipped names forward, grafts them onto the next driving leg, and sums the reclaimed minutes. Backbone moments are never removed even if a stale id lands in the dropped set, so nothing can strand a must-do.

## Tests

The trip-planner app had no tests; this adds a minimal node-environment Vitest setup to unit-test the pure scheduling logic and assert the data invariants — no must-do is ever droppable, and every remaining touring day offers at least one option. Verified live on the running app on Day 6.
