### PR TITLE
fix: close type-check gaps and fix css prop type

### DIFF
--- a/apps/web/src/babel.d.ts
+++ b/apps/web/src/babel.d.ts
@@ -1,18 +1,12 @@
-declare global {
-  import type {
-    CompiledStyles,
-    InlineStyles,
-    StyleXArray,
-  } from "@stylexjs/stylex/lib/StyleXTypes";
+// Global JSX augmentation for the `css` prop. `@tuja/babel-plugin-stylex-css-prop`
+// rewrites `css={...}` into `stylex.props(...)` at build time; this declaration is
+// what makes `<div css={styles.x} />` type-check. It reuses the exact `StyleProp`
+// type that `@tuja/ui` components declare for their own `css` prop, so the app's
+// intrinsic-element `css` and the component `css` prop share one contract.
+import type { StyleProp } from "@tuja/ui/css-prop-types";
 
-  type StyleProp = StyleXArray<
-    null | undefined | boolean | Readonly<[CompiledStyles, InlineStyles]>
-  >;
-
-  // Extend React types for native elements
-  declare module "react" {
-    interface Attributes {
-      css?: StyleProp;
-    }
+declare module "react" {
+  interface Attributes {
+    css?: StyleProp;
   }
 }

--- a/packages/i18n-codegen/package.json
+++ b/packages/i18n-codegen/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "src/generator.ts",
   "scripts": {
+    "build:tsc": "tsc --noEmit",
     "lint": "eslint .",
     "test": "vitest run"
   },

--- a/packages/i18n-codegen/src/generator.ts
+++ b/packages/i18n-codegen/src/generator.ts
@@ -12,9 +12,10 @@ const { values } = parseArgs({
   strict: false,
 });
 
-const projectRoot = values.root
-  ? path.resolve(values.root)
-  : path.resolve(import.meta.dirname, "../../../apps/web");
+const projectRoot =
+  typeof values.root === "string"
+    ? path.resolve(values.root)
+    : path.resolve(import.meta.dirname, "../../../apps/web");
 const srcDir = path.join(projectRoot, "src");
 const outputDir = path.join(srcDir, "_generated", "i18n");
 

--- a/packages/system-palette-codegen/package.json
+++ b/packages/system-palette-codegen/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "src/generator.ts",
   "scripts": {
+    "build:tsc": "tsc --noEmit",
     "lint": "eslint .",
     "test": "vitest run"
   },

--- a/packages/tmdb-codegen/package.json
+++ b/packages/tmdb-codegen/package.json
@@ -8,6 +8,7 @@
     "tmdb-codegen": "./src/generator.js"
   },
   "scripts": {
+    "build:tsc": "tsc --noEmit",
     "lint": "eslint .",
     "test": "vitest run"
   },

--- a/packages/tmdb-codegen/src/generate-selective-zod.ts
+++ b/packages/tmdb-codegen/src/generate-selective-zod.ts
@@ -27,9 +27,10 @@ const { values } = parseArgs({
   strict: false,
 });
 
-const projectRoot = values.root
-  ? path.resolve(values.root)
-  : path.resolve(import.meta.dirname, "../../../apps/web");
+const projectRoot =
+  typeof values.root === "string"
+    ? path.resolve(values.root)
+    : path.resolve(import.meta.dirname, "../../../apps/web");
 const outputPath = path.join(projectRoot, "src/_generated/tmdb-zod.ts");
 const tmdbTypesPath = path.resolve(
   import.meta.dirname,

--- a/packages/tmdb-types/package.json
+++ b/packages/tmdb-types/package.json
@@ -8,6 +8,7 @@
     "./vector-db": "./src/vector-db.ts"
   },
   "scripts": {
+    "build:tsc": "tsc --noEmit",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -42,6 +42,7 @@
   "exports": {
     "./package.json": "./package.json",
     "./css-prop": "./src/css-prop.d.ts",
+    "./css-prop-types": "./src/css-prop-types.ts",
     "./tokens.stylex": "./src/tokens.stylex.ts",
     "./breakpoints.stylex": "./src/breakpoints.stylex.ts",
     "./palette/*": "./src/_generated/palette/hues/*.stylex.ts",
@@ -90,6 +91,7 @@
     "./components/textarea": "./src/components/textarea.tsx"
   },
   "scripts": {
+    "build:tsc": "tsc --noEmit",
     "lint": "eslint .",
     "test": "vitest run"
   },

--- a/packages/ui/src/components/anchor-button-group.tsx
+++ b/packages/ui/src/components/anchor-button-group.tsx
@@ -1,6 +1,6 @@
-import type { StyleXStyles } from "@stylexjs/stylex";
 import * as stylex from "@stylexjs/stylex";
 import type { PropsWithChildren } from "react";
+import type { StyleProp } from "../css-prop-types.ts";
 import { border, color, controlSize, shadow } from "../tokens.stylex.ts";
 import { buttonTokens } from "./button.stylex.ts";
 
@@ -8,7 +8,7 @@ interface AnchorButtonGroupProps {
   /** Renders the group on a bright surface, to sit above elevated content. */
   bright?: boolean;
   /** StyleX styles merged over the container's own — the config-layer escape hatch. */
-  css?: StyleXStyles;
+  css?: StyleProp;
 }
 
 export function AnchorButtonGroup({

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import type { StyleXStyles } from "@stylexjs/stylex";
 import * as stylex from "@stylexjs/stylex";
 import { useRef, type ComponentProps, type ReactNode } from "react";
+import type { StyleProp } from "../css-prop-types.ts";
 import { usePressHandlers } from "../hooks/use-press-handlers.ts";
 import { a11y } from "../primitives/a11y.stylex.ts";
 import { font } from "../tokens.stylex.ts";
@@ -31,7 +31,7 @@ interface ButtonBaseProps extends Omit<ComponentProps<"button">, "children"> {
   /** Id applied to the label span, e.g. to wire an external `aria-labelledby`. */
   labelId?: string;
   /** StyleX styles merged over the button's own — the config-layer escape hatch. */
-  css?: StyleXStyles;
+  css?: StyleProp;
 }
 
 /**

--- a/packages/ui/src/components/callout.tsx
+++ b/packages/ui/src/components/callout.tsx
@@ -1,6 +1,6 @@
-import type { StyleXStyles } from "@stylexjs/stylex";
 import * as stylex from "@stylexjs/stylex";
 import type { ComponentProps, ReactNode } from "react";
+import type { StyleProp } from "../css-prop-types.ts";
 import { a11y } from "../primitives/a11y.stylex.ts";
 import { transition } from "../primitives/motion.stylex.ts";
 import { buttonReset } from "../primitives/reset.stylex.ts";
@@ -146,7 +146,7 @@ interface CalloutBaseProps extends Omit<
    */
   role?: "status" | "alert";
   /** StyleX overrides, composed last so a caller can win over the defaults. */
-  css?: StyleXStyles;
+  css?: StyleProp;
 }
 
 /**

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import type { StyleXStyles } from "@stylexjs/stylex";
 import * as stylex from "@stylexjs/stylex";
 import { useEffect, useRef, type ComponentProps } from "react";
+import type { StyleProp } from "../css-prop-types.ts";
 import { useFieldAria } from "../hooks/use-field-aria.ts";
 import { a11y } from "../primitives/a11y.stylex.ts";
 import { flex } from "../primitives/flex.stylex.ts";
@@ -51,7 +51,7 @@ interface CheckboxProps extends Omit<
   /** Box and type scale. Defaults to `"md"`. */
   size?: CheckboxSize;
   /** StyleX styles merged over the root wrapper — the config-layer escape hatch. */
-  css?: StyleXStyles;
+  css?: StyleProp;
 }
 
 /**

--- a/packages/ui/src/components/divider.tsx
+++ b/packages/ui/src/components/divider.tsx
@@ -1,6 +1,6 @@
-import type { StyleXStyles } from "@stylexjs/stylex";
 import * as stylex from "@stylexjs/stylex";
 import type { CSSProperties, Ref } from "react";
+import type { StyleProp } from "../css-prop-types.ts";
 import { color } from "../tokens.stylex.ts";
 import { mergeRefs } from "../utils/merge-refs.ts";
 
@@ -13,7 +13,7 @@ interface DividerProps {
   /** Weight / treatment of the rule. Defaults to `"subtle"`. */
   variant?: DividerVariant;
   /** StyleX overrides, composed last so a caller can win over the defaults. */
-  css?: StyleXStyles;
+  css?: StyleProp;
   /** Escape-hatch class applied to the rendered rule. */
   className?: string;
   /** Inline style applied to the rendered rule. */

--- a/packages/ui/src/components/heading.tsx
+++ b/packages/ui/src/components/heading.tsx
@@ -1,6 +1,6 @@
-import type { StyleXStyles } from "@stylexjs/stylex";
 import * as stylex from "@stylexjs/stylex";
 import type { CSSProperties, ReactNode, Ref } from "react";
+import type { StyleProp } from "../css-prop-types.ts";
 import { color, font } from "../tokens.stylex.ts";
 
 type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
@@ -24,7 +24,7 @@ interface HeadingProps {
   /** Text alignment (logical `start` / `center` / `end`). */
   align?: HeadingAlign;
   /** StyleX overrides, composed last so a caller can win over the defaults. */
-  css?: StyleXStyles;
+  css?: StyleProp;
   /** Escape-hatch class applied to the rendered heading. */
   className?: string;
   /** Inline style applied to the rendered heading. */

--- a/packages/ui/src/components/icon-button.tsx
+++ b/packages/ui/src/components/icon-button.tsx
@@ -1,6 +1,6 @@
-import type { StyleXStyles } from "@stylexjs/stylex";
 import * as stylex from "@stylexjs/stylex";
 import type { ComponentProps, ReactNode } from "react";
+import type { StyleProp } from "../css-prop-types.ts";
 import { a11y } from "../primitives/a11y.stylex.ts";
 import { flex } from "../primitives/flex.stylex.ts";
 import { transition } from "../primitives/motion.stylex.ts";
@@ -39,7 +39,7 @@ interface IconButtonBaseProps extends Omit<
   /** `"circle"` (fully rounded) or `"square"` (rounded corners). Defaults to `"circle"`. */
   shape?: IconButtonShape;
   /** StyleX styles merged over the button's own — the config-layer escape hatch, composed last. */
-  css?: StyleXStyles;
+  css?: StyleProp;
 }
 
 /**

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import type { StyleXStyles } from "@stylexjs/stylex";
 import * as stylex from "@stylexjs/stylex";
 import { type ComponentProps, type ReactNode } from "react";
+import type { StyleProp } from "../css-prop-types.ts";
 import { useFieldAria } from "../hooks/use-field-aria.ts";
 import { a11y } from "../primitives/a11y.stylex.ts";
 import { transition } from "../primitives/motion.stylex.ts";
@@ -59,7 +59,7 @@ interface SelectProps extends Omit<
   /** `<option>` elements — the escape hatch when `options` is not enough. */
   children?: ReactNode;
   /** StyleX styles merged over the field root — the config-layer escape hatch. */
-  css?: StyleXStyles;
+  css?: StyleProp;
 }
 
 /**

--- a/packages/ui/src/components/skeleton.tsx
+++ b/packages/ui/src/components/skeleton.tsx
@@ -1,6 +1,6 @@
-import type { StyleXStyles } from "@stylexjs/stylex";
 import * as stylex from "@stylexjs/stylex";
 import type { CSSProperties, Ref } from "react";
+import type { StyleProp } from "../css-prop-types.ts";
 import { motionConstants } from "../primitives/motion.stylex.ts";
 import { border, color } from "../tokens.stylex.ts";
 import { skeletonTokens } from "./skeleton.stylex.ts";
@@ -21,7 +21,7 @@ interface SkeletonProps {
   /** Staggers the pulse start by N milliseconds — useful for lists of rows. */
   delay?: number;
   /** StyleX overrides, composed last so a caller can win over the defaults. */
-  css?: StyleXStyles;
+  css?: StyleProp;
   /** Escape-hatch class applied to the rendered element. */
   className?: string;
   /** Inline style applied to the rendered element. */

--- a/packages/ui/src/components/spinner.tsx
+++ b/packages/ui/src/components/spinner.tsx
@@ -1,6 +1,6 @@
-import type { StyleXStyles } from "@stylexjs/stylex";
 import * as stylex from "@stylexjs/stylex";
 import type { ComponentProps } from "react";
+import type { StyleProp } from "../css-prop-types.ts";
 import { a11y } from "../primitives/a11y.stylex.ts";
 import { motionConstants } from "../primitives/motion.stylex.ts";
 import { color, space } from "../tokens.stylex.ts";
@@ -23,7 +23,7 @@ interface SpinnerBaseProps extends Omit<
    */
   tone?: SpinnerTone;
   /** StyleX overrides, composed last so a caller can win over the defaults. */
-  css?: StyleXStyles;
+  css?: StyleProp;
 }
 
 /**

--- a/packages/ui/src/components/text-field.tsx
+++ b/packages/ui/src/components/text-field.tsx
@@ -1,5 +1,5 @@
-import type { StyleXStyles } from "@stylexjs/stylex";
 import { type ComponentProps, type ReactNode } from "react";
+import type { StyleProp } from "../css-prop-types.ts";
 import { useFieldAria } from "../hooks/use-field-aria.ts";
 import { a11y } from "../primitives/a11y.stylex.ts";
 import { transition } from "../primitives/motion.stylex.ts";
@@ -41,7 +41,7 @@ interface TextFieldProps extends Omit<ComponentProps<"input">, "size"> {
   /** Decorative trailing adornment (icon), rendered `aria-hidden`. */
   trailing?: ReactNode;
   /** StyleX overrides merged over the control's own — the escape hatch. */
