### PR TITLE
refactor: use shared focus-ring primitive in compact cards

### DIFF
--- a/apps/web/src/components/ai-chat/compact-media-card.tsx
+++ b/apps/web/src/components/ai-chat/compact-media-card.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
+import { a11y } from "@tuja/ui/primitives/a11y.stylex";
 import { motionConstants } from "@tuja/ui/primitives/motion.stylex";
 import { buttonReset } from "@tuja/ui/primitives/reset.stylex";
-import { border, color, ratio, shadow } from "@tuja/ui/tokens.stylex";
+import { border, ratio, shadow } from "@tuja/ui/tokens.stylex";
 import { Anchor } from "#src/components/shared/anchor.tsx";
 import { t } from "#src/i18n.ts";
 import type { MediaListItem } from "#src/utils/types.ts";
@@ -32,7 +33,12 @@ export function CompactMediaCard({
       <Anchor
         href={href}
         indicateExternal={false}
-        css={[styles.compactCard, styles.interactive, styles.linkReset]}
+        css={[
+          styles.compactCard,
+          styles.interactive,
+          a11y.focusRing,
+          styles.linkReset,
+        ]}
         aria-label={getMediaLabel(media)}
       >
         <MediaPoster media={media} compact decorative />
@@ -44,7 +50,12 @@ export function CompactMediaCard({
     return (
       <button
         type="button"
-        css={[buttonReset.base, styles.compactCard, styles.interactive]}
+        css={[
+          buttonReset.base,
+          styles.compactCard,
+          styles.interactive,
+          a11y.focusRing,
+        ]}
         onClick={onClick}
         aria-label={getMediaLabel(media)}
       >
@@ -84,11 +95,6 @@ const styles = stylex.create({
       default: "none",
       ":hover": shadow._3,
     },
-    outline: {
-      default: "none",
-      ":focus-visible": `2px solid ${color.accent}`,
-    },
-    outlineOffset: { default: null, ":focus-visible": "2px" },
   },
   linkReset: {
     textDecoration: "none",

--- a/apps/web/src/components/ai-chat/compact-person-card.tsx
+++ b/apps/web/src/components/ai-chat/compact-person-card.tsx
@@ -2,6 +2,7 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { a11y } from "@tuja/ui/primitives/a11y.stylex";
 import { flex } from "@tuja/ui/primitives/flex.stylex";
 import { motionConstants } from "@tuja/ui/primitives/motion.stylex";
 import { buttonReset } from "@tuja/ui/primitives/reset.stylex";
@@ -89,7 +90,12 @@ export function CompactPersonCard({ person, onClick }: CompactPersonCardProps) {
     return (
       <button
         type="button"
-        css={[buttonReset.base, styles.card, styles.interactive]}
+        css={[
+          buttonReset.base,
+          styles.card,
+          styles.interactive,
+          a11y.focusRing,
+        ]}
         onClick={onClick}
         aria-label={label}
       >
@@ -127,11 +133,6 @@ const styles = stylex.create({
       ":hover": "scale(1.03)",
       ":active": "scale(0.98)",
     },
-    outline: {
-      default: "none",
-      ":focus-visible": `2px solid ${color.accent}`,
-    },
-    outlineOffset: { default: null, ":focus-visible": "2px" },
   },
   photoWrapper: {
     position: "relative",


### PR DESCRIPTION
## Why

The ai-chat compact cards had drifted from the design system's keyboard-focus convention. `CompactMediaCard` and `CompactPersonCard` each hand-rolled their `:focus-visible` indicator inline in StyleX — `outline: none` by default, `2px solid <accent>` on focus, `2px` offset — reimplementing the shared `a11y.focusRing` primitive that 18 sibling surfaces already compose (every DS control plus Anchor, Card, MenuItem, and the detail-overlay).

Per DESIGN.md's "watch the overrides" principle, repeatedly reimplementing a property the system already owns is exactly the drift the primitive exists to prevent: two hand-rolled copies can silently diverge in width, offset, or technique, while the primitive keeps a persistent transparent outline (no focus-in repaint) and can evolve centrally.

## What changes

Both cards now compose `a11y.focusRing` onto their interactive element (the `Anchor`/`button`), and the inline `outline` / `outlineOffset` focus declarations are deleted. The rendered ring is pixel-identical to before — same 2px solid accent, same +2px offset — so this is a no-visual-change refactor. Hover/active scale and shadow behaviour are untouched.

The now-unused `color` token import is dropped from compact-media-card; compact-person-card keeps it (still used elsewhere). The cards live inside `HorizontalScrollRow`, whose scroll container has generous padding, so the outward ring is not clipped.