### PR TITLE
fix: stop iOS Safari lazy-load false positive blanking every poster

### DIFF
--- a/apps/web/src/components/movie-database/tmdb-image.test.tsx
+++ b/apps/web/src/components/movie-database/tmdb-image.test.tsx
@@ -102,14 +102,21 @@ describe("TmdbImage", () => {
     expect(container.querySelectorAll("div, img")).toHaveLength(1);
   });
 
-  it("detects cached errors via the ref callback (complete + naturalWidth === 0) and shows the fallback", () => {
+  it("keeps the image on the iOS lazy false positive (complete + naturalWidth === 0) instead of erroring", () => {
+    // iOS Safari reports complete=true / naturalWidth=0 for a loading="lazy"
+    // image that hasn't loaded yet (deferred, off-screen). The ref probe must
+    // NOT read that as a failed fetch: doing so removed the <img> before it
+    // could load and blanked every poster. The image stays and the skeleton
+    // remains; onError is the only signal that renders the fallback.
     restore = stubImageElement({ complete: true, naturalWidth: 0 });
-    render(
+    const { container } = render(
       <TmdbImage {...COMMON_PROPS} errorFallback={<span>fallback ui</span>} />,
     );
 
-    expect(screen.getByText("fallback ui")).toBeInTheDocument();
-    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(screen.getByRole("img")).toBeInTheDocument();
+    expect(screen.queryByText("fallback ui")).not.toBeInTheDocument();
+    // Skeleton sibling still present because the image hasn't reported loaded.
+    expect(container.querySelectorAll("div, img")).toHaveLength(2);
   });
 
   it("resets the error state when the path prop changes", () => {

--- a/apps/web/src/components/movie-database/tmdb-image.tsx
+++ b/apps/web/src/components/movie-database/tmdb-image.tsx
@@ -79,20 +79,16 @@ export function TmdbImage({
           reportPosterFallback({ reason: "image-error", src });
         }}
         ref={(el) => {
-          if (!el?.complete) return;
-          // Browsers short-circuit cached responses without firing onLoad/onError,
-          // so probe the element directly. naturalWidth > 0 means a decoded image
-          // is in memory; naturalWidth === 0 on a complete image means the fetch
-          // failed (404, network error, etc.) and the response was cached.
-          if (el.naturalWidth > 0) {
+          // Adopt the decoded state of images the browser served from cache
+          // without firing onLoad — naturalWidth > 0 means a decoded image is
+          // in memory. Only ever conclude *success* here; leave *failure* to
+          // onError. iOS Safari reports `complete === true` with
+          // `naturalWidth === 0` for loading="lazy" images that haven't loaded
+          // yet (deferred, off-screen) — Chrome reports `complete === false`.
+          // Treating that as a failed fetch flipped every poster to the "No
+          // Poster" fallback on iOS and removed the <img>, so it never loaded.
+          if (el?.complete && el.naturalWidth > 0) {
             setLoaded(true);
-          } else {
-            setErrored(true);
-            reportPosterFallback({
-              reason: "image-error",
-              src,
-              cachedProbe: true,
-            });
           }
         }}
       />


### PR DESCRIPTION
## Why

Follow-up bug fix to #2491. On the movie-database page every media poster rendered the "No Poster" fallback on iPhone (iOS Safari), while Chrome, desktop, and both locales loaded fine.

The diagnostic beacon added in #2491 pinned it down using logs from the affected device (iOS 18.7): the fallback fired with `reason: image-error`, detected by `TmdbImage`'s ref probe (`complete === true && naturalWidth === 0`), with the TMDB image `configuration` fully intact — so this was an image-load path, not a config problem.

## Root cause

iOS Safari reports `complete === true` for `loading="lazy"` images that have not loaded yet (deferred / off-screen); Chrome reports `false` in the same state. The ref probe treated `complete && naturalWidth === 0` as a failed fetch, flipped the component to its error state, and removed the `<img>` from the DOM — so the image never got the chance to load. Every poster went straight to the fallback.

## Fix

The ref probe now only ever confirms *success*: it adopts the decoded state of cache-served images (`naturalWidth > 0`) and no longer infers failure. `onError` is once again the single source of failure truth, which behaves correctly across browsers. The unit test that asserted the old (buggy) probe-error behaviour was rewritten to assert the corrected behaviour — the image and skeleton stay put on the iOS false positive.

The diagnostic instrumentation from #2491 (the `/api/debug/poster-fallback` route and the client reporter) is intentionally left in place for one more deploy so the affected device can confirm the fix; it will be removed in a separate follow-up.