### PR TITLE
test: de-flake trailer overlay body-scroll-lock e2e test

### DIFF
--- a/apps/web/e2e/media-detail-pages.spec.ts
+++ b/apps/web/e2e/media-detail-pages.spec.ts
@@ -107,42 +107,40 @@ test("should prevent body scroll when trailer overlay is open", async ({
 }) => {
   await page.goto(`/en/movie-database/movie/${FIGHT_CLUB_ID}`);
 
-  // Scroll down a bit to have some scroll position
-  await page.evaluate(() => {
+  // Wait for the page to lay out, then scroll to a known position. Until the
+  // content is tall enough, `scrollTo(0, 200)` clamps on a still-hydrating page
+  // and never sticks, so poll until the scroll actually holds (source of a
+  // shard-5 flake).
+  await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+  await page.waitForFunction(() => {
     window.scrollTo(0, 200);
+    return window.scrollY === 200;
   });
-  await page.waitForFunction(() => window.scrollY === 200);
 
-  const scrollYBeforeOverlay = await page.evaluate(() => window.scrollY);
-  expect(scrollYBeforeOverlay).toBe(200);
-
-  // Open trailer overlay
+  // Open the trailer overlay.
   await page.getByRole("button", { name: /play trailer/i }).click();
-
   const iframe = page.locator('iframe[src*="youtube.com/embed"]');
   await expect(iframe).toBeVisible();
 
-  // Wait for scroll lock to be applied by checking data attribute added by RemoveScroll
-  await page.waitForSelector("[data-scroll-locked]", { timeout: 1000 });
+  // The overlay locks body scroll — react-remove-scroll marks the document
+  // with `data-scroll-locked` while active.
+  const scrollLock = page.locator("[data-scroll-locked]");
+  await expect(scrollLock).toHaveCount(1);
 
-  // Try to scroll - scroll position should not change
+  // A wheel gesture must not scroll the page past where it was.
   await page.mouse.wheel(0, 500);
-
   const scrollYDuringOverlay = await page.evaluate(() => window.scrollY);
-  // Scroll position should remain 200 (or possibly 0 due to fixed positioning)
-  // The important thing is it doesn't increase
   expect(scrollYDuringOverlay).toBeLessThanOrEqual(200);
 
-  // Close overlay
+  // Closing removes the overlay and releases the scroll lock. (We don't assert
+  // the exact restored scroll position: react-remove-scroll only locks/unlocks
+  // scrolling, it doesn't restore a saved offset, so the post-close position is
+  // not a stable guarantee — asserting `=== 200` was the original flake.)
   const closeButton = page
     .getByRole("button")
     .filter({ has: page.locator("svg") })
     .last();
   await closeButton.click();
   await expect(iframe).not.toBeVisible();
-
-  // Scroll position should be restored to 200
-  await page.waitForFunction(() => window.scrollY === 200, { timeout: 1000 });
-  const scrollYAfterOverlay = await page.evaluate(() => window.scrollY);
-  expect(scrollYAfterOverlay).toBe(200);
+  await expect(scrollLock).toHaveCount(0);
 });


### PR DESCRIPTION
## Why

The e2e test `apps/web/e2e/media-detail-pages.spec.ts` › **"should prevent body scroll when trailer overlay is open"** was flaky on test shard 5. Each failure burned two ~60s timeout retries, adding ~55s to CI roughly half the time — enough to cap the benefit of the just-merged pipeline speedup (#2517), dragging time-to-mergeable from ~97s back up to ~150s whenever it triggered.

Reproducing the flake locally (10× repeat loop, sampling the actual scroll position) surfaced two root causes:

1. **Scrolling before layout/hydration.** The test scrolled to `y=200` immediately after `page.goto`, before the page had laid out. On a still-short page `scrollTo(0, 200)` clamps to a smaller offset, so `waitForFunction(() => scrollY === 200)` never settled.
2. **A doubly-broken post-close assertion.** `await page.waitForFunction(() => window.scrollY === 200, { timeout: 1000 })` passed `{ timeout: 1000 }` as the page-function *argument*, not as options — so it silently waited the full 60s test timeout instead of 1s. Worse, it asserted the page is restored to exactly `y=200` after the overlay closes, but the shared `@tuja/ui` `Overlay` uses `react-remove-scroll`, which only **locks/unlocks** scrolling and does **not** restore a saved offset. Sampling showed the page sits at `scrollY=0` after close; it only reached 200 on lucky CI retries. So the assertion tested unreliable emergent behaviour — the root of the flake.

## What changed

The test now asserts the overlay's real, stable guarantee instead of brittle emergent behaviour:

- Wait for the `h1` (the readiness signal every sibling test already uses), then poll the scroll until it actually sticks before opening the overlay.
- While the overlay is open, body scroll is **locked** (via the `data-scroll-locked` marker `react-remove-scroll` adds to the document) and a wheel gesture cannot scroll past the pre-open position.
- On close, the overlay is removed and the scroll lock is **released**.

Verified locally: the same 10× repeat loop that previously produced 7 failed / 1 flaky now passes 10/10 with zero flakes.

## Reviewer note

This intentionally **drops** the "scroll restored to 200 after close" assertion, because the app does not reliably restore scroll position when the trailer overlay closes — it resets toward the top. Whether scroll-restoration-on-close *should* be a real feature is a separate potential UX question, not part of this test's named purpose. Flagging it so you can decide whether to pursue that as a separate app change.