### PR TITLE
feat: add sm/md/lg size scale to button and switch

### DIFF
--- a/apps/web/src/components/design-system/sections/components/button-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/components/button-showcase.tsx
@@ -35,6 +35,20 @@ export function ButtonShowcase() {
         </ShowcaseGrid>
       </Showcase>
 
+      <Showcase label={t({ en: "Sizes", zh: "尺寸" })}>
+        <ShowcaseGrid>
+          <ShowcaseItem label="sm">
+            <Button size="sm">{t({ en: "Small", zh: "小" })}</Button>
+          </ShowcaseItem>
+          <ShowcaseItem label="md">
+            <Button size="md">{t({ en: "Medium", zh: "中" })}</Button>
+          </ShowcaseItem>
+          <ShowcaseItem label="lg">
+            <Button size="lg">{t({ en: "Large", zh: "大" })}</Button>
+          </ShowcaseItem>
+        </ShowcaseGrid>
+      </Showcase>
+
       <Showcase label={t({ en: "With icon", zh: "带图标" })}>
         <ShowcaseGrid>
           <ShowcaseItem label="leading icon">
@@ -132,6 +146,15 @@ export function ButtonShowcase() {
               description: t({
                 en: "For icon-only buttons (no children), exactly one is required to supply the accessible name.",
                 zh: "对于纯图标按钮（无 children），必须二选一以提供可访问名称。",
+              }),
+            },
+            {
+              name: "size",
+              type: '"sm" | "md" | "lg"',
+              defaultValue: '"md"',
+              description: t({
+                en: 'Height ramp via controlSize. "lg" is for prominent CTAs; reserve "sm" for pointer-dense desktop toolbars.',
+                zh: '基于 controlSize 的高度梯度。"lg" 用于醒目的 CTA；"sm" 建议仅用于指针密集的桌面工具栏。',
               }),
             },
             {

--- a/apps/web/src/components/design-system/sections/components/switch-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/components/switch-showcase.tsx
@@ -82,6 +82,32 @@ export function SwitchShowcase() {
         </ShowcaseGrid>
       </Showcase>
 
+      <Showcase label={t({ en: "Sizes", zh: "尺寸" })}>
+        <ShowcaseGrid>
+          <ShowcaseItem label="sm">
+            <Switch
+              size="sm"
+              defaultValue="on"
+              aria-label={t({ en: "Small", zh: "小" })}
+            />
+          </ShowcaseItem>
+          <ShowcaseItem label="md">
+            <Switch
+              size="md"
+              defaultValue="on"
+              aria-label={t({ en: "Medium", zh: "中" })}
+            />
+          </ShowcaseItem>
+          <ShowcaseItem label="lg">
+            <Switch
+              size="lg"
+              defaultValue="on"
+              aria-label={t({ en: "Large", zh: "大" })}
+            />
+          </ShowcaseItem>
+        </ShowcaseGrid>
+      </Showcase>
+
       <Showcase label={t({ en: "Interactive", zh: "交互" })}>
         <div css={[flex.col, styles.interactiveStack]}>
           <Text variant="bodySmall" tone="muted">
@@ -132,6 +158,15 @@ const [state, setState] = useState<SwitchState>("off");
               description: t({
                 en: "Fires with the next state on every user toggle (pointer, keyboard, label).",
                 zh: "每次用户切换（指针、键盘、标签）时以下一状态触发。",
+              }),
+            },
+            {
+              name: "size",
+              type: '"sm" | "md" | "lg"',
+              defaultValue: '"md"',
+              description: t({
+                en: "Track-height ramp via controlSize; the width and thumb scale with it.",
+                zh: "基于 controlSize 的轨道高度梯度；宽度与滑块随之缩放。",
               }),
             },
             {

--- a/apps/web/src/components/design-system/sections/tokens/layout-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/tokens/layout-showcase.tsx
@@ -111,6 +111,7 @@ export function LayoutShowcase() {
     { token: "controlSize._7", meta: "33.6 → 28px", swatch: styles.cs7 },
     { token: "controlSize._8", meta: "38.4 → 32px", swatch: styles.cs8 },
     { token: "controlSize._9", meta: "48 → 40px", swatch: styles.cs9 },
+    { token: "controlSize._10", meta: "57.6 → 48px", swatch: styles.cs10 },
   ];
   const layers = [
     { name: "background", value: "-100", z: styles.lzBackground },
@@ -409,6 +410,7 @@ const styles = stylex.create({
   cs7: { inlineSize: controlSize._7, blockSize: controlSize._7 },
   cs8: { inlineSize: controlSize._8, blockSize: controlSize._8 },
   cs9: { inlineSize: controlSize._9, blockSize: controlSize._9 },
+  cs10: { inlineSize: controlSize._10, blockSize: controlSize._10 },
   layerScroll: {
     marginInline: `calc(-1 * ${space._1})`,
     paddingInline: space._1,

--- a/packages/ui/src/components/button.test.tsx
+++ b/packages/ui/src/components/button.test.tsx
@@ -49,6 +49,31 @@ describe("Button StyleX Integration", () => {
   });
 });
 
+describe("Button size", () => {
+  it("applies distinct classes per size", () => {
+    const { container: sm } = render(<Button size="sm">A</Button>);
+    const { container: lg } = render(<Button size="lg">B</Button>);
+
+    const smButton = sm.querySelector("button");
+    const lgButton = lg.querySelector("button");
+
+    expect(smButton?.className).not.toBe(lgButton?.className);
+    expect(smButton?.className).toContain("sizeStyles.sm");
+    expect(lgButton?.className).toContain("sizeStyles.lg");
+  });
+
+  it("defaults to the md size when size is omitted", () => {
+    const { container: implicit } = render(<Button>Implicit</Button>);
+    const { container: explicit } = render(<Button size="md">Explicit</Button>);
+
+    const implicitButton = implicit.querySelector("button");
+    const explicitButton = explicit.querySelector("button");
+
+    expect(implicitButton?.className).toContain("sizeStyles.md");
+    expect(implicitButton?.className).toBe(explicitButton?.className);
+  });
+});
+
 describe("Button Interaction", () => {
   it("triggers onClick when clicked", async () => {
     const handleClick = vi.fn();

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -5,10 +5,12 @@ import { useRef, type ComponentProps, type ReactNode } from "react";
 import type { StyleProp } from "../css-prop-types.ts";
 import { usePressHandlers } from "../hooks/use-press-handlers.ts";
 import { a11y } from "../primitives/a11y.stylex.ts";
-import { font } from "../tokens.stylex.ts";
+import { controlSize, font } from "../tokens.stylex.ts";
 import { mergeRefs } from "../utils/merge-refs.ts";
 import { sharedStyles } from "./button-shared.stylex.ts";
 import { buttonTokens } from "./button.stylex.ts";
+
+type ButtonSize = "sm" | "md" | "lg";
 
 interface ButtonBaseProps extends Omit<ComponentProps<"button">, "children"> {
   /** Lifts the button onto a bright surface, brightening further on hover. */
@@ -17,6 +19,14 @@ interface ButtonBaseProps extends Omit<ComponentProps<"button">, "children"> {
   hideLabelOnMobile?: boolean;
   /** Decorative leading glyph. Rendered `aria-hidden`; never the accessible name. */
   icon?: ReactNode;
+  /**
+   * Height ramp via `controlSize`. Defaults to `"md"` (the app's standard
+   * control height). `"lg"` is for prominent CTAs; `"sm"` best suits
+   * pointer-dense desktop toolbars — like the `controlSize` scale, every size
+   * renders taller below the `md` breakpoint, but `"sm"` still falls short of
+   * the 44px WCAG 2.5.8 touch target.
+   */
+  size?: ButtonSize;
   /**
    * Toggles the active highlight AND emits `aria-pressed` — use for toggle
    * buttons. For a non-toggle CTA that only wants the highlight, use
@@ -59,6 +69,7 @@ export function Button({
   isActive,
   labelId,
   ref: forwardedRef,
+  size = "md",
   style,
   type = "button",
   variant,
@@ -89,6 +100,7 @@ export function Button({
         sharedStyles.base,
         a11y.focusRing,
         styles.button,
+        sizeStyles[size],
         !!icon &&
           !!children &&
           (hideLabelOnMobile
@@ -134,7 +146,8 @@ const styles = stylex.create({
     cursor: { default: "pointer", ":disabled": "not-allowed" },
 
     // Button-specific styles. Height flows through the shared `buttonTokens`
-    // knob so a container (e.g. AnchorButtonGroup) can shrink grouped buttons.
+    // knob, which the `size` variants below set (and a container such as
+    // AnchorButtonGroup can likewise override to shrink grouped buttons).
     minHeight: buttonTokens.height,
     color: buttonTokens.color,
     backgroundColor: {
@@ -146,5 +159,28 @@ const styles = stylex.create({
       default: null,
       ":disabled": 0.7,
     },
+  },
+});
+
+// Each size drives the shared `buttonTokens.height` knob (read by
+// `styles.button.minHeight`) and scales the label size and padding to match.
+// `md` reproduces the historic default, so callsites that omit `size` are
+// pixel-identical. Padding/gap here override the `sharedStyles.base` values.
+const sizeStyles = stylex.create({
+  sm: {
+    [buttonTokens.height]: controlSize._8,
+    fontSize: font.uiBodySmall,
+    gap: controlSize._1,
+    paddingBlock: controlSize._0,
+    paddingInline: controlSize._2,
+  },
+  md: {
+    [buttonTokens.height]: controlSize._9,
+  },
+  lg: {
+    [buttonTokens.height]: controlSize._10,
+    fontSize: font.uiHeading2,
+    paddingBlock: controlSize._2,
+    paddingInline: controlSize._4,
   },
 });

--- a/packages/ui/src/components/switch.stylex.ts
+++ b/packages/ui/src/components/switch.stylex.ts
@@ -1,7 +1,12 @@
 import * as stylex from "@stylexjs/stylex";
+import { controlSize } from "../tokens.stylex.ts";
 
 export const switchTokens = stylex.defineVars({
   thumbPosition: "0",
   thumbShadow: "none",
   thumbTransitionDuration: "0.2s",
+  // The track height, and thus the whole switch's scale — width follows via the
+  // 2:1 aspect ratio and the thumb is derived from it. The `size` variants set
+  // this per size; `controlSize._9` is the historic (md) default.
+  trackHeight: controlSize._9,
 });

--- a/packages/ui/src/components/switch.test.tsx
+++ b/packages/ui/src/components/switch.test.tsx
@@ -110,6 +110,31 @@ describe("Switch Component", () => {
     });
   });
 
+  describe("Size", () => {
+    it("applies distinct classes per size", () => {
+      const { container: sm } = render(<Switch size="sm" />);
+      const { container: lg } = render(<Switch size="lg" />);
+
+      const smSwitch = sm.querySelector("input");
+      const lgSwitch = lg.querySelector("input");
+
+      expect(smSwitch?.className).not.toBe(lgSwitch?.className);
+      expect(smSwitch?.className).toContain("sizeStyles.sm");
+      expect(lgSwitch?.className).toContain("sizeStyles.lg");
+    });
+
+    it("defaults to the md size when size is omitted", () => {
+      const { container: implicit } = render(<Switch />);
+      const { container: explicit } = render(<Switch size="md" />);
+
+      const implicitSwitch = implicit.querySelector("input");
+      const explicitSwitch = explicit.querySelector("input");
+
+      expect(implicitSwitch?.className).toContain("sizeStyles.md");
+      expect(implicitSwitch?.className).toBe(explicitSwitch?.className);
+    });
+  });
+
   describe("Three-State Functionality", () => {
     it("defaults to 'off' state when uncontrolled", () => {
       render(<Switch />);

--- a/packages/ui/src/components/switch.tsx
+++ b/packages/ui/src/components/switch.tsx
@@ -19,9 +19,11 @@ import { switchTokens } from "./switch.stylex.ts";
 
 export type SwitchState = "off" | "on" | "indeterminate";
 
+type SwitchSize = "sm" | "md" | "lg";
+
 interface SwitchProps extends Omit<
   React.ComponentProps<"input">,
-  "checked" | "onChange"
+  "checked" | "onChange" | "size"
 > {
   /**
    * Controlled state. When provided, the parent owns the value and must update
@@ -32,6 +34,12 @@ interface SwitchProps extends Omit<
   defaultValue?: SwitchState;
   /** Fires with the next state on every user toggle (pointer, keyboard, label). */
   onChange?: (state: SwitchState) => void;
+  /**
+   * Track-height ramp via `controlSize`; the width and thumb scale with it.
+   * Defaults to `"md"` (the app's standard control height). Every size grows
+   * below the `md` breakpoint like the `controlSize` scale.
+   */
+  size?: SwitchSize;
 }
 
 /**
@@ -47,6 +55,7 @@ export function Switch({
   defaultValue,
   onChange,
   className,
+  size = "md",
   style,
   ref: forwardedRef,
   ...rest
@@ -180,6 +189,7 @@ export function Switch({
         buttonReset.base,
         a11y.focusRing,
         styles.switch,
+        sizeStyles[size],
         initialRendered && styles.animate,
         isDragging && styles.dragging(position),
       ]}
@@ -237,7 +247,7 @@ const styles = stylex.create({
     cursor: { default: "pointer", ":disabled": "not-allowed" },
     opacity: { default: 1, ":disabled": 0.6 },
     display: "flex",
-    height: controlSize._9,
+    height: switchTokens.trackHeight,
     padding: border.size_2,
     position: "relative",
     transition: `background-color 0.2s ease`,
@@ -253,8 +263,8 @@ const styles = stylex.create({
 
     [switchTokens.thumbPosition]: {
       default: 0,
-      ":checked": controlSize._9,
-      ":indeterminate": `calc(${controlSize._9} / 2)`,
+      ":checked": switchTokens.trackHeight,
+      ":indeterminate": `calc(${switchTokens.trackHeight} / 2)`,
     },
     [switchTokens.thumbShadow]: {
       default: null,
@@ -268,7 +278,7 @@ const styles = stylex.create({
       boxShadow: switchTokens.thumbShadow,
       content: "",
       display: "block",
-      width: `calc(${controlSize._9} - ${border.size_2} * 2)`,
+      width: `calc(${switchTokens.trackHeight} - ${border.size_2} * 2)`,
       aspectRatio: ratio.square,
       transform: `translateX(${switchTokens.thumbPosition})`,
       transition: null,
@@ -289,4 +299,14 @@ const styles = stylex.create({
       transition: null,
     },
   }),
+});
+
+// Each size sets the `switchTokens.trackHeight` knob; `styles.switch` derives
+// the track height, width (2:1 aspect ratio), thumb size, and travel from it.
+// `md` reproduces the historic default, so callsites that omit `size` are
+// pixel-identical.
+const sizeStyles = stylex.create({
+  sm: { [switchTokens.trackHeight]: controlSize._8 },
+  md: { [switchTokens.trackHeight]: controlSize._9 },
+  lg: { [switchTokens.trackHeight]: controlSize._10 },
 });

--- a/packages/ui/src/tokens.stylex.ts
+++ b/packages/ui/src/tokens.stylex.ts
@@ -426,6 +426,7 @@ export const controlSize = stylex.defineVars({
   _7: { default: "33.6px", [breakpoints.md]: "28px" },
   _8: { default: "38.4px", [breakpoints.md]: "32px" },
   _9: { default: "48px", [breakpoints.md]: "40px" },
+  _10: { default: "57.6px", [breakpoints.md]: "48px" },
 });
 
 export const border = stylex.defineVars({


### PR DESCRIPTION
## Why

`Button` and `Switch` only had a single fixed height, so any surface wanting a more compact or more prominent control had nowhere to go but one-off overrides. This promotes size from an implicit constant to a first-class, configured axis on both primitives — a complete sm/md/lg ramp rather than a scale sized to one callsite.

## What changes

Both `Button` and `Switch` gain a `size` prop (`"sm" | "md" | "lg"`, default `"md"`). `md` reproduces the historic fixed height exactly, so every existing callsite that omits `size` stays pixel-identical.

Each component sizes through a single knob — `buttonTokens.height` for the button, a new `switchTokens.trackHeight` for the switch — from which height, padding, label size, and (for the switch) track width and thumb travel all derive. A new `controlSize._10` token (57.6 → 48px) anchors the `lg` end and keeps Button and Switch height-matched at every size.

The Button and Switch showcases gain "Sizes" sections plus prop-table docs for `size`, and the layout token showcase gains the `controlSize._10` swatch.

---

The compact `sm` variant's first consumer — the redesigned design-system sidebar (side-by-side icon controls + full-bleed shell) — lands in a follow-up PR stacked on this one.

https://claude.ai/code/session_01Dzpst8CRixpkT2nHfvqL8t