### PR TITLE
fix: give detail-overlay close button focus ring and hover

### DIFF
--- a/apps/web/src/components/ai-chat/detail-overlay.tsx
+++ b/apps/web/src/components/ai-chat/detail-overlay.tsx
@@ -4,9 +4,10 @@ import { XIcon } from "@phosphor-icons/react/dist/ssr/X";
 import * as stylex from "@stylexjs/stylex";
 import { breakpoints } from "@tuja/ui/breakpoints.stylex";
 import { useDialogFocus } from "@tuja/ui/hooks/use-dialog-focus";
+import { a11y } from "@tuja/ui/primitives/a11y.stylex";
 import { flex } from "@tuja/ui/primitives/flex.stylex";
 import { fixedFill } from "@tuja/ui/primitives/layout.stylex";
-import { motionConstants } from "@tuja/ui/primitives/motion.stylex";
+import { motionConstants, transition } from "@tuja/ui/primitives/motion.stylex";
 import { buttonReset } from "@tuja/ui/primitives/reset.stylex";
 import { border, color, layer, space } from "@tuja/ui/tokens.stylex";
 import type { PropsWithChildren, RefObject } from "react";
@@ -106,7 +107,13 @@ export function DetailOverlay({
               <button
                 ref={closeButtonRef}
                 type="button"
-                css={[buttonReset.base, flex.inlineCenter, styles.closeButton]}
+                css={[
+                  buttonReset.base,
+                  flex.inlineCenter,
+                  a11y.focusRing,
+                  transition.colors,
+                  styles.closeButton,
+                ]}
                 onClick={onClose}
                 aria-label={t({ en: "Close", zh: "关闭" })}
               >
@@ -198,8 +205,14 @@ const styles = stylex.create({
     width: "2rem",
     height: "2rem",
     borderRadius: border.radius_round,
-    backgroundColor: "rgba(0, 0, 0, 0.5)",
-    color: "white",
-    transition: "background-color 0.15s ease",
+    // Fixed dark circle so the icon stays legible over arbitrary media in both
+    // themes; darkens to the scrim token on hover for feedback (animated via
+    // the composed `transition.colors`). The icon uses `accentOn` (white in
+    // both themes) rather than a raw literal.
+    backgroundColor: {
+      default: "rgba(0, 0, 0, 0.5)",
+      ":hover": color.bgScrim,
+    },
+    color: color.accentOn,
   },
 });


### PR DESCRIPTION
## Why

`DetailOverlay`'s floating close button is the modal's default initial-focus target, yet it was hand-rolled and skipped the conventions every other close/dismiss control follows (the DS `Overlay` close button and the `Callout` dismiss button both compose `a11y.focusRing` plus a real hover state). Three concrete problems:

- It declared a `transition` on `background-color` but never changed the background on any state — a dead no-op, so hovering gave zero visual feedback.
- It omitted the shared `a11y.focusRing` primitive, so keyboard focus fell back to the inconsistent UA outline instead of the design system's accent ring — on the very element that receives focus when the dialog opens.
- It hardcoded `rgba(0,0,0,0.5)` and `white` instead of design tokens.

## What changes

The button is brought in line with the shared convention:

- Composes `a11y.focusRing` so keyboard focus shows the standard accent ring.
- Adds a real `:hover` background change (darkening to the `color.bgScrim` token) so the already-declared `transition.colors` actually animates and the control gives hover feedback.
- Swaps the raw colour literals for tokens — the icon now uses `color.accentOn` (white in both themes) so it stays legible over arbitrary poster/media backgrounds.

The button's markup, absolute positioning, `aria-label`, and initial-focus behaviour are unchanged.