### PR TITLE
feat: unify @tuja/ui patterns and cut app-side custom styles

### DIFF
--- a/apps/web/src/app/[locale]/error.tsx
+++ b/apps/web/src/app/[locale]/error.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
-import { border, color, font, space } from "@tuja/ui/tokens.stylex";
+import { Button } from "@tuja/ui/components/button";
+import { align, flex, justify } from "@tuja/ui/primitives/flex.stylex";
+import { color, font, space } from "@tuja/ui/tokens.stylex";
 import { useEffect } from "react";
 import { t } from "#src/i18n.ts";
 
@@ -23,7 +25,10 @@ export default function LocaleError({
   }, [error]);
 
   return (
-    <div css={styles.container} role="alert">
+    <div
+      css={[flex.col, align.center, justify.center, styles.container]}
+      role="alert"
+    >
       <h1 css={styles.heading}>
         {t({ en: "Something went wrong", zh: "出了点问题" })}
       </h1>
@@ -33,19 +38,15 @@ export default function LocaleError({
           zh: "发生了意外错误，请重试。",
         })}
       </p>
-      <button type="button" css={styles.button} onClick={unstable_retry}>
+      <Button variant="primary" onClick={unstable_retry} css={styles.button}>
         {t({ en: "Try again", zh: "重试" })}
