### PR TITLE
fix: correct zh typography translations

### DIFF
--- a/apps/web/src/app/[locale]/design-system/components/heading/page.tsx
+++ b/apps/web/src/app/[locale]/design-system/components/heading/page.tsx
@@ -14,7 +14,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     title: t({ en: "Heading", zh: "标题" }),
     description: t({
       en: "The heading typography primitive. level sets the semantic rank for the document outline while variant sets the visual ramp — so an h2 can read as a display heading.",
-      zh: "标题排版基础组件。level 决定文档大纲中的语义层级，variant 决定视觉字号——因此 h2 也能以 display 大小呈现。",
+      zh: "标题文字排版基础组件。level 决定文档大纲中的语义层级，variant 决定视觉字号——因此 h2 也能以 display 大小呈现。",
     }),
   });
 }
@@ -25,7 +25,7 @@ export default function HeadingPage() {
       title={t({ en: "Heading", zh: "标题" })}
       description={t({
         en: "The heading typography primitive. Keep ranks in document order with level, then pick any visual size with variant — the two stay decoupled so the outline never fights the design.",
-        zh: "标题排版基础组件。用 level 让层级遵循文档顺序，再用 variant 选择任意视觉字号——二者解耦，让大纲不再与设计冲突。",
+        zh: "标题文字排版基础组件。用 level 让层级遵循文档顺序，再用 variant 选择任意视觉字号——二者解耦，让大纲不再与设计冲突。",
       })}
     >
       <HeadingShowcase />

--- a/apps/web/src/app/[locale]/design-system/components/text/page.tsx
+++ b/apps/web/src/app/[locale]/design-system/components/text/page.tsx
@@ -14,7 +14,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     title: t({ en: "Text", zh: "文本" }),
     description: t({
       en: "The body-copy typography primitive. A four-step type ramp, four tonal roles, and four weights — with the semantic element decoupled from the visual size.",
-      zh: "正文排版基础组件。四档字阶、四种色调角色与四种字重——语义元素与视觉字号相互独立。",
+      zh: "正文文字排版基础组件。四档字阶、四种色调角色与四种字重——语义元素与视觉字号相互独立。",
     }),
   });
 }
