### PR TITLE
fix: make SidebarLayout fill its container's height

### DIFF
--- a/apps/web/src/components/design-system/sections/components/sidebar-layout-showcase.tsx
+++ b/apps/web/src/components/design-system/sections/components/sidebar-layout-showcase.tsx
@@ -199,12 +199,11 @@ const styles = stylex.create({
     // the callsite).
     transform: "translateZ(0)",
   },
-  // The real navigation is tall, so the demo scrolls inside its own viewport
-  // — which also shows off the rail's sticky behaviour in miniature.
+  // Fixed-height box; the shell fills it, so the rail bounds here and its footer
+  // pins to the bottom without the demo scrolling.
   viewport: {
-    maxBlockSize: space._15,
-    overflowY: "auto",
-    overscrollBehavior: "contain",
+    blockSize: space._15,
+    overflow: "hidden",
   },
   contentInner: {
     display: "flex",

--- a/packages/ui/src/components/sidebar-layout.tsx
+++ b/packages/ui/src/components/sidebar-layout.tsx
@@ -123,6 +123,10 @@ function CloseIcon() {
  * dismissed by Escape, backdrop, or following a link).
  *
  * The rail width is overridable per page via `sidebarInlineSize`.
+ *
+ * The rail fills its container's height (capped at the viewport), so the shell
+ * works dropped into any bounded box — a split pane, the row beneath a spanning
+ * header — not only at the page root where the container is the viewport.
  */
 export function SidebarLayout({
   sidebar,
@@ -286,6 +290,12 @@ const styles = stylex.create({
       default: `calc(${space._3} + env(safe-area-inset-right))`,
       [breakpoints.md]: 0,
     },
+    // md+: fill the container's height, not the viewport, so the rail and its
+    // pinned footer track the container (inert at the page root, where the
+    // height is indefinite). minBlockSize:0 lets it shrink as a grid/flex item.
+    blockSize: { [breakpoints.md]: "100%" },
+    minBlockSize: { [breakpoints.md]: 0 },
+    gridTemplateRows: { [breakpoints.md]: "minmax(0, 1fr)" },
   },
   // Collapsed mobile chrome: a floating pill with the title and the menu
   // button. Fixed (a sticky grid item can't escape its own-height row), with


### PR DESCRIPTION
The design-system "Sidebar layout" preview couldn't show the sidebar's footer (the theme and language controls) without scrolling: the rail's height was hard-wired to the viewport (`max-block-size: 100dvh`), so inside the preview's ~480px window the footer sat ~850px down, off-screen.

The underlying cause is that the rail filled the *viewport* rather than its *container*, so the shell couldn't be dropped into any bounded space — a preview box, a split pane, or the area beneath a spanning header — without overshooting.

The rail now fills its container's block size instead (still capped at the viewport). At the page root the container is the viewport, so the existing design-system pages are unchanged — they still fill the screen and the document scrolls with the rail sticky. Dropped into a shorter container, the rail fills that container and its footer pins to the container's bottom. It's three CSS properties on the shell's root (md+), and a verified no-op on the current pages.

The preview now renders in a fixed-height box and shows the whole layout — header, scrolling nav, pinned footer, content column — at a glance.

Verified in-browser (desktop + mobile): the standalone pages are unchanged (document scroll, sticky rail, stays pinned on scroll); the preview and a header+sidebar composition both fill their container with the footer pinned.
