### PR TITLE
build: upgrade pnpm to 11.10.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-public-hoist-pattern[]=*@nextui-org/*
-public-hoist-pattern[]=*eslint*

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "24.x",
     "pnpm": ">=9"
   },
-  "packageManager": "pnpm@10.28.1+sha512.7d7dbbca9e99447b7c3bf7a73286afaaf6be99251eb9498baefa7d406892f67b879adb3a1d7e687fc4ccc1a388c7175fbaae567a26ab44d1067b54fcb0d6a316",
+  "packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8",
   "scripts": {
     "dev": "turbo dev",
     "build": "turbo build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,11 @@
 packages:
   - "apps/*"
   - "packages/*"
+allowBuilds:
+  esbuild: false
+  msw: false
+  sharp: false
+  unrs-resolver: false
 catalog:
   react: 19.3.0-canary-56824423-20260414
   react-dom: 19.3.0-canary-56824423-20260414


### PR DESCRIPTION
## Why

An update banner flagged pnpm 10.28.1 as outdated. This bumps the pinned package manager to pnpm 11.10.0. CI uses `pnpm/action-setup@v6` with no pinned version, so it reads the `packageManager` field from `package.json` and picks up 11.10.0 automatically — no workflow changes needed.

pnpm 11 changed two behaviours that had to be handled to keep the frozen install green:

### 1. Ignored build scripts are now a hard error

pnpm 11 promotes ignored build scripts from a soft warning (pnpm 10) to a hard `ERR_PNPM_IGNORED_BUILDS` failure (exit 1), which would break CI's `pnpm install --frozen-lockfile` step. The project previously had no build-script approval config.

The decision was to **keep these scripts skipped**, preserving the exact pnpm 10 behaviour rather than approving/running them. All four packages (`esbuild`, `msw`, `sharp`, `unrs-resolver`) ship prebuilt binaries, so skipping their build scripts is functionally fine. They are now listed under `allowBuilds` set to `false` in `pnpm-workspace.yaml` — pnpm 11's mechanism to explicitly acknowledge skipped builds and silence the error.

### 2. Settings moved out of `.npmrc`

pnpm 11 no longer reads most settings from `.npmrc` (only auth/registry). The file contained only two `public-hoist-pattern[]` entries, both of which were verified **dead**, not merely stale:

- `*@nextui-org/*` — the project migrated off NextUI to HeroUI; the package is no longer installed anywhere.
- `*eslint*` — proven unnecessary by running an uncached lint across all packages with the pattern removed and eslint un-hoisted from root: lint passed with 0 errors, because the flat config (`eslint.config.mjs`) imports plugins by path rather than resolving them by name from `node_modules`.

Since both entries were dead, `.npmrc` was deleted entirely rather than migrated.

## Verification

- `pnpm install --frozen-lockfile` exits 0; lockfile is unchanged (stays v9.0).
- Forced uncached `pnpm lint` across all 13 packages, `tsc --noEmit`, and `pnpm test` (1169 pass) all green.