@@ -25,7 +25,7 @@ export default function TextPage() {
       title={t({ en: "Text", zh: "文本" })}
       description={t({
         en: "The body-copy typography primitive. Choose the type step with variant and the colour with tone, then pick the element with as — the semantic tag and the visual size stay decoupled.",
-        zh: "正文排版基础组件。用 variant 选择字阶、用 tone 选择颜色，再用 as 选择元素——语义标签与视觉字号保持解耦。",
+        zh: "正文文字排版基础组件。用 variant 选择字阶、用 tone 选择颜色，再用 as 选择元素——语义标签与视觉字号保持解耦。",
       })}
     >
       <TextShowcase />

--- a/apps/web/src/app/[locale]/design-system/foundations/typography/page.tsx
+++ b/apps/web/src/app/[locale]/design-system/foundations/typography/page.tsx
@@ -16,14 +16,14 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   return designSystemMetadata({
     locale: validateLocale(locale),
     path: "/design-system/foundations/typography",
-    title: t({ en: "Typography", zh: "排版" }),
+    title: t({ en: "Typography", zh: "文字设计" }),
   });
 }
 
 export default function TypographyPage() {
   return (
     <DocPage
-      title={t({ en: "Typography", zh: "排版" })}
+      title={t({ en: "Typography", zh: "文字设计" })}
       description={t({
         en: "One family in Inter, shaped by a fluid type scale, weight ramp, line-heights, and tracking — then applied through the heading and body text styles.",
         zh: "以 Inter 为单一字体，通过流式字号阶梯、字重梯度、行高与字距塑形，并应用于标题与正文样式。",

--- a/apps/web/src/app/[locale]/design-system/page.tsx
+++ b/apps/web/src/app/[locale]/design-system/page.tsx
@@ -49,7 +49,7 @@ export default function DesignSystemOverview() {
       }),
     },
     "/design-system/foundations/typography": {
-      label: t({ en: "Typography", zh: "排版" }),
+      label: t({ en: "Typography", zh: "文字设计" }),
       description: t({
         en: "Families, the type scale, weights, and heading and body styles.",
         zh: "字体、字号阶梯、字重，以及标题与正文样式。",
@@ -101,7 +101,7 @@ export default function DesignSystemOverview() {
       label: t({ en: "Text", zh: "文本" }),
       description: t({
         en: "The body-copy type primitive: a four-step ramp, four tones, and four weights.",
-        zh: "正文排版基础组件：四档字阶、四种色调与四种字重。",
+        zh: "正文文字排版基础组件：四档字阶、四种色调与四种字重。",
       }),
     },
     "/design-system/components/heading": {

--- a/apps/web/src/components/design-system/design-system-nav.tsx
+++ b/apps/web/src/components/design-system/design-system-nav.tsx
@@ -36,7 +36,7 @@ export function DesignSystemNav() {
     "/design-system/foundations/color": t({ en: "Color", zh: "颜色" }),
     "/design-system/foundations/typography": t({
       en: "Typography",
-      zh: "排版",
+      zh: "文字设计",
     }),
     "/design-system/foundations/spacing": t({ en: "Spacing", zh: "间距" }),
     "/design-system/foundations/elevation": t({

--- a/apps/web/src/components/design-system/sections/components/card-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/components/card-showcase.tsx
@@ -10,7 +10,7 @@ import { Showcase } from "../../showcase.tsx";
 import { UsageSnippet } from "../../usage-snippet.tsx";
 
 export function CardShowcase() {
-  const sampleTitle = t({ en: "Typography", zh: "排版" });
+  const sampleTitle = t({ en: "Typography", zh: "文字设计" });
   const sampleBody = t({
     en: "Families, the type scale, weights, and heading and body styles.",
     zh: "字体、字号阶梯、字重，以及标题与正文样式。",

--- a/apps/web/src/components/design-system/sections/components/divider-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/components/divider-showcase.tsx
@@ -118,7 +118,7 @@ export function DividerShowcase() {
           <Text variant="bodySmall" tone="muted">
             {t({
               en: "Pair with hero typography or section transitions for richest effect.",
-              zh: "搭配英雄排版或区段转换，可获得最佳效果。",
+              zh: "搭配英雄文字排版或区段转换，可获得最佳效果。",
             })}
           </Text>
         </div>

--- a/apps/web/src/components/design-system/sections/tokens/iconography-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/tokens/iconography-showcase.tsx
@@ -106,7 +106,7 @@ export function IconographyShowcase() {
         <ShowcaseHelper>
           {t({
             en: "Icons size with font-size, not a width prop. Set the type token on the slot and the glyph follows — so an icon beside text always matches the line.",
-            zh: "图标随 font-size 缩放，而非通过宽度属性。在插槽上设置排版令牌，字形便随之变化——因此文字旁的图标始终与行高相称。",
+            zh: "图标随 font-size 缩放，而非通过宽度属性。在插槽上设置文字排版令牌，字形便随之变化——因此文字旁的图标始终与行高相称。",
           })}
         </ShowcaseHelper>
         <div css={styles.sizeRow}>
@@ -173,7 +173,7 @@ import { PlusIcon } from "@phosphor-icons/react/dist/ssr/Plus";
             defaultValue: '"1em"',
             description: t({
               en: "Rendered size. Defaults to 1em, so it scales with font-size — prefer sizing via the type token on the slot.",
-              zh: "渲染尺寸。默认 1em，随 font-size 缩放——优先通过插槽上的排版令牌来设定尺寸。",
+              zh: "渲染尺寸。默认 1em，随 font-size 缩放——优先通过插槽上的文字排版令牌来设定尺寸。",
             }),
           },
           {


### PR DESCRIPTION
## Why

On the design-system pages, the Chinese (zh) rendering of **Typography** used 排版 throughout. 排版 in Chinese leans toward *layout / typesetting* — the act of arranging text on a page — rather than *typography*, the discipline of type design and its application. Checking authoritative references (the W3C clreq glossary, The Type / thetype.com, and the major Chinese design systems — Ant, Arco, Semi, TDesign) confirmed the mismatch and pointed to translating by meaning instead of applying one blanket word.

## What changed

zh-only. English strings are untouched.

- **Discipline sense → 文字设计.** Where the string names Typography as the foundation/discipline — the foundation title and its SEO metadata title, the nav rail label, the overview grid tile, and the card-showcase sample title — 排版 becomes 文字设计.
- **Typesetting sense → 文字排版.** Where the prose describes the *act* of setting text — the Text/Heading primitive descriptions, the divider "hero typography" note, and the iconography "typography tokens" copy — 排版 becomes 文字排版.

## Notes

- **Spacing (间距) was evaluated and left as-is** — it is already the correct, standard term, so it is intentionally not part of this diff.