### PR TITLE
refactor: use shared a11y.srOnly for visually hidden text

### DIFF
--- a/apps/web/src/app/[locale]/(with-header)/calculator/page.tsx
+++ b/apps/web/src/app/[locale]/(with-header)/calculator/page.tsx
@@ -1,26 +1,12 @@
-import * as stylex from "@stylexjs/stylex";
+import { a11y } from "@tuja/ui/primitives/a11y.stylex";
 import { Calculator } from "#src/components/calculator/calculator.tsx";
 import { t } from "#src/i18n.ts";
 
 export default function Page() {
   return (
     <>
-      <h1 css={styles.srOnly}>{t({ en: "Calculator", zh: "计算器" })}</h1>
+      <h1 css={a11y.srOnly}>{t({ en: "Calculator", zh: "计算器" })}</h1>
       <Calculator />
     </>
   );
 }
-
-const styles = stylex.create({
-  srOnly: {
-    position: "absolute",
-    width: "1px",
-    height: "1px",
-    padding: 0,
-    margin: "-1px",
-    overflow: "hidden",
-    clipPath: "inset(50%)",
-    whiteSpace: "nowrap",
-    borderWidth: 0,
-  },
-});

--- a/apps/web/src/app/[locale]/(with-header)/pixel-creature-creator/create/page.tsx
+++ b/apps/web/src/app/[locale]/(with-header)/pixel-creature-creator/create/page.tsx
@@ -1,4 +1,4 @@
-import * as stylex from "@stylexjs/stylex";
+import { a11y } from "@tuja/ui/primitives/a11y.stylex";
 import type { Metadata } from "next";
 import { WizardShell } from "#src/components/pixel-creature-creator/wizard/wizard-shell.tsx";
 import { BASE_URL } from "#src/constants.ts";
@@ -50,24 +50,10 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
 export default function Page() {
   return (
     <>
-      <h1 css={styles.srOnly}>
+      <h1 css={a11y.srOnly}>
         {t({ en: "Create your creature", zh: "创建你的生物" })}
       </h1>
       <WizardShell />
     </>
   );
 }
-
-const styles = stylex.create({
-  srOnly: {
-    position: "absolute",
-    width: "1px",
-    height: "1px",
-    padding: 0,
-    margin: "-1px",
-    overflow: "hidden",
-    clipPath: "inset(50%)",
-    whiteSpace: "nowrap",
-    borderWidth: 0,
-  },
-});

--- a/apps/web/src/app/[locale]/(with-header)/sprite-editor/page.tsx
+++ b/apps/web/src/app/[locale]/(with-header)/sprite-editor/page.tsx
@@ -1,28 +1,12 @@
-import * as stylex from "@stylexjs/stylex";
+import { a11y } from "@tuja/ui/primitives/a11y.stylex";
 import { SpriteEditor } from "#src/components/sprite-editor/sprite-editor.tsx";
 import { t } from "#src/i18n.ts";
 
 export default function Page() {
   return (
     <>
-      <h1 css={styles.srOnly}>
-        {t({ en: "Sprite Editor", zh: "像素编辑器" })}
-      </h1>
+      <h1 css={a11y.srOnly}>{t({ en: "Sprite Editor", zh: "像素编辑器" })}</h1>
       <SpriteEditor />
     </>
   );
 }
-
-const styles = stylex.create({
-  srOnly: {
-    position: "absolute",
-    width: "1px",
-    height: "1px",
-    padding: 0,
-    margin: "-1px",
-    overflow: "hidden",
-    clipPath: "inset(50%)",
-    whiteSpace: "nowrap",
-    borderWidth: 0,
-  },
-});

