### PR TITLE
chore: instrument movie-database no-poster fallback

### DIFF
--- a/apps/web/src/app/api/debug/poster-fallback/route.ts
+++ b/apps/web/src/app/api/debug/poster-fallback/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+/**
+ * Diagnostic sink for {@link reportPosterFallback}. Records why a media poster
+ * fell back to the "No Poster" tile so a device-specific, hard-to-reproduce
+ * production failure can be pinned to config-missing vs image-error. Emits to
+ * Vercel Runtime Logs (searchable by the `[poster-fallback]` prefix).
+ *
+ * Safe to remove once the root cause is confirmed.
+ */
+export async function POST(request: NextRequest) {
+  let payload: unknown = null;
+  try {
+    payload = await request.json();
+  } catch {
+    // Empty or non-JSON body; still record the bare event below.
+  }
+  console.error("[poster-fallback]", JSON.stringify(payload));
+  return new NextResponse(null, { status: 204 });
+}

--- a/apps/web/src/components/movie-database/poster-image.tsx
+++ b/apps/web/src/components/movie-database/poster-image.tsx
@@ -5,7 +5,9 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { flex } from "@tuja/ui/primitives/flex.stylex";
 import { imageCover } from "@tuja/ui/primitives/layout.stylex";
 import { color, font, layer } from "@tuja/ui/tokens.stylex";
+import { useEffect } from "react";
 import { t } from "#src/i18n.ts";
+import { reportPosterFallback } from "#src/utils/report-poster-fallback.ts";
 import * as tmdbQueries from "#src/utils/tmdb-queries.ts";
 import { TmdbImage } from "./tmdb-image.tsx";
 
