### PR TITLE
feat: redesign the design-system sidebar shell

### DIFF
--- a/apps/web/src/components/design-system/sections/components/sidebar-layout-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/components/sidebar-layout-showcase.tsx
@@ -159,15 +159,6 @@ export function SidebarLayoutShowcase() {
             }),
           },
           {
-            name: "stickyInsetBlockStart",
-            type: "string",
-            defaultValue: "calc(env(safe-area-inset-top) + 1.25rem)",
-            description: t({
-              en: "Logical block-start offset the sticky rail pins to. The shell owns the whole page, so the default is a compact offset below the top safe-area inset.",
-              zh: "粘性侧栏吸附的逻辑起始偏移。骨架拥有整个页面，默认值为顶部安全区下方的紧凑偏移。",
-            }),
-          },
-          {
             name: "as",
             type: '"main" | "div"',
             defaultValue: '"main"',

--- a/apps/web/src/components/design-system/sidebar-chrome.tsx
+++ b/apps/web/src/components/design-system/sidebar-chrome.tsx
@@ -47,7 +47,8 @@ export function DesignSystemSidebarHeader({
 /**
  * Utility region pinned to the bottom of the design-system sidebar — the
  * theme toggle and language picker that header-driven pages get from the
- * fixed header chrome, presented as labelled rows above a hairline divider.
+ * fixed header chrome, sat side by side as compact icon controls above a
+ * hairline divider.
  */
 export function DesignSystemSidebarControls({
   locale,
@@ -55,28 +56,21 @@ export function DesignSystemSidebarControls({
   locale: SupportedLocale;
 }) {
   return (
-    <div css={[flex.col, styles.controls]}>
-      <div css={[flex.between, styles.controlRow]}>
-        <span css={styles.controlLabel}>{t({ en: "Theme", zh: "主题" })}</span>
-        <ThemeSwitch
-          labels={[
-            t({ en: "Switch to light theme", zh: "切换至浅色模式" }),
-            t({ en: "Switch to dark theme", zh: "切换至深色模式" }),
-            t({ en: "Switch to system theme", zh: "切换至系统颜色模式" }),
-          ]}
-        />
-      </div>
-      <div css={[flex.between, styles.controlRow]}>
-        <span css={styles.controlLabel}>
-          {t({ en: "Language", zh: "语言" })}
-        </span>
-        <LocaleSelector
-          label={locale === "zh" ? "中文" : "English"}
-          ariaLabel={t({ en: "Select a language", zh: "选择语言" })}
-          locale={locale}
-          menuPosition="bottomRight"
-        />
-      </div>
+    <div css={[flex.row, styles.controls]}>
+      <LocaleSelector
+        size="sm"
+        ariaLabel={t({ en: "Select a language", zh: "选择语言" })}
+        locale={locale}
+        menuPosition="bottomLeft"
+      />
+      <ThemeSwitch
+        size="sm"
+        labels={[
+          t({ en: "Switch to light theme", zh: "切换至浅色模式" }),
+          t({ en: "Switch to dark theme", zh: "切换至深色模式" }),
+          t({ en: "Switch to system theme", zh: "切换至系统颜色模式" }),
+        ]}
+      />
     </div>
   );
 }
@@ -112,18 +106,7 @@ const styles = stylex.create({
   },
   controls: {
     gap: space._2,
-    paddingBlockStart: space._3,
-    borderBlockStartWidth: border.size_1,
-    borderBlockStartStyle: "solid",
-    borderBlockStartColor: color.neutralBorder,
-  },
-  controlRow: {
-    gap: space._2,
-    minBlockSize: controlSize._9,
-  },
-  controlLabel: {
-    fontSize: font.uiBodySmall,
-    color: color.textMuted,
-    whiteSpace: "nowrap",
+    alignItems: "center",
+    justifyContent: "space-between",
   },
 });

--- a/apps/web/src/components/shared/locale-selector.tsx
+++ b/apps/web/src/components/shared/locale-selector.tsx
@@ -13,7 +13,11 @@ import { getLocalePath } from "#src/utils/pathname.ts";
 import { MenuItem } from "./menu-item";
 
 interface LocaleSelectorProps {
-  label: string;
+  /**
+   * Visible trigger label. Omit for an icon-only trigger — the accessible name
+   * still comes from `ariaLabel`.
+   */
+  label?: string;
   ariaLabel: string;
   locale: SupportedLocale;
   /**
@@ -22,6 +26,8 @@ interface LocaleSelectorProps {
    * of the viewport, e.g. in a sidebar's utility row.
    */
   menuPosition?: ComponentProps<typeof MenuButton>["position"];
+  /** Trigger size, forwarded to the underlying Button. Defaults to `"md"`. */
+  size?: ComponentProps<typeof MenuButton>["buttonProps"]["size"];
 }
 
 export function LocaleSelector({
@@ -29,6 +35,7 @@ export function LocaleSelector({
   ariaLabel,
   locale,
   menuPosition,
+  size,
 }: LocaleSelectorProps) {
   const searchParams = useSearchParams();
   const pathname = usePathname();
@@ -43,6 +50,7 @@ export function LocaleSelector({
         "aria-label": ariaLabel,
         icon: <TranslateIcon weight="bold" role="presentation" />,
         hideLabelOnMobile: true,
+        size,
       }}
       menuContent={
         <div css={[flex.col, styles.menu]}>

--- a/apps/web/src/components/shared/theme-switch.tsx
+++ b/apps/web/src/components/shared/theme-switch.tsx
@@ -23,9 +23,16 @@ const themeMap: { [theme in "light" | "dark"]: SwitchState } = {
 interface ThemeSwitchProps {
   /** [switchToLight, switchToDark, switchToSystem] */
   labels: [string, string, string];
+  /**
+   * Control size. `"md"` (default) matches the header chrome; `"sm"` is the
+   * compact form for dense utility rows like the sidebar. Threads through to
+   * the inner switch, system button, and icon overlays.
+   */
+  size?: "sm" | "md";
 }
 
-export function ThemeSwitch({ labels }: ThemeSwitchProps) {
+export function ThemeSwitch({ labels, size = "md" }: ThemeSwitchProps) {
+  const isSmall = size === "sm";
   const preferDark = useMediaQuery("(prefers-color-scheme: dark)", false);
 
   const [theme, setTheme] = useTheme();
@@ -83,6 +90,7 @@ export function ThemeSwitch({ labels }: ThemeSwitchProps) {
     >
       <div css={styles.systemButton}>
         <Button
+          size={size}
           aria-label={labels[2]}
           isActive={theme === "system"}
           onClick={() => {
@@ -91,7 +99,12 @@ export function ThemeSwitch({ labels }: ThemeSwitchProps) {
           }}
           title={labels[2]}
         >
-          <div css={styles.systemIcon}>
+          <div
+            css={[
+              styles.systemIcon,
+              isSmall ? sizeStyles.systemIconSm : sizeStyles.systemIconMd,
+            ]}
+          >
             <MoonIcon
               weight="fill"
               css={styles.systemMoon}
@@ -102,6 +115,7 @@ export function ThemeSwitch({ labels }: ThemeSwitchProps) {
         </Button>
       </div>
       <Switch
+        size={size}
         css={styles.switch}
         value={
           theme === "system"
@@ -117,10 +131,26 @@ export function ThemeSwitch({ labels }: ThemeSwitchProps) {
           ]
         }
       />
-      <span css={[flex.center, styles.icon, styles.moon]} aria-hidden>
+      <span
+        css={[
+          flex.center,
+          styles.icon,
+          isSmall ? sizeStyles.iconSm : sizeStyles.iconMd,
+          styles.moon,
+        ]}
+        aria-hidden
+      >
         <MoonIcon weight="fill" />
       </span>
-      <span css={[flex.center, styles.icon, styles.sun]} aria-hidden>
+      <span
+        css={[
+          flex.center,
+          styles.icon,
+          isSmall ? sizeStyles.iconSm : sizeStyles.iconMd,
+          styles.sun,
+        ]}
+        aria-hidden
+      >
         <SunIcon weight="fill" />
       </span>
     </div>
@@ -158,11 +188,9 @@ const styles = stylex.create({
   icon: {
     aspectRatio: ratio.square,
     bottom: 0,
-    fontSize: font.uiBody,
     pointerEvents: "none",
     position: "absolute",
     top: 0,
-    width: controlSize._9,
   },
   moon: {
     left: 0,
@@ -185,9 +213,6 @@ const styles = stylex.create({
   },
   systemIcon: {
     position: "relative",
-    width: `calc(${controlSize._9} - ${controlSize._4})`,
-    height: `calc(${controlSize._9} - ${controlSize._4})`,
-    fontSize: controlSize._4,
   },
   systemSun: {
     position: "absolute",
@@ -198,5 +223,30 @@ const styles = stylex.create({
     position: "absolute",
     bottom: 0,
     left: 0,
+  },
+});
+
+// The sun/moon overlays span one switch cell, so their width tracks the inner
+// Switch's track height per size (`md` → controlSize._9, `sm` → controlSize._8),
+// and the system-toggle glyph shrinks in step. `md` reproduces the historic
+// (header) sizing.
+const sizeStyles = stylex.create({
+  iconMd: {
+    width: controlSize._9,
+    fontSize: font.uiBody,
+  },
+  iconSm: {
+    width: controlSize._8,
+    fontSize: font.uiBodySmall,
+  },
+  systemIconMd: {
+    width: `calc(${controlSize._9} - ${controlSize._4})`,
+    height: `calc(${controlSize._9} - ${controlSize._4})`,
+    fontSize: controlSize._4,
+  },
+  systemIconSm: {
+    width: `calc(${controlSize._8} - ${controlSize._4})`,
+    height: `calc(${controlSize._8} - ${controlSize._4})`,
+    fontSize: controlSize._3,
   },
 });

--- a/packages/ui/src/components/menu-button.tsx
+++ b/packages/ui/src/components/menu-button.tsx
@@ -201,7 +201,11 @@ export function MenuButton({
               id={popupId}
               ref={popupRef}
               role={popupRole}
-              aria-labelledby={`${targetId}-label`}
+              // Name the popup by the trigger's visible label when there is one,
+              // otherwise fall back to the trigger button itself (an icon-only
+              // trigger renders no label span, so its name comes from
+              // `aria-label`). Keeps existing labelled triggers unchanged.
+              aria-labelledby={children ? `${targetId}-label` : targetId}
             >
               {/* Visible heading only. The popup is already named by the
                   trigger's label via `aria-labelledby`, so this duplicate is

--- a/packages/ui/src/components/sidebar-layout.test.tsx
+++ b/packages/ui/src/components/sidebar-layout.test.tsx
@@ -115,18 +115,14 @@ describe("SidebarLayout drawer", () => {
 });
 
 describe("SidebarLayout tuning props", () => {
-  it("threads the rail width into the grid track and the sticky offset onto the rail", () => {
+  it("threads the rail width into the grid track", () => {
     const { container } = renderShell({
       sidebarInlineSize: "240px",
-      stickyInsetBlockStart: "80px",
     });
     // The rail width feeds the responsive grid track on the root element.
     expect(container.firstElementChild?.getAttribute("style")).toContain(
       "240px",
     );
-    // The sticky offset is applied to the rail panel element itself.
-    const rail = screen.getByText("Rail").closest("[style*='80px']");
-    expect(rail).not.toBeNull();
   });
 
   it("caps the content column when contentMaxInlineSize is passed", () => {

--- a/packages/ui/src/components/sidebar-layout.tsx
+++ b/packages/ui/src/components/sidebar-layout.tsx
@@ -14,13 +14,10 @@ import {
   space,
 } from "../tokens.stylex.ts";
 import { IconButton } from "./icon-button.tsx";
+import { ScrollFade } from "./scroll-fade.tsx";
 
 // Default width of the navigation rail on wider viewports.
 const DEFAULT_SIDEBAR_INLINE_SIZE = "200px";
-
-// Default sticky offset for the rail. The shell owns the whole page (no fixed
-// header coexists with it), so the rail pins just below the top safe area.
-const DEFAULT_STICKY_INSET_BLOCK_START = `calc(env(safe-area-inset-top) + ${space._4})`;
 
 // Must stay in sync with `breakpoints.md` (768px): the drawer only exists
 // below it, the rail column at or above it.
@@ -39,8 +36,10 @@ interface SidebarLayoutProps {
    */
   sidebarHeader?: ReactNode;
   /**
-   * Utility region pinned to the bottom of the rail and the drawer — theme
-   * toggles, language pickers, and similar app-level controls.
+   * Utility region pinned to the bottom edge of the rail and the drawer —
+   * theme toggles, language pickers, and similar app-level controls. The nav
+   * between the header and this region takes the free space, so the utilities
+   * always sit at the sidebar's bottom edge regardless of how tall the nav is.
    */
   sidebarFooter?: ReactNode;
   /**
@@ -62,11 +61,6 @@ interface SidebarLayoutProps {
    * @default "200px"
    */
   sidebarInlineSize?: string;
-  /**
-   * Logical block-start offset the sticky rail pins to. Defaults to a compact
-   * offset below the top safe-area inset.
-   */
-  stickyInsetBlockStart?: string;
   /**
    * Landmark element for the content region. Use `"main"` (the default) for the
    * page's primary content, or `"div"` when the shell is nested inside a surface
@@ -121,15 +115,19 @@ function CloseIcon() {
 }
 
 /**
- * Full-bleed, app-density page shell with a sticky navigation rail. On wider
- * viewports the rail hugs the start edge — title on top, navigation in the
- * middle, utilities pinned to the bottom — while the content column keeps a
- * readable max width beside it. On mobile the rail collapses into a compact
- * top bar whose menu button opens the same content as a drawer (focus-trapped,
- * scroll-locked, dismissed by Escape, backdrop, or following a link).
+ * Full-bleed, app-density page shell with a full-height navigation rail. On
+ * wider viewports the rail bleeds to the top, start, and bottom edges of the
+ * viewport and sticks there as the page scrolls — title on top, navigation
+ * filling the middle (scrolling on its own when it outgrows the rail), and
+ * utilities pinned at the bottom edge — separated from the content by a
+ * hairline border. The content column keeps a readable max width beside it,
+ * with its own padding rather than a page-wide frame. On mobile the rail
+ * collapses into a compact top bar whose menu button opens the same content as
+ * a drawer (focus-trapped, scroll-locked, dismissed by Escape, backdrop, or
+ * following a link).
  *
- * The rail width and sticky offset are overridable per page; both default to
- * shared values so existing callers render unchanged.
+ * The rail width is overridable per page and defaults to a shared value so
+ * existing callers render unchanged.
  */
 export function SidebarLayout({
   sidebar,
@@ -140,7 +138,6 @@ export function SidebarLayout({
   children,
   contentMaxInlineSize,
   sidebarInlineSize,
-  stickyInsetBlockStart,
   as = "main",
 }: SidebarLayoutProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -184,9 +181,6 @@ export function SidebarLayout({
       document.body.style.overflow = overflow;
     };
   }, [isOpen]);
-
-  const resolvedStickyOffset =
-    stickyInsetBlockStart ?? DEFAULT_STICKY_INSET_BLOCK_START;
 
   const content = (
     <div
@@ -232,11 +226,7 @@ export function SidebarLayout({
       />
       <div
         ref={drawerRef}
-        css={[
-          styles.rail,
-          dynamicStyles.railOffsets(resolvedStickyOffset),
-          isOpen && styles.railOpen,
-        ]}
+        css={[styles.rail, isOpen && styles.railOpen]}
         role={isOpen ? "dialog" : undefined}
         aria-modal={isOpen || undefined}
         aria-label={isOpen ? menuLabel : undefined}
@@ -263,7 +253,9 @@ export function SidebarLayout({
             }}
           />
         </div>
-        <div css={styles.railNav}>{sidebar}</div>
+        <ScrollFade orientation="vertical" css={styles.railNav}>
+          {sidebar}
+        </ScrollFade>
         {sidebarFooter != null && (
           <div css={styles.railFooter}>{sidebarFooter}</div>
         )}
@@ -280,17 +272,35 @@ export function SidebarLayout({
 const styles = stylex.create({
   root: {
     display: "grid",
-    alignItems: "start",
-    gap: { default: space._4, [breakpoints.md]: space._8 },
-    // Mobile clears the fixed pill bar; wider viewports only need a compact
-    // offset since no fixed chrome coexists with the shell.
+    // Wider viewports stretch the rail to the grid row so it can fill the
+    // viewport height and pin its footer to the bottom edge; mobile only has
+    // the content column in flow (the rail is a fixed drawer), so alignment is
+    // moot there.
+    alignItems: { default: "start", [breakpoints.md]: "stretch" },
+    // Mobile keeps a compact gap between stacked rows; on wider viewports the
+    // rail bleeds to the edges and the content column owns its own padding, so
+    // the grid itself adds no gap or frame.
+    gap: { default: space._4, [breakpoints.md]: 0 },
+    // The mobile shell clears the fixed pill bar and insets its content from
+    // the safe areas. On wider viewports the frame is dropped entirely: the
+    // rail bleeds to the top, start, and bottom edges and the content area
+    // carries its own padding.
     paddingBlockStart: {
       default: `calc(${space._10} + env(safe-area-inset-top))`,
-      [breakpoints.md]: `calc(${space._4} + env(safe-area-inset-top))`,
+      [breakpoints.md]: 0,
     },
-    paddingBlockEnd: `calc(${space._8} + env(safe-area-inset-bottom))`,
-    paddingInlineStart: `calc(${space._3} + env(safe-area-inset-left))`,
-    paddingInlineEnd: `calc(${space._3} + env(safe-area-inset-right))`,
+    paddingBlockEnd: {
+      default: `calc(${space._8} + env(safe-area-inset-bottom))`,
+      [breakpoints.md]: 0,
+    },
+    paddingInlineStart: {
+      default: `calc(${space._3} + env(safe-area-inset-left))`,
+      [breakpoints.md]: 0,
+    },
+    paddingInlineEnd: {
+      default: `calc(${space._3} + env(safe-area-inset-right))`,
+      [breakpoints.md]: 0,
+    },
   },
   // Collapsed mobile chrome: a floating pill with the title and the menu
   // button. Fixed (a sticky grid item can't escape its own-height row), with
@@ -351,11 +361,18 @@ const styles = stylex.create({
   rail: {
     display: "flex",
     flexDirection: "column",
-    gap: space._4,
+    gap: space._2,
     minInlineSize: 0,
     position: { default: "fixed", [breakpoints.md]: "sticky" },
+    // md+: the sticky rail pins to the very top and stretches to the grid row
+    // (capped at the viewport) so it fills the height and its footer reaches
+    // the bottom edge. Mobile: top and bottom both pinned → a full-height
+    // off-canvas drawer.
+    insetBlockStart: { default: 0, [breakpoints.md]: 0 },
     insetBlockEnd: { default: 0, [breakpoints.md]: "auto" },
     insetInlineEnd: { default: 0, [breakpoints.md]: "auto" },
+    alignSelf: { default: "auto", [breakpoints.md]: "stretch" },
+    maxBlockSize: { default: "none", [breakpoints.md]: "100dvh" },
     inlineSize: {
       default: `min(${space._14}, 85vw)`,
       [breakpoints.md]: "auto",
@@ -363,16 +380,19 @@ const styles = stylex.create({
     zIndex: { default: layer.tooltip, [breakpoints.md]: layer.content },
     paddingBlockStart: {
       default: `calc(${space._3} + env(safe-area-inset-top))`,
-      [breakpoints.md]: 0,
+      [breakpoints.md]: space._2,
     },
     paddingBlockEnd: {
       default: `calc(${space._3} + env(safe-area-inset-bottom))`,
-      [breakpoints.md]: 0,
+      [breakpoints.md]: `calc(${space._2} + env(safe-area-inset-bottom))`,
     },
-    paddingInlineStart: { default: space._3, [breakpoints.md]: 0 },
+    paddingInlineStart: {
+      default: space._3,
+      [breakpoints.md]: `calc(${space._2} + env(safe-area-inset-left))`,
+    },
     paddingInlineEnd: {
       default: `calc(${space._3} + env(safe-area-inset-right))`,
-      [breakpoints.md]: 0,
+      [breakpoints.md]: space._2,
     },
     backgroundColor: {
       default: color.bgSurface,
@@ -380,6 +400,11 @@ const styles = stylex.create({
     },
     borderStartStartRadius: { default: border.radius_3, [breakpoints.md]: 0 },
     borderEndStartRadius: { default: border.radius_3, [breakpoints.md]: 0 },
+    // md+: a hairline right border separates the rail from the content in place
+    // of the mobile drawer's shadow.
+    borderInlineEndWidth: { default: 0, [breakpoints.md]: border.size_1 },
+    borderInlineEndStyle: "solid",
+    borderInlineEndColor: color.neutralBorder,
     boxShadow: { default: shadow._6, [breakpoints.md]: "none" },
     transform: {
       default: "translateX(110%)",
@@ -415,17 +440,38 @@ const styles = stylex.create({
     display: { default: "inline-flex", [breakpoints.md]: "none" },
   },
   railNav: {
+    // Takes the free space between the header and footer so the utilities pin
+    // to the rail's bottom edge. The `ScrollFade` wrapper owns the overflow,
+    // the shrink-to-scroll min-size, and the scroll-aware edge fade.
     flexGrow: 1,
-    minBlockSize: 0,
-    overflowY: "auto",
     overscrollBehavior: "contain",
-    scrollbarWidth: "none",
+    // The native scrollbar shows only while the nav actually overflows. Bleed
+    // the scroll container's end edge out over the rail's inline padding so the
+    // scrollbar sits flush against the rail's border, then pad the content back
+    // in by the same amount so the links keep their inset.
+    marginInlineEnd: { default: 0, [breakpoints.md]: `calc(-1 * ${space._2})` },
+    paddingInlineEnd: { default: 0, [breakpoints.md]: space._2 },
   },
   railFooter: {
     flexShrink: 0,
   },
   contentArea: {
     minInlineSize: 0,
+    // md+: the content owns its padding now that the rail bleeds to the edges
+    // and the root drops its frame. The inline-start value gives the content
+    // breathing room from the rail's border; the block values keep a compact
+    // reading offset from the top and clear the bottom safe area. Mobile takes
+    // its insets from the root frame, so these stay unset there.
+    paddingBlockStart: { default: 0, [breakpoints.md]: space._4 },
+    paddingBlockEnd: {
+      default: 0,
+      [breakpoints.md]: `calc(${space._8} + env(safe-area-inset-bottom))`,
+    },
+    paddingInlineStart: { default: 0, [breakpoints.md]: space._8 },
+    paddingInlineEnd: {
+      default: 0,
+      [breakpoints.md]: `calc(${space._6} + env(safe-area-inset-right))`,
+    },
   },
   content: {
     inlineSize: "100%",
@@ -435,24 +481,14 @@ const styles = stylex.create({
   },
 });
 
-// Dynamic tuning: StyleX generates the CSS variables and their references, so
-// the rail width participates in the responsive grid track and the sticky
-// offset stays a logical property. Values are runtime args, defaulted by the
-// caller.
+// Dynamic tuning: StyleX generates the CSS variable and its reference, so the
+// rail width participates in the responsive grid track. The value is a runtime
+// arg, defaulted by the caller.
 const dynamicStyles = stylex.create({
   columns: (sidebarInlineSize: string) => ({
     gridTemplateColumns: {
       default: "minmax(0, 1fr)",
       [breakpoints.md]: `${sidebarInlineSize} minmax(0, 1fr)`,
-    },
-  }),
-  railOffsets: (stickyInsetBlockStart: string) => ({
-    insetBlockStart: { default: 0, [breakpoints.md]: stickyInsetBlockStart },
-    // Mirrors the shell's block-end padding so a fully-scrolled page never
-    // squeezes the rail out of its sticky position.
-    maxBlockSize: {
-      default: "none",
-      [breakpoints.md]: `calc(100dvh - ${stickyInsetBlockStart} - ${space._8} - env(safe-area-inset-bottom))`,
     },
   }),
 });


### PR DESCRIPTION
> Stacked on #2524 (the reusable `ScrollFade` primitive), which sits on the now-merged #2521 (Button/Switch size scale). Review and merge #2524 first; this PR's diff should be read against `feat/scroll-fade`.

## Why

The navigation rail claimed to be a "full-bleed, app-density shell" in its own docstring, but it floated inside a page-wide padded frame and never reached the top, start, or bottom edges, leaving a large empty gap below the rail. The footer divider that separated it from the content read as old-school and never spanned the full width. This rebuilds the rail into the app sidebar the docstring always described.

## What changed

**The rail is now a real full-bleed, full-height sidebar.** On wider viewports it bleeds to the top, start, and bottom edges and sticks full-height as the page scrolls: title on top, navigation filling the middle (scrolling on its own when it outgrows the rail), utilities pinned to the bottom edge as a compact side-by-side icon row (theme toggle + language picker, at the `sm` control size), separated from the content by a hairline right border. The page-wide frame padding moved off the layout root and onto the content column. Framing, title, and footer spacing were tightened; nav item spacing was deliberately kept at its original density. The now-vestigial `stickyInsetBlockStart` prop was removed (the rail pins to the top edge), along with its test and showcase PropsTable row.

**The footer divider became a scroll-aware edge fade.** The inset border is gone; the nav now fades whichever edges still have hidden content, using the `ScrollFade` primitive introduced in #2524. Because that fade is scroll-aware, each edge fades only when there is genuinely hidden content in that direction, so a rail resting at the top shows no top fade and never obstructs the first nav item.

**The rail's scrollbar is native and flush.** It appears only while the nav overflows and is hidden otherwise, and sits flush against the sidebar's right border: the scroll container's end edge is bled out over the rail's inline padding, with the content padded back in so the links keep their inset.

**The utility controls became side-by-side icon controls.** `theme-switch` gained a `size` prop, `locale-selector` gained an optional icon-only mode and a `size` prop, and `menu-button` now names an icon-only trigger's popup by the trigger's own `aria-label`.

https://claude.ai/code/session_01Dzpst8CRixpkT2nHfvqL8t