-  css?: StyleXStyles;
+  css?: StyleProp;
 }
 
 /**

--- a/packages/ui/src/components/text.tsx
+++ b/packages/ui/src/components/text.tsx
@@ -1,6 +1,6 @@
-import type { StyleXStyles } from "@stylexjs/stylex";
 import * as stylex from "@stylexjs/stylex";
 import type { CSSProperties, ReactNode, Ref } from "react";
+import type { StyleProp } from "../css-prop-types.ts";
 import { color, font } from "../tokens.stylex.ts";
 import { mergeRefs } from "../utils/merge-refs.ts";
 
@@ -29,7 +29,7 @@ interface TextProps {
   /** Text alignment (logical `start` / `center` / `end`). */
   align?: TextAlign;
   /** StyleX overrides, composed last so a caller can win over the defaults. */
-  css?: StyleXStyles;
+  css?: StyleProp;
   /** Escape-hatch class applied to the rendered element. */
   className?: string;
   /** Inline style applied to the rendered element. */

--- a/packages/ui/src/components/textarea.tsx
+++ b/packages/ui/src/components/textarea.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import type { StyleXStyles } from "@stylexjs/stylex";
 import {
   useCallback,
   useLayoutEffect,
   useRef,
   type ComponentProps,
 } from "react";
