### PR TITLE
docs: document the control-size ramp under spacing, not layout

### DIFF
--- a/apps/web/src/app/[locale]/design-system/foundations/spacing/page.tsx
+++ b/apps/web/src/app/[locale]/design-system/foundations/spacing/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { DocPage } from "#src/components/design-system/doc-page.tsx";
+import { ControlSizeShowcase } from "#src/components/design-system/sections/tokens/control-size-showcase.tsx";
 import { SpaceScaleShowcase } from "#src/components/design-system/sections/tokens/space-scale-showcase.tsx";
 import { t } from "#src/i18n.ts";
 import type { PageProps } from "#src/types.ts";
@@ -20,11 +21,12 @@ export default function SpacingPage() {
     <DocPage
       title={t({ en: "Spacing", zh: "间距" })}
       description={t({
-        en: "One rem-based scale of eighteen steps, each drawn to true size as a ruler.",
-        zh: "一套以 rem 为基准、共十八级的阶梯，皆按真实尺寸以标尺呈现。",
+        en: "The rem-based spacing scale — eighteen steps drawn to true size as a ruler — and the responsive control-size ramp that sets the dimensions of every interactive control.",
+        zh: "以 rem 为基准的间距阶梯——十八级按真实尺寸如标尺般呈现——以及决定每个交互控件尺寸的响应式控件尺寸阶梯。",
       })}
     >
       <SpaceScaleShowcase />
+      <ControlSizeShowcase />
     </DocPage>
   );
 }

--- a/apps/web/src/components/design-system/sections/tokens/control-size-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/tokens/control-size-showcase.tsx
@@ -1,0 +1,73 @@
+import * as stylex from "@stylexjs/stylex";
+import { border, color, controlSize, space } from "@tuja/ui/tokens.stylex";
+import { t } from "#src/i18n.ts";
+import { ShowcaseHelper } from "../../showcase-helper.tsx";
+import { Showcase } from "../../showcase.tsx";
+import { SpecCard } from "../../spec-card.tsx";
+
+export function ControlSizeShowcase() {
+  // Control-size ramp: each square is drawn at its token, which itself shrinks at
+  // the md breakpoint — so the whole ramp steps down live as the window widens.
+  const controls = [
+    { token: "controlSize._0", meta: "2.4 → 2px", swatch: styles.cs0 },
+    { token: "controlSize._1", meta: "4.8 → 4px", swatch: styles.cs1 },
+    { token: "controlSize._2", meta: "9.6 → 8px", swatch: styles.cs2 },
+    { token: "controlSize._3", meta: "14.4 → 12px", swatch: styles.cs3 },
+    { token: "controlSize._4", meta: "19.2 → 16px", swatch: styles.cs4 },
+    { token: "controlSize._5", meta: "24 → 20px", swatch: styles.cs5 },
+    { token: "controlSize._6", meta: "28.8 → 24px", swatch: styles.cs6 },
+    { token: "controlSize._7", meta: "33.6 → 28px", swatch: styles.cs7 },
+    { token: "controlSize._8", meta: "38.4 → 32px", swatch: styles.cs8 },
+    { token: "controlSize._9", meta: "48 → 40px", swatch: styles.cs9 },
+    { token: "controlSize._10", meta: "57.6 → 48px", swatch: styles.cs10 },
+  ];
+
+  return (
+    <Showcase label={t({ en: "Control size", zh: "控件尺寸" })}>
+      <ShowcaseHelper>
+        {t({
+          en: "The dimension ramp for controls — heights, paddings, icon boxes. Every step renders larger on touch viewports and shrinks at the md breakpoint, so tap targets stay comfortable on phones.",
+          zh: "控件的尺寸阶梯——高度、内边距、图标盒。每一级在触摸视口上更大，并在 md 断点收缩，从而在手机上保持舒适的点按目标。",
+        })}
+      </ShowcaseHelper>
+      <div css={styles.grid}>
+        {controls.map((step) => (
+          <SpecCard key={step.token} token={step.token} meta={step.meta}>
+            <div css={styles.csFloor}>
+              <span css={[styles.csSwatch, step.swatch]} />
+            </div>
+          </SpecCard>
+        ))}
+      </div>
+    </Showcase>
+  );
+}
+
+const styles = stylex.create({
+  grid: {
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fill, minmax(150px, 1fr))",
+    gap: space._3,
+  },
+  csFloor: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    minBlockSize: "56px",
+  },
+  csSwatch: {
+    borderRadius: border.radius_1,
+    backgroundColor: color.accent,
+  },
+  cs0: { inlineSize: controlSize._0, blockSize: controlSize._0 },
+  cs1: { inlineSize: controlSize._1, blockSize: controlSize._1 },
+  cs2: { inlineSize: controlSize._2, blockSize: controlSize._2 },
+  cs3: { inlineSize: controlSize._3, blockSize: controlSize._3 },
+  cs4: { inlineSize: controlSize._4, blockSize: controlSize._4 },
+  cs5: { inlineSize: controlSize._5, blockSize: controlSize._5 },
+  cs6: { inlineSize: controlSize._6, blockSize: controlSize._6 },
+  cs7: { inlineSize: controlSize._7, blockSize: controlSize._7 },
+  cs8: { inlineSize: controlSize._8, blockSize: controlSize._8 },
+  cs9: { inlineSize: controlSize._9, blockSize: controlSize._9 },
+  cs10: { inlineSize: controlSize._10, blockSize: controlSize._10 },
+});

