### PR TITLE
ci: warm the shared e2e build via cached next.js compile cache

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,6 +27,17 @@ jobs:
         cache: 'pnpm'
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
+    # Persist Next.js's incremental compile cache across runs so this single
+    # build is warm (~incremental) rather than cold. Keeps build-once efficient
+    # without the wall-clock hit of a cold build gating the shards.
+    - name: Restore Next.js build cache
+      uses: actions/cache@v4
+      with:
+        path: apps/web/.next/cache
+        key: nextjs-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('apps/web/src/**', 'packages/*/src/**') }}
+        restore-keys: |
+          nextjs-cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+          nextjs-cache-${{ runner.os }}-
     - name: Build web app
       working-directory: apps/web
       run: pnpm build
@@ -37,9 +48,12 @@ jobs:
       with:
         name: web-build
         # `next start` serves from `.next`; `public` carries the generated
-        # service worker and hashed PWA icons.
+        # service worker and hashed PWA icons. The incremental compile cache
+        # (`.next/cache`) is build-only dead weight for the shards — exclude it
+        # so all 7 downloads stay small.
         path: |
           apps/web/.next
+          !apps/web/.next/cache
           apps/web/public
         include-hidden-files: true
         retention-days: 1


### PR DESCRIPTION
## Why

#2512 introduced building the e2e app **once** and sharing the artifact across the 7 Playwright shards, replacing 7 independent per-shard rebuilds. That was framed as a compute win — but this repo is **public**, so GitHub Actions minutes are free and unlimited. On real CI runs the change actually made end-to-end wall-clock ~25s *slower*: the single build is a **cold** build (~89s) that now sits as a serial gate before any shard can start, whereas the old approach ran all 7 builds fully in parallel (free, and gating nothing).

This keeps the good part of #2512 — one build, no 7× redundancy — while removing the wall-clock regression by making that one build **warm** instead of cold.

## What

- Caches Next.js's incremental compile cache (`apps/web/.next/cache`) across runs via `actions/cache`, keyed on the lockfile + source files with `restore-keys` fallbacks. The build script runs a plain webpack `next build` (no `--turbopack`), so a restored `.next/cache` turns the cold ~89s build into a warm incremental one (~30–40s expected). That shrinks the serial build gate below what the original parallel-build approach cost, so warm runs should land at or under the original wall-clock while keeping a single build.
- Excludes `.next/cache` from the uploaded build artifact. That incremental compile cache is build-only and useless to the shards (they just run `next start`), so excluding it keeps all 7 shard downloads small.

The first run after this lands is still cold — it seeds the cache; every run afterward is warm.

## After merge

Measure cold-seed vs warm runs on CI to confirm this actually beats the original parallel-build wall-clock. If it doesn't, the fallback is to revert to plain per-shard parallel builds (free on a public repo, no serial gate).