+import type { StyleProp } from "../css-prop-types.ts";
 import { useFieldAria } from "../hooks/use-field-aria.ts";
 import { a11y } from "../primitives/a11y.stylex.ts";
 import { transition } from "../primitives/motion.stylex.ts";
@@ -48,7 +48,7 @@ interface TextareaProps extends ComponentProps<"textarea"> {
    */
   autoGrow?: boolean;
   /** StyleX overrides merged over the control's own — the escape hatch. */
-  css?: StyleXStyles;
+  css?: StyleProp;
 }
 
 /**

--- a/packages/ui/src/css-prop-types.ts
+++ b/packages/ui/src/css-prop-types.ts
@@ -1,0 +1,25 @@
+import type {
+  CompiledStyles,
+  InlineStyles,
+  StyleXArray,
+} from "@stylexjs/stylex/lib/types/StyleXTypes";
+
+/**
+ * The type of the custom `css` prop. It mirrors the argument type of
+ * `stylex.props()` — which `@tuja/babel-plugin-stylex-css-prop` rewrites
+ * `css={...}` into at build time — so the union must include a bare
+ * `CompiledStyles` object (a plain `stylex.create` output), not only the
+ * `[CompiledStyles, InlineStyles]` tuple.
+ *
+ * Components declare their own `css` prop with this same type so that the
+ * component-level `css` and the ambient intrinsic-element `css` share one
+ * contract; typing components with the stricter authoring type `StyleXStyles`
+ * instead makes the two intersect and rejects composed `css={[...]}` arrays.
+ */
+export type StyleProp = StyleXArray<
+  | null
+  | undefined
+  | boolean
+  | CompiledStyles
+  | Readonly<[CompiledStyles, InlineStyles]>
+>;

