### PR TITLE
fix: prevent design-system sidebar nav overflow

### DIFF
--- a/apps/web/src/app/[locale]/design-system/layout.tsx
+++ b/apps/web/src/app/[locale]/design-system/layout.tsx
@@ -82,6 +82,11 @@ export default async function Layout({
       sidebar={<DesignSystemNav />}
       sidebarHeader={<DesignSystemSidebarHeader locale={validatedLocale} />}
       sidebarFooter={<DesignSystemSidebarControls locale={validatedLocale} />}
+      // Wider than the 200px default so the longest nav label ("Header &
+      // footer layout") keeps its full padding on one line — even once a
+      // classic (non-overlay) scrollbar claims its reserved gutter from the
+      // rail.
+      sidebarInlineSize="240px"
       menuLabel={t({ en: "Design system menu", zh: "设计系统菜单" })}
       closeLabel={t({ en: "Close menu", zh: "关闭菜单" })}
     >

--- a/apps/web/src/app/[locale]/design-system/layout.tsx
+++ b/apps/web/src/app/[locale]/design-system/layout.tsx
@@ -82,11 +82,6 @@ export default async function Layout({
       sidebar={<DesignSystemNav />}
       sidebarHeader={<DesignSystemSidebarHeader locale={validatedLocale} />}
       sidebarFooter={<DesignSystemSidebarControls locale={validatedLocale} />}
-      // Wider than the 200px default so the longest nav label ("Header &
-      // footer layout") keeps its full padding on one line — even once a
-      // classic (non-overlay) scrollbar claims its reserved gutter from the
-      // rail.
-      sidebarInlineSize="240px"
       menuLabel={t({ en: "Design system menu", zh: "设计系统菜单" })}
       closeLabel={t({ en: "Close menu", zh: "关闭菜单" })}
     >

--- a/apps/web/src/components/design-system/sections/components/sidebar-layout-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/components/sidebar-layout-showcase.tsx
@@ -152,7 +152,7 @@ export function SidebarLayoutShowcase() {
           {
             name: "sidebarInlineSize",
             type: "string",
-            defaultValue: '"200px"',
+            defaultValue: '"240px"',
             description: t({
               en: "Inline size of the rail column on wider viewports.",
               zh: "宽视口下侧栏列的行内尺寸。",

--- a/packages/ui/src/components/sidebar-layout.tsx
+++ b/packages/ui/src/components/sidebar-layout.tsx
@@ -445,6 +445,11 @@ const styles = stylex.create({
     // the shrink-to-scroll min-size, and the scroll-aware edge fade.
     flexGrow: 1,
     overscrollBehavior: "contain",
+    // Reserve the classic-scrollbar gutter up front (a no-op for overlay
+    // scrollbars) so a nav that overflows never renders its links underneath
+    // the scrollbar, and the link width stays constant whether or not the
+    // scrollbar is present.
+    scrollbarGutter: { default: "auto", [breakpoints.md]: "stable" },
     // The native scrollbar shows only while the nav actually overflows. Bleed
     // the scroll container's end edge out over the rail's inline padding so the
     // scrollbar sits flush against the rail's border, then pad the content back

--- a/packages/ui/src/components/sidebar-layout.tsx
+++ b/packages/ui/src/components/sidebar-layout.tsx
@@ -16,8 +16,10 @@ import {
 import { IconButton } from "./icon-button.tsx";
 import { ScrollFade } from "./scroll-fade.tsx";
 
-// Default width of the navigation rail on wider viewports.
-const DEFAULT_SIDEBAR_INLINE_SIZE = "200px";
+// Default width of the navigation rail on wider viewports — wide enough for
+// the nav labels used across the app to sit on one line, including once a
+// classic scrollbar claims its reserved gutter from the rail.
+const DEFAULT_SIDEBAR_INLINE_SIZE = "240px";
 
 // Must stay in sync with `breakpoints.md` (768px): the drawer only exists
 // below it, the rail column at or above it.
@@ -58,7 +60,7 @@ interface SidebarLayoutProps {
   contentMaxInlineSize?: string;
   /**
    * Inline size of the rail column on wider viewports.
-   * @default "200px"
+   * @default "240px"
    */
   sidebarInlineSize?: string;
   /**


### PR DESCRIPTION
## Why

On the design-system page, the longest sidebar nav item — "Header & footer layout" — spilled past the fixed 200px rail into the content area and overlapped the scrollbar. With a classic (non-overlay) scrollbar claiming ~15px, too little width was left for the single-line `nowrap` label, so the text overflowed the pill and the rail edge. On overlay-scrollbar systems (e.g. macOS) it sat flush at the boundary with zero slack; on classic-scrollbar systems it visibly overflowed.

Single-line labels are a requirement here — letting the label wrap to two lines was considered and rejected because a two-line pill breaks the single-line rhythm of the other nav items.

## What changed

- The shared `SidebarLayout` default rail width is raised from 200px to 240px, so the longest label keeps its full padding on one line even after a scrollbar narrows the usable rail width. The 200px default was consumed only by this app's design-system nav — once in the real shell and once in the docs live demo, both rendering that same long label — so a per-page override would have fixed the shell while leaving the demo at 200px with the same latent overflow. Bumping the default corrects both; no callsite needs its own width.
- The `SidebarLayout` scroll container now reserves the scrollbar gutter up front (`scrollbar-gutter: stable` at md+, a no-op for overlay scrollbars). This keeps nav link width constant whether or not the nav overflows, so an overflowing nav never renders its links underneath the scrollbar.

Both changes live in the shared `SidebarLayout`, so they apply to every consumer — currently the design-system shell and its in-docs demo.

Verified single-line labels with full padding and no overflow across both surfaces, in both natural (overlay) and simulated classic-scrollbar states.