### PR TITLE
refactor: frame system-palette swatches like surfaces

### DIFF
--- a/apps/web/src/components/design-system/sections/tokens/palette-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/tokens/palette-showcase.tsx
@@ -116,10 +116,15 @@ const styles = stylex.create({
     minInlineSize: "220px",
     display: "grid",
     // Columns are supplied inline (RAMP_COLUMNS) to taper the cell widths.
+    gap: border.size_1,
     blockSize: "26px",
+    boxSizing: "border-box",
+    backgroundColor: color.bgCanvas,
+    borderWidth: space._00,
+    borderStyle: "solid",
+    borderColor: color.neutralBorder,
     borderRadius: border.radius_2,
     overflow: "hidden",
-    boxShadow: `inset 0 0 0 1px ${color.neutralBorder}`,
   },
   tone: {
     minInlineSize: 0,


### PR DESCRIPTION
On the color foundations page (`/design-system/foundations/color`), the Surfaces specimen and the System palette section framed their swatches differently. Surfaces wrapped each swatch in a real `neutralBorder` border with quiet `bgCanvas` gaps showing through as internal dividers, whereas each hue's tonal ramp relied only on an inset box-shadow. The two specimens sat on the same page and read inconsistently.

This applies the Surfaces framing technique to the System palette ramps: a real `neutralBorder` border becomes the dominant outer edge of each ramp, and the grid's `bgCanvas` ground shows through hairline gaps as soft dividers between tones — border loud, dividers quiet, matching Surfaces exactly. The frame uses `border-box` sizing so the strip keeps its height, and `overflow: hidden` keeps the corner cells concentric with the rounded frame.

The internal divider gap is a crisp 1px (`border.size_1`) rather than a sub-pixel `0.1rem`. Across the tapered ramp columns a sub-pixel gap rasterised unevenly (some dividers landing at 1px, others at 2px); the whole-pixel gap renders evenly on every column.

Change is CSS-only, confined to the palette showcase's StyleX definitions. Verified visually in the browser.