--- a/packages/ui/src/css-prop.d.ts
+++ b/packages/ui/src/css-prop.d.ts
@@ -4,15 +4,7 @@
 // so `@tuja/ui` type-checks standalone. Consumers get the same augmentation by
 // adding an equivalent `css-prop.d.ts` to their own project (see the README) —
 // the augmentation must be part of the consumer's TS program, not just ours.
-import type {
-  CompiledStyles,
-  InlineStyles,
-  StyleXArray,
-} from "@stylexjs/stylex/lib/types/StyleXTypes";
-
-type StyleProp = StyleXArray<
-  null | undefined | boolean | Readonly<[CompiledStyles, InlineStyles]>
->;
+import type { StyleProp } from "./css-prop-types.ts";
 
 declare module "react" {
   interface Attributes {

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "jsx": "preserve",
     "lib": ["esnext", "dom", "dom.iterable"],
-    "types": ["node", "react", "react-dom"]
+    "types": ["node", "react", "react/canary", "react-dom"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "vitest.config.mts"]
 }

--- a/packages/vector-ingest/package.json
+++ b/packages/vector-ingest/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "src/ingest.ts",
   "scripts": {
+    "build:tsc": "tsc --noEmit",
     "lint": "eslint .",
     "test": "vitest run"
   },

--- a/packages/vector-ingest/src/tmdb-client.ts
+++ b/packages/vector-ingest/src/tmdb-client.ts
@@ -175,9 +175,9 @@ export class TmdbClient {
     }
 
     this.rateLimiter.resetBackoff();
-    // response.json() returns Promise<any>. We trust the TMDB OpenAPI contract
-    // for typing; full Zod validation is impractical for 22k lines of generated types.
-
-    return response.json();
+    // `response.json()` is typed `Promise<unknown>`. We trust the TMDB OpenAPI
+    // contract for the caller-supplied `T` rather than Zod-validating 22k lines
+    // of generated types (daily exports are validated at their own boundary).
+    return response.json() as Promise<T>;
   }
 }


