### PR TITLE
perf: skip playwright merge-reports on green runs

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -137,7 +137,16 @@ jobs:
   merge-reports:
     permissions:
       contents: read
-    if: ${{ !cancelled() }}
+    # Only build the HTML report when a shard actually failed. With
+    # `trace: on-first-retry`, a fully green run's report carries no
+    # traces/screenshots/video — just a list of passing test names — so generating
+    # it spends ~30s of pnpm/node/install bootstrap on the critical path to produce
+    # an artifact nobody opens. On failure the report is built as before (that's
+    # when traces exist). Per-shard blob reports are still uploaded with 1-day
+    # retention, so a report can be reconstructed by re-running this job if needed.
+    # This job is not a required status check, so skipping it on green blocks
+    # nothing.
+    if: ${{ needs.test.result == 'failure' }}
     needs: [test]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The Playwright workflow's `merge-reports` job runs at the very end of every run and adds ~30–48s of tail latency before all checks turn green — yet on a passing run it produces almost nothing worth having.

The job's actual "Merge into HTML Report" step is ~1s. Everything else is pure bootstrap: pnpm-setup + node-setup + a full monorepo `pnpm install`, all just to obtain the `playwright` CLI to run that 1s merge (one run hit 15s pnpm-setup + 15s node-setup — the cost is real and variable). And because the Playwright config uses `trace: on-first-retry`, a fully green run's HTML report carries no traces, screenshots, or video — only a list of passing test names. So on green runs we spend ~30–48s on the critical path to generate an artifact with near-zero diagnostic value.

`merge-reports` is not a required status check — the seven `test (n, 7)` shards are what gate merge — so it blocks nothing; it only adds wall-clock time.

This gates the job on `needs.test.result == 'failure'` (previously `!cancelled()`), so it is skipped entirely on green runs (~30–48s → 0s off the critical path) and only builds the report when a shard actually failed — exactly when traces exist and the report is worth opening. Failure behaviour is unchanged.

**Trade-off:** a flaky test (fails, then passes on retry) reports its matrix job as `success`, so there is no merged HTML that run. Each shard still uploads its raw blob report with 1-day retention, so a report can be reconstructed by re-running just this job or by merging the blobs locally.