### PR TITLE
fix: generate i18n manifest before dev server starts

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,7 @@
     "codegen:pwa-icons": "node ../../packages/pwa-icons/src/hash-icons.mjs",
     "codegen:tmdb": "node ../../packages/tmdb-codegen/src/generator.js && prettier 'src/_generated/*.ts' -w",
     "codegen:zod": "tsx ../../packages/tmdb-codegen/src/generate-selective-zod.ts && prettier 'src/_generated/tmdb-zod.ts' -w",
-    "predev": "pnpm codegen:palette",
+    "predev": "npm-run-all codegen:i18n codegen:palette",
     "dev": "run-p watch:i18n dev:next",
     "dev:next": "next dev --turbopack -p $(node ../../scripts/worktree-port.mjs)",
     "build": "next build && serwist build serwist.config.mjs",


### PR DESCRIPTION
## Why

On the first `pnpm dev` in a fresh worktree, client components (Card, ExternalLinkIndicator, Calculator, …) throw `[i18n] Missing translation key` during SSR. Pages still return HTTP 200, so it looks harmless — but the errors flood the dev log, and any agent (or human) reading that log wastes time chasing a non-bug before they can verify their actual change.

## Root cause

It's a startup race, not a translation problem:

- The i18n Babel plugin reads `src/_generated/i18n/manifest.json` via `fs.readFileSync` at plugin-construction time — **not** as a module import. So Turbopack never records that a compiled page depends on the manifest.
- `predev` previously generated only the palette, so on a fresh worktree the git-ignored i18n files don't exist yet. `dev` then runs the i18n watcher and `next dev` **in parallel** (`run-p watch:i18n dev:next`).
- Any page Turbopack compiles during that startup window — before the watcher has written the manifest — gets **no** `ClientTranslationsProvider` injected. `I18nContext` stays at its empty default and every client `t()` throws.
- Because Turbopack doesn't know about the untracked manifest, it caches that broken compile and never recompiles it — the page stays poisoned for the whole session.

This was confirmed deterministically: blanking `manifest.json` to `{}` with a clean `.next` reproduced the exact same keys/components; restoring the full manifest with a clean `.next` produced zero errors.

```mermaid
sequenceDiagram
    participant predev
    participant watch_i18n
    participant next_dev
    Note over predev,next_dev: Before — predev generates palette only
    predev->>predev: codegen:palette (no i18n)
    par dev runs watch_i18n and next_dev in parallel
        watch_i18n-->>watch_i18n: writes manifest.json (eventually)
    and
        next_dev->>next_dev: compiles page NOW, manifest missing,<br/>no provider injected, t() throws, compile cached
    end
    Note over predev,next_dev: After — predev generates i18n first
    predev->>predev: codegen:i18n, then codegen:palette
    predev-->>next_dev: manifest complete before boot, no race
```

## Fix

Generate i18n in `predev` so the manifest is complete before `next dev` boots. `predev` blocks `dev`, so the race is eliminated. This mirrors what `prebuild` and `pretest` already do — both run `codegen:i18n` up front. `predev` now matches `pretest` exactly.

## Validation

Fresh-worktree simulation (removed `.next` + generated i18n) → `pnpm dev` while hammering pages during startup → 0 missing-key errors; i18n codegen finishes before Next is ready. `pnpm format:changed`, `pnpm lint:changed`, `pnpm test` (1270 passed), and `pnpm build` all green.

## Caveat

This protects genuinely fresh worktrees, which start with no `.next`. A worktree that already carries a **poisoned** `.next` from prior activity needs a one-time `rm -rf apps/web/.next`; newly created `git worktree add` trees don't carry `.next`, so they're covered.
