### PR TITLE
feat: add card component to the design system

### DIFF
--- a/apps/web/src/app/[locale]/design-system/components/card/page.tsx
+++ b/apps/web/src/app/[locale]/design-system/components/card/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import { DocPage } from "#src/components/design-system/doc-page.tsx";
+import { CardShowcase } from "#src/components/design-system/sections/components/card-showcase.tsx";
+import { t } from "#src/i18n.ts";
+import type { PageProps } from "#src/types.ts";
+import { validateLocale } from "#src/utils/validate-locale.ts";
+import { designSystemMetadata } from "../../route-metadata.ts";
+
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { locale } = await props.params;
+  return designSystemMetadata({
+    locale: validateLocale(locale),
+    path: "/design-system/components/card",
+    title: t({ en: "Card", zh: "卡片" }),
+  });
+}
+
+export default function CardPage() {
+  return (
+    <DocPage
+      title={t({ en: "Card", zh: "卡片" })}
+      description={t({
+        en: "A bordered surface container. Static by default for panels and alerts; interactive for a clickable tile. When the whole card is a link, compose the surface onto a real anchor.",
+        zh: "带描边的表面容器。默认为静态形态，用于面板与提示；可交互形态用于可点击的卡片。当整张卡片为链接时，将该表面组合到真实的锚点元素上。",
+      })}
+    >
+      <CardShowcase />
+    </DocPage>
+  );
+}

--- a/apps/web/src/app/[locale]/design-system/page.tsx
+++ b/apps/web/src/app/[locale]/design-system/page.tsx
@@ -1,6 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
+import { cardSurface } from "@tuja/ui/components/card.stylex";
 import { transition } from "@tuja/ui/primitives/motion.stylex";
-import { border, color, font, space } from "@tuja/ui/tokens.stylex";
+import { color, font, space } from "@tuja/ui/tokens.stylex";
 import Link from "next/link";
 import { ViewTransition } from "react";
 import {
@@ -145,6 +146,13 @@ export default function DesignSystemOverview() {
         zh: "六种色调的行内消息框，用于状态与提示。",
       }),
     },
