### PR TITLE
refactor: restructure color foundations page around hierarchy

### DIFF
--- a/apps/web/src/app/[locale]/design-system/foundations/color/page.tsx
+++ b/apps/web/src/app/[locale]/design-system/foundations/color/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { DocPage } from "#src/components/design-system/doc-page.tsx";
 import { BackgroundsShowcase } from "#src/components/design-system/sections/tokens/backgrounds-showcase.tsx";
+import { ColorHierarchy } from "#src/components/design-system/sections/tokens/color-hierarchy.tsx";
 import { PaletteShowcase } from "#src/components/design-system/sections/tokens/palette-showcase.tsx";
 import { RolesShowcase } from "#src/components/design-system/sections/tokens/roles-showcase.tsx";
 import { t } from "#src/i18n.ts";
@@ -26,6 +27,7 @@ export default function ColorPage() {
         zh: "十三种系统色调通过 Material 3 的 HCT 展开为感知均匀的色调阶梯，再映射到语义化的背景、表面与文本角色令牌。",
       })}
     >
+      <ColorHierarchy />
       <PaletteShowcase />
       <BackgroundsShowcase />
       <RolesShowcase />

--- a/apps/web/src/app/[locale]/design-system/foundations/color/page.tsx
+++ b/apps/web/src/app/[locale]/design-system/foundations/color/page.tsx
@@ -23,8 +23,8 @@ export default function ColorPage() {
     <DocPage
       title={t({ en: "Color", zh: "颜色" })}
       description={t({
-        en: "Thirteen system hues, expanded into perceptually even tonal palettes via Material 3's HCT, then mapped onto semantic background, surface, and text-role tokens.",
-        zh: "十三种系统色调通过 Material 3 的 HCT 展开为感知均匀的色调阶梯，再映射到语义化的背景、表面与文本角色令牌。",
+        en: "Thirteen system hues, expanded into perceptually even tonal palettes, then mapped onto semantic background, surface, and text-role tokens.",
+        zh: "十三种系统色调展开为感知均匀的色调阶梯，再映射到语义化的背景、表面与文本角色令牌。",
       })}
     >
       <ColorHierarchy />

--- a/apps/web/src/components/design-system/role-column.tsx
+++ b/apps/web/src/components/design-system/role-column.tsx
@@ -52,18 +52,18 @@ const styles = stylex.create({
     gridRow: "span 5",
     // Gridline-via-gap: the column is a solid bgCanvas rectangle (the canvas
     // ground the tiles sit on); the cells cover it except the row gaps, so the
-    // ground shows through as hairline dividers, with a matching bgCanvas
-    // border as the outer frame. A border (unlike padding) makes overflow
-    // shrink the clip radius by its own width, so the corner cells stay
-    // concentric with the frame and the ground doesn't bulge at the rounded
-    // corners. Replaces the inset box-shadow, which children paint over.
-    // Translucent role fills composite over this ground, so dividers read
-    // softer next to them.
+    // ground shows through as hairline dividers. The outer frame is neutralBorder
+    // so each column still reads as a self-contained unit now that the section
+    // sits on the bare page canvas rather than inside a surface card. A border
+    // (unlike padding) makes overflow shrink the clip radius by its own width, so
+    // the corner cells stay concentric with the frame and the ground doesn't
+    // bulge at the rounded corners. Translucent role fills still composite over
+    // the bgCanvas ground, so dividers read softer next to them.
     rowGap: space._00,
     backgroundColor: color.bgCanvas,
     borderWidth: space._00,
     borderStyle: "solid",
-    borderColor: color.bgCanvas,
+    borderColor: color.neutralBorder,
     borderRadius: border.radius_2,
     overflow: "hidden",
   },

--- a/apps/web/src/components/design-system/sections/tokens/backgrounds-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/tokens/backgrounds-showcase.tsx
@@ -66,7 +66,7 @@ function Band({ name, description, children, columns }: BandProps) {
 
 export function BackgroundsShowcase() {
   return (
-    <Showcase label={t({ en: "Backgrounds", zh: "背景" })}>
+    <Showcase label={t({ en: "Surfaces", zh: "表面" })} frame="plain">
       <ShowcaseHelper>
         {t({
           en: "Surfaces are organised by role, not tonal step. Pick by what the surface is for — scaffolding, a card, an interactive state, an attention-grabbing inverse, or a floating overlay — and the right tone follows.",
@@ -248,19 +248,21 @@ const styles = stylex.create({
     lineHeight: font.lineHeight_4,
   },
   // Gridline-via-gap: the grid is a solid bgCanvas rectangle (the canvas ground
-  // the surface tiles sit on); the opaque cells cover it except the gaps, so
-  // the ground shows through as hairline dividers, with a matching bgCanvas
-  // border as the outer frame. A border (unlike padding) makes overflow shrink
-  // the clip radius by its own width, so the corner cells stay concentric with
-  // the frame instead of bulging the ground at the rounded corners. (The Page
-  // band's Canvas swatch shares this tone, so it reads flush with the ground.)
+  // the surface tiles sit on); the opaque cells cover it except the gaps, so the
+  // ground shows through as hairline dividers. The outer frame is neutralBorder
+  // so the specimen still reads as a self-contained unit now that it sits on the
+  // bare page canvas rather than inside a surface card — the Page band's Canvas
+  // swatch shares the interior ground, so it reads flush there while the frame
+  // keeps a crisp edge. A border (unlike padding) makes overflow shrink the clip
+  // radius by its own width, so the corner cells stay concentric with the frame
+  // instead of bulging the ground at the rounded corners.
   grid: {
     display: "grid",
     gap: space._00,
     backgroundColor: color.bgCanvas,
     borderWidth: space._00,
     borderStyle: "solid",
-    borderColor: color.bgCanvas,
+    borderColor: color.neutralBorder,
     borderRadius: border.radius_2,
     overflow: "hidden",
   },

--- a/apps/web/src/components/design-system/sections/tokens/color-hierarchy.tsx
+++ b/apps/web/src/components/design-system/sections/tokens/color-hierarchy.tsx
@@ -1,0 +1,334 @@
+import * as stylex from "@stylexjs/stylex";
+import { breakpoints } from "@tuja/ui/breakpoints.stylex";
+import { systemPalette } from "@tuja/ui/palette-table";
+import { border, color, font, shadow, space } from "@tuja/ui/tokens.stylex";
+import type { ReactNode } from "react";
+import { t } from "#src/i18n.ts";
+import { Showcase } from "../../showcase.tsx";
+
+// Tones sampled for the miniature hue ramps — a light-to-dark spread that reads
+// as a compact stand-in for the full 21-tone scale demonstrated further down.
+const MINI_TONES = [11, 20, 40, 60, 80, 92] as const;
+
+// The semantic roles previewed as dots in stage 3, in the order they appear in
+// the Roles section below.
+const ROLE_DOTS = [
+  color.accent,
+  color.info,
+  color.success,
+  color.warning,
+  color.danger,
+];
+
+/**
+ * Opening explainer for the colour page: a three-stage flow that names how the
+ * system is layered — the system palette feeds design tokens, which are grouped
+ * into the surfaces and roles shown below. This is the one deliberately
+ * highlighted block on the page, so it renders through the shared Showcase card
+ * frame while the sections beneath it read plainly from the page canvas.
+ */
+export function ColorHierarchy() {
+  return (
+    <Showcase frame="card">
+      <p css={styles.lead}>
+        {t({
+          en: "Colour is layered. A fixed system palette defines every available tone; design tokens reference those tones with intent; and the tokens are grouped into the surfaces and roles the app actually uses.",
+          zh: "颜色是分层的。固定的系统调色板定义了所有可用色调；设计令牌带着语义引用这些色调；令牌再归类为应用真正使用的表面与角色。",
+        })}
+      </p>
+
+      <div css={styles.flow}>
+        <Stage
+          step="01"
+          name={t({ en: "System palette", zh: "系统调色板" })}
+          detail={t({
+            en: "13 hues × 21 tones. The full range of available colour — never referenced directly.",
+            zh: "13 种色相 × 21 级色调。全部可用颜色的范围——但从不直接引用。",
+          })}
+          visual={<PaletteVisual />}
+        />
+
+        <Connector label={t({ en: "referenced by", zh: "被引用" })} />
+
+        <Stage
+          step="02"
+          name={t({ en: "Design tokens", zh: "设计令牌" })}
+          detail={t({
+            en: "Semantic, purpose-named values that point at specific palette tones. What the app is built from.",
+            zh: "语义化、按用途命名的值，指向特定的调色板色调。应用由此构建。",
+          })}
+          visual={<TokensVisual />}
+        />
+
+        <Connector label={t({ en: "grouped into", zh: "归类为" })} />
+
+        <Stage
+          step="03"
+          name={t({ en: "Surfaces & roles", zh: "表面与角色" })}
+          detail={t({
+            en: "Tokens organised by purpose — background surfaces and semantic colour roles. Demonstrated below.",
+            zh: "按用途组织的令牌——背景表面与语义颜色角色。下方演示。",
+          })}
+          visual={<TokensDownstreamVisual />}
+        />
+      </div>
+    </Showcase>
+  );
+}
+
+interface StageProps {
+  step: string;
+  name: string;
+  detail: string;
+  visual: ReactNode;
+}
+
+function Stage({ step, name, detail, visual }: StageProps) {
+  return (
+    <article css={styles.stage}>
+      <header css={styles.stageHeader}>
+        <span css={styles.step}>{step}</span>
+        <h3 css={styles.stageName}>{name}</h3>
+      </header>
+      <div css={styles.visual}>{visual}</div>
+      <p css={styles.detail}>{detail}</p>
+    </article>
+  );
+}
+
+function Connector({ label }: { label: string }) {
+  return (
+    <div css={styles.connector} aria-hidden>
+      <span css={styles.connectorArrow}>→</span>
+      <span css={styles.connectorLabel}>{label}</span>
+    </div>
+  );
+}
+
+// Stage 1 — thirteen thin hue columns, each a stack of tone segments: the
+// hues × tones grid in miniature.
+function PaletteVisual() {
+  return (
+    <div css={styles.palette} aria-hidden>
+      {systemPalette.map((hue) => (
+        <div key={hue.name} css={styles.paletteColumn}>
+          {MINI_TONES.map((tone) => (
+            <span
+              key={tone}
+              css={styles.paletteCell}
+              style={{ backgroundColor: hue.tones[tone].bg }}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// Stage 2 — token chips, each a named reference resolving to a live token value.
+function TokensVisual() {
+  return (
+    <div css={styles.tokens} aria-hidden>
+      <span css={[styles.tokenChip, styles.chipAccent]}>accent</span>
+      <span css={[styles.tokenChip, styles.chipSurface]}>bgSurface</span>
+      <span css={[styles.tokenChip, styles.chipDanger]}>danger</span>
+    </div>
+  );
+}
+
+// Stage 3 — layered surface cards beside a role dot cluster: the two families
+// demonstrated below.
+function TokensDownstreamVisual() {
+  return (
+    <div css={styles.downstream} aria-hidden>
+      <div css={styles.surfaceStack}>
+        <span css={[styles.surfaceCard, styles.surfaceCardBack]} />
+        <span css={[styles.surfaceCard, styles.surfaceCardFront]} />
+      </div>
+      <div css={styles.roleDots}>
+        {ROLE_DOTS.map((role) => (
+          <span
+            key={role}
+            css={styles.roleDot}
+            style={{ backgroundColor: role }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  lead: {
+    margin: 0,
+    fontSize: font.uiBody,
+    color: color.textMuted,
+    lineHeight: font.lineHeight_4,
+    maxInlineSize: "70ch",
+    textWrap: "pretty",
+  },
+  flow: {
+    display: "flex",
+    flexDirection: { default: "column", [breakpoints.lg]: "row" },
+    gap: space._2,
+  },
+  stage: {
+    flex: "1",
+    minInlineSize: 0,
+    display: "flex",
+    flexDirection: "column",
+    gap: space._3,
+    padding: space._4,
+    backgroundColor: color.bgCanvas,
+    border: `1px solid ${color.neutralBorder}`,
+    borderRadius: border.radius_2,
+  },
+  stageHeader: {
+    display: "flex",
+    alignItems: "baseline",
+    gap: space._2,
+  },
+  step: {
+    fontFamily: font.familyMono,
+    fontSize: font.uiOverline,
+    fontWeight: font.weight_6,
+    color: color.textSubtle,
+    letterSpacing: font.trackingWider,
+  },
+  stageName: {
+    margin: 0,
+    fontSize: font.uiBody,
+    fontWeight: font.weight_7,
+    color: color.textMain,
+    letterSpacing: font.trackingTight,
+    lineHeight: font.lineHeight_1,
+  },
+  visual: {
+    display: "flex",
+    alignItems: "center",
+    minBlockSize: "48px",
+  },
+  detail: {
+    margin: 0,
+    fontSize: font.uiCaption,
+    color: color.textSubtle,
+    lineHeight: font.lineHeight_4,
+    textWrap: "pretty",
+  },
+
+  // Connector between stages: horizontal arrow on wide layouts, pointing down
+  // when the flow stacks.
+  connector: {
+    display: "flex",
+    flexDirection: { default: "row", [breakpoints.lg]: "column" },
+    alignItems: "center",
+    justifyContent: "center",
+    gap: space._1,
+    paddingBlock: { default: space._0, [breakpoints.lg]: 0 },
+    paddingInline: { default: 0, [breakpoints.lg]: space._0 },
+  },
+  connectorArrow: {
+    fontSize: font.uiBodySmall,
+    lineHeight: font.lineHeight_1,
+    color: color.textSubtle,
+    transform: { default: "rotate(90deg)", [breakpoints.lg]: "rotate(0deg)" },
+  },
+  connectorLabel: {
+    fontSize: font.uiOverline,
+    color: color.textSubtle,
+    letterSpacing: font.trackingWide,
+    whiteSpace: "nowrap",
+  },
+
+  // Stage 1 visual
+  palette: {
+    display: "flex",
+    gap: "2px",
+    inlineSize: "100%",
+  },
+  paletteColumn: {
+    flex: "1",
+    minInlineSize: 0,
+    display: "flex",
+    flexDirection: "column",
+    borderRadius: border.radius_1,
+    overflow: "hidden",
+  },
+  paletteCell: {
+    blockSize: "8px",
+  },
+
+  // Stage 2 visual
+  tokens: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: space._1,
+  },
+  tokenChip: {
+    display: "inline-flex",
+    alignItems: "center",
+    paddingBlock: space._0,
+    paddingInline: space._2,
+    borderRadius: border.radius_round,
+    fontFamily: font.familyMono,
+    fontSize: font.uiOverline,
+    fontWeight: font.weight_6,
+    letterSpacing: font.trackingWide,
+  },
+  chipAccent: {
+    backgroundColor: color.surfaceAccentSubtle,
+    color: color.accentText,
+  },
+  chipSurface: {
+    backgroundColor: color.bgSurfaceSunken,
+    color: color.textMuted,
+    boxShadow: `inset 0 0 0 1px ${color.neutralBorder}`,
+  },
+  chipDanger: {
+    backgroundColor: color.surfaceDangerSubtle,
+    color: color.dangerText,
+  },
+
+  // Stage 3 visual
+  downstream: {
+    display: "flex",
+    alignItems: "center",
+    gap: space._4,
+  },
+  // Two offset cards — the back one recessed, the front one raised with a
+  // shadow — so "surfaces" reads as layered depth rather than three near-equal
+  // near-white swatches.
+  surfaceStack: {
+    position: "relative",
+    inlineSize: "42px",
+    blockSize: "34px",
+    flexShrink: 0,
+  },
+  surfaceCard: {
+    position: "absolute",
+    inlineSize: "28px",
+    blockSize: "28px",
+    borderRadius: border.radius_2,
+    border: `1px solid ${color.neutralBorder}`,
+  },
+  surfaceCardBack: {
+    insetBlockStart: 0,
+    insetInlineStart: 0,
+    backgroundColor: color.bgSurfaceSunken,
+  },
+  surfaceCardFront: {
+    insetBlockEnd: 0,
+    insetInlineEnd: 0,
+    backgroundColor: color.bgSurfaceRaised,
+    boxShadow: shadow._2,
+  },
+  roleDots: {
+    display: "flex",
+    gap: "4px",
+  },
+  roleDot: {
+    inlineSize: "12px",
+    blockSize: "12px",
+    borderRadius: border.radius_round,
+  },
+});

--- a/apps/web/src/components/design-system/sections/tokens/palette-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/tokens/palette-showcase.tsx
@@ -36,8 +36,8 @@ export function PaletteShowcase() {
     >
       <ShowcaseHelper>
         {t({
-          en: "Thirteen hues, each expanded into a 21-step tonal scale via Material 3's HCT. The complete range of available colour — consumed only through the design tokens above.",
-          zh: "十三种色相，各自通过 Material 3 的 HCT 展开为 21 级色调阶梯。全部可用颜色的范围——仅通过上方的设计令牌使用。",
+          en: "Thirteen hues, each expanded into a perceptually even 21-step tonal scale. The complete range of available colour — consumed only through the design tokens above.",
+          zh: "十三种色相，各自展开为感知均匀的 21 级色调阶梯。全部可用颜色的范围——仅通过上方的设计令牌使用。",
         })}
       </ShowcaseHelper>
       <ul css={styles.list}>

--- a/apps/web/src/components/design-system/sections/tokens/palette-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/tokens/palette-showcase.tsx
@@ -1,276 +1,127 @@
 import * as stylex from "@stylexjs/stylex";
-import { breakpoints } from "@tuja/ui/breakpoints.stylex";
 import {
   type SystemHuePalette,
   SYSTEM_PALETTE_TONES,
   systemPalette,
 } from "@tuja/ui/palette-table";
-import {
-  border,
-  color,
-  font,
-  layer,
-  shadow,
-  space,
-} from "@tuja/ui/tokens.stylex";
+import { border, color, font, space } from "@tuja/ui/tokens.stylex";
 import { t } from "#src/i18n.ts";
 import { ShowcaseHelper } from "../../showcase-helper.tsx";
 import { Showcase } from "../../showcase.tsx";
 
-const FEATURED_TONES: ReadonlySet<number> = new Set([40, 80]);
+// Cell widths taper smoothly from a wide centre to narrow ends, so each ramp
+// reads like a lens over its mid-tones. Raising the sine to the fourth power
+// concentrates the width into a sharp central peak — the mid tones dominate and
+// the taper accelerates toward the ends — while the 0.18fr floor keeps the
+// outermost cells legible. Applied inline because the varying template is not a
+// static value StyleX can inline. Every ramp shares the same 21-tone shape,
+// computed once.
+const RAMP_COLUMNS = SYSTEM_PALETTE_TONES.map((_tone, index) => {
+  const position = index / (SYSTEM_PALETTE_TONES.length - 1);
+  const width = 0.18 + 2.8 * Math.sin(Math.PI * position) ** 4;
+  return `${width.toFixed(3)}fr`;
+}).join(" ");
 
-// Column counts per breakpoint — keep in sync with styles.grid.
-const GRID_COLUMNS = { md: 2, lg: 3 };
-
-// When the hue count leaves a single card alone on the final row, center it
-// rather than stranding it flush-left: full width in the 2-col grid, the middle
-// column in the 3-col grid. Gating each breakpoint on `count % cols === 1` means
-// the override disappears cleanly when the count is a multiple of that column
-// count (no stray-span collision), and it keeps working as hues are added.
-function orphanColumnVars(count: number) {
-  const center = (cols: number) =>
-    cols % 2 === 1 ? String(Math.ceil(cols / 2)) : "1 / -1";
-  return {
-    "--orphan-col-md":
-      count % GRID_COLUMNS.md === 1 ? center(GRID_COLUMNS.md) : "auto",
-    "--orphan-col-lg":
-      count % GRID_COLUMNS.lg === 1 ? center(GRID_COLUMNS.lg) : "auto",
-  };
-}
-
+/**
+ * The system palette, shown as a plain reference sheet: one row per hue, each a
+ * label and its full tonal ramp. It is intentionally quiet — this is the raw
+ * range the tokens draw from, not something the app styles against directly — so
+ * the surfaces and roles below carry the visual weight.
+ */
 export function PaletteShowcase() {
-  const lastIndex = systemPalette.length - 1;
-  const orphanVars = orphanColumnVars(systemPalette.length);
-
   return (
-    <Showcase label={t({ en: "Tonal palettes", zh: "色调阶梯" })}>
+    <Showcase
+      label={t({ en: "System palette", zh: "系统调色板" })}
+      frame="plain"
+    >
       <ShowcaseHelper>
         {t({
-          en: "Tones 40 and 80 are featured as key stops — the typical pairing for solid roles and their soft surfaces.",
-          zh: "40 与 80 为关键色阶——通常用作实色角色与对应柔和表面。",
+          en: "Thirteen hues, each expanded into a 21-step tonal scale via Material 3's HCT. The complete range of available colour — consumed only through the design tokens above.",
+          zh: "十三种色相，各自通过 Material 3 的 HCT 展开为 21 级色调阶梯。全部可用颜色的范围——仅通过上方的设计令牌使用。",
         })}
       </ShowcaseHelper>
-      <div css={styles.grid}>
-        {systemPalette.map((palette, index) => (
-          <PaletteSpecimen
-            key={palette.name}
-            palette={palette}
-            orphanVars={index === lastIndex ? orphanVars : undefined}
-          />
+      <ul css={styles.list}>
+        {systemPalette.map((palette) => (
+          <PaletteRow key={palette.name} palette={palette} />
         ))}
-      </div>
+      </ul>
     </Showcase>
   );
 }
 
-function PaletteSpecimen({
-  palette,
-  orphanVars,
-}: {
-  palette: SystemHuePalette;
-  orphanVars?: ReturnType<typeof orphanColumnVars>;
-}) {
-  const solid = palette.tones[40];
-  const soft = palette.tones[80];
-
+function PaletteRow({ palette }: { palette: SystemHuePalette }) {
   return (
-    <article
-      css={styles.card}
-      role="group"
-      aria-label={palette.name}
-      style={{ "--source": palette.source, ...orphanVars }}
-    >
-      <div css={styles.wash} aria-hidden />
-
-      <header css={styles.header}>
-        <div css={styles.identity}>
-          <h3 css={styles.name}>{palette.name}</h3>
-          <span css={styles.source}>{palette.source}</span>
-        </div>
-
-        <div css={styles.demo} aria-hidden>
-          <div
-            css={styles.demoSurface}
-            style={{
-              backgroundColor: soft.bg,
-              color: `contrast-color(${soft.bg})`,
-            }}
-          >
-            <div
-              css={styles.demoChip}
-              style={{
-                backgroundColor: solid.bg,
-                color: `contrast-color(${solid.bg})`,
-              }}
-            >
-              Aa
-            </div>
-            <div css={styles.demoMeta}>
-              <span css={styles.demoMetaPrimary}>40</span>
-              <span css={styles.demoMetaDivider}>·</span>
-              <span css={styles.demoMetaSecondary}>80</span>
-            </div>
-          </div>
-        </div>
-      </header>
-
-      <div css={styles.tones}>
-        {SYSTEM_PALETTE_TONES.map((tone) => {
-          const swatch = palette.tones[tone];
-          const featured = FEATURED_TONES.has(tone);
-          return (
-            <div
-              key={tone}
-              css={[styles.tone, featured && styles.toneFeatured]}
-              style={{
-                backgroundColor: swatch.bg,
-                color: `contrast-color(${swatch.bg})`,
-              }}
-              role="img"
-              aria-label={`${palette.name} ${String(tone)}`}
-            />
-          );
-        })}
+    <li css={styles.row}>
+      <div css={styles.identity}>
+        <span css={styles.name}>{palette.name}</span>
+        <span css={styles.source}>{palette.source}</span>
       </div>
-    </article>
+      <div
+        css={styles.ramp}
+        style={{ gridTemplateColumns: RAMP_COLUMNS }}
+        role="img"
+        aria-label={palette.name}
+      >
+        {SYSTEM_PALETTE_TONES.map((tone) => (
+          <span
+            key={tone}
+            css={styles.tone}
+            style={{ backgroundColor: palette.tones[tone].bg }}
+          />
+        ))}
+      </div>
+    </li>
   );
 }
 
 const styles = stylex.create({
-  // Two-up field-guide layout: specimen cards flow into a responsive grid so the
-  // thirteen hues read as a compact reference sheet rather than a tall stack.
-  grid: {
-    display: "grid",
-    gridTemplateColumns: {
-      default: "minmax(0, 1fr)",
-      [breakpoints.md]: "repeat(2, minmax(0, 1fr))",
-      [breakpoints.lg]: "repeat(3, minmax(0, 1fr))",
-    },
-    gap: space._3,
-  },
-  card: {
-    position: "relative",
-    // A lone card on the final row reads `--orphan-col-*` (set only on that card
-    // by `orphanColumnVars`) to center itself — full width at md, middle column at
-    // lg. Every other card leaves the vars unset and falls back to `auto`.
-    gridColumn: {
-      default: "auto",
-      [breakpoints.md]: "var(--orphan-col-md, auto)",
-      [breakpoints.lg]: "var(--orphan-col-lg, auto)",
-    },
+  list: {
+    listStyle: "none",
+    margin: 0,
+    padding: 0,
     display: "flex",
     flexDirection: "column",
     gap: space._2,
-    paddingBlock: space._3,
-    paddingInline: space._4,
-    backgroundColor: color.bgSurfaceRaised,
-    border: `1px solid ${color.neutralBorder}`,
-    borderRadius: border.radius_3,
-    overflow: "hidden",
-    isolation: "isolate",
   },
-  wash: {
-    position: "absolute",
-    insetBlockStart: 0,
-    insetInlineEnd: 0,
-    inlineSize: "55%",
-    blockSize: "100%",
-    background:
-      "radial-gradient(120% 140% at 100% 0%, var(--source) 0%, transparent 55%)",
-    opacity: 0.12,
-    pointerEvents: "none",
-    zIndex: layer.background,
-  },
-  header: {
+  // Label sits beside the ramp on wide rows and wraps above it when space runs
+  // out, so the ramp always keeps a usable width.
+  row: {
     display: "flex",
     flexWrap: "wrap",
-    alignItems: "flex-start",
-    justifyContent: "space-between",
-    gap: space._3,
+    alignItems: "center",
+    columnGap: space._4,
+    rowGap: space._1,
   },
   identity: {
+    flexShrink: 0,
+    inlineSize: "6.5rem",
     display: "flex",
-    flexDirection: "column",
-    gap: space._00,
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    gap: space._2,
   },
   name: {
-    margin: 0,
-    fontSize: font.uiHeading2,
-    fontWeight: font.weight_7,
+    fontSize: font.uiBodySmall,
+    fontWeight: font.weight_6,
     color: color.textMain,
     letterSpacing: font.trackingTight,
-    lineHeight: font.lineHeight_1,
   },
   source: {
     fontFamily: font.familyMono,
-    fontSize: font.uiCaption,
-    color: color.textSubtle,
-    letterSpacing: font.trackingWide,
-  },
-  demo: {
-    flexShrink: 0,
-    display: "flex",
-  },
-  demoSurface: {
-    display: "flex",
-    alignItems: "center",
-    gap: space._2,
-    paddingBlock: space._1,
-    paddingInline: space._2,
-    borderRadius: border.radius_2,
-    boxShadow: shadow._1,
-  },
-  demoChip: {
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    inlineSize: "28px",
-    blockSize: "28px",
-    borderRadius: border.radius_round,
-    fontFamily: font.family,
-    fontSize: font.uiBodySmall,
-    fontWeight: font.weight_7,
-    letterSpacing: font.trackingTight,
-  },
-  demoMeta: {
-    display: "flex",
-    alignItems: "center",
-    gap: "4px",
-    fontFamily: font.familyMono,
     fontSize: font.uiOverline,
-    fontWeight: font.weight_6,
-    letterSpacing: font.trackingWider,
+    color: color.textSubtle,
   },
-  demoMetaPrimary: {
-    opacity: 0.95,
-  },
-  demoMetaSecondary: {
-    opacity: 0.55,
-  },
-  demoMetaDivider: {
-    opacity: 0.4,
-  },
-  tones: {
+  ramp: {
+    flex: "1",
+    minInlineSize: "220px",
     display: "grid",
-    // Compact mode unfurls all 21 tones into a single slim ramp at every width,
-    // so the brightness curve reads as one gesture; featured 40/80 carry rings
-    // and the Aa demo names the key stops, replacing per-cell numerals.
-    gridTemplateColumns: "repeat(21, minmax(0, 1fr))",
+    // Columns are supplied inline (RAMP_COLUMNS) to taper the cell widths.
+    blockSize: "26px",
     borderRadius: border.radius_2,
     overflow: "hidden",
     boxShadow: `inset 0 0 0 1px ${color.neutralBorder}`,
   },
   tone: {
-    position: "relative",
-    minBlockSize: "30px",
-    // Hover widens the swatch over its neighbours and lifts it above them; the
-    // z-index reset is delayed so it stays on top while scaling back. A drop
-    // shadow would be clipped by the ramp's `overflow: hidden`, so there is none.
-    transition: "transform 220ms cubic-bezier(0.2, 0, 0, 1), z-index 0ms 220ms",
-    zIndex: { default: layer.base, ":hover": layer.content },
-    transform: { default: "scale(1)", ":hover": "scale(1.12)" },
-  },
-  toneFeatured: {
-    boxShadow: "inset 0 0 0 1.5px currentColor",
+    minInlineSize: 0,
   },
 });

--- a/apps/web/src/components/design-system/sections/tokens/roles-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/tokens/roles-showcase.tsx
@@ -7,7 +7,7 @@ import { Showcase } from "../../showcase.tsx";
 
 export function RolesShowcase() {
   return (
-    <Showcase label={t({ en: "Roles", zh: "角色" })}>
+    <Showcase label={t({ en: "Roles", zh: "角色" })} frame="plain">
       <div css={styles.grid}>
         <RoleColumn
           name={t({ en: "Neutral", zh: "中性" })}

--- a/apps/web/src/components/design-system/showcase.tsx
+++ b/apps/web/src/components/design-system/showcase.tsx
@@ -5,15 +5,26 @@ import type { ReactNode } from "react";
 
 interface ShowcaseProps {
   label?: string;
+  /**
+   * Section framing. `"card"` (default) wraps the section in a raised surface —
+   * the treatment shared across the design-system doc pages. `"plain"` drops the
+   * card chrome so the section reads from its heading and surrounding spacing
+   * alone, letting inner surfaces carry the emphasis instead. The colour page
+   * pilots `"plain"`; other pages keep the card default untouched.
+   */
+  frame?: "card" | "plain";
   children: ReactNode;
 }
 
-export function Showcase({ label, children }: ShowcaseProps) {
+export function Showcase({ label, frame = "card", children }: ShowcaseProps) {
+  const plain = frame === "plain";
   return (
-    <div css={styles.showcase}>
-      {label ? <span css={styles.label}>{label}</span> : null}
+    <section css={[styles.showcase, plain ? styles.plainFrame : styles.card]}>
+      {label ? (
+        <h2 css={plain ? styles.headingPlain : styles.label}>{label}</h2>
+      ) : null}
       <div css={styles.body}>{children}</div>
-    </div>
+    </section>
   );
 }
 
@@ -44,17 +55,35 @@ const styles = stylex.create({
     display: "flex",
     flexDirection: "column",
     gap: space._3,
+  },
+  // Default doc-page framing: a raised surface card.
+  card: {
     padding: space._5,
     backgroundColor: color.bgSurface,
     border: `1px solid ${color.neutralBorder}`,
     borderRadius: border.radius_3,
   },
+  // Plain framing: no card chrome. The section is delineated by its heading and
+  // the generous gap the doc-page body puts between siblings, so the page canvas
+  // stays the ground and inner surfaces do the highlighting.
+  plainFrame: {
+    gap: space._4,
+  },
   label: {
+    margin: 0,
     fontSize: font.uiCaption,
     color: color.textSubtle,
     letterSpacing: font.trackingWider,
     textTransform: "uppercase",
     fontWeight: font.weight_6,
+  },
+  headingPlain: {
+    margin: 0,
+    fontSize: font.uiHeading2,
+    fontWeight: font.weight_7,
+    color: color.textMain,
+    letterSpacing: font.trackingTight,
+    lineHeight: font.lineHeight_1,
   },
   body: {
     display: "flex",


### PR DESCRIPTION
## Why

The color foundations page (`/design-system/foundations/color`) opened straight into swatches with no explanation of what the color system is actually made of. Every section also sat inside its own raised surface card, so the card background — not the heading and content — was what delineated a section. And the system-palette section was visually loud (13 bordered cards, radial wash gradients, decorative "Aa · 40·80" demo pills) competing for attention with the surfaces and roles the app actually consumes.

This reorders the page around the system's real hierarchy and quiets the raw-material section so the consumable tokens carry the weight.

## The hierarchy the page now teaches

```mermaid
flowchart LR
  A["System palette<br/>13 hues × 21 tones<br/>(never referenced directly)"]
  -- referenced by --> B["Design tokens<br/>purpose-named values<br/>pointing at palette tones"]
  -- grouped into --> C["Surfaces &amp; roles<br/>what the app consumes<br/>(demonstrated below)"]
```

## What changed

- **New opening explainer** names those three stages up front, with a miniature visual for each, so the rest of the page has a frame of reference. It is the one deliberately highlighted block, so it keeps a card surface.
- **The system palette reads as raw material.** It is now a compact reference list — one row per hue (name + source hex + a clean tonal ramp) — instead of a grid of washed cards, so it sits secondary to the surfaces and roles below. The ramps use a center-wide / edge-narrow width taper, so mid-tones read as a dominant band lensing out to thin cells at the dark and light ends.
- **Sections are delineated by heading and spacing, not cards.** A new `frame="card" | "plain"` variant on the shared `Showcase` lets the color page's sections opt out of the card chrome and read from the bare page canvas. The default stays `"card"`, so the other doc pages (typography, elevation, badge, divider) are untouched. The surfaces/roles tile grids switch their outer frame from the page-canvas color to a neutral border so they still read as self-contained specimens now that they sit on the canvas rather than inside a card.

Only application/component code changed, plus the one new explainer component.