### PR DESCRIPTION
## Why

`turbo build:tsc` was quietly type-checking only part of the monorepo. Six TypeScript-bearing workspace packages had a `tsconfig` but no `build:tsc` script, so turbo skipped them entirely. That blind spot hid two things: a design-system `css` prop whose type was both broken and unsafe, and a handful of real latent bugs in codegen/ingest tooling that only ever ran through `tsx`/`node` (which strip types without checking).

The trigger was a user hitting VSCode type errors on the `css` prop in `@tuja/ui` — errors CI never saw, because `packages/ui` had no `build:tsc` at all and only VSCode type-checks open files live.

## The `css` prop was broken and unsafe

- **Too narrow in `@tuja/ui`.** The custom `css` prop type `StyleProp` allowed only the `[CompiledStyles, InlineStyles]` tuple. But `css={x}` compiles to `stylex.props(x)`, which accepts a bare `CompiledStyles` — and every `stylex.create(...)` output *is* a bare `CompiledStyles`. So essentially every `css={styles.x}` in the package failed to type-check (183 errors), invisible to CI.
- **Silently `any` in the web app.** `apps/web/src/babel.d.ts` imported the StyleX types from a non-existent path (`@stylexjs/stylex/lib/StyleXTypes`, missing the `/types/` segment). That degraded the whole app's `css` prop to `any` — zero type safety — which in turn masked the narrow-type bug and 4 real latent errors.

Fix: one shared exported `StyleProp` type (`packages/ui/src/css-prop-types.ts`) whose union mirrors `stylex.props()` (bare `CompiledStyles` included), wired into both the ui and web JSX augmentations so intrinsic-element `css` and component `css` share one contract. The ~13 `@tuja/ui` component props moved from StyleX's authoring type `StyleXStyles` to this shared type — `StyleXStyles` intersected badly with the ambient prop and rejected composed `css={[...]}` arrays (this had hidden 4 real web-app errors). `packages/ui` now type-checks in CI, with `react/canary` enabled in its tsconfig so its standalone check resolves the `ViewTransition` API it uses.

## Same gap in tooling packages

Five more packages were being skipped. Three had real latent type errors, now fixed:

- **`@tuja/vector-ingest`** — `response.json()` is `Promise<unknown>`, unassignable to the method's generic `Promise<T>`. Asserted at the documented TMDB JSON trust boundary (Zod-validating 22k lines of generated types is impractical; daily exports are validated at their own boundary).
- **`@tuja/i18n-codegen` and `@tuja/tmdb-codegen`** — both use `parseArgs({ strict: false })`, which widens `--root` to `string | true` before passing it to `path.resolve` (which requires `string`). A real runtime hazard: a bare `--root` flag would crash. Narrowed with `typeof === "string"`.

`@tuja/system-palette-codegen` and `@tuja/tmdb-types` were already clean and just gained the guard.

## Net effect

Every TypeScript-bearing workspace package now has a `build:tsc` guard, so `turbo build:tsc` can no longer silently skip a package — this whole class of invisible breakage can't recur.
