### PR TITLE
fix: let modified clicks on filter links open in a new tab

### DIFF
--- a/apps/web/src/components/shared/anchor-button.test.tsx
+++ b/apps/web/src/components/shared/anchor-button.test.tsx
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import { render, screen } from "#src/test-utils.tsx";
+import { fireEvent, render, screen } from "#src/test-utils.tsx";
 import { AnchorButton } from "./anchor-button";
 
 beforeAll(() => {
@@ -49,4 +49,55 @@ describe("AnchorButton aria-current from isActive", () => {
       "page",
     );
   });
+});
+
+describe("AnchorButton modified-click passthrough", () => {
+  it("runs the consumer onClick and prevents default on a plain click", () => {
+    const onClick = vi.fn((e: React.MouseEvent) => {
+      e.preventDefault();
+    });
+    render(
+      <AnchorButton href="/a" onClick={onClick}>
+        Filter
+      </AnchorButton>,
+    );
+
+    const notPrevented = fireEvent.click(
+      screen.getByRole("link", { name: "Filter" }),
+    );
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    // dispatchEvent returns false when a handler called preventDefault, so the
+    // browser stays on the page and the consumer drives client-side state.
+    expect(notPrevented).toBe(false);
+  });
+
+  it.each([
+    ["metaKey", { metaKey: true }],
+    ["ctrlKey", { ctrlKey: true }],
+    ["shiftKey", { shiftKey: true }],
+    ["altKey", { altKey: true }],
+    ["a non-primary button", { button: 1 }],
+  ])(
+    "skips the consumer onClick and leaves default unprevented for %s",
+    (_label, init) => {
+      const onClick = vi.fn((e: React.MouseEvent) => {
+        e.preventDefault();
+      });
+      render(
+        <AnchorButton href="/a" onClick={onClick}>
+          Filter
+        </AnchorButton>,
+      );
+
+      const notPrevented = fireEvent.click(
+        screen.getByRole("link", { name: "Filter" }),
+        init,
+      );
+
+      expect(onClick).not.toHaveBeenCalled();
+      // Default left intact, so the browser can open the href in a new tab.
+      expect(notPrevented).toBe(true);
+    },
+  );
 });

--- a/apps/web/src/components/shared/anchor-button.tsx
+++ b/apps/web/src/components/shared/anchor-button.tsx
@@ -7,6 +7,7 @@ import { buttonTokens } from "@tuja/ui/components/button.stylex";
 import { usePressHandlers } from "@tuja/ui/hooks/use-press-handlers";
 import { controlSize } from "@tuja/ui/tokens.stylex";
 import { useRef } from "react";
+import { isModifiedClick } from "#src/utils/is-modified-click.ts";
 import { Anchor } from "./anchor";
 
 interface AnchorButtonProps extends React.ComponentProps<typeof Anchor> {
@@ -23,6 +24,7 @@ export function AnchorButton({
   hideLabelOnMobile,
   icon,
   isActive,
+  onClick,
   ref: forwardedRef,
   style,
   ...restProps
@@ -40,10 +42,23 @@ export function AnchorButton({
     }
   };
 
+  // Let modifier / non-primary clicks fall through to the browser so the link's
+  // real `href` opens in a new tab/window. Consumers wire `onClick` to
+  // `preventDefault()` and drive client-side state (filters, etc.); skipping
+  // that on a modified click preserves the standard link convention while plain
+  // primary clicks keep the in-place behavior.
+  const handleClick = onClick
+    ? (event: React.MouseEvent<HTMLAnchorElement>) => {
+        if (isModifiedClick(event)) return;
+        onClick(event);
+      }
+    : undefined;
+
   const { isPressed, releasedOutside, pressedStyle, handlers } =
     usePressHandlers({
       targetRef: anchorRef,
       ...restProps,
+      onClick: handleClick,
     });
 
   return (

--- a/apps/web/src/components/shared/menu-item.test.tsx
+++ b/apps/web/src/components/shared/menu-item.test.tsx
@@ -1,7 +1,7 @@
 import { AppRouterContext } from "next/dist/shared/lib/app-router-context.shared-runtime";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "#src/test-utils.tsx";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "#src/test-utils.tsx";
 import { MenuItem } from "./menu-item";
 
 // MenuItem calls useRouter() at render time, which requires the Next.js App
@@ -111,5 +111,44 @@ describe("MenuItem", () => {
       name: "Default-language item",
     });
     expect(item).not.toHaveAttribute("lang");
+  });
+});
+
+describe("MenuItem navigation", () => {
+  beforeEach(() => {
+    stubRouter.push.mockClear();
+  });
+
+  it("navigates in place and prevents default on a plain click", () => {
+    render(
+      <RouterProvider>
+        <MenuItem href="/zh">中文</MenuItem>
+      </RouterProvider>,
+    );
+
+    const notPrevented = fireEvent.click(
+      screen.getByRole("menuitem", { name: "中文" }),
+    );
+
+    expect(stubRouter.push).toHaveBeenCalledWith("/zh");
+    // Default prevented, so the browser doesn't do a full-page navigation.
+    expect(notPrevented).toBe(false);
+  });
+
+  it("lets a modifier click fall through to native navigation", () => {
+    render(
+      <RouterProvider>
+        <MenuItem href="/zh">中文</MenuItem>
+      </RouterProvider>,
+    );
+
+    const notPrevented = fireEvent.click(
+      screen.getByRole("menuitem", { name: "中文" }),
+      { metaKey: true },
+    );
+
+    expect(stubRouter.push).not.toHaveBeenCalled();
+    // Default left intact, so the browser can open the href in a new tab.
+    expect(notPrevented).toBe(true);
   });
 });