+    "/design-system/components/card": {
+      label: t({ en: "Card", zh: "卡片" }),
+      description: t({
+        en: "A bordered surface container, static or interactive.",
+        zh: "带描边的表面容器，支持静态或可交互两种形态。",
+      }),
+    },
     "/design-system/components/spinner": {
       label: t({ en: "Spinner", zh: "加载指示器" }),
       description: t({
@@ -257,7 +265,12 @@ export default function DesignSystemOverview() {
                   <Link
                     key={path}
                     href={getLocalePath(path, locale)}
-                    css={[transition.colors, styles.tile]}
+                    css={[
+                      transition.colors,
+                      cardSurface.base,
+                      cardSurface.interactive,
+                      styles.tile,
+                    ]}
                   >
                     <span css={styles.tileName}>{entry.label}</span>
                     <span css={styles.tileDescription}>
@@ -325,14 +338,6 @@ const styles = stylex.create({
     gap: space._1,
     paddingBlock: space._3,
     paddingInline: space._4,
-    borderWidth: border.size_1,
-    borderStyle: "solid",
-    borderColor: { default: color.neutralBorder, ":hover": color.accentBorder },
-    borderRadius: border.radius_3,
-    backgroundColor: {
-      default: color.bgSurface,
-      ":hover": color.bgInteractiveHover,
-    },
     textDecoration: "none",
   },
   tileName: {

--- a/apps/web/src/app/sitemap.xml
+++ b/apps/web/src/app/sitemap.xml
@@ -341,6 +341,16 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/design-system/components/callout" />
   </url>
   <url>
+    <loc>https://qingqi.dev/design-system/components/card</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/design-system/components/card" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/design-system/components/card" />
+  </url>
+  <url>
+    <loc>https://qingqi.dev/zh/design-system/components/card</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/design-system/components/card" />
+    <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/design-system/components/card" />
+  </url>
+  <url>
     <loc>https://qingqi.dev/design-system/components/spinner</loc>
     <xhtml:link rel="alternate" hreflang="en" href="https://qingqi.dev/design-system/components/spinner" />
     <xhtml:link rel="alternate" hreflang="zh" href="https://qingqi.dev/zh/design-system/components/spinner" />

--- a/apps/web/src/components/ai-chat/session-restore-banner.tsx
+++ b/apps/web/src/components/ai-chat/session-restore-banner.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
+import { Card } from "@tuja/ui/components/card";
 import { flex } from "@tuja/ui/primitives/flex.stylex";
 import { buttonReset } from "@tuja/ui/primitives/reset.stylex";
 import { border, color, font, space } from "@tuja/ui/tokens.stylex";
@@ -36,7 +37,7 @@ export function SessionRestoreBanner({
       : t({ en: "Continue", zh: "继续" });
 
   return (
-    <div css={[flex.row, styles.banner]} role={hasError ? "alert" : undefined}>
+    <Card css={[flex.row, styles.banner]} role={hasError ? "alert" : undefined}>
       <p css={[styles.text, hasError && styles.errorText]}>{message}</p>
       <div css={[flex.row, styles.actions]}>
         <button
@@ -57,7 +58,7 @@ export function SessionRestoreBanner({
           {continueLabel}
         </button>
       </div>
-    </div>
+    </Card>
   );
 }
 
@@ -65,13 +66,6 @@ const styles = stylex.create({
   banner: {
     alignItems: "center",
     gap: space._2,
-    paddingBlock: space._3,
-    paddingInline: space._4,
-    borderWidth: border.size_1,
-    borderStyle: "solid",
-    borderColor: color.neutralBorder,
-    borderRadius: border.radius_3,
-    backgroundColor: color.bgSurface,
   },
   text: {
     margin: 0,

--- a/apps/web/src/components/design-system/design-system-nav.tsx
+++ b/apps/web/src/components/design-system/design-system-nav.tsx
@@ -66,6 +66,7 @@ export function DesignSystemNav() {
     }),
     "/design-system/components/badge": t({ en: "Badge", zh: "徽章" }),
     "/design-system/components/callout": t({ en: "Callout", zh: "提示框" }),
+    "/design-system/components/card": t({ en: "Card", zh: "卡片" }),
     "/design-system/components/spinner": t({ en: "Spinner", zh: "加载指示器" }),
     "/design-system/components/skeleton": t({ en: "Skeleton", zh: "骨架屏" }),
     "/design-system/components/divider": t({ en: "Divider", zh: "分隔线" }),

--- a/apps/web/src/components/design-system/routes.ts
+++ b/apps/web/src/components/design-system/routes.ts
@@ -56,6 +56,7 @@ export const DESIGN_SYSTEM_ROUTES = [
   { group: "components", path: "/design-system/components/menu-button" },
   { group: "components", path: "/design-system/components/badge" },
   { group: "components", path: "/design-system/components/callout" },
+  { group: "components", path: "/design-system/components/card" },
   { group: "components", path: "/design-system/components/spinner" },
   { group: "components", path: "/design-system/components/skeleton" },
   { group: "components", path: "/design-system/components/divider" },

--- a/apps/web/src/components/design-system/sections/components/card-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/components/card-showcase.tsx
@@ -1,0 +1,176 @@
+import * as stylex from "@stylexjs/stylex";
+import { Card } from "@tuja/ui/components/card";
+import { cardSurface } from "@tuja/ui/components/card.stylex";
+import { transition } from "@tuja/ui/primitives/motion.stylex";
+import { color, font, space } from "@tuja/ui/tokens.stylex";
+import { t } from "#src/i18n.ts";
+import { DoDont } from "../../do-dont.tsx";
+import { PropsTable } from "../../props-table.tsx";
+import { Showcase } from "../../showcase.tsx";
+import { UsageSnippet } from "../../usage-snippet.tsx";
+
+export function CardShowcase() {
+  const sampleTitle = t({ en: "Typography", zh: "排版" });
+  const sampleBody = t({
+    en: "Families, the type scale, weights, and heading and body styles.",
+    zh: "字体、字号阶梯、字重，以及标题与正文样式。",
+  });
+
+  return (
+    <>
+      <Showcase label={t({ en: "Surface", zh: "表面" })}>
+        <Card css={styles.stack}>
+          <span css={styles.title}>{sampleTitle}</span>
+          <span css={styles.body}>{sampleBody}</span>
+        </Card>
+      </Showcase>
+
+      <Showcase label={t({ en: "Interactive", zh: "可交互" })}>
+        <Card interactive css={styles.stack}>
+          <span css={styles.title}>{sampleTitle}</span>
+          <span css={styles.body}>{sampleBody}</span>
+        </Card>
+      </Showcase>
+
+      <Showcase label={t({ en: "As a link", zh: "作为链接" })}>
+        {/* The whole card is clickable, so it renders a real anchor and composes
+            the same surface. This is the pattern the design-system overview grid
+            uses for its Next.js <Link> tiles. */}
+        <a
+          href="#card"
+          css={[
+            transition.colors,
+            cardSurface.base,
+            cardSurface.interactive,
+            styles.link,
+          ]}
+        >
+          <span css={styles.title}>{sampleTitle}</span>
+          <span css={styles.body}>{sampleBody}</span>
+        </a>
+      </Showcase>
+
+      <Showcase label={t({ en: "Usage", zh: "用法" })}>
+        <UsageSnippet
+          code={`import { Card } from "@tuja/ui/components/card";
+
+// A static surface — a panel, an alert, a list item.
+<Card role="alert">Heads up.</Card>
+
+// When the whole card is clickable, render a real anchor or button and
+// compose the surface from the escape-hatch styles.
+import { cardSurface } from "@tuja/ui/components/card.stylex";
+import { transition } from "@tuja/ui/primitives/motion.stylex";
+
+<Link
+  href={href}
+  css={[transition.colors, cardSurface.base, cardSurface.interactive]}
+>
+  …
+</Link>`}
+          label="tsx"
+        />
+      </Showcase>
+
+      <Showcase>
+        <PropsTable
+          rows={[
+            {
+              name: "children",
+              type: "ReactNode",
+              required: true,
+              description: t({
+                en: "Card contents.",
+                zh: "卡片内容。",
+              }),
+            },
+            {
+              name: "interactive",
+              type: "boolean",
+              defaultValue: "false",
+              description: t({
+                en: "Adds a hover border and background lift plus an eased transition, for a card that is itself clickable.",
+                zh: "添加悬停描边、背景抬升与缓动过渡，适用于本身可点击的卡片。",
+              }),
+            },
+            {
+              name: "css",
+              type: "StyleXStyles",
+              description: t({
+                en: "StyleX overrides composed last — including the padding, so a denser or roomier card is a one-liner.",
+                zh: "最后合成的 StyleX 覆盖样式——包括内边距，因此更紧凑或更宽松的卡片只需一行。",
+              }),
+            },
+            {
+              name: "…div attributes",
+              type: 'ComponentProps<"div">',
+              description: t({
+                en: "Native div attributes (role, id, onClick, data-*, className, style, ref) are forwarded.",
+                zh: "原生 div 属性（role、id、onClick、data-*、className、style、ref）会被转发。",
+              }),
+            },
+          ]}
+        />
+      </Showcase>
+
+      <Showcase label={t({ en: "Guidelines", zh: "使用准则" })}>
+        <DoDont
+          do={
+            <a
+              href="#card"
+              css={[
+                transition.colors,
+                cardSurface.base,
+                cardSurface.interactive,
+                styles.link,
+              ]}
+            >
+              <span css={styles.title}>{sampleTitle}</span>
+              <span css={styles.body}>{sampleBody}</span>
+            </a>
+          }
+          doCaption={t({
+            en: "For a clickable card, render a real anchor or button and compose cardSurface — it stays focusable and is announced as a link.",
+            zh: "可点击的卡片应渲染真实的链接或按钮并组合 cardSurface——它可获得焦点并被读屏识别为链接。",
+          })}
+          dont={
+            <Card interactive css={styles.stack}>
+              <span css={styles.title}>{sampleTitle}</span>
+              <span css={styles.body}>{sampleBody}</span>
+            </Card>
+          }
+          dontCaption={t({
+            en: "Don't use a bare interactive Card (a div) as a link — it isn't keyboard-focusable and screen readers won't announce it.",
+            zh: "不要把可交互的 Card（一个 div）当作链接使用——它无法通过键盘聚焦，读屏软件也不会识别它。",
+          })}
+        />
+      </Showcase>
+    </>
+  );
+}
+
+const styles = stylex.create({
+  stack: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space._1,
+  },
+  link: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space._1,
+    paddingBlock: space._3,
+    paddingInline: space._4,
+    textDecoration: "none",
+  },
+  title: {
+    fontSize: font.uiHeading3,
+    fontWeight: font.weight_7,
+    color: color.textMain,
+  },
+  body: {
+    fontSize: font.uiBodySmall,
+    color: color.textMuted,
+    lineHeight: font.lineHeight_4,
+  },
+});

--- a/apps/web/src/components/pixel-creature-creator/landing/featured-row.tsx
+++ b/apps/web/src/components/pixel-creature-creator/landing/featured-row.tsx
@@ -1,5 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 import { breakpoints } from "@tuja/ui/breakpoints.stylex";
+import { cardSurface } from "@tuja/ui/components/card.stylex";
 import { color, font, space } from "@tuja/ui/tokens.stylex";
 import { t } from "#src/i18n.ts";
 import type { SupportedLocale } from "#src/types.ts";
@@ -42,7 +43,7 @@ export function FeaturedRow({ locale }: FeaturedRowProps) {
             <li key={featured.labelKey} css={styles.item}>
               <a
                 href={href}
-                css={styles.link}
+                css={[cardSurface.base, styles.link]}
                 aria-label={featured.def.name}
                 data-testid={`featured-${featured.labelKey}`}
               >
@@ -110,10 +111,6 @@ const styles = stylex.create({
       ":hover": color.bgInteractiveHover,
       ":focus-visible": color.bgInteractiveHover,
     },
-    borderWidth: "1px",
-    borderStyle: "solid",
-    borderColor: color.neutralBorder,
-    borderRadius: "16px",
     transitionProperty: "background-color, transform",
     transitionDuration: "160ms",
     transform: {

--- a/apps/web/src/components/pixel-creature-creator/landing/your-creations.tsx
+++ b/apps/web/src/components/pixel-creature-creator/landing/your-creations.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
+import { cardSurface } from "@tuja/ui/components/card.stylex";
 import { color, font, space } from "@tuja/ui/tokens.stylex";
 import { useSyncExternalStore } from "react";
 import { t } from "#src/i18n.ts";
@@ -82,7 +83,7 @@ export function YourCreations({ locale }: YourCreationsProps) {
             return (
               <li
                 key={entry.id}
-                css={styles.item}
+                css={[cardSurface.base, styles.item]}
                 data-testid="your-creations-item"
               >
                 <a href={href} css={styles.thumbLink} aria-label={displayName}>
@@ -160,11 +161,6 @@ const styles = stylex.create({
     alignItems: "stretch",
     gap: space._1,
     padding: space._2,
-    backgroundColor: color.bgSurface,
-    borderRadius: "12px",
-    borderWidth: "1px",
-    borderStyle: "solid",
-    borderColor: color.neutralBorder,
   },
   thumbLink: {
     display: "flex",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -66,6 +66,8 @@
     "./components/button.stylex": "./src/components/button.stylex.ts",
     "./components/button-shared.stylex": "./src/components/button-shared.stylex.ts",
     "./components/callout": "./src/components/callout.tsx",
+    "./components/card": "./src/components/card.tsx",
+    "./components/card.stylex": "./src/components/card.stylex.ts",
     "./components/checkbox": "./src/components/checkbox.tsx",
     "./components/divider": "./src/components/divider.tsx",
     "./components/field-shared.stylex": "./src/components/field-shared.stylex.ts",

--- a/packages/ui/src/components/card.stylex.ts
+++ b/packages/ui/src/components/card.stylex.ts
@@ -1,0 +1,36 @@
+import * as stylex from "@stylexjs/stylex";
+import { border, color } from "../tokens.stylex.ts";
+
+/**
+ * The bordered-surface skin shared by every card in the system, exposed as
+ * composable StyleX so a consumer can drop the exact same surface onto an
+ * element the `Card` component can't be — a Next.js `<Link>`, a plain `<a>`, or
+ * an `<li>` inside a list. This is the custom-layer escape hatch behind the
+ * `Card` component (which composes these same styles), mirroring how
+ * `button-shared.stylex` backs both `Button` and the app's anchor button.
+ *
+ * `interactive` layers pointer affordances on top of `base`: it re-declares the
+ * hover-sensitive properties so the two compose cleanly (last write wins per
+ * property). Pair it with the `transition.colors` motion primitive at the call
+ * site so the hover eases rather than snaps.
+ */
+export const cardSurface = stylex.create({
+  base: {
+    borderWidth: border.size_1,
+    borderStyle: "solid",
+    borderColor: color.neutralBorder,
+    borderRadius: border.radius_3,
+    backgroundColor: color.bgSurface,
+  },
+  interactive: {
+    cursor: "pointer",
+    borderColor: {
+      default: color.neutralBorder,
+      ":hover": color.accentBorder,
+    },
+    backgroundColor: {
+      default: color.bgSurface,
+      ":hover": color.bgInteractiveHover,
+    },
+  },
+});

--- a/packages/ui/src/components/card.test.tsx
+++ b/packages/ui/src/components/card.test.tsx
@@ -1,0 +1,87 @@
+import * as stylex from "@stylexjs/stylex";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Card } from "./card.tsx";
+
+describe("Card rendering", () => {
+  it("renders its children", () => {
+    render(<Card>Panel body</Card>);
+    expect(screen.getByText("Panel body")).toBeInTheDocument();
+  });
+
+  it("applies the bordered surface by default", () => {
+    render(<Card data-testid="card">Body</Card>);
+    const card = screen.getByTestId("card");
+    expect(card.className).toContain("styles.base");
+    expect(card.className).toContain("cardSurface.base");
+  });
+
+  it("stays static without the interactive prop", () => {
+    render(<Card data-testid="card">Body</Card>);
+    expect(screen.getByTestId("card").className).not.toContain(
+      "cardSurface.interactive",
+    );
+  });
+
+  it("adds hover affordances when interactive", () => {
+    render(
+      <Card interactive data-testid="card">
+        Body
+      </Card>,
+    );
+    const card = screen.getByTestId("card");
+    expect(card.className).toContain("cardSurface.interactive");
+    expect(card.className).toContain("transition.colors");
+  });
+});
+
+describe("Card prop forwarding", () => {
+  it("merges className and forwards style", () => {
+    render(
+      <Card data-testid="card" className="extra" style={{ margin: 4 }}>
+        Body
+      </Card>,
+    );
+    const card = screen.getByTestId("card");
+    expect(card.className).toContain("extra");
+    expect(card).toHaveStyle({ margin: "4px" });
+  });
+
+  it("forwards native attributes and events", () => {
+    const onClick = vi.fn();
+    render(
+      <Card data-testid="card" id="alert" role="alert" onClick={onClick}>
+        Body
+      </Card>,
+    );
+    const card = screen.getByTestId("card");
+    expect(card).toHaveAttribute("id", "alert");
+    expect(card).toHaveAttribute("role", "alert");
+    fireEvent.click(card);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards a ref to the underlying div", () => {
+    let node: HTMLDivElement | null = null;
+    render(
+      <Card
+        ref={(element) => {
+          node = element;
+        }}
+      >
+        Body
+      </Card>,
+    );
+    expect(node).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it("composes a caller css override last", () => {
+    const overrides = stylex.create({ box: { opacity: 0.9 } });
+    render(
+      <Card css={overrides.box} data-testid="card">
+        Body
+      </Card>,
+    );
+    expect(screen.getByTestId("card").className).toContain("overrides.box");
+  });
+});

--- a/packages/ui/src/components/card.tsx
+++ b/packages/ui/src/components/card.tsx
@@ -1,0 +1,63 @@
+import * as stylex from "@stylexjs/stylex";
+import type { ComponentProps, ReactNode } from "react";
+import { transition } from "../primitives/motion.stylex.ts";
+import { space } from "../tokens.stylex.ts";
+import { cardSurface } from "./card.stylex.ts";
+
+interface CardProps extends ComponentProps<"div"> {
+  /**
+   * Adds pointer affordances — a hover border and background lift plus an eased
+   * colour transition — for a card that is itself clickable. Leave `false` (the
+   * default) for a static surface such as a panel or an alert. When the whole
+   * card needs to be a link, render your `<Link>`/`<a>` directly and compose
+   * `cardSurface` from `@tuja/ui/components/card.stylex` instead — the package
+   * intentionally keeps `Card` a `<div>` and framework-agnostic.
+   */
+  interactive?: boolean;
+  /** Card contents. */
+  children: ReactNode;
+}
+
+/**
+ * The system's bordered-surface container: a 1px neutral border, rounded
+ * corners, and a raised surface background. Renders a `<div>` and forwards
+ * native div attributes (`role`, `id`, `onClick`, `data-*`, `className`,
+ * `style`, `ref`) so a caller can add behaviour or a one-off override without a
+ * wrapper. The `css` prop is composed last, letting a caller win over the
+ * defaults — including the padding, so a denser or roomier card is a one-liner.
+ */
+export function Card({
+  interactive = false,
+  css,
+  className,
+  style,
+  ref,
+  children,
+  ...restProps
+}: CardProps) {
+  return (
+    <div
+      {...restProps}
+      ref={ref}
+      className={className}
+      style={style}
+      css={[
+        styles.base,
+        cardSurface.base,
+        interactive && transition.colors,
+        interactive && cardSurface.interactive,
+        css,
+      ]}
+    >
+      {children}
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  base: {
+    boxSizing: "border-box",
+    paddingBlock: space._3,
+    paddingInline: space._4,
+  },
+});


### PR DESCRIPTION
## Why

While looking at the design-system overview page, the card-like tiles that link to each foundation/component page looked like they should come from the design system — but they didn't. They were ad-hoc `<Link>` elements styled with a local StyleX object defined inline in the page.

Pulling the thread surfaced the real problem: the same bordered-surface skin — a 1px `neutralBorder`, a rounded corner, and a raised `bgSurface` background — was copy-pasted across four unrelated callsites, and two of them had already drifted to hard-coded corner radii (12px and 16px) instead of the `radius_3` token. `DESIGN.md` says a pattern that shows up in two or more places has earned promotion from customization to the shared system, so this promotes it.

## What

The pattern lands in `@tuja/ui` following the package's existing two-layer precedent (how `button-shared.stylex` backs `Button`). Because the package can't import `next/link` and the codebase deliberately avoids `as`-polymorphism, it ships as two layers so a consumer can start high and drop down only as far as they need:

- **`Card`** — the config layer. Renders a `<div>`, forwards native div attributes, and takes an `interactive` prop for a card that is itself clickable. For static surfaces: panels, alerts, list items.
- **`cardSurface`** — the custom-layer escape hatch. A composable StyleX object that skins the exact same surface onto an element `Card` can't be: a Next.js `<Link>`, a plain `<a>`, or an `<li>`.

All four duplicated callsites migrate onto the new abstraction — the design-system overview tiles, the pixel-creature-creator featured-row and your-creations landing cards, and the ai-chat session-restore banner — which also normalizes the two drifted radii back to the `radius_3` token. A `/design-system/components/card` showcase route documents the component like every other one.

```mermaid
graph TD
    surface["cardSurface.stylex<br/>(custom layer — composable skin)"]
    card["Card component<br/>(config layer — div + interactive)"]
    surface --> card
    card --> banner["ai-chat: session-restore banner"]
    card --> showcase["design-system: card showcase"]
    surface --> tiles["design-system: overview tiles (Link)"]
    surface --> featured["pixel-creature-creator: featured-row (a)"]
    surface --> creations["pixel-creature-creator: your-creations (li)"]
```

## Notes

The change is visual-parity across the board with one intentional delta: the your-creations list item corner radius moves from a hard-coded 12px to the 16px `radius_3` token, for consistency with the rest of the system. All four migrated surfaces plus the new showcase page were verified visually in the browser; lint, format, test, and build all pass.