--- a/apps/web/src/components/design-system/sections/tokens/layout-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/tokens/layout-showcase.tsx
@@ -5,7 +5,6 @@ import { scrollX } from "@tuja/ui/primitives/layout.stylex";
 import {
   border,
   color,
-  controlSize,
   font,
   layer,
   shadow,
@@ -98,21 +97,6 @@ function BreakpointBands() {
 }
 
 export function LayoutShowcase() {
-  // Control-size ramp: each square is drawn at its token, which itself shrinks at
-  // the md breakpoint — so the whole ramp steps down live as the window widens.
-  const controls = [
-    { token: "controlSize._0", meta: "2.4 → 2px", swatch: styles.cs0 },
-    { token: "controlSize._1", meta: "4.8 → 4px", swatch: styles.cs1 },
-    { token: "controlSize._2", meta: "9.6 → 8px", swatch: styles.cs2 },
-    { token: "controlSize._3", meta: "14.4 → 12px", swatch: styles.cs3 },
-    { token: "controlSize._4", meta: "19.2 → 16px", swatch: styles.cs4 },
-    { token: "controlSize._5", meta: "24 → 20px", swatch: styles.cs5 },
-    { token: "controlSize._6", meta: "28.8 → 24px", swatch: styles.cs6 },
-    { token: "controlSize._7", meta: "33.6 → 28px", swatch: styles.cs7 },
-    { token: "controlSize._8", meta: "38.4 → 32px", swatch: styles.cs8 },
-    { token: "controlSize._9", meta: "48 → 40px", swatch: styles.cs9 },
-    { token: "controlSize._10", meta: "57.6 → 48px", swatch: styles.cs10 },
-  ];
   const layers = [
     { name: "background", value: "-100", z: styles.lzBackground },
     { name: "base", value: "0", z: styles.lzBase },
@@ -167,24 +151,6 @@ export function LayoutShowcase() {
         </div>
       </Showcase>
 
-      <Showcase label={t({ en: "Control size", zh: "控件尺寸" })}>
-        <ShowcaseHelper>
-          {t({
-            en: "The dimension ramp for controls — heights, paddings, icon boxes. Every step renders larger on touch viewports and shrinks at the md breakpoint, so tap targets stay comfortable on phones.",
-            zh: "控件的尺寸阶梯——高度、内边距、图标盒。每一级在触摸视口上更大，并在 md 断点收缩，从而在手机上保持舒适的点按目标。",
-          })}
-        </ShowcaseHelper>
-        <div css={styles.grid}>
-          {controls.map((step) => (
-            <SpecCard key={step.token} token={step.token} meta={step.meta}>
-              <div css={styles.csFloor}>
-                <span css={[styles.csSwatch, step.swatch]} />
-              </div>
-            </SpecCard>
-          ))}
-        </div>
-      </Showcase>
-
       <Showcase label={t({ en: "Layers", zh: "层级" })}>
         <ShowcaseHelper>
           {t({
@@ -230,7 +196,7 @@ export function LayoutShowcase() {
 
       <UsageSnippet
         code={`import { breakpoints } from "@tuja/ui/breakpoints.stylex";
-import { layout, controlSize, layer, ratio } from "@tuja/ui/tokens.stylex";
+import { layout, layer, ratio } from "@tuja/ui/tokens.stylex";
 
 const styles = stylex.create({
   page: { maxInlineSize: layout.maxInlineSize, marginInline: "auto" },
@@ -390,27 +356,6 @@ const styles = stylex.create({
     gridTemplateColumns: "repeat(auto-fill, minmax(150px, 1fr))",
     gap: space._3,
   },
-  csFloor: {
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    minBlockSize: "56px",
-  },
-  csSwatch: {
-    borderRadius: border.radius_1,
-    backgroundColor: color.accent,
-  },
-  cs0: { inlineSize: controlSize._0, blockSize: controlSize._0 },
-  cs1: { inlineSize: controlSize._1, blockSize: controlSize._1 },
-  cs2: { inlineSize: controlSize._2, blockSize: controlSize._2 },
-  cs3: { inlineSize: controlSize._3, blockSize: controlSize._3 },
-  cs4: { inlineSize: controlSize._4, blockSize: controlSize._4 },
-  cs5: { inlineSize: controlSize._5, blockSize: controlSize._5 },
-  cs6: { inlineSize: controlSize._6, blockSize: controlSize._6 },
-  cs7: { inlineSize: controlSize._7, blockSize: controlSize._7 },
-  cs8: { inlineSize: controlSize._8, blockSize: controlSize._8 },
-  cs9: { inlineSize: controlSize._9, blockSize: controlSize._9 },
-  cs10: { inlineSize: controlSize._10, blockSize: controlSize._10 },
   layerScroll: {
     marginInline: `calc(-1 * ${space._1})`,
     paddingInline: space._1,


### PR DESCRIPTION
## Why

`controlSize` sizes interactive controls — button/switch/icon-button heights, paddings, icon boxes. That is a **sizing** concern, not a layout one. It only lived on the **Layout** foundations page (alongside breakpoints, content width, z-index layers, and aspect ratios) because it is breakpoint-responsive: each step renders ~20% larger on touch viewports and shrinks at the `md` breakpoint for comfortable tap targets, so it was originally filed next to the breakpoint tokens.

But a reader looking for control dimensions expects them beside the **spacing** scale — a control's size derives from the same base rhythm (a height is padding plus line-height). This moves the documentation to where readers will look for it.

## What changed

Purely a reorganization of the design-system showcase pages — **no token values or component behaviour change.**

- The **Control size** showcase is now a standalone `ControlSizeShowcase` component, rendered on the **Spacing** page after its space-scale ruler.
- The **Spacing** page intro now covers both the rem-based spacing scale and the responsive control-size ramp.
- The **Layout** page now shows only breakpoints, content width, layers, and aspect ratios (its usage snippet drops the `controlSize` import too).

The ramp on display spans `controlSize._0` through `_10` (`_10` was added by the first PR in this stack).

> Stacked on top of #2522 (`feat/sidebar-shell`) — review/merge that first.