--- a/apps/web/src/components/shared/menu-item.tsx
+++ b/apps/web/src/components/shared/menu-item.tsx
@@ -5,6 +5,7 @@ import { color, font, border, controlSize } from "@tuja/ui/tokens.stylex";
 import { useRouter } from "next/navigation";
 import type { PropsWithChildren } from "react";
 import { useTransition } from "react";
+import { isModifiedClick } from "#src/utils/is-modified-click.ts";
 
 interface ItemProps {
   ariaLabel?: string;
@@ -51,6 +52,9 @@ export function MenuItem({
       data-menu-autofocus={autoFocus ? "true" : undefined}
       tabIndex={isActive ? -1 : 0}
       onClick={(e) => {
+        // Modifier / non-primary clicks fall through to the browser so the
+        // `href` opens in a new tab/window; plain clicks navigate in place.
+        if (isModifiedClick(e)) return;
         e.preventDefault();
 
         onBeforeNavigation?.();

--- a/apps/web/src/utils/is-modified-click.test.ts
+++ b/apps/web/src/utils/is-modified-click.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { isModifiedClick } from "./is-modified-click";
+
+const plainClick = {
+  metaKey: false,
+  ctrlKey: false,
+  shiftKey: false,
+  altKey: false,
+  button: 0,
+};
+
+describe("isModifiedClick", () => {
+  it("returns false for a plain primary-button click", () => {
+    expect(isModifiedClick(plainClick)).toBe(false);
+  });
+
+  it("returns true when the Meta key is held", () => {
+    expect(isModifiedClick({ ...plainClick, metaKey: true })).toBe(true);
+  });
+
+  it("returns true when the Ctrl key is held", () => {
+    expect(isModifiedClick({ ...plainClick, ctrlKey: true })).toBe(true);
+  });
+
+  it("returns true when the Shift key is held", () => {
+    expect(isModifiedClick({ ...plainClick, shiftKey: true })).toBe(true);
+  });
+
+  it("returns true when the Alt key is held", () => {
+    expect(isModifiedClick({ ...plainClick, altKey: true })).toBe(true);
+  });
+
+  it("returns true for a non-primary button (e.g. middle-click)", () => {
+    expect(isModifiedClick({ ...plainClick, button: 1 })).toBe(true);
+  });
+});

--- a/apps/web/src/utils/is-modified-click.ts
+++ b/apps/web/src/utils/is-modified-click.ts
@@ -1,0 +1,22 @@
+/**
+ * A mouse-click event carries a modifier when the user holds Meta/Ctrl/Shift/Alt
+ * or uses a non-primary button (e.g. middle-click). Browsers treat these as
+ * "open the link's href in a new tab/window" gestures on a real `<a href>`, so
+ * a link that hijacks the click to drive client-side state must let them fall
+ * through to native navigation instead.
+ */
+export function isModifiedClick(event: {
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  button: number;
+}): boolean {
+  return (
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey ||
+    event.button !== 0
+  );
+}


### PR DESCRIPTION
## Why

Every movie-database filter control (media-type toggle, sort, genre pills, genre match-type toggle, reset) and the locale menu item renders a real `<a href={canonicalFilterUrl}>` — these are genuinely shareable, URL-driven states. But each control's `onClick` unconditionally called `e.preventDefault()` before mutating client-side state. Because `AnchorButton → Anchor → next/link` forwards `onClick` straight through and Next's `<Link>` respects `defaultPrevented`, a user who Cmd/Ctrl/Shift/Alt+clicks (or middle/non-primary-button clicks) one of these links had the browser's native "open in new tab/window" suppressed — the current tab's view got mutated instead. That is a broken link convention, and it was repeated across 7+ callsites.

## What changed

A single shared guard, `isModifiedClick(event)` (true for `metaKey`/`ctrlKey`/`shiftKey`/`altKey` or a non-primary button), is applied at the two chokepoints every affected link already flows through — the shared `AnchorButton` handler and `MenuItem`. On a modified or non-primary click the guard skips `preventDefault()` and the consumer handler, so the event falls through to native link navigation and the `href` opens in a new tab/window. A plain left-click keeps the existing behavior: filter update with no full reload, and in-place navigation for the menu item.

The guard lives in one helper rather than being copy-pasted per callsite, so the 7+ filter controls are fixed without touching any of them individually.

```mermaid
flowchart TD
    A[Click on filter / locale link] --> B{isModifiedClick?<br/>meta / ctrl / shift / alt<br/>or non-primary button}
    B -- yes --> C[Fall through to native nav<br/>href opens in new tab/window]
    B -- no --> D[preventDefault + consumer handler<br/>client-side filter update / in-place nav]
```

## Tests

Added unit coverage for the helper, and extended `AnchorButton` and `MenuItem` tests to assert a plain click runs the consumer handler and prevents default, while a modified/non-primary click leaves the default intact for native navigation.
