### PR TITLE
ci: add dependabot cooldown to clear pnpm release-age gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,13 @@ updates:
     schedule:
       interval: "daily"
       time: "15:00"
+    # Wait until a version has aged before opening a PR, so it has cleared
+    # pnpm 11's default 24h `minimumReleaseAge` supply-chain gate by the time
+    # CI runs `pnpm install`. Cooldown applies to version updates only —
+    # security updates still flow immediately.
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
     assignees:
       - "QingqiShi"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Why

After the pnpm 11.10.0 upgrade (#2469), pnpm enforces a built-in default `minimumReleaseAge` of 1440 min (24h) as a supply-chain guard — it refuses to install any package version younger than 24 hours. Dependabot, however, opens PRs the instant a new version publishes. The two systems weren't aligned: Dependabot's PRs landed inside pnpm's 24h window, so CI's `pnpm install` rejected them with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`.

Three routine bumps hit this while triaging — #2478 (eslint-plugin-unicorn), #2474 (ai-sdk group), and #2473 (vitest group) — all failing CI purely because the packages were "too new".

## What

Adds a `cooldown` block to the npm ecosystem entry in `.github/dependabot.yml` so Dependabot waits for a version to age before opening a PR — by which point it has cleared pnpm's 24h gate and CI passes.

Values chosen:

- `default-days: 3` — a comfortable buffer past the 24h gate, and a window for bad releases to be yanked.
- `semver-major-days: 7` — let major bumps settle longer before adopting them.

Dependabot cooldown applies to **version updates only**, not security updates, so urgent CVE patches still flow through immediately.
