### PR TITLE
fix: match mobile theme-color to page canvas

### DIFF
--- a/apps/web/src/components/shared/theme-switch.tsx
+++ b/apps/web/src/components/shared/theme-switch.tsx
@@ -5,6 +5,7 @@ import { SunIcon } from "@phosphor-icons/react/dist/ssr/Sun";
 import * as stylex from "@stylexjs/stylex";
 import { Button } from "@tuja/ui/components/button";
 import { Switch, type SwitchState } from "@tuja/ui/components/switch";
+import { gray } from "@tuja/ui/palette/gray";
 import { flex } from "@tuja/ui/primitives/flex.stylex";
 import { motionConstants } from "@tuja/ui/primitives/motion.stylex";
 import { color, controlSize, font, ratio, space } from "@tuja/ui/tokens.stylex";
@@ -40,15 +41,18 @@ export function ThemeSwitch({ labels }: ThemeSwitchProps) {
       document.head.appendChild(metaTag);
     }
 
+    // Mirror `color.bgCanvas` so the mobile browser chrome matches the page
+    // background: light canvas is `gray._97`, dark is `gray._0`. Keep this in
+    // sync with the pre-hydration `themeHack` script to avoid a color flash.
     metaTag.setAttribute(
       "content",
       theme === "system"
         ? preferDark
-          ? "#000000"
-          : "#ffffff"
+          ? gray._0
+          : gray._97
         : theme === "dark"
-          ? "#000000"
-          : "#ffffff",
+          ? gray._0
+          : gray._97,
     );
   }, [theme, preferDark]);
 

--- a/apps/web/src/utils/theme-hack.ts
+++ b/apps/web/src/utils/theme-hack.ts
@@ -1,8 +1,16 @@
+import { gray } from "@tuja/ui/palette/gray";
 import { getDocumentClassName } from "#src/app/global-styles.ts";
 
 const darkClassName = getDocumentClassName("dark");
 const lightClassName = getDocumentClassName("light");
 const systemClassName = getDocumentClassName(null);
+
+// Keep the mobile browser-chrome tint in lockstep with `color.bgCanvas`
+// (see tokens.stylex.ts): light canvas is `gray._97`, dark is `gray._0`.
+// `gray` is a `defineConsts` palette, so these bake in as literal hex here
+// and cannot drift from the canvas background.
+const darkThemeColor = gray._0;
+const lightThemeColor = gray._97;
 
 /**
  * This is a inline script hack we use to set the initial theme of the page to avoid flash of incorrect
@@ -15,14 +23,14 @@ export const themeHack = `(function(){
         meta.setAttribute("name", "theme-color");
         if (theme === "dark") {
             document.documentElement.className = "${darkClassName}";
-            meta.setAttribute("content", "#000000");
+            meta.setAttribute("content", "${darkThemeColor}");
         } else if (theme === "light") {
             document.documentElement.className = "${lightClassName}";
-            meta.setAttribute("content", "#ffffff");
+            meta.setAttribute("content", "${lightThemeColor}");
         } else {
             document.documentElement.className = "${systemClassName}";
             const isDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-            meta.setAttribute("content", isDark ? "#000000" : "#ffffff");
+            meta.setAttribute("content", isDark ? "${darkThemeColor}" : "${lightThemeColor}");
         }
         document.head.appendChild(meta);
     }catch(t){}


### PR DESCRIPTION
## Why

On mobile, the `<meta name="theme-color">` tag tints the browser's address/status bar, and the app's `viewportFit: "cover"` makes that chrome sit flush against the page — so any mismatch between the chrome tint and the page background shows as a color seam at the boundary.

The theme-color was hardcoded to `#ffffff` (light) and `#000000` (dark) in two places: the pre-hydration inline script (`theme-hack.ts`) and the runtime effect in `ThemeSwitch`. But the page's root background is `color.bgCanvas`, which resolves to a warm off-white `#F8F6F2` (`gray._97`) in light mode. So in light mode the browser chrome rendered pure white over an off-white page — a faint but real seam on every page for every light-mode mobile visitor.

Dark mode was already correct (`#000000` matches `gray._0`), which shows the intent was always to track `bgCanvas`; the light value was simply an oversight.

## What changed

Both places now source the theme-color from the `gray` palette const — `gray._97` for light, `gray._0` for dark — exactly mirroring how the design tokens derive `bgCanvas`. Because `gray` is a StyleX `defineConsts` palette, the hex literals bake into the pre-hydration inline script at module-eval time, so there's no runtime cost and no way for the tint to drift from the canvas background if the canvas ever changes.

Keeping both files in sync also means no flash between the pre-hydration script and the client effect.