@@ -31,7 +33,24 @@ export function PosterImage({
 }: PosterImageProps) {
   const { data: config } = useSuspenseQuery(tmdbQueries.configuration);
   const visibleLabel = fallbackLabel ?? alt;
+  const configMissing = !config.images?.base_url || !config.images.poster_sizes;
 
+  // Diagnostic: `posterPath` is truthy here (MediaPoster only renders this
+  // component when it is), so a missing config is always abnormal. Report it so
+  // a device-specific "No Poster" can be attributed to config vs image failure.
+  useEffect(() => {
+    if (!configMissing) return;
+    reportPosterFallback({
+      reason: "config-missing",
+      configImagesPresent: Boolean(config.images),
+      configBaseUrl: Boolean(config.images?.base_url),
+      configSecureBaseUrl: Boolean(config.images?.secure_base_url),
+      configPosterSizes: config.images?.poster_sizes?.length ?? 0,
+    });
+  }, [configMissing, config]);
+
+  // Repeat the condition inline (rather than reuse `configMissing`) so
+  // TypeScript narrows `config.images` to non-null for the `TmdbImage` props.
   if (!config.images?.base_url || !config.images.poster_sizes) {
     return (
       <div css={[imageCover.base, flex.center, styles.errored]}>

--- a/apps/web/src/components/movie-database/tmdb-image.tsx
+++ b/apps/web/src/components/movie-database/tmdb-image.tsx
@@ -2,6 +2,7 @@
 
 import { Skeleton } from "@tuja/ui/components/skeleton";
 import { useState, type ReactNode } from "react";
+import { reportPosterFallback } from "#src/utils/report-poster-fallback.ts";
 import { buildSrcSet } from "#src/utils/tmdb-image.ts";
 
 interface TmdbImageProps {
@@ -75,6 +76,7 @@ export function TmdbImage({
         }}
         onError={() => {
           setErrored(true);
+          reportPosterFallback({ reason: "image-error", src });
         }}
         ref={(el) => {
           if (!el?.complete) return;
@@ -86,6 +88,11 @@ export function TmdbImage({
             setLoaded(true);
           } else {
             setErrored(true);
+            reportPosterFallback({
+              reason: "image-error",
+              src,
+              cachedProbe: true,
+            });
           }
         }}
       />

--- a/apps/web/src/utils/report-poster-fallback.ts
+++ b/apps/web/src/utils/report-poster-fallback.ts
@@ -1,0 +1,95 @@
+/**
+ * Diagnostic beacon for the movie-database "No Poster" tile.
+ *
+ * The tile is rendered by two indistinguishable code paths — a missing image
+ * `configuration` (`PosterImage`) or an image that failed to load
+ * (`TmdbImage`). A screenshot can't tell them apart, and the failure has only
+ * been observed on a specific device (stale PWA cache suspected), so we can't
+ * reproduce it on demand. This reports which path fired, plus service-worker /
+ * Cache Storage context, so the next occurrence pins the root cause instead of
+ * being reverse-engineered.
+ *
+ * Fire-and-forget and defensive: it must never affect rendering. Deduped to at
+ * most one beacon per reason per page load. Inert wherever `sendBeacon` is
+ * absent (SSR, jsdom tests), so it adds no behaviour to the happy path.
+ *
+ * Remove once the root cause is confirmed.
+ */
+
+export type PosterFallbackReason = "config-missing" | "image-error";
+
+export interface PosterFallbackInput {
+  reason: PosterFallbackReason;
+  /** The image URL that failed to load (image-error only). */
+  src?: string;
+  /** True when detected via the cached-response probe rather than `onError`. */
+  cachedProbe?: boolean;
+  /** Whether the fetched config carried an `images` object at all. */
+  configImagesPresent?: boolean;
+  configBaseUrl?: boolean;
+  configSecureBaseUrl?: boolean;
+  configPosterSizes?: number;
+}
+
+const reportedReasons = new Set<PosterFallbackReason>();
+
+export function reportPosterFallback(input: PosterFallbackInput): void {
+  if (
+    typeof navigator === "undefined" ||
+    typeof navigator.sendBeacon !== "function"
+  ) {
+    return;
+  }
+  if (reportedReasons.has(input.reason)) return;
+  reportedReasons.add(input.reason);
+  void deliver(input);
+}
+
+async function deliver(input: PosterFallbackInput): Promise<void> {
+  try {
+    const swContainer =
+      "serviceWorker" in navigator ? navigator.serviceWorker : undefined;
+    const controller = swContainer?.controller ?? null;
+    const bundleScript = Array.from(document.scripts)
+      .map((script) => script.src)
+      .find((src) => src.includes("/_next/static/chunks/"));
+
+    let configCached: boolean | undefined;
+    let srcCached: boolean | undefined;
+    if (typeof caches !== "undefined") {
+      try {
+        configCached = Boolean(
+          await caches.match("/api/tmdb/get-configuration", {
+            ignoreSearch: true,
+          }),
+        );
+        if (input.src) {
+          srcCached = Boolean(await caches.match(input.src));
+        }
+      } catch {
+        // Cache Storage can be unavailable (private mode, etc.); skip it.
+      }
+    }
+
+    const diagnostics = {
+      ...input,
+      url: window.location.href,
+      userAgent: navigator.userAgent,
+      swControlled: controller !== null,
+      swScriptUrl: controller?.scriptURL,
+      bundleScript,
+      configCached,
+      srcCached,
+    };
+
+    // Visible in Safari Web Inspector when the device is connected to a Mac.
+    console.warn("[poster-fallback]", diagnostics);
+
+    navigator.sendBeacon(
+      "/api/debug/poster-fallback",
+      new Blob([JSON.stringify(diagnostics)], { type: "application/json" }),
+    );
+  } catch {
+    // Diagnostics must never interfere with rendering.
+  }
+}


### PR DESCRIPTION
> **Correction:** the title and description of this PR were briefly edited by mistake to describe the follow-up *fix*. This PR contains **only the diagnostic instrumentation**. The actual iOS Safari poster fix is in #2493.

## Why

Media posters on the movie-database page rendered the "No Poster" fallback for a specific device (iPhone / iOS Safari) while loading correctly everywhere else, and the failure couldn't be reproduced on demand. The tile is produced by two visually identical paths — a missing image `configuration`, or an image that failed to load — so a screenshot couldn't tell which one fired.

## What this adds

A fire-and-forget diagnostic beacon that reports which fallback path fired (config-missing vs image-error), plus service-worker / Cache-Storage / bundle context, delivered to a new `/api/debug/poster-fallback` route (Vercel Runtime Logs) and to the console (Safari Web Inspector). Deduped to one report per reason per page load, and inert wherever `sendBeacon` is unavailable (SSR, tests) so it adds nothing to the happy path. Intended to be removed once the root cause is confirmed (see #2493).