-      </button>
+      </Button>
     </div>
   );
 }
 
 const styles = stylex.create({
   container: {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    justifyContent: "center",
     minHeight: "60dvh",
     textAlign: "center",
     padding: space._4,
@@ -62,16 +63,5 @@ const styles = stylex.create({
   },
   button: {
     marginTop: space._4,
-    paddingBlock: space._2,
-    paddingInline: space._5,
-    fontSize: font.uiBody,
-    fontWeight: font.weight_5,
-    fontFamily: font.family,
-    borderWidth: 0,
-    borderStyle: "none",
-    borderRadius: border.radius_round,
-    backgroundColor: color.accent,
-    color: color.accentOn,
-    cursor: "pointer",
   },
 });

--- a/apps/web/src/components/ai-chat/preference-panel.tsx
+++ b/apps/web/src/components/ai-chat/preference-panel.tsx
@@ -7,6 +7,7 @@ import { ThumbsUpIcon } from "@phosphor-icons/react/dist/ssr/ThumbsUp";
 import { TrashIcon } from "@phosphor-icons/react/dist/ssr/Trash";
 import { XIcon } from "@phosphor-icons/react/dist/ssr/X";
 import * as stylex from "@stylexjs/stylex";
+import { a11y } from "@tuja/ui/primitives/a11y.stylex";
 import { flex } from "@tuja/ui/primitives/flex.stylex";
 import { buttonReset } from "@tuja/ui/primitives/reset.stylex";
 import { border, color, font, space } from "@tuja/ui/tokens.stylex";
@@ -269,7 +270,7 @@ export function PreferencePanel({
           {/* Stable live region: mounted whenever the footer is, populated
               only while confirming, so AT reliably detects the content
               change and announces the prompt. */}
-          <div role="status" aria-live="polite" css={styles.srOnly}>
+          <div role="status" aria-live="polite" css={a11y.srOnly}>
             {confirmingClear
               ? t({
                   en: "Clear all preferences? Confirm or cancel.",
@@ -531,16 +532,5 @@ const styles = stylex.create({
     color: color.textMuted,
     cursor: "pointer",
     transition: "background-color 0.15s ease",
-  },
-  srOnly: {
-    position: "absolute",
-    width: "1px",
-    height: "1px",
-    padding: 0,
-    margin: "-1px",
-    overflow: "hidden",
-    clipPath: "inset(50%)",
-    whiteSpace: "nowrap",
-    borderWidth: 0,
   },
 });

--- a/apps/web/src/components/ai-chat/tool-activity-group.tsx
+++ b/apps/web/src/components/ai-chat/tool-activity-group.tsx
@@ -2,6 +2,7 @@
 
 import { CaretRightIcon } from "@phosphor-icons/react/dist/ssr/CaretRight";
 import * as stylex from "@stylexjs/stylex";
+import { a11y } from "@tuja/ui/primitives/a11y.stylex";
 import { flex } from "@tuja/ui/primitives/flex.stylex";
 import { motionConstants } from "@tuja/ui/primitives/motion.stylex";
 import { buttonReset } from "@tuja/ui/primitives/reset.stylex";
@@ -61,7 +62,12 @@ export function ToolActivityGroup({
     <div css={styles.container}>
       <button
         type="button"
-        css={[buttonReset.base, flex.row, styles.disclosureButton]}
+        css={[
+          buttonReset.base,
+          flex.row,
+          a11y.focusRingInset,
+          styles.disclosureButton,
+        ]}
         aria-expanded={isOpen}
         aria-controls={expandedId}
         onClick={() => {

--- a/apps/web/src/components/ai-chat/tool-activity-line.tsx
+++ b/apps/web/src/components/ai-chat/tool-activity-line.tsx
@@ -3,6 +3,7 @@
 import { CheckIcon } from "@phosphor-icons/react/dist/ssr/Check";
 import { WarningCircleIcon } from "@phosphor-icons/react/dist/ssr/WarningCircle";
 import * as stylex from "@stylexjs/stylex";
+import { a11y } from "@tuja/ui/primitives/a11y.stylex";
 import { flex } from "@tuja/ui/primitives/flex.stylex";
 import { truncate } from "@tuja/ui/primitives/layout.stylex";
 import { motionConstants } from "@tuja/ui/primitives/motion.stylex";
@@ -190,7 +191,7 @@ export function ToolActivityLine({
             aria-hidden="true"
           />
         )}
-        <span css={styles.srOnly}>{statusText}</span>
+        <span css={a11y.srOnly}>{statusText}</span>
       </span>
       <span css={styles.label}>{label}</span>
       {summary != null && (
@@ -247,16 +248,5 @@ const styles = stylex.create({
   },
   separator: {
     opacity: 0.5,
-  },
-  srOnly: {
-    position: "absolute",
-    width: "1px",
-    height: "1px",
-    padding: 0,
-    margin: "-1px",
-    overflow: "hidden",
-    clipPath: "inset(50%)",
-    whiteSpace: "nowrap",
-    borderWidth: 0,
   },
 });

--- a/apps/web/src/components/ai-chat/typing-indicator.tsx
+++ b/apps/web/src/components/ai-chat/typing-indicator.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
+import { a11y } from "@tuja/ui/primitives/a11y.stylex";
 import { motionConstants } from "@tuja/ui/primitives/motion.stylex";
 import { color, font } from "@tuja/ui/tokens.stylex";
 
@@ -19,7 +20,7 @@ export function TypingIndicator({ label, isExiting }: TypingIndicatorProps) {
       <span aria-hidden="true" css={styles.shimmerText}>
         {label}
       </span>
-      <span css={styles.srOnly}>{label}</span>
+      <span css={a11y.srOnly}>{label}</span>
     </div>
   );
 }
@@ -67,16 +68,5 @@ const styles = stylex.create({
     },
     animationTimingFunction: "linear",
     animationIterationCount: "infinite",
-  },
-  srOnly: {
-    position: "absolute",
-    width: "1px",
-    height: "1px",
-    padding: 0,
-    margin: "-1px",
-    overflow: "hidden",
-    clipPath: "inset(50%)",
-    whiteSpace: "nowrap",
-    borderWidth: 0,
   },
 });

--- a/apps/web/src/components/design-system/sections/components/heading-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/components/heading-showcase.tsx
@@ -80,6 +80,36 @@ export function HeadingShowcase() {
     },
   ];
 
+  const weightOverrides = [
+    {
+      meta: 'variant="display" · regular',
+      node: (
+        <Heading level={2} variant="display" weight="regular">
+          {t({ en: "Featured this week", zh: "本周精选" })}
+        </Heading>
+      ),
+    },
+    {
+      meta: t({
+        en: 'variant="display" · bold (default)',
+        zh: 'variant="display" · bold（默认）',
+      }),
+      node: (
+        <Heading level={2} variant="display">
+          {t({ en: "Featured this week", zh: "本周精选" })}
+        </Heading>
+      ),
+    },
+    {
+      meta: 'variant="display" · black',
+      node: (
+        <Heading level={2} variant="display" weight="black">
+          {t({ en: "Featured this week", zh: "本周精选" })}
+        </Heading>
+      ),
+    },
+  ];
+
   const alignments = [
     {
       meta: 'align="start"',
@@ -148,6 +178,22 @@ export function HeadingShowcase() {
         </div>
       </Showcase>
 
+      <Showcase label={t({ en: "Weight", zh: "字重" })}>
+        <ShowcaseHelper>
+          {t({
+            en: "weight overrides the weight the variant sets, so a display heading can read light or extra-heavy without touching its size.",
+            zh: "weight 会覆盖 variant 设定的字重，因此 display 标题可以变轻或加重，而无需改动字号。",
+          })}
+        </ShowcaseHelper>
+        <div css={styles.ladder}>
+          {weightOverrides.map((row) => (
+            <SpecRow key={row.meta} meta={row.meta}>
+              {row.node}
+            </SpecRow>
+          ))}
+        </div>
+      </Showcase>
+
       <Showcase label={t({ en: "Alignment", zh: "对齐" })}>
         <div css={styles.ladder}>
           {alignments.map((row) => (
@@ -191,6 +237,18 @@ export function HeadingShowcase() {
             description: t({
               en: "Visual type ramp, decoupled from level so rank and size can differ.",
               zh: "视觉字号档位，与 level 解耦，使层级与字号可以不同。",
+            }),
+          },
+          {
+            name: "weight",
+            type: '"regular" | "medium" | "semibold" | "bold" | "extrabold" | "black"',
+            defaultValue: t({
+              en: "weight matching variant",
+              zh: "与 variant 匹配的字重",
+            }),
+            description: t({
+              en: "Font weight, overriding the weight the variant sets so rank, size, and weight stay independent.",
+              zh: "字重，覆盖 variant 设定的字重，使层级、字号与字重相互独立。",
             }),
           },
           {

--- a/apps/web/src/components/design-system/sections/components/select-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/components/select-showcase.tsx
@@ -128,6 +128,12 @@ export function SelectShowcase() {
             defaultValue="newest"
           />
           <Select
+            size="lg"
+            label={t({ en: "Large", zh: "大" })}
+            options={sortOptions}
+            defaultValue="newest"
+          />
+          <Select
             label={t({ en: "Timezone", zh: "时区" })}
             description={t({
               en: "Pass <option> children for optgroups — the escape hatch.",
@@ -207,7 +213,7 @@ export function SelectShowcase() {
           },
           {
             name: "size",
-            type: '"sm" | "md"',
+            type: '"sm" | "md" | "lg"',
             defaultValue: '"md"',
             description: t({
               en: "Control height and type scale.",

--- a/apps/web/src/components/design-system/sections/components/text-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/components/text-showcase.tsx
@@ -125,6 +125,33 @@ export function TextShowcase() {
     },
   ];
 
+  const transforms = [
+    {
+      meta: 'transform="uppercase"',
+      node: (
+        <Text variant="caption" transform="uppercase">
+          {t({ en: "Now streaming", zh: "正在热播" })}
+        </Text>
+      ),
+    },
+    {
+      meta: 'transform="capitalize"',
+      node: (
+        <Text variant="caption" transform="capitalize">
+          {t({ en: "now streaming", zh: "正在热播" })}
+        </Text>
+      ),
+    },
+    {
+      meta: 'transform="lowercase"',
+      node: (
+        <Text variant="caption" transform="lowercase">
+          {t({ en: "NOW STREAMING", zh: "正在热播" })}
+        </Text>
+      ),
+    },
+  ];
+
   const alignments = [
     {
       meta: 'align="start"',
@@ -222,6 +249,22 @@ export function TextShowcase() {
         </ShowcaseGrid>
       </Showcase>
 
+      <Showcase label={t({ en: "Case transform", zh: "大小写转换" })}>
+        <ShowcaseHelper>
+          {t({
+            en: "transform sets the letter case independently of variant — e.g. an uppercase eyebrow at caption size.",
+            zh: "transform 独立于 variant 设定字母大小写——例如以 caption 字号呈现的大写眉标。",
+          })}
+        </ShowcaseHelper>
+        <div css={styles.ladder}>
+          {transforms.map((row) => (
+            <SpecRow key={row.meta} meta={row.meta}>
+              {row.node}
+            </SpecRow>
+          ))}
+        </div>
+      </Showcase>
+
       <Showcase label={t({ en: "Alignment", zh: "对齐" })}>
         <div css={styles.ladder}>
           {alignments.map((row) => (
@@ -283,6 +326,14 @@ export function TextShowcase() {
             description: t({
               en: "Font weight. Unset overline defaults to semibold; other variants inherit the base weight.",
               zh: "字重。未设置时 overline 默认半粗，其余字号沿用基础字重。",
+            }),
+          },
+          {
+            name: "transform",
+            type: '"uppercase" | "lowercase" | "capitalize"',
+            description: t({
+              en: "Letter case, decoupled from variant — e.g. an uppercase eyebrow at caption size.",
+              zh: "字母大小写，与 variant 解耦——例如以 caption 字号呈现的大写眉标。",
             }),
           },
           {

--- a/apps/web/src/components/design-system/showcase.tsx
+++ b/apps/web/src/components/design-system/showcase.tsx
@@ -1,6 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
+import { cardSurface } from "@tuja/ui/components/card.stylex";
 import { flex } from "@tuja/ui/primitives/flex.stylex";
-import { border, color, font, space } from "@tuja/ui/tokens.stylex";
+import { color, font, space } from "@tuja/ui/tokens.stylex";
 import type { ReactNode } from "react";
 
 interface ShowcaseProps {
@@ -19,7 +20,12 @@ interface ShowcaseProps {
 export function Showcase({ label, frame = "card", children }: ShowcaseProps) {
   const plain = frame === "plain";
   return (
-    <section css={[styles.showcase, plain ? styles.plainFrame : styles.card]}>
+    <section
+      css={[
+        styles.showcase,
+        plain ? styles.plainFrame : [cardSurface.base, styles.card],
+      ]}
+    >
       {label ? (
         <h2 css={plain ? styles.headingPlain : styles.label}>{label}</h2>
       ) : null}
@@ -56,12 +62,10 @@ const styles = stylex.create({
     flexDirection: "column",
     gap: space._3,
   },
-  // Default doc-page framing: a raised surface card.
+  // Default doc-page framing: the shared card surface (cardSurface.base) plus
+  // the doc-page padding.
   card: {
     padding: space._5,
-    backgroundColor: color.bgSurface,
-    border: `1px solid ${color.neutralBorder}`,
-    borderRadius: border.radius_3,
   },
   // Plain framing: no card chrome. The section is delineated by its heading and
   // the generous gap the doc-page body puts between siblings, so the page canvas

--- a/apps/web/src/components/home/background-lines.tsx
+++ b/apps/web/src/components/home/background-lines.tsx
@@ -1,35 +1,43 @@
 import * as stylex from "@stylexjs/stylex";
 import { breakpoints } from "@tuja/ui/breakpoints.stylex";
+import { absoluteFill } from "@tuja/ui/primitives/layout.stylex";
 import { border, color, layer } from "@tuja/ui/tokens.stylex";
 
 export function BackgroundLines() {
   return (
-    <div css={styles.linesContainer} role="presentation">
-      <div css={[styles.line, styles.line1]} role="presentation" />
-      <div css={[styles.line, styles.line2]} role="presentation" />
-      <div css={[styles.line, styles.line3]} role="presentation" />
-      <div css={[styles.line, styles.line4]} role="presentation" />
-      <div css={[styles.line, styles.line5]} role="presentation" />
+    <div css={[absoluteFill.all, styles.linesContainer]} role="presentation">
+      <div
+        css={[absoluteFill.y, styles.line, styles.line1]}
+        role="presentation"
+      />
+      <div
+        css={[absoluteFill.y, styles.line, styles.line2]}
+        role="presentation"
+      />
+      <div
+        css={[absoluteFill.y, styles.line, styles.line3]}
+        role="presentation"
+      />
+      <div
+        css={[absoluteFill.y, styles.line, styles.line4]}
+        role="presentation"
+      />
+      <div
+        css={[absoluteFill.y, styles.line, styles.line5]}
+        role="presentation"
+      />
     </div>
   );
 }
 
 const styles = stylex.create({
   linesContainer: {
-    position: "absolute",
-    top: 0,
-    right: 0,
-    bottom: 0,
-    left: 0,
     zIndex: layer.base,
     pointerEvents: "none",
     opacity: 0.24,
   },
   line: {
     display: "none",
-    position: "absolute",
-    top: 0,
-    bottom: 0,
     width: border.size_1,
     backgroundImage: `linear-gradient(${color.textMuted} 33%, transparent 0%)`,
     backgroundPosition: "right",

--- a/apps/web/src/components/home/education-card.tsx
+++ b/apps/web/src/components/home/education-card.tsx
@@ -1,5 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 import { Skeleton } from "@tuja/ui/components/skeleton";
+import { flex } from "@tuja/ui/primitives/flex.stylex";
 import { color, font, ratio, space } from "@tuja/ui/tokens.stylex";
 import type { StaticImageData } from "next/image";
 import Image from "next/image";
@@ -30,7 +31,7 @@ export function EducationCard({
   return (
     <Card {...rest} className={className} style={style} css={styles.card}>
       <div css={styles.row}>
-        <div css={styles.logo}>
+        <div css={[flex.row, styles.logo]}>
           {typeof logo === "object" && logo && "src" in logo ? (
             <Image
               src={logo.src}
@@ -78,9 +79,6 @@ const styles = stylex.create({
     marginBottom: space._1,
   },
   logo: {
-    alignItems: "center",
-    display: "flex",
-    justifyContent: "flex-start",
     maxInlineSize: "64px",
     blockSize: "64px",
     aspectRatio: {

--- a/apps/web/src/components/home/experience-card.tsx
+++ b/apps/web/src/components/home/experience-card.tsx
@@ -1,5 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 import { Skeleton } from "@tuja/ui/components/skeleton";
+import { flex } from "@tuja/ui/primitives/flex.stylex";
 import { color, font, ratio, space } from "@tuja/ui/tokens.stylex";
 import { Suspense } from "react";
 import { Card } from "#src/components/shared/card.tsx";
@@ -23,7 +24,7 @@ export function ExperienceCard({
   return (
     <Card {...rest} className={className} style={style} css={styles.card}>
       <Suspense fallback={<Skeleton />}>
-        <div css={styles.logo}>{logo}</div>
+        <div css={[flex.row, styles.logo]}>{logo}</div>
       </Suspense>
       <time dateTime={dateTime} css={styles.dates}>
         {dates}
@@ -43,12 +44,9 @@ const styles = stylex.create({
     [svgTokens.fill]: { ":not(:hover)": color.textMuted },
   },
   logo: {
-    alignItems: "center",
     aspectRatio: ratio.double,
-    display: "flex",
     width: "100%",
     maxInlineSize: space._13,
-    justifyContent: "flex-start",
     minHeight: 0,
   },
   dates: {

--- a/apps/web/src/components/home/project-card.tsx
+++ b/apps/web/src/components/home/project-card.tsx
@@ -1,4 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
+import { Text } from "@tuja/ui/components/text";
+import { flex } from "@tuja/ui/primitives/flex.stylex";
 import { color, font, space } from "@tuja/ui/tokens.stylex";
 import { ViewTransition, type ReactNode } from "react";
 import { Card } from "#src/components/shared/card.tsx";
@@ -21,12 +23,14 @@ export function ProjectCard({
   return (
     <Card {...rest} className={className} style={style} css={styles.card}>
       <div css={styles.row}>
-        <div css={styles.logo}>{icon}</div>
+        <div css={[flex.row, styles.logo]}>{icon}</div>
         <ViewTransition name={`project-card-name-${name}`}>
           <div css={styles.name}>{name}</div>
         </ViewTransition>
       </div>
-      <div css={styles.description}>{description}</div>
+      <Text as="div" variant="bodySmall" tone="muted">
+        {description}
+      </Text>
     </Card>
   );
 }
@@ -49,20 +53,12 @@ const styles = stylex.create({
     marginBottom: space._1,
   },
   logo: {
-    alignItems: "center",
-    display: "flex",
-    justifyContent: "flex-start",
     minBlockSize: 0,
     color: svgTokens.fill,
   },
   name: {
     fontSize: font.cqTitle,
     fontWeight: font.weight_7,
-    color: color.textMuted,
-  },
-  description: {
-    fontSize: font.uiBodySmall,
-    fontWeight: font.weight_4,
     color: color.textMuted,
   },
 });

--- a/apps/web/src/components/movie-database/grid.tsx
+++ b/apps/web/src/components/movie-database/grid.tsx
@@ -1,5 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 import { breakpoints } from "@tuja/ui/breakpoints.stylex";
+import { space } from "@tuja/ui/tokens.stylex";
 import type { HTMLAttributes, PropsWithChildren, Ref } from "react";
 
 export function Grid({
@@ -18,9 +19,9 @@ export function Grid({
 
 const styles = stylex.create({
   skeletonGrid: {
-    padding: "0.5rem",
+    padding: space._1,
     display: "grid",
-    gap: "0.5rem",
+    gap: space._1,
     gridTemplateColumns: {
       default: "1fr",
       [breakpoints.sm]: "repeat(auto-fill, minmax(150px, 1fr))",

--- a/apps/web/src/components/movie-database/media-poster.tsx
+++ b/apps/web/src/components/movie-database/media-poster.tsx
@@ -75,7 +75,7 @@ const styles = stylex.create({
     flexDirection: "column",
     textAlign: "center",
     backgroundColor: color.bgSurface,
-    borderWidth: 1,
+    borderWidth: border.size_1,
     borderStyle: "solid",
     borderColor: color.neutralBorder,
     borderRadius: border.radius_2,

--- a/apps/web/src/components/pixel-creature-creator/review/action-row.tsx
+++ b/apps/web/src/components/pixel-creature-creator/review/action-row.tsx
@@ -1,14 +1,17 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
-import { color, font, layer, space } from "@tuja/ui/tokens.stylex";
+import { Textarea } from "@tuja/ui/components/textarea";
+import { transition } from "@tuja/ui/primitives/motion.stylex";
 import {
-  useEffect,
-  useId,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from "react";
+  border,
+  color,
+  font,
+  layer,
+  shadow,
+  space,
+} from "@tuja/ui/tokens.stylex";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { useLocale } from "#src/hooks/use-locale.ts";
 import { t } from "#src/i18n.ts";
 import type { CreatureDef, Emotion } from "../state/creature-schema";
@@ -164,7 +167,6 @@ export function ActionRow({
   const [manualLore, setManualLore] = useState("");
   const downloadRef = useRef<HTMLDivElement>(null);
   const downloadTriggerRef = useRef<HTMLButtonElement>(null);
-  const manualTextareaId = useId();
 
   // All translated strings live here so the i18n Babel plugin can extract
   // them (it only transforms `t()` calls inside the render scope of a
@@ -389,7 +391,7 @@ export function ActionRow({
       <div css={styles.buttonRow}>
         <button
           type="button"
-          css={[styles.button, styles.buttonPrimary]}
+          css={[styles.button, styles.buttonPrimary, transition.colors]}
           onClick={() => {
             void handleConjureLore();
           }}
@@ -403,7 +405,7 @@ export function ActionRow({
 
         <button
           type="button"
-          css={styles.button}
+          css={[styles.button, transition.colors]}
           onClick={() => {
             void handleCopyLink();
           }}
@@ -417,7 +419,7 @@ export function ActionRow({
           <button
             type="button"
             ref={downloadTriggerRef}
-            css={styles.button}
+            css={[styles.button, transition.colors]}
             aria-haspopup="menu"
             aria-expanded={downloadOpen}
             onClick={() => {
@@ -458,7 +460,7 @@ export function ActionRow({
 
         <button
           type="button"
-          css={[styles.button, saved && styles.buttonSaved]}
+          css={[styles.button, saved && styles.buttonSaved, transition.colors]}
           onClick={handleSave}
           data-testid="action-save"
           aria-pressed={saved}
@@ -469,7 +471,7 @@ export function ActionRow({
 
         <button
           type="button"
-          css={styles.button}
+          css={[styles.button, transition.colors]}
           onClick={handleShuffle}
           data-testid="action-shuffle"
           aria-label={labels.shuffle}
@@ -479,7 +481,7 @@ export function ActionRow({
 
         <button
           type="button"
-          css={styles.button}
+          css={[styles.button, transition.colors]}
           onClick={handleEdit}
           data-testid="action-edit"
           aria-label={labels.edit}
@@ -503,12 +505,8 @@ export function ActionRow({
 
       {showManualFallback && (
         <div css={styles.manualFallback} data-testid="lore-manual">
-          <label htmlFor={manualTextareaId} css={styles.manualLabel}>
-            {labels.manualLabel}
-          </label>
-          <textarea
-            id={manualTextareaId}
-            css={styles.manualTextarea}
+          <Textarea
+            label={labels.manualLabel}
             value={manualLore}
             onChange={(event) => {
               setManualLore(event.target.value);
@@ -520,7 +518,7 @@ export function ActionRow({
           />
           <button
             type="button"
-            css={[styles.button, styles.buttonPrimary]}
+            css={[styles.button, styles.buttonPrimary, transition.colors]}
             onClick={handleManualLoreSubmit}
             disabled={manualLore.trim().length === 0}
             data-testid="lore-manual-submit"
@@ -572,7 +570,7 @@ const styles = stylex.create({
     borderWidth: "1px",
     borderStyle: "solid",
     borderColor: color.neutralBorder,
-    borderRadius: "999px",
+    borderRadius: border.radius_round,
     fontSize: font.uiBodySmall,
     fontWeight: font.weight_6,
     cursor: {
@@ -584,8 +582,6 @@ const styles = stylex.create({
       ":disabled": 0.7,
     },
     outlineOffset: "2px",
-    transitionProperty: "background-color, border-color, color",
-    transitionDuration: "120ms",
   },
   buttonPrimary: {
     backgroundColor: {
@@ -613,11 +609,11 @@ const styles = stylex.create({
     borderWidth: "1px",
     borderStyle: "solid",
     borderColor: color.neutralBorder,
-    borderRadius: "10px",
+    borderRadius: border.radius_2,
     padding: space._0,
     display: "flex",
     flexDirection: "column",
-    boxShadow: "0 4px 20px rgba(0,0,0,0.12)",
+    boxShadow: shadow._2,
     zIndex: layer.overlay,
   },
   menuItem: {
@@ -630,7 +626,7 @@ const styles = stylex.create({
     },
     color: color.textMain,
     borderWidth: 0,
-    borderRadius: "8px",
+    borderRadius: border.radius_2,
     fontSize: font.uiBodySmall,
     fontWeight: font.weight_5,
     cursor: "pointer",
@@ -641,7 +637,7 @@ const styles = stylex.create({
     paddingBlock: space._1,
     paddingInline: space._3,
     backgroundColor: color.bgSurface,
-    borderRadius: "10px",
+    borderRadius: border.radius_2,
     fontSize: font.uiBodySmall,
     color: color.textMain,
     alignSelf: "center",
@@ -659,29 +655,9 @@ const styles = stylex.create({
     paddingBlock: space._2,
     paddingInline: space._3,
     backgroundColor: color.bgSurface,
-    borderRadius: "10px",
+    borderRadius: border.radius_2,
     alignSelf: "center",
     inlineSize: "100%",
     maxInlineSize: "32rem",
-  },
-  manualLabel: {
-    fontSize: font.uiBodySmall,
-    fontWeight: font.weight_6,
-    color: color.textMuted,
-  },
-  manualTextarea: {
-    inlineSize: "100%",
-    minBlockSize: "5rem",
-    boxSizing: "border-box",
-    padding: space._2,
-    fontSize: font.uiBody,
-    fontFamily: "inherit",
-    color: color.textMain,
-    backgroundColor: color.bgSurfaceSunken,
-    borderWidth: "1px",
-    borderStyle: "solid",
-    borderColor: color.neutralBorder,
-    borderRadius: "8px",
-    resize: "vertical",
   },
 });

--- a/apps/web/src/components/pixel-creature-creator/review/creature-card.tsx
+++ b/apps/web/src/components/pixel-creature-creator/review/creature-card.tsx
@@ -270,7 +270,7 @@ const styles = stylex.create({
   statBar: {
     position: "relative",
     height: "10px",
-    borderRadius: "999px",
+    borderRadius: border.radius_round,
     backgroundColor: color.surfaceNeutralSubtle,
     overflow: "hidden",
   },

--- a/apps/web/src/components/pixel-creature-creator/review/emotion-toggle.tsx
+++ b/apps/web/src/components/pixel-creature-creator/review/emotion-toggle.tsx
@@ -2,7 +2,8 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { useRadioGroup } from "@tuja/ui/hooks/use-radio-group";
-import { color, font, space } from "@tuja/ui/tokens.stylex";
+import { transition } from "@tuja/ui/primitives/motion.stylex";
+import { border, color, font, space } from "@tuja/ui/tokens.stylex";
 import { t } from "#src/i18n.ts";
 import { EMOTIONS, type Emotion } from "../state/creature-schema";
 
@@ -54,7 +55,11 @@ export function EmotionToggle({ active, onChange }: EmotionToggleProps) {
             type="button"
             {...getOptionProps(emotion)}
             data-testid={`emotion-button-${emotion}`}
-            css={[styles.button, isActive && styles.buttonActive]}
+            css={[
+              styles.button,
+              transition.colors,
+              isActive && styles.buttonActive,
+            ]}
           >
             {emotionLabels[emotion]}
           </button>
@@ -89,13 +94,11 @@ const styles = stylex.create({
     borderWidth: "1px",
     borderStyle: "solid",
     borderColor: "transparent",
-    borderRadius: "999px",
+    borderRadius: border.radius_round,
     fontSize: font.uiBodySmall,
     fontWeight: font.weight_5,
     cursor: "pointer",
     outlineOffset: "2px",
-    transitionProperty: "background-color, border-color, color",
-    transitionDuration: "120ms",
   },
   buttonActive: {
     backgroundColor: {

--- a/apps/web/src/components/pixel-creature-creator/wizard/step-features.tsx
+++ b/apps/web/src/components/pixel-creature-creator/wizard/step-features.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
+import { transition } from "@tuja/ui/primitives/motion.stylex";
 import { color, font, space } from "@tuja/ui/tokens.stylex";
 import { t } from "#src/i18n.ts";
 import { PixelLayer } from "../sprite/pixel-layer";
@@ -69,6 +70,7 @@ export function StepFeatures({ def, onChange }: StepFeaturesProps) {
               data-testid={`accessory-option-${accessory.id}`}
               css={[
                 styles.option,
+                transition.colors,
                 isSelected && styles.optionSelected,
                 disabledByCap && styles.optionDisabled,
               ]}
@@ -129,8 +131,6 @@ const styles = stylex.create({
     cursor: { default: "pointer", ":disabled": "not-allowed" },
     opacity: { default: 1, ":disabled": 0.5 },
     color: color.textMain,
-    transitionProperty: "border-color, background-color",
-    transitionDuration: "120ms",
   },
   optionSelected: {
     borderColor: color.accent,

--- a/apps/web/src/components/pixel-creature-creator/wizard/step-name.tsx
+++ b/apps/web/src/components/pixel-creature-creator/wizard/step-name.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
+import { transition } from "@tuja/ui/primitives/motion.stylex";
 import { color, font, space } from "@tuja/ui/tokens.stylex";
 import { useId } from "react";
 import { t } from "#src/i18n.ts";
@@ -51,7 +52,7 @@ export function StepName({ def, onChange }: StepNameProps) {
           aria-describedby={describedBy}
           placeholder={t({ en: "e.g. Mochi", zh: "例如:团子" })}
           data-testid="creature-name-input"
-          css={styles.input}
+          css={[styles.input, transition.colors]}
         />
       </label>
       {/*
@@ -129,8 +130,6 @@ const styles = stylex.create({
     backgroundColor: color.bgSurfaceSunken,
     color: color.textMain,
     outlineWidth: 0,
-    transitionProperty: "border-color",
-    transitionDuration: "120ms",
   },
   // Always reserve a line of vertical space so the input doesn't jump as
   // the message appears/disappears.
@@ -138,7 +137,7 @@ const styles = stylex.create({
     margin: 0,
     minHeight: "1.2em",
     fontSize: font.uiBodySmall,
-    color: color.brandBristol,
+    color: color.dangerText,
   },
   lorePanel: {
     marginTop: space._2,

--- a/apps/web/src/components/pixel-creature-creator/wizard/step-species.tsx
+++ b/apps/web/src/components/pixel-creature-creator/wizard/step-species.tsx
@@ -2,6 +2,7 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { useRadioGroup } from "@tuja/ui/hooks/use-radio-group";
+import { transition } from "@tuja/ui/primitives/motion.stylex";
 import { color, font, space } from "@tuja/ui/tokens.stylex";
 import Image from "next/image";
 import { useId, useMemo } from "react";
@@ -73,7 +74,11 @@ export function StepSpecies({ def, onChange }: StepSpeciesProps) {
               type="button"
               {...getOptionProps(entry.id)}
               data-testid={`species-option-${entry.id}`}
-              css={[styles.option, selected && styles.optionSelected]}
+              css={[
+                styles.option,
+                transition.colors,
+                selected && styles.optionSelected,
+              ]}
             >
               <div css={styles.thumb}>
                 <Image
@@ -139,8 +144,6 @@ const styles = stylex.create({
     borderColor: "transparent",
     cursor: "pointer",
     color: color.textMain,
-    transitionProperty: "border-color, background-color",
-    transitionDuration: "120ms",
   },
   optionSelected: {
     borderColor: color.accent,

--- a/apps/web/src/components/pixel-creature-creator/wizard/wizard-shell.tsx
+++ b/apps/web/src/components/pixel-creature-creator/wizard/wizard-shell.tsx
@@ -2,7 +2,8 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { breakpoints } from "@tuja/ui/breakpoints.stylex";
-import { color, font, space } from "@tuja/ui/tokens.stylex";
+import { transition } from "@tuja/ui/primitives/motion.stylex";
+import { border, color, font, space } from "@tuja/ui/tokens.stylex";
 import { useEffect, useMemo, useReducer, useRef } from "react";
 import { useLocale } from "#src/hooks/use-locale.ts";
 import { t } from "#src/i18n.ts";
@@ -159,7 +160,7 @@ export function WizardShell({ initialDef }: WizardShellProps) {
           type="button"
           onClick={handleShuffle}
           data-testid="wizard-shuffle"
-          css={styles.shuffleBtn}
+          css={[styles.shuffleBtn, transition.colors]}
         >
           {shuffleLabel}
         </button>
@@ -184,6 +185,7 @@ export function WizardShell({ initialDef }: WizardShellProps) {
               data-testid={`wizard-pill-${String(stepNumber)}`}
               css={[
                 styles.pill,
+                transition.colors,
                 isActive && styles.pillActive,
                 !isVisited && styles.pillLocked,
               ]}
@@ -214,7 +216,7 @@ export function WizardShell({ initialDef }: WizardShellProps) {
           }}
           disabled={state.step === 1}
           data-testid="wizard-back"
-          css={[styles.footerBtn, styles.footerBtnSecondary]}
+          css={[styles.footerBtn, transition.colors, styles.footerBtnSecondary]}
         >
           {backLabel}
         </button>
@@ -229,7 +231,7 @@ export function WizardShell({ initialDef }: WizardShellProps) {
           }}
           disabled={nameTooShort}
           data-testid={isLastStep ? "wizard-finish" : "wizard-next"}
-          css={[styles.footerBtn, styles.footerBtnPrimary]}
+          css={[styles.footerBtn, transition.colors, styles.footerBtnPrimary]}
         >
           {isLastStep ? finishLabel : nextLabel}
         </button>
@@ -274,12 +276,10 @@ const styles = stylex.create({
     borderWidth: "1px",
     borderStyle: "solid",
     borderColor: color.neutralBorder,
-    borderRadius: "999px",
+    borderRadius: border.radius_round,
     fontSize: font.uiBodySmall,
     fontWeight: font.weight_5,
     cursor: "pointer",
-    transitionProperty: "background-color",
-    transitionDuration: "120ms",
   },
   breadcrumb: {
     display: "flex",
@@ -297,13 +297,11 @@ const styles = stylex.create({
     borderWidth: "1px",
     borderStyle: "solid",
     borderColor: "transparent",
-    borderRadius: "999px",
+    borderRadius: border.radius_round,
     fontSize: font.uiBodySmall,
     fontWeight: font.weight_5,
     cursor: { default: "pointer", ":disabled": "not-allowed" },
     opacity: { default: 1, ":disabled": 0.45 },
-    transitionProperty: "border-color, background-color, color",
-    transitionDuration: "120ms",
   },
   pillActive: {
     backgroundColor: color.accent,
@@ -335,7 +333,7 @@ const styles = stylex.create({
     gap: space._1,
     padding: space._3,
     backgroundColor: color.bgSurface,
-    borderRadius: "16px",
+    borderRadius: border.radius_3,
     position: { default: "static", [breakpoints.md]: "sticky" },
     top: { default: "auto", [breakpoints.md]: space._3 },
     flexShrink: { default: 1, [breakpoints.md]: 0 },
@@ -378,8 +376,6 @@ const styles = stylex.create({
     opacity: { default: 1, ":disabled": 0.5 },
     borderWidth: "1px",
     borderStyle: "solid",
-    transitionProperty: "background-color, border-color",
-    transitionDuration: "120ms",
   },
   footerBtnSecondary: {
     backgroundColor: {

--- a/apps/web/src/components/shared/anchor.tsx
+++ b/apps/web/src/components/shared/anchor.tsx
@@ -2,7 +2,8 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { anchorTokens } from "@tuja/ui/components/anchor.stylex";
-import { border, color } from "@tuja/ui/tokens.stylex";
+import { a11y } from "@tuja/ui/primitives/a11y.stylex";
+import { border } from "@tuja/ui/tokens.stylex";
 import Link from "next/link";
 import { useState } from "react";
 import { ExternalLinkIndicator } from "./external-link-indicator";
@@ -59,7 +60,7 @@ export function Anchor({
       }}
       className={className}
       style={style}
-      css={styles.a}
+      css={[styles.a, a11y.focusRing]}
     >
       {children}
       {showIndicator && <ExternalLinkIndicator />}
@@ -84,10 +85,5 @@ const styles = stylex.create({
     color: anchorTokens.color,
     fontWeight: anchorTokens.fontWeight,
     textDecorationThickness: { default: null, ":hover": border.size_2 },
-    outline: {
-      default: "none",
-      ":focus-visible": `2px solid ${color.accent}`,
-    },
-    outlineOffset: { default: null, ":focus-visible": "2px" },
   },
 });

--- a/apps/web/src/components/shared/card.tsx
+++ b/apps/web/src/components/shared/card.tsx
@@ -3,6 +3,7 @@
 import { ArrowRightIcon } from "@phosphor-icons/react/dist/ssr/ArrowRight";
 import { ArrowSquareOutIcon } from "@phosphor-icons/react/dist/ssr/ArrowSquareOut";
 import * as stylex from "@stylexjs/stylex";
+import { a11y } from "@tuja/ui/primitives/a11y.stylex";
 import { motionConstants } from "@tuja/ui/primitives/motion.stylex";
 import {
   border,
@@ -26,7 +27,7 @@ export function Card({ children, className, style, ...rest }: CardProps) {
       indicateExternal={false}
       className={className}
       style={style}
-      css={styles.card}
+      css={[styles.card, a11y.focusRingInset]}
     >
       {children}
       <div css={styles.detailsBackdrop} />
@@ -42,7 +43,7 @@ export function Card({ children, className, style, ...rest }: CardProps) {
           <ArrowRightIcon aria-hidden="true" />
         )}
         {isExternal && (
-          <span css={styles.srOnly}>
+          <span css={a11y.srOnly}>
             {t({
               en: "(opens in new tab)",
               zh: "(在新标签页中打开)",
@@ -85,12 +86,6 @@ const styles = stylex.create({
       ":hover": "scale(1.05) translate3d(0, -0.2rem, 0)",
     },
     backdropFilter: { default: null, ":hover": "blur(2rem)" },
-    outline: {
-      default: "none",
-      ":focus-visible": `2px solid ${color.accent}`,
-    },
-    // Draw the ring inside the box so `overflow: hidden` doesn't clip it.
-    outlineOffset: { default: null, ":focus-visible": "-2px" },
 
     [cardTokens.detailsIndicatorOpacity]: {
       default: 0,
@@ -156,16 +151,5 @@ const styles = stylex.create({
   },
   detailsText: {
     fontWeight: font.weight_6,
-  },
-  srOnly: {
-    position: "absolute",
-    width: "1px",
-    height: "1px",
-    padding: 0,
-    margin: "-1px",
-    overflow: "hidden",
-    clipPath: "inset(50%)",
-    whiteSpace: "nowrap",
-    borderWidth: 0,
   },
 });

--- a/apps/web/src/components/shared/external-link-indicator.tsx
+++ b/apps/web/src/components/shared/external-link-indicator.tsx
@@ -2,13 +2,14 @@
 
 import { ArrowSquareOutIcon } from "@phosphor-icons/react/dist/ssr/ArrowSquareOut";
 import * as stylex from "@stylexjs/stylex";
+import { a11y } from "@tuja/ui/primitives/a11y.stylex";
 import { t } from "#src/i18n.ts";
 
 export function ExternalLinkIndicator() {
   return (
     <>
       <ArrowSquareOutIcon size="0.85em" css={styles.icon} aria-hidden="true" />
-      <span css={styles.srOnly}>
+      <span css={a11y.srOnly}>
         {t({ en: "(opens in new tab)", zh: "(在新标签页中打开)" })}
       </span>
     </>
@@ -22,16 +23,5 @@ const styles = stylex.create({
     top: "0.1em",
     marginInlineStart: "0.1em",
     opacity: 0.7,
-  },
-  srOnly: {
-    position: "absolute",
-    width: "1px",
-    height: "1px",
-    padding: 0,
-    margin: "-1px",
-    overflow: "hidden",
-    clipPath: "inset(50%)",
-    whiteSpace: "nowrap",
-    borderWidth: 0,
   },
 });

--- a/apps/web/src/components/shared/menu-item.tsx
+++ b/apps/web/src/components/shared/menu-item.tsx
@@ -1,4 +1,5 @@
 import * as stylex from "@stylexjs/stylex";
+import { a11y } from "@tuja/ui/primitives/a11y.stylex";
 import { flex } from "@tuja/ui/primitives/flex.stylex";
 import { color, font, border, controlSize } from "@tuja/ui/tokens.stylex";
 import { useRouter } from "next/navigation";
@@ -41,7 +42,12 @@ export function MenuItem({
       aria-current={isActive ? "true" : undefined}
       lang={lang}
       role="menuitem"
-      css={[flex.between, styles.item, isActive && styles.itemActive]}
+      css={[
+        flex.between,
+        styles.item,
+        a11y.focusRing,
+        isActive && styles.itemActive,
+      ]}
       data-menu-autofocus={autoFocus ? "true" : undefined}
       tabIndex={isActive ? -1 : 0}
       onClick={(e) => {
@@ -71,11 +77,6 @@ const styles = stylex.create({
     padding: controlSize._3,
     textDecoration: "none",
     transition: "background-color 0.2s",
-    outline: {
-      default: "none",
-      ":focus-visible": `2px solid ${color.accent}`,
-    },
-    outlineOffset: { default: null, ":focus-visible": "2px" },
   },
   itemActive: {
     color: color.accentOn,

--- a/apps/web/src/components/sprite-editor/animation-mode.tsx
+++ b/apps/web/src/components/sprite-editor/animation-mode.tsx
@@ -9,6 +9,7 @@ import { PlusIcon } from "@phosphor-icons/react/dist/ssr/Plus";
 import { TrashIcon } from "@phosphor-icons/react/dist/ssr/Trash";
 import * as stylex from "@stylexjs/stylex";
 import { Button } from "@tuja/ui/components/button";
+import { IconButton } from "@tuja/ui/components/icon-button";
 import {
   duration as motionDuration,
   easing,
@@ -326,39 +327,36 @@ export function AnimationMode({
                   </label>
                 </div>
                 <div css={styles.frameActions}>
-                  <button
-                    type="button"
-                    css={styles.iconButton}
+                  <IconButton
+                    size="sm"
+                    shape="square"
+                    icon={<ArrowUpIcon size={14} weight="bold" />}
                     onClick={() => {
                       moveFrame(index, -1);
                     }}
                     disabled={index === 0}
                     aria-label={moveUpLabel}
-                  >
-                    <ArrowUpIcon size={14} weight="bold" />
-                  </button>
-                  <button
-                    type="button"
-                    css={styles.iconButton}
+                  />
+                  <IconButton
+                    size="sm"
+                    shape="square"
+                    icon={<ArrowDownIcon size={14} weight="bold" />}
                     onClick={() => {
                       moveFrame(index, 1);
                     }}
                     disabled={index === frames.length - 1}
                     aria-label={moveDownLabel}
-                  >
-                    <ArrowDownIcon size={14} weight="bold" />
-                  </button>
-                  <button
-                    type="button"
-                    css={styles.iconButton}
+                  />
+                  <IconButton
+                    size="sm"
+                    shape="square"
+                    icon={<TrashIcon size={14} weight="bold" />}
                     onClick={() => {
                       removeFrame(index);
                     }}
                     aria-label={removeLabel}
                     data-testid={`remove-frame-${String(index)}`}
-                  >
-                    <TrashIcon size={14} weight="bold" />
-                  </button>
+                  />
                 </div>
               </li>
             ))}
@@ -572,21 +570,5 @@ const styles = stylex.create({
   frameActions: {
     display: "flex",
     gap: "2px",
-  },
-  iconButton: {
-    display: "inline-flex",
-    alignItems: "center",
-    justifyContent: "center",
-    width: "26px",
-    height: "26px",
-    border: `1px solid ${color.neutralBorder}`,
-    borderRadius: border.radius_2,
-    backgroundColor: {
-      default: color.bgSurface,
-      ":hover:not(:disabled)": color.bgInteractiveHover,
-    },
-    color: color.textMain,
-    cursor: { default: "pointer", ":disabled": "not-allowed" },
-    opacity: { default: 1, ":disabled": 0.4 },
   },
 });

--- a/apps/web/src/components/sprite-editor/grid-controls.tsx
+++ b/apps/web/src/components/sprite-editor/grid-controls.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
+import { Divider } from "@tuja/ui/components/divider";
 import {
   duration,
   easing,
@@ -195,7 +196,7 @@ export function GridControls({
         </div>
       </section>
 
-      <div css={styles.divider} aria-hidden="true" />
+      <Divider variant="subtle" />
 
       <section css={styles.group}>
         <h3 css={styles.sectionLabel}>
@@ -248,10 +249,6 @@ const styles = stylex.create({
     fontWeight: font.weight_7,
     letterSpacing: font.trackingSnug,
     color: color.textMain,
-  },
-  divider: {
-    height: "1px",
-    backgroundColor: color.neutralBorder,
   },
   primaryRow: {
     display: "grid",

--- a/apps/web/src/components/sprite-editor/sprite-editor.tsx
+++ b/apps/web/src/components/sprite-editor/sprite-editor.tsx
@@ -7,6 +7,7 @@ import { PencilSimpleIcon } from "@phosphor-icons/react/dist/ssr/PencilSimple";
 import * as stylex from "@stylexjs/stylex";
 import { breakpoints } from "@tuja/ui/breakpoints.stylex";
 import { Button } from "@tuja/ui/components/button";
+import { Divider } from "@tuja/ui/components/divider";
 import { border, color, font, space } from "@tuja/ui/tokens.stylex";
 import { useCallback, useMemo, useState } from "react";
 import { t } from "#src/i18n.ts";
@@ -263,7 +264,7 @@ export function SpriteEditor() {
             source={source}
             onSourceChange={setSource}
           />
-          <div css={styles.divider} aria-hidden="true" />
+          <Divider variant="subtle" css={styles.divider} />
           <GridControls
             source={source}
             grid={grid}
@@ -271,9 +272,9 @@ export function SpriteEditor() {
             output={output}
             onOutputChange={setOutput}
           />
-          <div css={styles.divider} aria-hidden="true" />
+          <Divider variant="subtle" css={styles.divider} />
           <GuideControls guides={guides} onGuidesChange={setGuides} />
-          <div css={styles.divider} aria-hidden="true" />
+          <Divider variant="subtle" css={styles.divider} />
           <div css={styles.actions}>
             <Button
               icon={
@@ -449,9 +450,7 @@ const styles = stylex.create({
     overflowX: "hidden",
   },
   divider: {
-    height: "1px",
     marginInline: `calc(${space._4} * -1)`,
-    backgroundColor: color.neutralBorder,
   },
   canvasArea: {
     display: "flex",

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -60,7 +60,7 @@ export function Badge({
       ]}
     >
       {icon ? (
-        <span css={[flex.inlineCenter, iconSizeStyles[size]]} aria-hidden>
+        <span css={[flex.inlineCenter, styles.icon]} aria-hidden>
           {icon}
         </span>
       ) : null}
@@ -76,9 +76,15 @@ const styles = stylex.create({
     whiteSpace: "nowrap",
     lineHeight: font.lineHeight_2,
     gap: space._0,
-    borderWidth: "1px",
+    borderWidth: border.size_1,
     borderStyle: "solid",
     borderColor: "transparent",
+  },
+  // `em` box so the glyph tracks the chip's font-size across sizes.
+  icon: {
+    inlineSize: "1em",
+    blockSize: "1em",
+    color: "currentColor",
   },
 });
 
@@ -95,27 +101,17 @@ const sizeStyles = stylex.create({
   },
 });
 
-const iconSizeStyles = stylex.create({
-  small: {
-    inlineSize: "0.7rem",
-    blockSize: "0.7rem",
-    color: "currentColor",
-  },
-  medium: {
-    inlineSize: "0.8rem",
-    blockSize: "0.8rem",
-    color: "currentColor",
-  },
-});
-
 const variantStyles = stylex.create({
   default: {
     backgroundColor: color.bgSurface,
     color: color.textMuted,
     borderColor: color.neutralBorder,
   },
+  // Borderless low-emphasis chip. Uses the neutral intent tint (like Callout's
+  // neutral) rather than an opaque surface, so it stays visible on cards and
+  // raised surfaces instead of blending into a same-colour parent.
   neutral: {
-    backgroundColor: color.bgSurface,
+    backgroundColor: color.surfaceNeutralSubtle,
     color: color.textMuted,
   },
   info: {

--- a/packages/ui/src/components/button-shared.stylex.ts
+++ b/packages/ui/src/components/button-shared.stylex.ts
@@ -1,12 +1,22 @@
 import * as stylex from "@stylexjs/stylex";
 import { breakpoints } from "../breakpoints.stylex.ts";
-import { motionConstants } from "../primitives/motion.stylex.ts";
+import {
+  duration,
+  easing,
+  motionConstants,
+} from "../primitives/motion.stylex.ts";
 import { color, controlSize } from "../tokens.stylex.ts";
 import { anchorTokens } from "./anchor.stylex.ts";
 import { buttonTokens } from "./button.stylex.ts";
 
 export const PRESS_ANIMATION_DURATION = 150;
-const RELEASE_OUTSIDE_ANIMATION_DURATION = 300;
+
+// Press/release transitions built from the motion scale. The compound
+// transform+filter transition can't be a plain `transition.*` preset, but its
+// numbers come from the shared duration/easing tokens so it tracks the scale.
+const pressTransition = `background ${duration._200} ${easing.ease}, transform ${duration._150} ${easing.easeOut}, filter ${duration._150} ${easing.easeOut}`;
+const releaseTransition = `background ${duration._200} ${easing.ease}, transform ${duration._300} ${easing.easeOut}, filter ${duration._300} ${easing.easeOut}`;
+const reducedTransition = `background ${duration._200} ${easing.ease}`;
 
 export const sharedStyles = stylex.create({
   base: {
@@ -18,8 +28,8 @@ export const sharedStyles = stylex.create({
     borderRadius: buttonTokens.borderRadius,
     boxShadow: buttonTokens.boxShadow,
     transition: {
-      default: `background 0.2s ease, transform ${String(PRESS_ANIMATION_DURATION)}ms ease-out, filter ${String(PRESS_ANIMATION_DURATION)}ms ease-out`,
-      [motionConstants.REDUCED_MOTION]: "background 0.2s ease",
+      default: pressTransition,
+      [motionConstants.REDUCED_MOTION]: reducedTransition,
     },
     backgroundColor: {
       default: buttonTokens.backgroundColor,
@@ -30,13 +40,9 @@ export const sharedStyles = stylex.create({
     filter: "brightness(1)",
     // Touch action to prevent browser gestures from interfering
     touchAction: "manipulation",
-    // Focus ring for keyboard users (WCAG 2.4.7). Replaces the browser
-    // default so the indicator stays consistent across browsers.
-    outline: {
-      default: "none",
-      ":focus-visible": `2px solid ${color.accent}`,
-    },
-    outlineOffset: { default: null, ":focus-visible": "2px" },
+    // The keyboard focus ring (WCAG 2.4.7) is composed at the component via the
+    // shared `a11y.focusRing` primitive, so Button, IconButton, and the app's
+    // anchor button all paint one identical indicator.
   },
   hasIcon: {
     paddingInlineStart: controlSize._2,
@@ -101,8 +107,8 @@ export const sharedStyles = stylex.create({
   },
   releasedOutside: {
     transition: {
-      default: `background 0.2s ease, transform ${String(RELEASE_OUTSIDE_ANIMATION_DURATION)}ms ease-out, filter ${String(RELEASE_OUTSIDE_ANIMATION_DURATION)}ms ease-out`,
-      [motionConstants.REDUCED_MOTION]: "background 0.2s ease",
+      default: releaseTransition,
+      [motionConstants.REDUCED_MOTION]: reducedTransition,
     },
   },
 });

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -4,7 +4,8 @@ import type { StyleXStyles } from "@stylexjs/stylex";
 import * as stylex from "@stylexjs/stylex";
 import { useRef, type ComponentProps, type ReactNode } from "react";
 import { usePressHandlers } from "../hooks/use-press-handlers.ts";
-import { controlSize, font } from "../tokens.stylex.ts";
+import { a11y } from "../primitives/a11y.stylex.ts";
+import { font } from "../tokens.stylex.ts";
 import { mergeRefs } from "../utils/merge-refs.ts";
 import { sharedStyles } from "./button-shared.stylex.ts";
 import { buttonTokens } from "./button.stylex.ts";
@@ -86,6 +87,7 @@ export function Button({
       style={{ ...style, ...pressedStyle }}
       css={[
         sharedStyles.base,
+        a11y.focusRing,
         styles.button,
         !!icon &&
           !!children &&
@@ -131,8 +133,9 @@ const styles = stylex.create({
     fontWeight: font.weight_5,
     cursor: { default: "pointer", ":disabled": "not-allowed" },
 
-    // Button-specific styles
-    minHeight: controlSize._9,
+    // Button-specific styles. Height flows through the shared `buttonTokens`
+    // knob so a container (e.g. AnchorButtonGroup) can shrink grouped buttons.
+    minHeight: buttonTokens.height,
     color: buttonTokens.color,
     backgroundColor: {
       default: buttonTokens.backgroundColor,

--- a/packages/ui/src/components/card.stylex.ts
+++ b/packages/ui/src/components/card.stylex.ts
@@ -12,7 +12,12 @@ import { border, color } from "../tokens.stylex.ts";
  * `interactive` layers pointer affordances on top of `base`: it re-declares the
  * hover-sensitive properties so the two compose cleanly (last write wins per
  * property). Pair it with the `transition.colors` motion primitive at the call
- * site so the hover eases rather than snaps.
+ * site so the hover eases rather than snaps. It also carries the shared
+ * keyboard focus ring (WCAG 2.4.7) — inlined inset (mirroring
+ * `a11y.focusRingInset`) because a rounded, overflow-clipping card would crop an
+ * outward ring, and because a style-object primitive cannot compose another one
+ * at definition time. Every interactive card thus gets one identical indicator
+ * without the call site re-declaring it.
  */
 export const cardSurface = stylex.create({
   base: {
@@ -32,5 +37,9 @@ export const cardSurface = stylex.create({
       default: color.bgSurface,
       ":hover": color.bgInteractiveHover,
     },
+    outlineWidth: "2px",
+    outlineStyle: "solid",
+    outlineColor: { default: "transparent", ":focus-visible": color.accent },
+    outlineOffset: "-2px",
   },
 });

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -193,6 +193,10 @@ const styles = stylex.create({
       ":checked": color.danger,
       ":indeterminate": color.danger,
     },
+    // Recolour the shared focus ring to danger in the error state, matching
+    // TextField/Textarea/Select's invalid treatment (composed after
+    // `a11y.focusRing`, so it wins).
+    outlineColor: { default: "transparent", ":focus-visible": color.danger },
   },
   labelText: {
     color: color.textMain,

--- a/packages/ui/src/components/divider.tsx
+++ b/packages/ui/src/components/divider.tsx
@@ -42,6 +42,10 @@ export function Divider({
   // illegal).
   const setRef = mergeRefs(ref);
 
+  // The `decorative` variant is an ornamental gradient flourish, not a content
+  // boundary, so it opts out of the `separator` role rather than announcing one.
+  const decorative = variant === "decorative";
+
   if (orientation === "vertical") {
     const composedCss = [
       styles.base,
@@ -51,8 +55,8 @@ export function Divider({
     ];
     return (
       <div
-        role="separator"
-        aria-orientation="vertical"
+        role={decorative ? "presentation" : "separator"}
+        aria-orientation={decorative ? undefined : "vertical"}
         ref={setRef}
         css={composedCss}
         className={className}
@@ -68,7 +72,13 @@ export function Divider({
     css,
   ];
   return (
-    <hr ref={setRef} css={composedCss} className={className} style={style} />
+    <hr
+      ref={setRef}
+      role={decorative ? "presentation" : undefined}
+      css={composedCss}
+      className={className}
+      style={style}
+    />
   );
 }
 

--- a/packages/ui/src/components/field-shared.stylex.ts
+++ b/packages/ui/src/components/field-shared.stylex.ts
@@ -84,10 +84,13 @@ export const fieldStyles = stylex.create({
     borderWidth: border.size_1,
     // Neutral at rest, lifts on hover, accents on any focus (the "active field"
     // affordance); the keyboard-only ring is layered on via `a11y.focusRing`.
+    // A disabled control keeps the resting border even under hover (`:hover`
+    // still matches disabled elements), so the compound selector pins it.
     borderColor: {
       default: color.neutralBorder,
       ":hover": color.neutral,
       ":focus": color.accent,
+      ":disabled:hover": color.neutralBorder,
     },
     borderRadius: border.radius_2,
     paddingInline: fieldVars.paddingInline,

--- a/packages/ui/src/components/heading.test.tsx
+++ b/packages/ui/src/components/heading.test.tsx
@@ -34,6 +34,26 @@ describe("Heading variant decoupling", () => {
   });
 });
 
+describe("Heading weight override", () => {
+  it("applies the weight override on top of the variant ramp", () => {
+    render(
+      <Heading level={1} weight="regular">
+        Light title
+      </Heading>,
+    );
+    const el = screen.getByRole("heading", { level: 1 });
+    expect(el.className).toContain("variantStyles.h1");
+    expect(el.className).toContain("weightStyles.regular");
+  });
+
+  it("does not apply a weight override when weight is unset", () => {
+    render(<Heading level={1}>Title</Heading>);
+    expect(screen.getByRole("heading", { level: 1 }).className).not.toContain(
+      "weightStyles",
+    );
+  });
+});
+
 describe("Heading prop forwarding", () => {
   it("merges a caller className with the StyleX classes", () => {
     render(<Heading className="my-heading">Title</Heading>);

--- a/packages/ui/src/components/heading.tsx
+++ b/packages/ui/src/components/heading.tsx
@@ -5,6 +5,13 @@ import { color, font } from "../tokens.stylex.ts";
 
 type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
 type HeadingVariant = "display" | "h1" | "h2" | "h3" | "h4";
+type HeadingWeight =
+  | "regular"
+  | "medium"
+  | "semibold"
+  | "bold"
+  | "extrabold"
+  | "black";
 type HeadingAlign = "start" | "center" | "end";
 
 interface HeadingProps {
@@ -12,6 +19,13 @@ interface HeadingProps {
   level?: HeadingLevel;
   /** Type-scale ramp. Defaults to the ramp matching `level`. */
   variant?: HeadingVariant;
+  /**
+   * Overrides the weight the `variant` sets — e.g. `"regular"` for an elegant
+   * light display heading — so a lighter (or heavier) heading no longer needs a
+   * hand-rolled `fontWeight`. Shares the `Text` weight vocabulary, extended with
+   * `extrabold`/`black` for the display range.
+   */
+  weight?: HeadingWeight;
   /** Text alignment (logical `start` / `center` / `end`). */
   align?: HeadingAlign;
   /** StyleX overrides, composed last so a caller can win over the defaults. */
@@ -46,6 +60,7 @@ function defaultVariantForLevel(level: HeadingLevel): HeadingVariant {
 export function Heading({
   level = 2,
   variant,
+  weight,
   align,
   css,
   className,
@@ -57,6 +72,7 @@ export function Heading({
   const composedCss = [
     styles.base,
     variantStyles[resolvedVariant],
+    weight ? weightStyles[weight] : null,
     align ? alignStyles[align] : null,
     css,
   ];
@@ -136,6 +152,15 @@ const variantStyles = stylex.create({
     fontWeight: font.weight_7,
     lineHeight: font.lineHeight_3,
   },
+});
+
+const weightStyles = stylex.create({
+  regular: { fontWeight: font.weight_4 },
+  medium: { fontWeight: font.weight_5 },
+  semibold: { fontWeight: font.weight_6 },
+  bold: { fontWeight: font.weight_7 },
+  extrabold: { fontWeight: font.weight_8 },
+  black: { fontWeight: font.weight_9 },
 });
 
 const alignStyles = stylex.create({

--- a/packages/ui/src/components/menu-button.tsx
+++ b/packages/ui/src/components/menu-button.tsx
@@ -175,7 +175,7 @@ export function MenuButton({
           <Button
             {...buttonProps}
             aria-expanded={isMenuShown}
-            aria-haspopup={popupRole === "menu" ? "menu" : "true"}
+            aria-haspopup={popupRole === "menu" ? "menu" : undefined}
             aria-controls={popupId}
             onClick={(event) => {
               buttonProps.onClick?.(event);
@@ -207,7 +207,15 @@ export function MenuButton({
               role={popupRole}
               aria-labelledby={`${targetId}-label`}
             >
-              {children && <div css={styles.menuTitle}>{children}</div>}
+              {/* Visible heading only. The popup is already named by the
+                  trigger's label via `aria-labelledby`, so this duplicate is
+                  `aria-hidden` — which also keeps a bare non-menuitem node out
+                  of the `role="menu"` accessibility tree. */}
+              {children && (
+                <div css={styles.menuTitle} aria-hidden>
+                  {children}
+                </div>
+              )}
               {menuContent}
             </div>
           </AnimateToTarget>

--- a/packages/ui/src/components/menu-label.tsx
+++ b/packages/ui/src/components/menu-label.tsx
@@ -1,14 +1,20 @@
 import * as stylex from "@stylexjs/stylex";
-import type { PropsWithChildren } from "react";
+import type { ComponentProps } from "react";
 import { color, controlSize } from "../tokens.stylex.ts";
 
 /**
  * Muted caption for a group of controls inside a `MenuButton` popup. Purely
- * presentational — pair it with `aria-labelledby` on the group it titles when
- * the popup contains multiple sections.
+ * presentational — give it an `id` and point the group's `aria-labelledby` at
+ * it when the popup contains multiple sections. Forwards native `<div>`
+ * attributes (`id`, `aria-*`, `className`, `style`, `ref`) so that wiring, and
+ * one-off overrides via `css`, are possible.
  */
-export function MenuLabel({ children }: PropsWithChildren) {
-  return <div css={styles.label}>{children}</div>;
+export function MenuLabel({ children, css, ...props }: ComponentProps<"div">) {
+  return (
+    <div {...props} css={[styles.label, css]}>
+      {children}
+    </div>
+  );
 }
 
 const styles = stylex.create({

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -5,12 +5,14 @@ import * as stylex from "@stylexjs/stylex";
 import { type ComponentProps, type ReactNode } from "react";
 import { useFieldAria } from "../hooks/use-field-aria.ts";
 import { a11y } from "../primitives/a11y.stylex.ts";
-import { flex } from "../primitives/flex.stylex.ts";
 import { transition } from "../primitives/motion.stylex.ts";
-import { border, color, controlSize, font, space } from "../tokens.stylex.ts";
-import { fieldStyles } from "./field-shared.stylex.ts";
+import {
+  fieldSizeBox,
+  fieldSizeInline,
+  fieldStyles,
+} from "./field-shared.stylex.ts";
 
-type SelectSize = "sm" | "md";
+type SelectSize = "sm" | "md" | "lg";
 
 /** A single choice for the {@link Select} `options` config layer. */
 interface SelectOption {
@@ -49,27 +51,25 @@ interface SelectProps extends Omit<
    * the empty placeholder is selected initially.
    */
   placeholder?: string;
-  /** Control height and type scale. Defaults to `"md"`. */
+  /**
+   * Control height and type scale. Shares the field size ramp with `TextField`
+   * / `Textarea`. Defaults to `"md"`.
+   */
   size?: SelectSize;
   /** `<option>` elements — the escape hatch when `options` is not enough. */
   children?: ReactNode;
-  /** StyleX styles merged over the root wrapper — the config-layer escape hatch. */
+  /** StyleX styles merged over the field root — the config-layer escape hatch. */
   css?: StyleXStyles;
 }
 
 /**
- * Inline chevron matching Phosphor "CaretDown" metrics. Decorative — the select
- * carries its own accessible name — so it is `aria-hidden` and ignores pointer
- * events, letting clicks fall through to the native control beneath it.
+ * Inline chevron matching Phosphor "CaretDown" metrics. Rendered inside the
+ * shared trailing-affix slot (`aria-hidden`, no pointer events), so clicks fall
+ * through to the native control beneath it.
  */
 function ChevronIcon() {
   return (
-    <svg
-      css={styles.chevron}
-      aria-hidden="true"
-      viewBox="0 0 256 256"
-      fill="none"
-    >
+    <svg width="1em" height="1em" viewBox="0 0 256 256" fill="none">
       <path
         d="M208 96l-80 80-80-80"
         stroke="currentColor"
@@ -83,10 +83,12 @@ function ChevronIcon() {
 
 /**
  * A labelled wrapper around a native `<select>` — chosen over a custom listbox
- * for its built-in keyboard handling, platform picker, and reliability. The
- * native chevron is replaced with a themed one; the box is restyled but keeps
- * every native behaviour and forwards native select props (`value`,
- * `defaultValue`, `onChange`, `name`, `disabled`, `ref`, `className`, …).
+ * for its built-in keyboard handling, platform picker, and reliability. It
+ * composes the same {@link fieldStyles} chrome as `TextField` / `Textarea`
+ * (label, control box, hover/focus affordance, sizes, invalid state) so the
+ * form-control family reads identically; only the native chevron is swapped for
+ * a themed one in the trailing-affix slot. Forwards native select props
+ * (`value`, `defaultValue`, `onChange`, `name`, `disabled`, `ref`, …).
  *
  * Provide choices via the `options` prop (config layer) or by passing
  * `<option>` `children` (escape hatch).
@@ -138,14 +140,19 @@ export function Select({
     : (defaultValue ?? (placeholder !== undefined ? "" : undefined));
 
   return (
-    <span css={[flex.col, styles.root, css]}>
+    <div css={[fieldStyles.root, css]}>
       <label
         htmlFor={fieldId}
-        css={labelHidden ? a11y.srOnly : [styles.label, labelSizeStyles[size]]}
+        css={[fieldStyles.label, labelHidden && a11y.srOnly]}
       >
         {label}
       </label>
-      <span css={styles.control}>
+      {hasDescription ? (
+        <span id={descriptionId} css={fieldStyles.description}>
+          {description}
+        </span>
+      ) : null}
+      <div css={[fieldStyles.controlAffixRow, fieldSizeInline[size]]}>
         <select
           {...rest}
           id={fieldId}
@@ -158,11 +165,13 @@ export function Select({
           className={className}
           style={style}
           css={[
-            a11y.focusRing,
+            fieldStyles.control,
+            fieldSizeBox[size],
+            fieldStyles.hasTrailingAffix,
             transition.colors,
+            a11y.focusRing,
             styles.select,
-            sizeStyles[size],
-            !!error && styles.selectError,
+            hasError ? fieldStyles.controlInvalid : null,
           ]}
         >
           {placeholder !== undefined ? (
@@ -182,97 +191,23 @@ export function Select({
               ))
             : children}
         </select>
-        <ChevronIcon />
-      </span>
-      {hasDescription ? (
-        <span id={descriptionId} css={fieldStyles.description}>
-          {description}
+        <span css={[fieldStyles.affix, fieldStyles.affixEnd]} aria-hidden>
+          <ChevronIcon />
         </span>
-      ) : null}
+      </div>
       {hasError ? (
         <span id={errorId} role="alert" css={fieldStyles.errorText}>
           {error}
         </span>
       ) : null}
-    </span>
+    </div>
   );
 }
 
 const styles = stylex.create({
-  root: {
-    gap: space._1,
-    alignItems: "stretch",
-  },
-  label: {
-    color: color.textMain,
-    fontWeight: font.weight_5,
-    lineHeight: font.lineHeight_2,
-  },
-  control: {
-    position: "relative",
-    display: "block",
-    inlineSize: "100%",
-  },
+  // A select is a picker, not a text input, so it overrides the field control's
+  // text caret with a pointer.
   select: {
-    appearance: "none",
-    inlineSize: "100%",
-    margin: 0,
-    fontFamily: "inherit",
-    color: color.textMain,
-    backgroundColor: {
-      default: color.bgSurface,
-      ":disabled": color.bgInteractiveDisabled,
-    },
-    borderStyle: "solid",
-    borderWidth: border.size_1,
-    borderColor: {
-      default: color.neutralBorder,
-      ":hover": color.accent,
-      ":disabled": color.neutralBorder,
-    },
-    borderRadius: border.radius_2,
-    paddingInlineStart: space._2,
-    // Leaves room for the absolutely-positioned chevron.
-    paddingInlineEnd: space._7,
     cursor: { default: "pointer", ":disabled": "not-allowed" },
-    opacity: { default: 1, ":disabled": 0.6 },
-  },
-  selectError: {
-    borderColor: {
-      default: color.danger,
-      ":hover": color.danger,
-    },
-  },
-  chevron: {
-    position: "absolute",
-    insetInlineEnd: space._2,
-    insetBlockStart: "50%",
-    transform: "translateY(-50%)",
-    inlineSize: "1em",
-    blockSize: "1em",
-    pointerEvents: "none",
-    color: color.textMuted,
-  },
-});
-
-const sizeStyles = stylex.create({
-  sm: {
-    minBlockSize: controlSize._8,
-    paddingBlock: space._0,
-    fontSize: font.uiBodySmall,
-  },
-  md: {
-    minBlockSize: controlSize._9,
-    paddingBlock: space._1,
-    fontSize: font.uiControl,
-  },
-});
-
-const labelSizeStyles = stylex.create({
-  sm: {
-    fontSize: font.uiBodySmall,
-  },
-  md: {
-    fontSize: font.uiControl,
   },
 });

--- a/packages/ui/src/components/switch.tsx
+++ b/packages/ui/src/components/switch.tsx
@@ -3,6 +3,7 @@
 import * as stylex from "@stylexjs/stylex";
 import React, { useLayoutEffect, useRef, useState } from "react";
 import { useControlled } from "../hooks/use-controlled.ts";
+import { a11y } from "../primitives/a11y.stylex.ts";
 import { motionConstants } from "../primitives/motion.stylex.ts";
 import { buttonReset } from "../primitives/reset.stylex.ts";
 import {
@@ -177,6 +178,7 @@ export function Switch({
       style={style}
       css={[
         buttonReset.base,
+        a11y.focusRing,
         styles.switch,
         initialRendered && styles.animate,
         isDragging && styles.dragging(position),
@@ -232,7 +234,8 @@ const styles = stylex.create({
     // Custom styles
     aspectRatio: ratio.double,
     borderRadius: border.radius_round,
-    cursor: "pointer",
+    cursor: { default: "pointer", ":disabled": "not-allowed" },
+    opacity: { default: 1, ":disabled": 0.6 },
     display: "flex",
     height: controlSize._9,
     padding: border.size_2,

--- a/packages/ui/src/components/text.test.tsx
+++ b/packages/ui/src/components/text.test.tsx
@@ -34,6 +34,17 @@ describe("Text variant and modifier classes", () => {
     expect(screen.getByText("Muted").className).toContain("toneStyles.muted");
   });
 
+  it("applies a case transform decoupled from the variant", () => {
+    render(
+      <Text variant="caption" transform="uppercase">
+        Eyebrow
+      </Text>,
+    );
+    const el = screen.getByText("Eyebrow");
+    expect(el.className).toContain("variantStyles.caption");
+    expect(el.className).toContain("transformStyles.uppercase");
+  });
+
   it("applies alignment", () => {
     render(<Text align="center">Centered</Text>);
     expect(screen.getByText("Centered").className).toContain(

--- a/packages/ui/src/components/text.tsx
+++ b/packages/ui/src/components/text.tsx
@@ -8,6 +8,7 @@ type TextElement = "p" | "span" | "div";
 type TextVariant = "body" | "bodySmall" | "caption" | "overline";
 type TextTone = "default" | "muted" | "subtle" | "accent";
 type TextWeight = "regular" | "medium" | "semibold" | "bold";
+type TextTransform = "uppercase" | "lowercase" | "capitalize";
 type TextAlign = "start" | "center" | "end";
 
 interface TextProps {
@@ -19,6 +20,12 @@ interface TextProps {
   tone?: TextTone;
   /** Font weight. `"overline"` defaults to semibold when unset. */
   weight?: TextWeight;
+  /**
+   * Case transform, decoupled from `variant` — so an uppercase "eyebrow" label
+   * can sit at any size (`caption`, `bodySmall`, …) rather than only through the
+   * `overline` ramp.
+   */
+  transform?: TextTransform;
   /** Text alignment (logical `start` / `center` / `end`). */
   align?: TextAlign;
   /** StyleX overrides, composed last so a caller can win over the defaults. */
@@ -43,6 +50,7 @@ export function Text({
   variant = "body",
   tone = "default",
   weight,
+  transform,
   align,
   css,
   className,
@@ -58,6 +66,7 @@ export function Text({
       ? weightStyles.semibold
       : null,
     weight ? weightStyles[weight] : null,
+    transform ? transformStyles[transform] : null,
     align ? alignStyles[align] : null,
     css,
   ];
@@ -135,6 +144,12 @@ const weightStyles = stylex.create({
   medium: { fontWeight: font.weight_5 },
   semibold: { fontWeight: font.weight_6 },
   bold: { fontWeight: font.weight_7 },
+});
+
+const transformStyles = stylex.create({
+  uppercase: { textTransform: "uppercase" },
+  lowercase: { textTransform: "lowercase" },
+  capitalize: { textTransform: "capitalize" },
 });
 
 const alignStyles = stylex.create({

--- a/packages/ui/src/primitives/motion.stylex.ts
+++ b/packages/ui/src/primitives/motion.stylex.ts
@@ -115,13 +115,21 @@ export const animate = stylex.create({
     animationTimingFunction: "cubic-bezier(0.32, 0.72, 0, 1)",
   },
   pulse: {
-    animationName: pulseKeyframes,
+    // No infinite motion under reduced-motion (mirrors Skeleton's own guard),
+    // so consumers of the preset get the accessible behaviour for free.
+    animationName: {
+      default: pulseKeyframes,
+      [REDUCED_MOTION]: "none",
+    },
     animationDuration: "2s",
     animationTimingFunction: "cubic-bezier(.4,0,.6,1)",
     animationIterationCount: "infinite",
   },
   bounce: {
-    animationName: bounceKeyframes,
+    animationName: {
+      default: bounceKeyframes,
+      [REDUCED_MOTION]: "none",
+    },
     animationDuration: "1.4s",
     animationTimingFunction: "ease-in-out",
     animationIterationCount: "infinite",


### PR DESCRIPTION
## Why

An audit of `@tuja/ui` (against Material, ShadCN, and the system's own `DESIGN.md`) found the design system is already mature and principled — so the real problem wasn't missing features but **consistency drift**: the same pattern implemented several different ways inside the system, then re-hand-rolled again across `apps/web`. Every change here favours deduplication and promotes patterns that already repeat, rather than pre-emptively configuring for hypothetical reuse (per `DESIGN.md`'s stance).

## What changed

**One source of truth for shared patterns**

- **Keyboard focus ring (WCAG 2.4.7)** existed three ways — the `a11y.focusRing` primitive, an identical inline copy in Button, and missing entirely on Switch — plus re-hand-rolled in several app files. Everything now composes the one primitive, so there is a single WCAG indicator. Clickable cards (`cardSurface.interactive`) had a hover style but no focus ring; they now carry one.
- **Form controls** — `Select` and `Checkbox` bypassed the shared `field-shared` chrome that `TextField`/`Textarea` use, so labels, rest background (a visible Select↔TextField mismatch in dark mode), and hover/focus affordance diverged. `Select` was rebuilt on `field-shared` (matching label/background/hover→neutral/focus→accent, `sm`/`md`/`lg` sizes, chevron as a trailing affix, danger invalid state); Checkbox's error state now recolours its focus ring to danger like the rest.

**Real defects fixed**

- `buttonTokens.height` was set by `AnchorButtonGroup` but ignored by `Button`, so grouped buttons couldn't actually shrink — now wired.
- `Badge`'s `neutral` variant used an opaque surface and vanished on white cards — now a visible tint.
- `MenuButton` rendered a bare `<div>` title as an invalid child of `role="menu"`, and `MenuLabel` documented an `aria-labelledby` pairing its API couldn't fulfil — both fixed.
- `Switch` gained a disabled visual treatment; `Divider`'s decorative variant no longer announces as a separator; the shared `animate.pulse`/`animate.bounce` presets are now reduced-motion-safe; a disabled field no longer brightens its border on hover.

**Two additive APIs, both evidence-backed by repeated hand-rolling in product code**

- `Heading` gained a `weight` prop (product headings were hand-rolling lighter weights).
- `Text` gained a `transform` prop (an uppercase "eyebrow" treatment was hand-rolled 6+ times, previously welded to the overline size).

**App consolidation (`apps/web`)**

Replaced hand-rolled focus rings and `srOnly` recipes with the DS primitives across shared chrome and ai-chat; a raw `<button>` reimplementing the primary Button in the locale error page → `<Button>`; the design-system showcase section frame → `cardSurface.base`; layout/typography primitives on the home page; token swaps in movie-database; and in the creative tools (pixel-creature-creator, sprite-editor) swapped hardcoded pill radii → `border.radius_round`, unguarded raw transitions → the reduced-motion-aware `transition.colors` preset, hand-rolled dividers/icon-buttons → the DS `Divider`/`IconButton`, and a hand-rolled manual-lore textarea → `Textarea`.

## Deliberately deferred

Kept custom because a swap would change appearance or break behaviour, not because they were missed:

- ai-chat info banner → `Callout` (would shift muted→main text colour and add a border).
- creature-creator download dropdown → `MenuButton` (its trigger is one of six sibling pill buttons the DS Button wouldn't visually match).
- creature-name input → `TextField` (its test asserts bespoke behaviour `TextField` can't express).
- Making the tri-state Switch's `aria-checked="mixed"` spec-compliant — a product-semantics decision (accept non-standard AT semantics vs switch to `role="checkbox"`).

https://claude.ai/code/session_01TPiRdGbLf1sjw3P8QCTPue