### PR TITLE
fix: keep i18n manifest fresh in dev and fix SSG locale dedup

### DIFF
--- a/packages/i18n-babel-plugin/src/index.js
+++ b/packages/i18n-babel-plugin/src/index.js
@@ -47,7 +47,6 @@ module.exports = function i18nBabelPlugin({ types: t }, opts) {
   const manifestPath =
     opts?.manifestPath ||
     nodePath.join(projectRoot, "src/_generated/i18n/manifest.json");
-  const manifest = readManifest(manifestPath);
 
   return {
     name: "i18n-transform",
@@ -79,8 +78,15 @@ module.exports = function i18nBabelPlugin({ types: t }, opts) {
             }
           }
 
-          // Check if this file is a page/layout with client translations
+          // Check if this file is a page/layout with client translations.
+          // Read the manifest per-file (not once at plugin construction) so
+          // the mtime cache in readManifest picks up codegen re-runs during a
+          // running dev server. A long-lived plugin instance that captured the
+          // manifest once would keep injecting a stale page→bundle mapping
+          // after a route is renamed/added, poisoning newly compiled pages
+          // with "Missing translation key" until `.next` is wiped.
           if (state.filename) {
+            const manifest = readManifest(manifestPath);
             const relPath = nodePath.relative(projectRoot, state.filename);
             const entry = manifest[relPath];
             if (entry) {
@@ -181,8 +187,14 @@ function injectRuntimeImports(t, path, state) {
  * Auto-inject setLocale for server page/layout files under [locale].
  *
  * Next.js SSG can deduplicate renders when a function doesn't read
- * `params`. Any function with t() calls produces locale-dependent
- * output, so it must accept params and call setLocale().
+ * `params`. A page produces locale-dependent output in two ways:
+ *   - it calls t() directly (usedLookup/usedLookupParse), or
+ *   - it is a manifest-wrapped page whose injected
+ *     ClientTranslationsProvider resolves its client bundle via
+ *     getClientTranslations() → getLocale().
+ * Either way the page must accept params and call setLocale(); otherwise
+ * SSG can serve one locale's bundle on another route (e.g. English text
+ * rendered on a /zh URL for a page that only renders client t() children).
  *
  * This targets two kinds of functions:
  *   1. `export default function` in page files
@@ -194,8 +206,11 @@ function injectRuntimeImports(t, path, state) {
  * @param {string} projectRoot
  */
 function injectSetLocaleForPages(t, path, state, projectRoot) {
+  const producesLocaleDependentOutput =
+    state.usedLookup || state.usedLookupParse || Boolean(state.__manifestEntry);
+
   if (
-    (!state.usedLookup && !state.usedLookupParse) ||
+    !producesLocaleDependentOutput ||
     state.isClientComponent ||
     state.hasSetLocaleImport ||
     !state.filename

--- a/packages/i18n-babel-plugin/src/index.test.mjs
+++ b/packages/i18n-babel-plugin/src/index.test.mjs
@@ -4,7 +4,7 @@ import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { transformSync } from "@babel/core";
+import { transformSync, types } from "@babel/core";
 import { describe, expect, it } from "vitest";
 
 const require = createRequire(import.meta.url);
@@ -675,6 +675,117 @@ export default function Page() {
       // (in other files) need the translations context
       expect(output).toContain("__I18nProvider");
       expect(output).toContain("__getClientTx");
+    });
+
+    it("injects setLocale into a manifest-wrapped page even without direct t() calls", () => {
+      // A page that only renders client t() children still produces
+      // locale-dependent output via the injected ClientTranslationsProvider,
+      // whose getClientTranslations() resolves the bundle by getLocale(). If
+      // the page never reads params, Next.js SSG can dedupe the per-locale
+      // renders and serve one locale's bundle on the other's route (English
+      // on /zh). Reading params + calling setLocale keeps them distinct.
+      const input = `
+export default function Page() {
+  return <ClientChild />;
+}
+`;
+      const filename = path.join(
+        fakeRoot,
+        "src/app/[locale]/movie-database/(list)/page.tsx",
+      );
+      const output = transformWithManifest(input, filename);
+
+      expect(output).toContain("__I18nProvider");
+      expect(output).toContain("__setLocale");
+      expect(output).toContain("__validateLocale");
+      expect(output).toMatch(/async function Page/);
+      expect(output).toContain(".params");
+    });
+
+    it("does not inject setLocale into a non-manifest page without t() calls", () => {
+      // Boundary: only manifest-wrapped pages (or pages calling t()) get the
+      // setLocale injection. A plain page outside the manifest is untouched.
+      const input = `
+export default function Page() {
+  return <div>No translations</div>;
+}
+`;
+      const filename = path.join(
+        fakeRoot,
+        "src/app/[locale]/calculator/page.tsx",
+      );
+      const output = transformWithManifest(input, filename);
+
+      expect(output).not.toContain("__I18nProvider");
+      expect(output).not.toContain("__setLocale");
+    });
+
+    it("re-reads the manifest per file so a long-lived instance picks up codegen re-runs", () => {
+      // In dev, the plugin is constructed once and reused for every compiled
+      // file. If it captured the manifest only at construction, a route
+      // renamed/added after startup would be compiled against a stale
+      // page→bundle mapping — no ClientTranslationsProvider gets injected and
+      // client t() calls throw "Missing translation key" until `.next` is
+      // wiped. Reading the manifest per file (guarded by an mtime cache) keeps
+      // a single instance current without a restart.
+      const reuseManifestPath = path.join(
+        os.tmpdir(),
+        `i18n-babel-plugin-reuse-manifest-${String(process.pid)}.json`,
+      );
+      const filename = path.join(
+        fakeRoot,
+        "src/app/[locale]/movie-database/(list)/page.tsx",
+      );
+      const input = `
+import { t } from "#src/i18n";
+export default function Page() {
+  return <div>{t({ en: "Hello", zh: "你好" })}</div>;
+}
+`;
+
+      // v1: the page is not yet in the manifest (e.g. codegen has not caught
+      // up to a just-created route). Force an old mtime so the second write is
+      // unambiguously newer even on coarse-resolution filesystems.
+      fs.writeFileSync(reuseManifestPath, JSON.stringify({}));
+      fs.utimesSync(reuseManifestPath, new Date(1000), new Date(1000));
+
+      // Construct the plugin ONCE and reuse the instance across transforms,
+      // exactly as a dev server does.
+      const pluginInstance = require(pluginPath)(
+        { types },
+        { manifestPath: reuseManifestPath, rootDir: fakeRoot },
+      );
+      const runWithInstance = () => {
+        const result = transformSync(input, {
+          filename,
+          parserOpts: { plugins: ["typescript", "jsx"] },
+          plugins: [pluginInstance],
+          configFile: false,
+          babelrc: false,
+        });
+        if (!result || result.code == null) {
+          throw new Error("Transform returned no code");
+        }
+        return result.code;
+      };
+
+      expect(runWithInstance()).not.toContain("__I18nProvider");
+
+      // v2: codegen adds the route to the manifest with a newer mtime.
+      fs.writeFileSync(
+        reuseManifestPath,
+        JSON.stringify({
+          "src/app/[locale]/movie-database/(list)/page.tsx":
+            "movie-database-list-page",
+        }),
+      );
+      fs.utimesSync(reuseManifestPath, new Date(5000), new Date(5000));
+
+      // The same instance must now inject the provider for the freshly mapped
+      // page — no reconstruction required.
+      expect(runWithInstance()).toContain("__I18nProvider");
+
+      fs.rmSync(reuseManifestPath, { force: true });
     });
   });
 });

--- a/packages/i18n-codegen/src/generator.ts
+++ b/packages/i18n-codegen/src/generator.ts
@@ -19,6 +19,29 @@ const srcDir = path.join(projectRoot, "src");
 const outputDir = path.join(srcDir, "_generated", "i18n");
 
 /**
+ * Write `content` to `filePath` only when it differs from what is already on
+ * disk, using an atomic rename so readers (the Babel plugin, Turbopack) never
+ * observe a truncated or partially written file.
+ *
+ * Skipping unchanged writes keeps mtimes stable, which matters at dev startup:
+ * `predev` generates every bundle up front, then `watch:i18n` re-runs the same
+ * generation concurrently with an already-Ready dev server. Rewriting
+ * byte-identical files would churn mtimes and briefly truncate the manifest
+ * under a live server — the window that produces spurious "Missing translation
+ * key" errors — for no benefit.
+ */
+function writeFileIfChanged(filePath: string, content: string): void {
+  try {
+    if (fs.readFileSync(filePath, "utf8") === content) return;
+  } catch {
+    // File missing or unreadable — fall through and write it.
+  }
+  const tmpPath = `${filePath}.${String(process.pid)}.tmp`;
+  fs.writeFileSync(tmpPath, content, "utf8");
+  fs.renameSync(tmpPath, filePath);
+}
+
+/**
  * Recursively collect .ts and .tsx files from a directory,
  * excluding _generated/ and .d.ts files.
  */
@@ -187,22 +210,19 @@ function generatePerPageBundles(allEntries: TranslationEntry[]): void {
       zhMap[entry.key] = entry.zh;
     }
 
-    fs.writeFileSync(
+    writeFileIfChanged(
       path.join(clientDir, `${name}.en.json`),
       JSON.stringify(enMap, null, 2) + "\n",
-      "utf8",
     );
-    fs.writeFileSync(
+    writeFileIfChanged(
       path.join(clientDir, `${name}.zh.json`),
       JSON.stringify(zhMap, null, 2) + "\n",
-      "utf8",
     );
 
     // Generate loader module
-    fs.writeFileSync(
+    writeFileIfChanged(
       path.join(loadersDir, `${name}.ts`),
       generateLoaderSource(name),
-      "utf8",
     );
 
     // Add to manifest
@@ -216,10 +236,9 @@ function generatePerPageBundles(allEntries: TranslationEntry[]): void {
   }
 
   // Write manifest
-  fs.writeFileSync(
+  writeFileIfChanged(
     path.join(outputDir, "manifest.json"),
     JSON.stringify(manifest, null, 2) + "\n",
-    "utf8",
   );
 
   console.log(`Generated ${String(totalBundles)} per-page client bundles`);
@@ -283,8 +302,8 @@ function main(): void {
   const enPath = path.join(outputDir, "translations.en.json");
   const zhPath = path.join(outputDir, "translations.zh.json");
 
-  fs.writeFileSync(enPath, JSON.stringify(enMap, null, 2) + "\n", "utf8");
-  fs.writeFileSync(zhPath, JSON.stringify(zhMap, null, 2) + "\n", "utf8");
+  writeFileIfChanged(enPath, JSON.stringify(enMap, null, 2) + "\n");
+  writeFileIfChanged(zhPath, JSON.stringify(zhMap, null, 2) + "\n");
 
   console.log(
     `Generated ${String(sortedEntries.length)} global translation entries`,


### PR DESCRIPTION
## Why

The local dev server kept flooding the console with `[i18n] Missing translation key` errors. Prior fix #2465 (moving `codegen:i18n` into `predev`) only addressed part of it — renaming or adding a route mid-session still triggered a flood that nothing but `rm -rf .next` + restart could clear. That sends you chasing a non-bug and wastes real time. This closes the remaining causes, and fixes a locale bug that surfaced while verifying.

## What was going wrong

**1. The Babel plugin froze the manifest in a closure.** The i18n plugin read `manifest.json` once, at plugin construction. In dev the plugin instance is long-lived and reused for every compiled file, so that read never happened again. The manifest reader has an mtime-based cache specifically designed to pick up codegen re-runs without a server restart — but it was dead code, because a single instance only ever asked once. When a route was renamed or added mid-session, newly compiled pages were transformed against the *stale* manifest, so no `ClientTranslationsProvider` was injected and every client `t()` threw `Missing translation key`.

**2. The i18n watcher rewrote files under the live server.** `predev` generates the manifest and bundles up front; `dev` then starts `watch:i18n`, whose initial pass redundantly re-ran the *entire* generation concurrently with an already-Ready `next dev`. Rewriting byte-identical files churned mtimes and briefly truncated the manifest — the exact window that produces spurious missing-key errors.

**3. Manifest-wrapped pages could serve the wrong locale.** A page that renders client `t()` children but never calls `t()` itself still produces locale-dependent output, because the injected `ClientTranslationsProvider` resolves its bundle via `getLocale()`. The plugin only injected `setLocale` + a `params` read for pages that called `t()` directly, so such a page never read `params`. Next.js SSG can dedupe per-locale renders when a function doesn't read `params`, serving one locale's bundle on the other's route — English text on a `/zh` URL. Observed live on a mid-session-added route.

## The fix

- Read the manifest **per file** inside the plugin's `Program.enter` rather than once at construction, activating the mtime cache so a running dev server reflects codegen re-runs with no restart.
- Add a **write-if-changed** helper in the codegen generator that skips unchanged files and writes atomically (temp file + rename). The watcher's redundant startup pass now writes nothing, and readers never observe a partial file.
- Inject `setLocale` (params read) for **manifest-wrapped pages too**, not only pages with direct `t()` calls, so SSG keeps per-locale renders distinct.

```mermaid
sequenceDiagram
    participant CG as codegen (predev / watch:i18n)
    participant FS as manifest.json
    participant BP as Babel plugin (long-lived)
    participant Next as next dev

    Note over CG,FS: before
    CG->>FS: rewrite manifest + bundles (churns mtime, truncates)
    Note over BP: read manifest ONCE at construction
    Next->>BP: compile renamed/added page
    BP-->>Next: stale mapping → no provider → Missing key

    Note over CG,FS: after
    CG->>FS: write-if-changed (atomic, skips unchanged)
    Next->>BP: compile page
    BP->>FS: read per file (mtime cache)
    FS-->>BP: fresh mapping → provider injected ✓
```

## Verification

Clean startup and mid-session route addition both produced **0** missing-key errors with no `.next` wipe; hot manifest reload works without restart; codegen re-runs are idempotent (unchanged files keep stable mtimes); the locale fix was confirmed live in the browser for both request orders, and again in an independent isolated worktree. New regression tests were added for each cause and confirmed to fail against the pre-fix code.