### PR TITLE
perf: skip redundant in-build type-check pass

### DIFF
--- a/apps/trip-planner/next.config.js
+++ b/apps/trip-planner/next.config.js
@@ -5,6 +5,11 @@ module.exports = async () => {
   const nextConfig = {
     reactStrictMode: true,
     reactCompiler: true,
+    // Type-checking runs as a dedicated CI job (build:tsc), so skip the
+    // redundant in-build type-check pass to keep `next build` lean. (Linting
+    // is enforced by the dedicated CI `lint` job; Next 16 no longer runs
+    // ESLint during `next build`.)
+    typescript: { ignoreBuildErrors: true },
     // The app lives in a pnpm workspace; trace from the repo root so Next
     // bundles workspace dependencies correctly for serverless output.
     outputFileTracingRoot: path.resolve(__dirname, "../.."),

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -5,6 +5,11 @@ module.exports = async () => {
   const nextConfig = {
     reactStrictMode: true,
     reactCompiler: true,
+    // Type-checking runs as a dedicated CI job (build:tsc), so skip the
+    // redundant in-build type-check pass to keep `next build` lean. (Linting
+    // is enforced by the dedicated CI `lint` job; Next 16 no longer runs
+    // ESLint during `next build`.)
+    typescript: { ignoreBuildErrors: true },
     transpilePackages: ["@tuja/ui"],
     serverExternalPackages: ["esbuild-wasm", "@babel/parser", "prettier"],
     outputFileTracingRoot: path.resolve(__dirname, "../.."),


### PR DESCRIPTION
## Why

Production builds are slow, and part of that cost is pure duplication. `next build` runs a full TypeScript type-check pass over the app before emitting output — work this repo already does in a dedicated CI job (`build:tsc`, run as its own matrix task on every PR). Running it a second time inside `next build` buys nothing: it can't catch anything the `build:tsc` job doesn't, and merges to `master` are already gated by that job.

## What changes

Both apps (`web` and `trip-planner`) now tell Next to skip its in-build type-check pass (`typescript.ignoreBuildErrors`). `next build` goes straight to compiling and emitting output instead of type-checking first.

Correctness is unchanged: a type error still fails CI via the dedicated `build:tsc` job and blocks the merge. We only remove the redundant second execution that happened inside `next build` — the error can't slip through this path.

## Measured impact (local)

- `next build`: ~14.5s → ~9.6s (~33% faster)
- full `pnpm build` (prebuild + next build + serwist): ~17.6s → ~10.8s
- `turbo build` across both apps: ~12.3s

On CI's slower cores this is roughly ~15s off each build. Output verified still correct: StyleX CSS still emitted, service workers still written, build exits 0, and the unit suite passes.

## Note on ESLint

The original intent was to also skip an in-build ESLint pass, but Next 16 no longer runs ESLint during `next build` at all — the `eslint` config key is now rejected (`Unrecognized key(s) in object: 'eslint'`) and emits a warning on every build. So there is no in-build ESLint pass left to skip, and setting that key would only add build-log noise. Linting remains fully enforced by the dedicated CI `lint` job.

## Levers deliberately not taken (reviewer context)

Two other options were measured as no-ops and skipped:

- **Turbopack builder** (`next build --turbopack`) — no speedup, because StyleX / i18n / custom Babel plugins force everything through `babel.config.js` regardless of bundler.
- **Caching `.next/cache` across CI runs** — no speedup, because the build cost is the Babel/StyleX compile pipeline, not webpack module compilation.