--- a/apps/web/src/components/sprite-editor/source-canvas.tsx
+++ b/apps/web/src/components/sprite-editor/source-canvas.tsx
@@ -2,6 +2,7 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { purple } from "@tuja/ui/palette/purple";
+import { a11y } from "@tuja/ui/primitives/a11y.stylex";
 import { border, color, shadow } from "@tuja/ui/tokens.stylex";
 import { useEffect, useId, useRef, useState } from "react";
 import { useResolvedTheme } from "#src/hooks/use-resolved-theme.ts";
@@ -315,7 +316,7 @@ export function SourceCanvas({
 
   return (
     <section ref={containerRef} css={styles.root} aria-labelledby={headingId}>
-      <h2 id={headingId} css={styles.srOnly}>
+      <h2 id={headingId} css={a11y.srOnly}>
         {t({ en: "Source viewport", zh: "源图视图" })}
       </h2>
       <canvas
@@ -355,18 +356,5 @@ const styles = stylex.create({
   },
   panning: {
     cursor: "grabbing",
-  },
-  srOnly: {
-    position: "absolute",
-    width: "1px",
-    height: "1px",
-    padding: 0,
-    margin: "-1px",
-    overflow: "hidden",
-    clipPath: "inset(50%)",
-    whiteSpace: "nowrap",
-    borderWidth: 0,
-    insetBlockStart: 0,
-    insetInlineStart: 0,
   },
 });

--- a/apps/web/src/components/sprite-editor/source-image-input.tsx
+++ b/apps/web/src/components/sprite-editor/source-image-input.tsx
@@ -6,6 +6,7 @@ import { ScissorsIcon } from "@phosphor-icons/react/dist/ssr/Scissors";
 import { UploadSimpleIcon } from "@phosphor-icons/react/dist/ssr/UploadSimple";
 import * as stylex from "@stylexjs/stylex";
 import { Button } from "@tuja/ui/components/button";
+import { a11y } from "@tuja/ui/primitives/a11y.stylex";
 import {
   duration,
   easing,
@@ -97,7 +98,7 @@ export function SourceImageInput({
       type="file"
       accept="image/*"
       onChange={handleFile}
-      css={styles.input}
+      css={a11y.srOnly}
       data-testid="source-input"
     />
   );
@@ -208,18 +209,6 @@ export function SourceImageInput({
 }
 
 const styles = stylex.create({
-  input: {
-    position: "absolute",
-    width: "1px",
-    height: "1px",
-    padding: 0,
-    margin: "-1px",
-    overflow: "hidden",
-    clipPath: "inset(50%)",
-    whiteSpace: "nowrap",
-    borderWidth: 0,
-  },
-
   // Hero ------------------------------------------------------------------
   hero: {
     display: "flex",


### PR DESCRIPTION
The design system already ships a canonical visually-hidden primitive — `a11y.srOnly` from `@tuja/ui/primitives/a11y.stylex`. It's the standard screen-reader-only recipe (absolutely positioned 1px box, `clip-path: inset(50%)`, negative margin) that keeps content in the accessibility tree while hiding it visually, and around fifteen callsites already rely on it.

Five other callsites had each hand-rolled that exact same CSS instead of importing it. That's the drift DESIGN.md warns against: accessibility defaults should "ship in the base — not bolted on per use." The visually-hidden technique is a known cross-browser footgun, so with six independent copies any future fix would have to be applied in six places — and inevitably missed in some.

This points all five at the shared primitive. Behaviour is unchanged: every screen-reader-only heading stays in the accessibility tree and renders as a 1×1px clipped, invisible element, and the sprite editor's visually-hidden file input still works.

Three of the five — the calculator, sprite-editor, and creature-creator page files — used StyleX solely for this one block, so their now-empty local style objects (and the lone `import * as stylex`) were removed with it. The sprite editor's source-canvas heading had also picked up redundant `inset-block-start`/`inset-inline-start: 0` on its copy; those are no-ops on an out-of-flow, fully-clipped 1px box, so they were dropped to match the primitive.

https://claude.ai/code/session_01MwCwdcsgL7L89ntf1oHixL